### PR TITLE
Putative coordinate fixes for Eiger and NeXus data

### DIFF
--- a/dxtbx/format/FormatHDFEigerNearlyNexus.py
+++ b/dxtbx/format/FormatHDFEigerNearlyNexus.py
@@ -145,7 +145,9 @@ class EigerNXmxFixer(object):
     # Add fast_pixel_size dataset
     # print "Using /entry/instrument/detector/geometry/orientation/value as fast/slow pixel directions"
     fast_axis = handle['/entry/instrument/detector/geometry/orientation/value'][0:3]
+    fast_axis = [fast_axis[0], fast_axis[1], -fast_axis[2]] # swap Z axis to align with Dectis/NeXus documentation
     slow_axis = handle['/entry/instrument/detector/geometry/orientation/value'][3:6]
+    slow_axis = [slow_axis[0], slow_axis[1], -slow_axis[2]] # swap Z axis to align with Dectis/NeXus documentation
     create_scalar(
       group,
       "fast_pixel_direction",
@@ -192,7 +194,9 @@ class EigerNXmxFixer(object):
 
     # Add detector position
     # print "Using /entry/instrument/detector/geometry/translation/distances as transformation"
-    detector_offset_vector = matrix.col(handle['/entry/instrument/detector/geometry/translation/distances'][()])
+    detector_offset_vector = handle['/entry/instrument/detector/geometry/translation/distances'][()]
+    # swap Z axis to align with Dectis/NeXus documentation
+    detector_offset_vector = matrix.col((detector_offset_vector[0], detector_offset_vector[1], -detector_offset_vector[2]))
     group = handle.create_group('/entry/instrument/detector/transformations')
     group.attrs['NX_class'] = 'NXtransformations'
     create_scalar(

--- a/dxtbx/format/nexus.py
+++ b/dxtbx/format/nexus.py
@@ -883,7 +883,7 @@ class BeamFactory(object):
 
     # Construct the beam model
     self.model = Beam(
-      direction=(0, 0, -1),
+      direction=(0, 0, 1),
       wavelength=wavelength_value)
 
 
@@ -951,9 +951,13 @@ class DetectorFactory(object):
       nx_file,
       module_offset.name)
 
-    origin = -matrix.col(origin)
-    fast_axis = - fast_axis
-    slow_axis = - slow_axis
+    # Change of basis to convert from NeXus to IUCr/ImageCIF convention
+    cob = matrix.sqr((-1,  0,  0,
+                       0,  1,  0,
+                       0,  0, -1))
+    origin = cob * matrix.col(origin)
+    fast_axis = cob * fast_axis
+    slow_axis = cob * slow_axis
 
     # Ensure that fast and slow axis are orthogonal
     normal = fast_axis.cross(slow_axis)

--- a/iotbx/detectors/eiger.py
+++ b/iotbx/detectors/eiger.py
@@ -34,7 +34,7 @@ class EIGERImage(DetectorImageBase):
       self.parameters['WAVELENGTH'] = B.get_wavelength()
       from scitbx.matrix import col
       detector_normal = D[0].get_normal()
-      tt_angle_deg = col(detector_normal).angle(col((0.,0.,1.)),deg=True)
+      tt_angle_deg = col(detector_normal).angle(col((0.,0.,-1.)),deg=True)
       assert tt_angle_deg < 0.01 # assert normal to within 0.01 degree
       self.parameters['TWOTHETA'] = 0.0
 


### PR DESCRIPTION
1) Swap Z values in Eiger data using NearlyNexus.  This is to align stored data with documented coordinate systems.  The Eiger system should match the NeXus system, but the Eiger stores negative Z values instead of positive.
2) Revert 'world inversion' where the beam vector, origin, fast and slow vectors were all inverted.  Instead, add a change of basis to nexus.py that converts between the NeXus and IUCr systems.  Essentialy swaps sign of X and Z directions.