### PR TITLE
move cbf.h outside extern C

### DIFF
--- a/cbflib_adaptbx/detectors/cbf_byte_offset_optimized.cpp
+++ b/cbflib_adaptbx/detectors/cbf_byte_offset_optimized.cpp
@@ -234,6 +234,8 @@
 
 #ifdef __cplusplus
 
+#include "cbf.h"
+
 extern "C" {
 
 #endif
@@ -244,7 +246,6 @@ extern "C" {
 #include <limits.h>
 #include <ctype.h>
 
-#include "cbf.h"
 #include "cbf_file.h"
 #include "cbf_byte_offset.h"
 #include <cbflib_adaptbx/detectors/cbf_byte_offset_optimized.h>


### PR DESCRIPTION
Move cbf.h outside of the extern C block. This make cctbx compile if the hdf5 library is build with c++ bindings.

related to :
https://github.com/yayahjb/cbflib/pull/4