### PR TITLE
changes to Registry.py

### DIFF
--- a/dxtbx/format/Registry.py
+++ b/dxtbx/format/Registry.py
@@ -66,13 +66,19 @@ class _Registry:
     # format.
     def recurse(format, image_file):
       for child in format._children:
-        if child.understand(image_file):
-          return recurse(child, image_file)
+        try:
+          if child.understand(image_file):
+            return recurse(child, image_file)
+        except Exception:
+          pass
       return format
 
     for format in self._formats:
-      if format.understand(image_file):
-        return recurse(format, image_file)
+      try:
+        if format.understand(image_file):
+          return recurse(format, image_file)
+      except Exception:
+        pass
 
     raise IOError('no format support found for %s' % image_file)
 


### PR DESCRIPTION
Changes to Registry.py to allow dxtbx.print_header to not fail when a string is passed to the command line. For example, if we have a format class called FormatRedHerring.py whose understand method checks if the string passed on the command line is "redherring", the following should not fail.

dxtbx.print_header redherring

Currently, the program fails without searching for all the format classes in dxtbx. This change will be useful for future development where we can pass file identifiers on the command line. 