### PR TITLE
this appears to be ~100x faster than the existing code

### DIFF
--- a/scitbx/array_family/boost_python/flex_bool.cpp
+++ b/scitbx/array_family/boost_python/flex_bool.cpp
@@ -140,7 +140,12 @@ namespace {
     if (a1.accessor() != a2.accessor()) {
       raise_incompatible_arrays();
     }
-    for(std::size_t i=0;i<a1.size();i++) if(!a2[i]) a1[i] = false;
+    bool* lhs = a1.begin();
+    bool* lhs_end = a1.end();
+    const bool* rhs = a2.begin();
+    while (lhs != lhs_end) {
+      *lhs++ &= *rhs++;
+    }
     return a1;
   }
 
@@ -150,7 +155,12 @@ namespace {
     if (a1.accessor() != a2.accessor()) {
       raise_incompatible_arrays();
     }
-    for(std::size_t i=0;i<a1.size();i++) if(a2[i]) a1[i] = true;
+    bool* lhs = a1.begin();
+    bool* lhs_end = a1.end();
+    const bool* rhs = a2.begin();
+    while (lhs != lhs_end) {
+      *lhs++ |= *rhs++;
+    }
     return a1;
   }
 


### PR DESCRIPTION
Using this test script:
```
from scitbx.array_family import flex
g = flex.grid((2527, 2463))

import time
t0 = time.time()
N = 100

a = flex.random_bool(size=g.size_1d(), threshold=0.5)
b = flex.random_bool(size=g.size_1d(), threshold=0.5)
t0 = time.time()
for i in range(N):
  a &= b
t1 = time.time()

print "scitbx: a &= b"
print "Total time:", t1 - t0
print "Per call:", (t1 - t0)/N

a = flex.random_bool(size=g.size_1d(), threshold=0.5)
b = flex.random_bool(size=g.size_1d(), threshold=0.5)
t0 = time.time()
for i in range(N):
  c = (a & b)
t1 = time.time()

print "scitbx: c = (a & b)"
print "Total time:", t1 - t0
print "Per call:", (t1 - t0)/N

a = flex.random_bool(size=g.size_1d(), threshold=0.5).as_numpy_array()
b = flex.random_bool(size=g.size_1d(), threshold=0.5).as_numpy_array()
t0 = time.time()
for i in range(N):
  a &= b
t1 = time.time()

print "numpy: a &= b"
print "Total time:", t1 - t0
print "Per call:", (t1 - t0)/N

a = flex.random_bool(size=g.size_1d(), threshold=0.5).as_numpy_array()
b = flex.random_bool(size=g.size_1d(), threshold=0.5).as_numpy_array()
t0 = time.time()
for i in range(N):
  c = (a & b)
t1 = time.time()

print "numpy: c = (a & b)"
print "Total time:", t1 - t0
print "Per call:", (t1 - t0)/N
```
The existing code gives the following output:
```
$ dials.python tst.py 
scitbx: a &= b
Total time: 7.25099992752
Per call: 0.0725099992752
scitbx: c = (a & b)
Total time: 0.0954639911652
Per call: 0.000954639911652
numpy: a &= b
Total time: 0.0795631408691
Per call: 0.000795631408691
numpy: c = (a & b)
Total time: 0.0930099487305
Per call: 0.000930099487305
```
With the changes in this pull request:
```
$ dials.python tst.py 
scitbx: a &= b
Total time: 0.0577290058136
Per call: 0.000577290058136
scitbx: c = (a & b)
Total time: 0.0922310352325
Per call: 0.000922310352325
numpy: a &= b
Total time: 0.0630779266357
Per call: 0.000630779266357
numpy: c = (a & b)
Total time: 0.0931711196899
Per call: 0.000931711196899
```