### PR TITLE
Explicit template instantiation of smtbx' geometrical_hydrogen_sites<N>

### DIFF
--- a/smtbx/refinement/constraints/geometrical_hydrogens.cpp
+++ b/smtbx/refinement/constraints/geometrical_hydrogens.cpp
@@ -476,4 +476,8 @@ namespace smtbx { namespace refinement { namespace constraints {
     }
   }
 
+  // Explicitly instantiate template classes used in other libraries
+  template class geometrical_hydrogen_sites<1>;
+  template class geometrical_hydrogen_sites<2>;
+  template class geometrical_hydrogen_sites<3>;
 }}}


### PR DESCRIPTION
Anyone see any problems/have any objection to this? It's fixing a problem that isn't currently exhibited by the *standard* build, but I believe is technically is more standards-correct.

Effectively, it fixes a problem compiling `libsmtbx_refinement_constraints` as a shared library
on macOS (which is currently explicitly disabled for default builds).

The Problem
-------------
  This template class is defined privately in `libsmtbx_refinement_constraints`. On linux systems the implicit instantiation via usage in the rest of the library results in a weak-symbol export that can be linked to (by `smtbx_refinement_constraints_ext`), but it looks like the macOS linker is stricter about symbol visibility and exporting - the symbol ends up in a private (non-external) ELF section.

The Cause of Problem:
-------------
Relying on linking to visible implicit declarations seems to be, at best, implementation-specific behaviour. See standards:

>   14 Templates
>   8 ... A ... template must be defined in every translation unit in which it is implicitly instantiated (14.7.1), unless the corresponding specialization is explicitly instantiated (14.7.2) in some translation unit; no diagnostic is required.

The Solution
-------------
  Explicitly declare the template instantiations