### PR TITLE
New dxtbx models

### DIFF
--- a/dxtbx/model/__init__.py
+++ b/dxtbx/model/__init__.py
@@ -42,6 +42,10 @@ class DetectorAux(boost.python.injector, Detector):
 class CrystalAux(boost.python.injector, Crystal):
 
   def show(self, show_scan_varying=False, out=None):
+    CrystalAux._show(self, show_scan_varying, out)
+
+  @staticmethod
+  def _show(self, show_scan_varying=False, out=None):
     from scitbx import matrix
     if out is None:
       import sys
@@ -109,7 +113,8 @@ class CrystalAux(boost.python.injector, Crystal):
     s.seek(0)
     return s.read()
 
-  def to_dict(crystal):
+  @staticmethod
+  def _to_dict(crystal):
     ''' Convert the crystal model to a dictionary
 
     Params:
@@ -130,9 +135,6 @@ class CrystalAux(boost.python.injector, Crystal):
 
     # Get the space group Hall symbol
     hall = crystal.get_space_group().info().type().hall_symbol()
-
-    # Get the mosaicity
-    mosaicity = crystal.get_mosaicity()
 
     # New parameters for maximum likelihood values
     try:
@@ -157,7 +159,6 @@ class CrystalAux(boost.python.injector, Crystal):
       ('real_space_b', real_space_b),
       ('real_space_c', real_space_c),
       ('space_group_hall_symbol', hall),
-      ('mosaicity', mosaicity),
       ('ML_half_mosaicity_deg', ML_half_mosaicity_deg),
       ('ML_domain_size_ang', ML_domain_size_ang)])
 
@@ -176,6 +177,9 @@ class CrystalAux(boost.python.injector, Crystal):
       xl_dict['B_covariance'] = cov_B
 
     return xl_dict
+
+  def to_dict(crystal):
+    return CrystalAux._to_dict(crystal)
 
   @staticmethod
   def from_dict(d):
@@ -236,6 +240,78 @@ class CrystalAux(boost.python.injector, Crystal):
     except KeyError:
       pass
 
+    return xl
+
+class MosaicCrystalAux(CrystalAux, MosaicCrystal):
+  def show(self, show_scan_varying=False, out=None):
+    from scitbx import matrix
+    CrystalAux._show(self, show_scan_varying, out)
+
+    if out is None:
+      import sys
+      out = sys.stdout
+
+    msg = []
+    msg.append("    Mosaicity:  %.6f"%self.get_mosaicity())
+
+    print >> out, "\n".join(msg)
+
+  def __str__(self):
+    from cStringIO import StringIO
+    s = StringIO()
+    msg = self.show(out=s)
+    s.seek(0)
+    return s.read()
+
+  def to_dict(crystal):
+    ''' Convert the crystal model to a dictionary
+
+    Params:
+        crystal The crystal model
+
+    Returns:
+        A dictionary of the parameters
+
+    '''
+    xl_dict = CrystalAux._to_dict(crystal)
+
+
+    # Get the mosaicity
+    mosaicity = crystal.get_mosaicity()
+    xl_dict['mosaicity'] = mosaicity
+
+    return xl_dict
+
+  @staticmethod
+  def from_dict(d):
+    ''' Convert the dictionary to a crystal model
+
+    Params:
+        d The dictionary of parameters
+
+    Returns:
+        The crystal model
+
+    '''
+    xl = MosaicCrystal(CrystalAux.from_dict(d))
+
+    # These parameters don't survive the Crystal copy constructor so have to be re-set
+    # New parameters for maximum likelihood values
+    try:
+      xl._ML_half_mosaicity_deg = d['ML_half_mosaicity_deg']
+    except KeyError:
+      pass
+    try:
+      xl._ML_domain_size_ang = d['ML_domain_size_ang']
+    except KeyError:
+      pass
+
+    # Isoforms used for stills
+    try:
+      xl.identified_isoform = d['identified_isoform']
+    except KeyError:
+      pass
+
     # Extract mosaicity, if present
     try:
       mosaicity = d['mosaicity']
@@ -244,7 +320,6 @@ class CrystalAux(boost.python.injector, Crystal):
       pass
 
     return xl
-
 
 class ExperimentListAux(boost.python.injector, ExperimentList):
 
@@ -323,7 +398,6 @@ class ExperimentListAux(boost.python.injector, ExperimentList):
     ''' Serialize the experiment list to dictionary. '''
     from libtbx.containers import OrderedDict
     from dxtbx.imageset import ImageSet, ImageSweep, ImageGrid
-    from dxtbx.format.FormatMultiImage import FormatMultiImage
 
     # Check the experiment list is consistent
     assert(self.is_consistent())

--- a/dxtbx/model/__init__.py
+++ b/dxtbx/model/__init__.py
@@ -242,7 +242,7 @@ class CrystalAux(boost.python.injector, Crystal):
 
     return xl
 
-class MosaicCrystalAux(CrystalAux, MosaicCrystal):
+class MosaicCrystalKabsch2010Aux(CrystalAux, MosaicCrystalKabsch2010):
   def show(self, show_scan_varying=False, out=None):
     from scitbx import matrix
     CrystalAux._show(self, show_scan_varying, out)
@@ -293,7 +293,7 @@ class MosaicCrystalAux(CrystalAux, MosaicCrystal):
         The crystal model
 
     '''
