### PR TITLE
Disable libtbx.run_tests_parallel 'ERROR BEGIN' etc output by default 

### DIFF
--- a/libtbx/test_utils/parallel.py
+++ b/libtbx/test_utils/parallel.py
@@ -289,16 +289,18 @@ class run_command_list (object) :
   def check_alert(self, result):
     alert = 0
     if result.error_lines:
-      print >> self.out, "ERROR BEGIN "*10
-      print >> self.out, result.error_lines
-      print >> self.out, '-'*80
-      print >> self.out, result.stderr_lines
-      print >> self.out, "ERROR -END- "*10
+      if self.verbosity == EXTRA_VERBOSE:
+        print >> self.out, "ERROR BEGIN "*10
+        print >> self.out, result.error_lines
+        print >> self.out, '-'*80
+        print >> self.out, result.stderr_lines
+        print >> self.out, "ERROR -END- "*10
       alert = 1
     if result.return_code != 0:
-      print >> self.out, "RETURN CODE BEGIN "*5
-      print >> self.out, result.return_code
-      print >> self.out, "RETURN CODE -END- "*5
+      if self.verbosity == EXTRA_VERBOSE:
+        print >> self.out, "RETURN CODE BEGIN "*5
+        print >> self.out, result.return_code
+        print >> self.out, "RETURN CODE -END- "*5
       alert = 2
     return alert
 


### PR DESCRIPTION
Hi Nigel,

Do we really need these
```ERROR BEGIN ERROR BEGIN ERROR BEGIN ERROR BEGIN ERROR BEGIN
...
ERROR -END- ERROR -END- ERROR -END- ERROR -END- ERROR -END-```
blocks in the ```libtbx.run_tests_parallel``` output by default?
I find that when I run it manually they obscure the relevant OK/FAIL/WARNING overview and are generally not helpful because in 99% of the time they are false positives anyway. The similar block for the exit code is redundant because that is displayed in any case.

May I suggest removing this output by default?
With this patch you can run ```libtbx.run_tests_parallel verbosity=2``` to switch it back on, but it is no longer printed for everyone.
(In case you use these markers to scrape the ```libtbx.run_tests_parallel``` output with another script - have a look at the ```output.xml```)