### PR TITLE
Fixes issue #46 with an apparently innocuous change

### DIFF
--- a/wxtbx/utils.py
+++ b/wxtbx/utils.py
@@ -106,6 +106,7 @@ class SettingsPanel (wx.Panel, SettingsToolBase) :
     self.panel_sizer = wx.BoxSizer(wx.VERTICAL)
     self.SetSizer(self.panel_sizer)
     self.add_controls()
+    self.panel_sizer.SetSizeHints(self)
     self.panel_sizer.Layout()
 
 def bold_text (parent, label) :


### PR DESCRIPTION
I put this simple change on a branch so that its effect can be more easily checked for applications other than `dials.reciprocal_lattice_viewer`. In that case at least the change fixes the `Gtk-CRITICAL` with apparently no changes to the operation of the gui.