-    xl = MosaicCrystal(CrystalAux.from_dict(d))
+    xl = MosaicCrystalKabsch2010(CrystalAux.from_dict(d))
 
     # These parameters don't survive the Crystal copy constructor so have to be re-set
     # New parameters for maximum likelihood values

--- a/dxtbx/model/boost_python/crystal.cc
+++ b/dxtbx/model/boost_python/crystal.cc
@@ -282,7 +282,7 @@ namespace dxtbx { namespace model { namespace boost_python {
       crystal.set_B_covariance(cov_B);
       double half_mosaicity_deg = boost::python::extract<double>(state[3]);
       crystal.set_half_mosaicity_deg(half_mosaicity_deg);
-      double domain_size_ang = boost::python::extract<double>(state[3]);
+      double domain_size_ang = boost::python::extract<double>(state[4]);
       crystal.set_domain_size_ang(domain_size_ang);
     }
   };

--- a/dxtbx/model/boost_python/crystal.cc
+++ b/dxtbx/model/boost_python/crystal.cc
@@ -53,13 +53,13 @@ namespace dxtbx { namespace model { namespace boost_python {
   }
 
   static
-  MosaicCrystal* make_mosaic_crystal_default(
+  MosaicCrystalKabsch2010* make_mosaic_crystal_default(
       const vec3<double> &real_space_a,
       const vec3<double> &real_space_b,
       const vec3<double> &real_space_c,
       const cctbx::sgtbx::space_group &space_group) {
 
-    MosaicCrystal *crystal = new MosaicCrystal(
+    MosaicCrystalKabsch2010 *crystal = new MosaicCrystalKabsch2010(
       real_space_a,
       real_space_b,
       real_space_c,
@@ -69,13 +69,13 @@ namespace dxtbx { namespace model { namespace boost_python {
   }
 
   static
-  MosaicCrystal* make_mosaic_crystal_with_symbol(
+  MosaicCrystalKabsch2010* make_mosaic_crystal_with_symbol(
       const vec3<double> &real_space_a,
       const vec3<double> &real_space_b,
       const vec3<double> &real_space_c,
       const std::string &space_group_symbol) {
 
-    MosaicCrystal *crystal = new MosaicCrystal(
+    MosaicCrystalKabsch2010 *crystal = new MosaicCrystalKabsch2010(
       real_space_a,
       real_space_b,
       real_space_c,
@@ -160,9 +160,9 @@ namespace dxtbx { namespace model { namespace boost_python {
     static bool getstate_manages_dict() { return true; }
   };
 
-  struct MosaicCrystalPickleSuite: CrystalPickleSuite {
+  struct MosaicCrystalKabsch2010PickleSuite: CrystalPickleSuite {
     static
-    boost::python::tuple getinitargs(const MosaicCrystal &obj) {
+    boost::python::tuple getinitargs(const MosaicCrystalKabsch2010 &obj) {
       scitbx::af::shared< vec3<double> > real_space_v = obj.get_real_space_vectors();
       return boost::python::make_tuple(
           real_space_v[0],
@@ -174,7 +174,7 @@ namespace dxtbx { namespace model { namespace boost_python {
     static
     boost::python::tuple getstate(boost::python::object obj)
     {
-      const MosaicCrystal &crystal = boost::python::extract<const MosaicCrystal &>(obj)();
+      const MosaicCrystalKabsch2010 &crystal = boost::python::extract<const MosaicCrystalKabsch2010 &>(obj)();
       return boost::python::make_tuple(
           obj.attr("__dict__"),
           crystal.get_A_at_scan_points(),
@@ -185,7 +185,7 @@ namespace dxtbx { namespace model { namespace boost_python {
     static
     void setstate(boost::python::object obj, boost::python::tuple state)
     {
-      MosaicCrystal &crystal = boost::python::extract<MosaicCrystal&>(obj)();
+      MosaicCrystalKabsch2010 &crystal = boost::python::extract<MosaicCrystalKabsch2010&>(obj)();
       DXTBX_ASSERT(boost::python::len(state) == 4);
 
         // restore the object's __dict__
@@ -270,8 +270,8 @@ namespace dxtbx { namespace model { namespace boost_python {
             arg("space_group_symbol"))))
       .def_pickle(CrystalPickleSuite());
 
-    class_ <MosaicCrystal, bases <CrystalBase> > ("MosaicCrystal", no_init)
-      .def(init<const MosaicCrystal&>())
+    class_ <MosaicCrystalKabsch2010, bases <CrystalBase> > ("MosaicCrystalKabsch2010", no_init)
+      .def(init<const MosaicCrystalKabsch2010&>())
       .def(init<const Crystal&>())
       .def("__init__",
           make_constructor(
@@ -289,22 +289,22 @@ namespace dxtbx { namespace model { namespace boost_python {
             arg("real_space_b"),
             arg("real_space_c"),
             arg("space_group_symbol"))))
-      .def("is_similar_to", &MosaicCrystal::is_similar_to, (
+      .def("is_similar_to", &MosaicCrystalKabsch2010::is_similar_to, (
             arg("other"),
             arg("angle_tolerance")=0.01,
             arg("uc_rel_length_tolerance")=0.01,
             arg("uc_abs_angle_tolerance")=1.0,
             arg("mosaicity_tolerance")=0.8))
-      .def("get_mosaicity", &MosaicCrystal::get_mosaicity, (
+      .def("get_mosaicity", &MosaicCrystalKabsch2010::get_mosaicity, (
             arg("deg")=true))
-      .def("set_mosaicity", &MosaicCrystal::set_mosaicity, (
+      .def("set_mosaicity", &MosaicCrystalKabsch2010::set_mosaicity, (
             arg("mosaicity"),
             arg("deg")=true))
-      .def_pickle(MosaicCrystalPickleSuite());
+      .def_pickle(MosaicCrystalKabsch2010PickleSuite());
 
     register_ptr_to_python<boost::shared_ptr<CrystalBase> >();
     register_ptr_to_python<boost::shared_ptr<Crystal> >();
-    register_ptr_to_python<boost::shared_ptr<MosaicCrystal> >();
+    register_ptr_to_python<boost::shared_ptr<MosaicCrystalKabsch2010> >();
   }
 
 }}} // namespace = dxtbx::model::boost_python

--- a/dxtbx/model/crystal.h
+++ b/dxtbx/model/crystal.h
@@ -946,18 +946,18 @@ namespace dxtbx { namespace model {
    * The deg parameter controlls whether this value is treated as being an
    * angle in degrees or radians.
    */
-  class MosaicCrystal : public Crystal {
+  class MosaicCrystalKabsch2010 : public Crystal {
   public:
     /**
-     * Copy crystal model from MosaicCrystal class
+     * Copy crystal model from MosaicCrystalKabsch2010 class
      */
-    MosaicCrystal(const MosaicCrystal &other)
+    MosaicCrystalKabsch2010(const MosaicCrystalKabsch2010 &other)
       : Crystal(other),
         mosaicity_(other.mosaicity_) {}
     /**
      * Copy crystal model from Crystal class
      */
-    MosaicCrystal(const Crystal &other)
+    MosaicCrystalKabsch2010(const Crystal &other)
       : Crystal(other),
         mosaicity_(0) {}
 
@@ -969,7 +969,7 @@ namespace dxtbx { namespace model {
      * @param real_space_c The real_space c axis
      * @param space_group The space group object
      */
-    MosaicCrystal(const vec3<double> &real_space_a,
+    MosaicCrystalKabsch2010(const vec3<double> &real_space_a,
             const vec3<double> &real_space_b,
             const vec3<double> &real_space_c,
             const cctbx::sgtbx::space_group &space_group)
@@ -979,7 +979,7 @@ namespace dxtbx { namespace model {
     /**
      * Constructor for pickling
      */
-    MosaicCrystal(
+    MosaicCrystalKabsch2010(
         cctbx::sgtbx::space_group space_group,
         cctbx::uctbx::unit_cell unit_cell,
         mat3<double> U,
@@ -998,7 +998,7 @@ namespace dxtbx { namespace model {
      */
     bool operator==(const CrystalBase &other) const {
       double eps = 1e-7;
-      const MosaicCrystal* mosaic_other = dynamic_cast<const MosaicCrystal*>(&other);
+      const MosaicCrystalKabsch2010* mosaic_other = dynamic_cast<const MosaicCrystalKabsch2010*>(&other);
       if (!mosaic_other) return false;
 
       double d_mosaicity = std::abs(mosaicity_ - mosaic_other->get_mosaicity());
@@ -1017,7 +1017,7 @@ namespace dxtbx { namespace model {
         double mosaicity_tolerance=0.8) const {
 
       // mosaicity test
-      const MosaicCrystal* mosaic_other = dynamic_cast<const MosaicCrystal*>(&other);
+      const MosaicCrystalKabsch2010* mosaic_other = dynamic_cast<const MosaicCrystalKabsch2010*>(&other);
       if (!mosaic_other) return false;
 
       double m_a = get_mosaicity();

--- a/dxtbx/model/crystal.py
+++ b/dxtbx/model/crystal.py
@@ -25,6 +25,15 @@ class CrystalFactory(object):
       d = dict(t.items() + d.items())
 
     # Create the model from the dictionary
+    if 'ML_half_mosaicity_deg' in d:
+      assert 'ML_domain_size_ang' in d
+      if d['ML_half_mosaicity_deg'] is None or d['ML_domain_size_ang'] is None:
+        assert d['ML_half_mosaicity_deg'] is None and d['ML_domain_size_ang'] is None
+      else:
+        if 'mosaicity' in d and d['mosaicity'] > 0:
+          print "Warning, two kinds of mosaicity found. Using Sauter2014 model"
+        from dxtbx.model import MosaicCrystalSauter2014
+        return MosaicCrystalSauter2014.from_dict(d)
     if 'mosaicity' in d:
       from dxtbx.model import MosaicCrystalKabsch2010
       return MosaicCrystalKabsch2010.from_dict(d)

--- a/dxtbx/model/crystal.py
+++ b/dxtbx/model/crystal.py
@@ -26,8 +26,8 @@ class CrystalFactory(object):
 
     # Create the model from the dictionary
     if 'mosaicity' in d:
-      from dxtbx.model import MosaicCrystal
-      return MosaicCrystal.from_dict(d)
+      from dxtbx.model import MosaicCrystalKabsch2010
+      return MosaicCrystalKabsch2010.from_dict(d)
     else:
       from dxtbx.model import Crystal
       return Crystal.from_dict(d)

--- a/dxtbx/model/crystal.py
+++ b/dxtbx/model/crystal.py
@@ -17,8 +17,6 @@ class CrystalFactory(object):
         The crystal model
 
     '''
-    from dxtbx.model import Crystal
-
     # If None, return None
     if d == None:
       if t == None: return None
@@ -27,7 +25,12 @@ class CrystalFactory(object):
       d = dict(t.items() + d.items())
 
     # Create the model from the dictionary
-    return Crystal.from_dict(d)
+    if 'mosaicity' in d:
+      from dxtbx.model import MosaicCrystal
+      return MosaicCrystal.from_dict(d)
+    else:
+      from dxtbx.model import Crystal
+      return Crystal.from_dict(d)
 
   @staticmethod
   def from_mosflm_matrix(mosflm_A_matrix,

--- a/dxtbx/serialize/xds.py
+++ b/dxtbx/serialize/xds.py
@@ -100,7 +100,6 @@ def to_crystal(filename):
   '''
   from rstbx.cftbx.coordinate_frame_converter import \
       coordinate_frame_converter
-  from dxtbx.model import Crystal
   from cctbx.sgtbx import space_group, space_group_symbols
 
   # Get the real space coordinate frame
@@ -113,12 +112,20 @@ def to_crystal(filename):
   mosaicity = cfc.get('mosaicity')
 
   # Return the crystal model
-  crystal = Crystal(
-      real_space_a=real_space_a,
-      real_space_b=real_space_b,
-      real_space_c=real_space_c,
-      space_group=space_group)
-  if (mosaicity is not None):
+  if (mosaicity is None):
+    from dxtbx.model import Crystal
+    crystal = Crystal(
+        real_space_a=real_space_a,
+        real_space_b=real_space_b,
+        real_space_c=real_space_c,
+        space_group=space_group)
+  else:
+    from dxtbx.model import MosaicCrystal
+    crystal = MosaicCrystal(
+        real_space_a=real_space_a,
+        real_space_b=real_space_b,
+        real_space_c=real_space_c,
+        space_group=space_group)
     crystal.set_mosaicity(mosaicity)
   return crystal
 

--- a/dxtbx/serialize/xds.py
+++ b/dxtbx/serialize/xds.py
@@ -120,8 +120,8 @@ def to_crystal(filename):
         real_space_c=real_space_c,
         space_group=space_group)
   else:
-    from dxtbx.model import MosaicCrystal
-    crystal = MosaicCrystal(
+    from dxtbx.model import MosaicCrystalKabsch2010
+    crystal = MosaicCrystalKabsch2010(
         real_space_a=real_space_a,
         real_space_b=real_space_b,
         real_space_c=real_space_c,

--- a/dxtbx/tests/model/tst_crystal_model.py
+++ b/dxtbx/tests/model/tst_crystal_model.py
@@ -4,7 +4,7 @@ from cStringIO import StringIO
 from libtbx.test_utils import approx_equal, show_diff
 from scitbx import matrix
 from cctbx import crystal, sgtbx, uctbx
-from dxtbx.model import Crystal, MosaicCrystalKabsch2010, CrystalFactory
+from dxtbx.model import Crystal, MosaicCrystalKabsch2010, MosaicCrystalSauter2014, CrystalFactory
 
 def random_rotation():
   import random
@@ -222,6 +222,24 @@ Crystal:
   # print "mosaic_model == model4", mosaic_model == model4 # False
   # print "mosaic_model2 == model4", mosaic_model2 == model4 # False
   # print "model4 == mosaic_model2", model4 == mosaic_model2 # True
+
+  mosaic_model = MosaicCrystalSauter2014(real_space_a=(10,0,0),
+                               real_space_b=(0,11,0),
+                               real_space_c=(0,0,12),
+                               space_group_symbol="P 1")
+  mosaic_model2 = MosaicCrystalSauter2014(real_space_a=(10,0,0),
+                                real_space_b=(0,11,0),
+                                real_space_c=(0,0,12),
+                                space_group_symbol="P 1")
+  assert approx_equal(mosaic_model.get_half_mosaicity_deg(), 0)
+  assert approx_equal(mosaic_model.get_domain_size_ang(), 0)
+  assert mosaic_model == mosaic_model2
+  mosaic_model2.set_half_mosaicity_deg(0.01)
+  assert mosaic_model != mosaic_model2
+  mosaic_model2.set_half_mosaicity_deg(0)
+  assert mosaic_model == mosaic_model2
+  mosaic_model2.set_domain_size_ang(1000)
+  assert mosaic_model != mosaic_model2
 
 def exercise_similarity():
 

--- a/dxtbx/tests/model/tst_crystal_model.py
+++ b/dxtbx/tests/model/tst_crystal_model.py
@@ -4,7 +4,7 @@ from cStringIO import StringIO
 from libtbx.test_utils import approx_equal, show_diff
 from scitbx import matrix
 from cctbx import crystal, sgtbx, uctbx
-from dxtbx.model import Crystal, CrystalFactory
+from dxtbx.model import Crystal, MosaicCrystal, CrystalFactory
 
 def random_rotation():
   import random
@@ -47,15 +47,13 @@ def exercise_crystal_model():
   assert approx_equal(model.get_U(), (1, 0, 0, 0, 1, 0, 0, 0, 1))
   assert approx_equal(model.get_real_space_vectors(),
                       (real_space_a, real_space_b, real_space_c))
-  assert approx_equal(model.get_mosaicity(), 0)
 
   model2 = Crystal(real_space_a=(10,0,0),
                          real_space_b=(0,11,0),
                          real_space_c=(0,0,12),
                          space_group_symbol="P 1")
-  assert model == model2
-  model2.set_mosaicity(0.01)
-  assert model != model2
+  assert model == model2 and not (model != model2)
+
   # rotate 45 degrees about x-axis
   R1 = matrix.sqr((1, 0, 0,
                    0, math.cos(math.pi/4), -math.sin(math.pi/4),
@@ -112,7 +110,6 @@ Crystal:
     real_space_b=(0,11,0),
     real_space_c=(0,0,12),
     space_group=sgtbx.space_group_info("P 222").group())
-  model3.set_mosaicity(0.01)
   assert model3.get_space_group().type().hall_symbol() == " P 2 2"
   assert model != model3
   #
@@ -204,14 +201,36 @@ Crystal:
     A_min = matrix.sqr(model_minimum.get_A_at_scan_point(i))
     assert approx_equal(A_min, A_orig * M_inv)
 
+  mosaic_model = MosaicCrystal(real_space_a=(10,0,0),
+                               real_space_b=(0,11,0),
+                               real_space_c=(0,0,12),
+                               space_group_symbol="P 1")
+  mosaic_model2 = MosaicCrystal(real_space_a=(10,0,0),
+                                real_space_b=(0,11,0),
+                                real_space_c=(0,0,12),
+                                space_group_symbol="P 1")
+  assert approx_equal(mosaic_model.get_mosaicity(), 0)
+  assert mosaic_model == mosaic_model2
+  mosaic_model2.set_mosaicity(0.01)
+  assert mosaic_model != mosaic_model2
+  # FIXME Crystal == MosaicCrytal gives unexpected result, depending on parameter order
+  # model4 = Crystal(real_space_a=(10,0,0),
+  #                  real_space_b=(0,11,0),
+  #                  real_space_c=(0,0,12),
+  #                  space_group_symbol="P 1")
+  # print "model4 == mosaic_model", model4 == mosaic_model # True
+  # print "mosaic_model == model4", mosaic_model == model4 # False
+  # print "mosaic_model2 == model4", mosaic_model2 == model4 # False
+  # print "model4 == mosaic_model2", model4 == mosaic_model2 # True
+
 def exercise_similarity():
 
-  model_1 = Crystal(real_space_a=(10,0,0),
+  model_1 = MosaicCrystal(real_space_a=(10,0,0),
                           real_space_b=(0,11,0),
                           real_space_c=(0,0,12),
                           space_group_symbol="P 1")
   model_1.set_mosaicity(0.5)
-  model_2 = Crystal(real_space_a=(10,0,0),
+  model_2 = MosaicCrystal(real_space_a=(10,0,0),
                           real_space_b=(0,11,0),
                           real_space_c=(0,0,12),
                           space_group_symbol="P 1")

--- a/dxtbx/tests/model/tst_crystal_model.py
+++ b/dxtbx/tests/model/tst_crystal_model.py
@@ -4,7 +4,7 @@ from cStringIO import StringIO
 from libtbx.test_utils import approx_equal, show_diff
 from scitbx import matrix
 from cctbx import crystal, sgtbx, uctbx
-from dxtbx.model import Crystal, MosaicCrystal, CrystalFactory
+from dxtbx.model import Crystal, MosaicCrystalKabsch2010, CrystalFactory
 
 def random_rotation():
   import random
@@ -201,11 +201,11 @@ Crystal:
     A_min = matrix.sqr(model_minimum.get_A_at_scan_point(i))
     assert approx_equal(A_min, A_orig * M_inv)
 
-  mosaic_model = MosaicCrystal(real_space_a=(10,0,0),
+  mosaic_model = MosaicCrystalKabsch2010(real_space_a=(10,0,0),
                                real_space_b=(0,11,0),
                                real_space_c=(0,0,12),
                                space_group_symbol="P 1")
-  mosaic_model2 = MosaicCrystal(real_space_a=(10,0,0),
+  mosaic_model2 = MosaicCrystalKabsch2010(real_space_a=(10,0,0),
                                 real_space_b=(0,11,0),
                                 real_space_c=(0,0,12),
                                 space_group_symbol="P 1")
@@ -225,12 +225,12 @@ Crystal:
 
 def exercise_similarity():
 
-  model_1 = MosaicCrystal(real_space_a=(10,0,0),
+  model_1 = MosaicCrystalKabsch2010(real_space_a=(10,0,0),
                           real_space_b=(0,11,0),
                           real_space_c=(0,0,12),
                           space_group_symbol="P 1")
   model_1.set_mosaicity(0.5)
-  model_2 = MosaicCrystal(real_space_a=(10,0,0),
+  model_2 = MosaicCrystalKabsch2010(real_space_a=(10,0,0),
                           real_space_b=(0,11,0),
                           real_space_c=(0,0,12),
                           space_group_symbol="P 1")

--- a/dxtbx/tests/serialize/tst_crystal_model_serialize.py
+++ b/dxtbx/tests/serialize/tst_crystal_model_serialize.py
@@ -7,22 +7,32 @@ class Test(object):
 
   def run(self):
     self.tst_crystal()
+    self.tst_crystal(mosaic=True)
     self.tst_crystal_with_scan_points()
 
-  def tst_crystal(self):
-    from dxtbx.model import Crystal, CrystalFactory
+  def tst_crystal(self, mosaic=False):
+    from dxtbx.model import CrystalFactory
     from scitbx import matrix
 
     real_space_a = matrix.col((35.2402102454, -7.60002142787, 22.080026774))
     real_space_b = matrix.col((22.659572494, 1.47163505925, -35.6586361881))
     real_space_c = matrix.col((5.29417246554, 38.9981792999, 4.97368666613))
 
-    c1 = Crystal(
-        real_space_a=real_space_a,
-        real_space_b=real_space_b,
-        real_space_c=real_space_c,
-        space_group_symbol="P 1 2/m 1")
-    c1.set_mosaicity(0.1)
+    if mosaic:
+      from dxtbx.model import MosaicCrystal
+      c1 = MosaicCrystal(
+          real_space_a=real_space_a,
+          real_space_b=real_space_b,
+          real_space_c=real_space_c,
+          space_group_symbol="P 1 2/m 1")
+      c1.set_mosaicity(0.1)
+    else:
+      from dxtbx.model import Crystal
+      c1 = Crystal(
+          real_space_a=real_space_a,
+          real_space_b=real_space_b,
+          real_space_c=real_space_c,
+          space_group_symbol="P 1 2/m 1")
 
     d = c1.to_dict()
     c2 = CrystalFactory.from_dict(d)
@@ -31,7 +41,8 @@ class Test(object):
     assert(abs(matrix.col(d['real_space_b']) - real_space_b) <= eps)
     assert(abs(matrix.col(d['real_space_c']) - real_space_c) <= eps)
     assert(d['space_group_hall_symbol'] == "-P 2y")
-    assert(d['mosaicity'] == 0.1)
+    if mosaic:
+      assert(d['mosaicity'] == 0.1)
     assert(c1 == c2)
     print 'OK'
 

--- a/dxtbx/tests/serialize/tst_crystal_model_serialize.py
+++ b/dxtbx/tests/serialize/tst_crystal_model_serialize.py
@@ -19,8 +19,8 @@ class Test(object):
     real_space_c = matrix.col((5.29417246554, 38.9981792999, 4.97368666613))
 
     if mosaic:
-      from dxtbx.model import MosaicCrystal
-      c1 = MosaicCrystal(
+      from dxtbx.model import MosaicCrystalKabsch2010
+      c1 = MosaicCrystalKabsch2010(
           real_space_a=real_space_a,
           real_space_b=real_space_b,
           real_space_c=real_space_c,

--- a/prime/command_line/frame_extractor_by_scan.py
+++ b/prime/command_line/frame_extractor_by_scan.py
@@ -111,11 +111,11 @@ class ConstructFrame(object):
   # get any available ML values
   def populate_ML_values(self):
     try:
-      self.frame['ML_half_mosaicity_deg'] = [self.xtal._ML_half_mosaicity_deg]
+      self.frame['ML_half_mosaicity_deg'] = [self.xtal.get_half_mosaicity_deg()]
     except AttributeError:
       pass
     try:
-      self.frame['ML_domain_size_ang'] = [self.xtal._ML_domain_size_ang]
+      self.frame['ML_domain_size_ang'] = [self.xtal.get_domain_size_ang()]
     except AttributeError:
       pass
 

--- a/prime/command_line/frame_extractor_by_scan.py
+++ b/prime/command_line/frame_extractor_by_scan.py
@@ -103,8 +103,10 @@ class ConstructFrame(object):
 
   # get mosaicity
   def populate_mosaicity(self):
-    assert self.xtal.get_mosaicity() is not None, "no mosaicity"
-    self.frame['mosaicity'] = self.xtal.get_mosaicity()
+    try:
+      self.frame['mosaicity'] = self.xtal.get_mosaicity()
+    except AttributeError, e:
+      pass
 
   # get any available ML values
   def populate_ML_values(self):

--- a/rstbx/apps/stills/dials_refinement_preceding_integration.py
+++ b/rstbx/apps/stills/dials_refinement_preceding_integration.py
@@ -485,8 +485,8 @@ class integrate_one_frame(IntegrationMetaProcedure):
       )
 
     direct = matrix.sqr(setting_specific_ai.getOrientation().direct_matrix())
-    from dxtbx.model import MosaicCrystal
-    crystal = MosaicCrystal(
+    from dxtbx.model import MosaicCrystalKabsch2010
+    crystal = MosaicCrystalKabsch2010(
       real_space_a = matrix.row(direct[0:3]),
       real_space_b = matrix.row(direct[3:6]),
       real_space_c = matrix.row(direct[6:9]),

--- a/rstbx/apps/stills/dials_refinement_preceding_integration.py
+++ b/rstbx/apps/stills/dials_refinement_preceding_integration.py
@@ -485,8 +485,8 @@ class integrate_one_frame(IntegrationMetaProcedure):
       )
 
     direct = matrix.sqr(setting_specific_ai.getOrientation().direct_matrix())
-    from dxtbx.model import Crystal
-    crystal = Crystal(
+    from dxtbx.model import MosaicCrystal
+    crystal = MosaicCrystal(
       real_space_a = matrix.row(direct[0:3]),
       real_space_b = matrix.row(direct[3:6]),
       real_space_c = matrix.row(direct[6:9]),

--- a/xfel/command_line/frame_extractor.py
+++ b/xfel/command_line/frame_extractor.py
@@ -134,11 +134,11 @@ class ConstructFrame(object):
   # get any available ML values
   def populate_ML_values(self):
     try:
-      self.frame['ML_half_mosaicity_deg'] = [self.xtal._ML_half_mosaicity_deg]
+      self.frame['ML_half_mosaicity_deg'] = [self.xtal.get_half_mosaicity_deg()]
     except AttributeError:
       pass
     try:
-      self.frame['ML_domain_size_ang'] = [self.xtal._ML_domain_size_ang]
+      self.frame['ML_domain_size_ang'] = [self.xtal.get_domain_size_ang()]
     except AttributeError:
       pass
 

--- a/xfel/command_line/frame_unpickler.py
+++ b/xfel/command_line/frame_unpickler.py
@@ -116,8 +116,8 @@ class construct_reflection_table_and_experiment_list(object):
     real_c = direct_matrix[6:9]
     lattice = self.ucell.lattice_symmetry_group()
     if 'mosaicity' in self.data:
-      from dxtbx.model import MosaicCrystal
-      self.crystal = MosaicCrystal(real_a, real_b, real_c, space_group=lattice)
+      from dxtbx.model import MosaicCrystalKabsch2010
+      self.crystal = MosaicCrystalKabsch2010(real_a, real_b, real_c, space_group=lattice)
       self.crystal.set_mosaicity(self.data['mosaicity'])
     else:
       from dxtbx.model import Crystal

--- a/xfel/command_line/frame_unpickler.py
+++ b/xfel/command_line/frame_unpickler.py
@@ -115,15 +115,27 @@ class construct_reflection_table_and_experiment_list(object):
     real_b = direct_matrix[3:6]
     real_c = direct_matrix[6:9]
     lattice = self.ucell.lattice_symmetry_group()
-    if 'mosaicity' in self.data:
-      from dxtbx.model import MosaicCrystalKabsch2010
-      self.crystal = MosaicCrystalKabsch2010(real_a, real_b, real_c, space_group=lattice)
-      self.crystal.set_mosaicity(self.data['mosaicity'])
-    else:
-      from dxtbx.model import Crystal
-      self.crystal = Crystal(real_a, real_b, real_c, space_group=lattice)
-    self.crystal._ML_half_mosaicity_deg = self.data['ML_half_mosaicity_deg'][0]
-    self.crystal._ML_domain_size_ang = self.data['ML_domain_size_ang'][0]
+    found_it = False
+    if 'ML_half_mosaicity_deg' in self.data:
+      assert 'ML_domain_size_ang' in self.data
+      if d['ML_half_mosaicity_deg'][0] is None or d['ML_domain_size_ang'][0] is None:
+        assert d['ML_half_mosaicity_deg'][0] is None and d['ML_domain_size_ang'][0] is None
+      else:
+        found_it = True
+        if 'mosaicity' in self.data and self.data['mosaicity'] > 0:
+          print "Warning, two kinds of mosaicity found. Using Sauter2014 model"
+        from dxtbx.model import MosaicCrystalSauter2014
+        self.crystal = MosaicCrystalSauter2014(real_a, real_b, real_c, space_group=lattice)
+        self.crystal.set_half_mosaicity_deg(self.data['ML_half_mosaicity_deg'][0])
+        self.crystal.set_domain_size_ang(self.data['ML_domain_size_ang'][0])
+    if not found_it:
+      if 'mosaicity' in self.data:
+        from dxtbx.model import MosaicCrystalKabsch2010
+        self.crystal = MosaicCrystalKabsch2010(real_a, real_b, real_c, space_group=lattice)
+        self.crystal.set_mosaicity(self.data['mosaicity'])
+      else:
+        from dxtbx.model import Crystal
+        self.crystal = Crystal(real_a, real_b, real_c, space_group=lattice)
     if 'identified_isoform' in self.data.keys() and self.data['identified_isoform'] is not None:
       self.crystal.identified_isoform = self.data['identified_isoform']
 

--- a/xfel/command_line/frame_unpickler.py
+++ b/xfel/command_line/frame_unpickler.py
@@ -10,7 +10,7 @@ from scitbx.array_family import flex as sciflex
 from libtbx import easy_pickle
 from libtbx.utils import Sorry
 from dials.util.options import OptionParser
-from dxtbx.model import BeamFactory, Crystal, DetectorFactory
+from dxtbx.model import BeamFactory, DetectorFactory
 from dxtbx.format import FormatMultiImage
 from dxtbx.model import Experiment, ExperimentList
 from dxtbx import imageset
@@ -115,8 +115,13 @@ class construct_reflection_table_and_experiment_list(object):
     real_b = direct_matrix[3:6]
     real_c = direct_matrix[6:9]
     lattice = self.ucell.lattice_symmetry_group()
-    self.crystal = Crystal(real_a, real_b, real_c, space_group=lattice)
-    self.crystal.set_mosaicity(self.data['mosaicity'])
+    if 'mosaicity' in self.data:
+      from dxtbx.model import MosaicCrystal
+      self.crystal = MosaicCrystal(real_a, real_b, real_c, space_group=lattice)
+      self.crystal.set_mosaicity(self.data['mosaicity'])
+    else:
+      from dxtbx.model import Crystal
+      self.crystal = Crystal(real_a, real_b, real_c, space_group=lattice)
     self.crystal._ML_half_mosaicity_deg = self.data['ML_half_mosaicity_deg'][0]
     self.crystal._ML_domain_size_ang = self.data['ML_domain_size_ang'][0]
     if 'identified_isoform' in self.data.keys() and self.data['identified_isoform'] is not None:

--- a/xfel/ui/db/experiment.py
+++ b/xfel/ui/db/experiment.py
@@ -66,8 +66,11 @@ class Crystal(db_proxy):
       u = matrix.sqr(crystal.get_U())  # orientation matrix
       for i in xrange(len(u)):
         kwargs['ori_%d' % (i + 1)] = u[i]
-      kwargs['mosaic_block_rotation'] = crystal._ML_half_mosaicity_deg
-      kwargs['mosaic_block_size'] = crystal._ML_domain_size_ang
+      try:
+        kwargs['mosaic_block_rotation'] = crystal.get_half_mosaicity_deg()
+        kwargs['mosaic_block_size'] = crystal.get_domain_size_ang()
+      except AttributeError:
+        pass
 
       try:
         isoform_name = crystal.identified_isoform


### PR DESCRIPTION
Remove mosaicity from Crystal model. Add two classes that derive from Crystal: MosaicCrystalKabsch2010 (single mosaic parameter expressed as an angle) and MosaicCrystalSauter2014 (two mosaic parameters, domain size and angle).