### PR TITLE
Added sept_sprint MPI merge files into new command_line directory structure

### DIFF
--- a/xfel/libtbx_config
+++ b/xfel/libtbx_config
@@ -1,5 +1,5 @@
 {
   "modules_required_for_use": ["cma_es", "dxtbx", "dials"],
   "optional_modules": ["labelit","simtbx"],
-  "extra_command_line_locations": ["ui","cxi","clustering"],
+  "extra_command_line_locations": ["ui","cxi","clustering", "merging"],
 }

--- a/xfel/merging/command_line/mpi_cluster_merge.py
+++ b/xfel/merging/command_line/mpi_cluster_merge.py
@@ -1,0 +1,278 @@
+# LIBTBX_SET_DISPATCHER_NAME mpi.cluster_merge
+from __future__ import division
+import sys,time,os
+from xfel.command_line import cxi_merge
+from libtbx.utils import Usage, multi_out
+from cctbx.array_family import flex
+from libtbx import easy_pickle
+
+from xfel.command_line.single_node_merge import get_observations
+
+from xfel.command_line.single_node_merge import scaling_manager as scaling_manager_base
+class scaling_manager_mpi(scaling_manager_base):
+
+  def mpi_initialize (self, file_names) :
+    tar_list,self.integration_pickle_names = file_names
+    self.t1 = time.time()
+
+    assert self.params.backend == 'MySQL' # only sensible choice
+    from xfel.cxi.merging_database import manager
+    db_mgr = manager(self.params)
+    db_mgr.initialize_db(self.miller_set.indices())
+
+  def mpi_finalize (self) :
+    t2 = time.time()
+    print >> self.log, ""
+    print >> self.log, "#" * 80
+    print >> self.log, "FINISHED MERGING"
+    print >> self.log, "  Elapsed time: %.1fs" % (t2 - self.t1)
+    print >> self.log, "  %d of %d integration files were accepted" % (
+      self.n_accepted, len(self.integration_pickle_names))
+    print >> self.log, "  %d rejected due to wrong Bravais group" % \
+      self.n_wrong_bravais
+    print >> self.log, "  %d rejected for unit cell outliers" % \
+      self.n_wrong_cell
+    print >> self.log, "  %d rejected for low signal" % \
+      self.n_low_signal
+    print >> self.log, "  %d rejected due to up-front poor correlation under min_corr parameter" % \
+      self.n_low_corr
+    print >> self.log, "  %d rejected for file errors or no reindex matrix" % \
+      self.n_file_error
+    for key in self.failure_modes.keys():
+      print >>self.log, "  %d rejected due to %s"%(self.failure_modes[key], key)
+
+    checksum = self.n_accepted  + self.n_file_error \
+               + self.n_low_corr + self.n_low_signal \
+               + self.n_wrong_bravais + self.n_wrong_cell \
+               + sum([val for val in self.failure_modes.itervalues()])
+    assert checksum == len(self.integration_pickle_names)
+
+    high_res_count = (self.d_min_values <= self.params.d_min).count(True)
+    print >> self.log, "Of %d accepted images, %d accepted to %5.2f Angstrom resolution" % \
+      (self.n_accepted, high_res_count, self.params.d_min)
+
+    if self.params.raw_data.sdfac_refine:
+      self.scale_errors()
+
+    if self.params.raw_data.errors_from_sample_residuals:
+      self.errors_from_residuals()
+
+class run_manager(object):
+ def initialize(self,args):
+  import iotbx.phil
+  from xfel.command_line.cxi_merge import master_phil
+  if ("--help" in args) :
+    iotbx.phil.parse(master_phil).show(attributes_level=2)
+    return
+  phil = iotbx.phil.process_command_line(args=args, master_string=master_phil).show()
+  work_params = phil.work.extract()
+  from xfel.merging.phil_validation import application
+  application(work_params)
+
+  if ((work_params.d_min is None) or
+      (work_params.data is None) or
+      ( (work_params.model is None) and work_params.scaling.algorithm != "mark1") ) :
+    command_name = os.environ["LIBTBX_DISPATCHER_NAME"]
+    raise Usage(command_name + " "
+                "d_min=4.0 "
+                "data=~/scratch/r0220/006/strong/ "
+                "model=3bz1_3bz2_core.pdb")
+  if ((work_params.rescale_with_average_cell) and
+      (not work_params.set_average_unit_cell)) :
+    raise Usage("If rescale_with_average_cell=True, you must also specify "+
+      "set_average_unit_cell=True.")
+  if [work_params.raw_data.sdfac_auto, work_params.raw_data.sdfac_refine, work_params.raw_data.errors_from_sample_residuals].count(True) > 1:
+    raise Usage("Specify only one of sdfac_auto, sdfac_refine or errors_from_sample_residuals.")
+
+  # Read Nat's reference model from an MTZ file.  XXX The observation
+  # type is given as F, not I--should they be squared?  Check with Nat!
+  log = open("%s.log" % work_params.output.prefix, "w")
+  out = multi_out()
+  out.register("log", log, atexit_send_to=None)
+  out.register("stdout", sys.stdout)
+  print >> out, "I model"
+  if work_params.model is not None:
+    from xfel.merging.general_fcalc import run as run_fmodel
+    i_model = run_fmodel(work_params)
+    work_params.target_unit_cell = i_model.unit_cell()
+    work_params.target_space_group = i_model.space_group_info()
+    i_model.show_summary()
+  else:
+    i_model = None
+
+  print >> out, "Target unit cell and space group:"
+  print >> out, "  ", work_params.target_unit_cell
+  print >> out, "  ", work_params.target_space_group
+  from xfel.command_line.cxi_merge import consistent_set_and_model
+  self.miller_set, self.i_model = consistent_set_and_model(work_params,i_model)
+  self.work_params = work_params
+  self.frame_files = get_observations(work_params)
+  self.out = out
+
+ def other(self,scaler):
+  out = self.out
+  work_params = self.work_params
+  miller_set = self.miller_set
+  if scaler.n_accepted == 0:
+    return None
+  scaler.show_unit_cell_histograms()
+  if (work_params.rescale_with_average_cell) :
+    average_cell_abc = scaler.uc_values.get_average_cell_dimensions()
+    average_cell = uctbx.unit_cell(list(average_cell_abc) +
+      list(work_params.target_unit_cell.parameters()[3:]))
+    work_params.target_unit_cell = average_cell
+    print >> out, ""
+    print >> out, "#" * 80
+    print >> out, "RESCALING WITH NEW TARGET CELL"
+    print >> out, "  average cell: %g %g %g %g %g %g" % \
+      work_params.target_unit_cell.parameters()
+    print >> out, ""
+    assert False,"must do this step again with MPI"
+    scaler.reset()
+    scaler.scale_all(frame_files)
+    scaler.show_unit_cell_histograms()
+  print >> out, "\n"
+
+  # Sum the observations of I and I/sig(I) for each reflection.
+  sum_I = flex.double(miller_set.size(), 0.)
+  sum_I_SIGI = flex.double(miller_set.size(), 0.)
+  for i in xrange(miller_set.size()) :
+    index = miller_set.indices()[i]
+    if index in scaler.ISIGI :
+      for t in scaler.ISIGI[index]:
+        sum_I[i] += t[0]
+        sum_I_SIGI[i] += t[1]
+
+  miller_set_avg = miller_set.customized_copy(
+    unit_cell=work_params.target_unit_cell)
+  table1 = cxi_merge.show_overall_observations(
+    obs=miller_set_avg,
+    redundancy=scaler.completeness,
+    redundancy_to_edge=scaler.completeness_predictions,
+    summed_wt_I=scaler.summed_wt_I,
+    summed_weight=scaler.summed_weight,
+    ISIGI=scaler.ISIGI,
+    n_bins=work_params.output.n_bins,
+    title="Statistics for all reflections",
+    out=out,
+    work_params=work_params)
+  print >> out, ""
+  if work_params.model is not None:
+    n_refl, corr = scaler.get_overall_correlation(sum_I)
+  else:
+    n_refl, corr = ((scaler.completeness > 0).count(True), 0)
+  print >> out, "\n"
+  table2 = cxi_merge.show_overall_observations(
+    obs=miller_set_avg,
+    redundancy=scaler.summed_N,
+    redundancy_to_edge=scaler.completeness_predictions,
+    summed_wt_I=scaler.summed_wt_I,
+    summed_weight=scaler.summed_weight,
+    ISIGI=scaler.ISIGI,
+    n_bins=work_params.output.n_bins,
+    title="Statistics for reflections where I > 0",
+    out=out,
+    work_params=work_params)
+  #from libtbx import easy_pickle
+  #easy_pickle.dump(file_name="stats.pickle", obj=stats)
+  #stats.report(plot=work_params.plot)
+  #miller_counts = miller_set_p1.array(data=stats.counts.as_double()).select(
+  #  stats.counts != 0)
+  #miller_counts.as_mtz_dataset(column_root_label="NOBS").mtz_object().write(
+  #  file_name="nobs.mtz")
+  if work_params.data_subsubsets.subsubset is not None and work_params.data_subsubsets.subsubset_total is not None:
+    easy_pickle.dump("scaler_%d.pickle"%work_params.data_subsubsets.subsubset, scaler)
+  explanation = """
+Explanation:
+Completeness       = # unique Miller indices present in data / # Miller indices theoretical in asymmetric unit
+Asu. Multiplicity  = # measurements / # Miller indices theoretical in asymmetric unit
+Obs. Multiplicity  = # measurements / # unique Miller indices present in data
+Pred. Multiplicity = # predictions on all accepted images / # Miller indices theoretical in asymmetric unit"""
+  print >> out, explanation
+  mtz_file, miller_array = scaler.finalize_and_save_data()
+  #table_pickle_file = "%s_graphs.pkl" % work_params.output.prefix
+  #easy_pickle.dump(table_pickle_file, [table1, table2])
+  loggraph_file = os.path.abspath("%s_graphs.log" % work_params.output.prefix)
+  f = open(loggraph_file, "w")
+  f.write(table1.format_loggraph())
+  f.write("\n")
+  f.write(table2.format_loggraph())
+  f.close()
+  result = cxi_merge.scaling_result(
+    miller_array=miller_array,
+    plots=scaler.get_plot_statistics(),
+    mtz_file=mtz_file,
+    loggraph_file=loggraph_file,
+    obs_table=table1,
+    all_obs_table=table2,
+    n_reflections=n_refl,
+    overall_correlation=corr)
+  easy_pickle.dump("%s.pkl" % work_params.output.prefix, result)
+  return result
+
+
+if (__name__ == "__main__"):
+  from mpi4py import MPI
+  comm = MPI.COMM_WORLD
+  rank = comm.Get_rank()
+  size = comm.Get_size()
+  from time import time as tt
+
+  # set things up
+  if rank == 0:
+    print "SETUP START RANK=%d TIME=%f"%(rank,tt())
+    run = run_manager()
+    run.initialize(args=sys.argv[1:])
+    scaler_master = scaling_manager_mpi(
+      miller_set=run.miller_set,
+      i_model=run.i_model,
+      params=run.work_params,
+      log=run.out)
+    scaler_master.mpi_initialize(run.frame_files)
+
+    transmitted_info = dict(file_names=run.frame_files,
+                            miller_set=run.miller_set,
+                            model = run.i_model,
+                            params = run.work_params )
+    print "SETUP END RANK=%d TIME=%f"%(rank,tt())
+  else:
+    print "SETUP START RANK=%d TIME=%f"%(rank,tt())
+    transmitted_info = None
+    print "SETUP END RANK=%d TIME=%f"%(rank,tt())
+
+  print "BROADCAST START RANK=%d TIME=%f"%(rank,tt())
+  transmitted_info = comm.bcast(transmitted_info, root = 0)
+  print "BROADCAST END RANK=%d TIME=%f"%(rank,tt())
+
+  # now actually do the work
+  print "SCALERWORKER START RANK=%d TIME=%f"%(rank,tt())
+  scaler_worker = scaling_manager_mpi(transmitted_info["miller_set"],
+                                      transmitted_info["model"],
+                                      transmitted_info["params"],
+                                      log = sys.stdout)
+  print "SCALERWORKER END RANK=%d TIME=%f"%(rank,tt())
+
+  assert scaler_worker.params.backend == 'MySQL' # only option that makes sense
+  from xfel.cxi.merging_database import manager
+  db_mgr = manager(scaler_worker.params)
+  tar_file_names = transmitted_info["file_names"][0]
+
+  for ix in xrange(len(tar_file_names)):
+    if ix%size == rank:
+      scaler_worker.tar_to_scale_frame_adapter(tar_list=[tar_file_names[ix],], db_mgr=db_mgr)
+  # might want to clean up a bit before returning
+  del scaler_worker.log
+  del scaler_worker.params
+  del scaler_worker.miller_set
+  del scaler_worker.i_model
+  del scaler_worker.reverse_lookup
+
+  # gather reports and all add together
+  reports = comm.gather(scaler_worker,root=0)
+  if rank == 0:
+    print "Processing reports from %d ranks"%(len(reports))
+    for item in reports:
+      scaler_master._add_all_frames(item)
+    scaler_master.mpi_finalize()
+    print "OK"
+    run.other(scaler_master)

--- a/xfel/merging/command_line/mpi_cluster_two_merge.py
+++ b/xfel/merging/command_line/mpi_cluster_two_merge.py
@@ -1,0 +1,307 @@
+# LIBTBX_SET_DISPATCHER_NAME mpi.cluster_two_merge
+from __future__ import division
+import sys,time,os
+from xfel.command_line import cxi_merge
+from libtbx.utils import Usage, multi_out
+from cctbx.array_family import flex
+from libtbx import easy_pickle
+
+from xfel.command_line.single_node_merge import get_observations
+
+from xfel.command_line.single_node_merge import scaling_manager as scaling_manager_base
+class scaling_manager_mpi(scaling_manager_base):
+
+  def mpi_initialize (self, file_names) :
+    tar_list,self.integration_pickle_names = file_names
+    self.t1 = time.time()
+
+    assert self.params.backend == 'FS' # for prototyping rank=0 marshalling
+    from xfel.cxi.merging_database_fs import manager
+    db_mgr = manager(self.params)
+    db_mgr.initialize_db(self.miller_set.indices())
+    self.master_db_mgr = db_mgr
+
+  def mpi_finalize (self) :
+    t2 = time.time()
+    print >> self.log, ""
+    print >> self.log, "#" * 80
+    print >> self.log, "FINISHED MERGING"
+    print >> self.log, "  Elapsed time: %.1fs" % (t2 - self.t1)
+    print >> self.log, "  %d of %d integration files were accepted" % (
+      self.n_accepted, len(self.integration_pickle_names))
+    print >> self.log, "  %d rejected due to wrong Bravais group" % \
+      self.n_wrong_bravais
+    print >> self.log, "  %d rejected for unit cell outliers" % \
+      self.n_wrong_cell
+    print >> self.log, "  %d rejected for low signal" % \
+      self.n_low_signal
+    print >> self.log, "  %d rejected due to up-front poor correlation under min_corr parameter" % \
+      self.n_low_corr
+    print >> self.log, "  %d rejected for file errors or no reindex matrix" % \
+      self.n_file_error
+    for key in self.failure_modes.keys():
+      print >>self.log, "  %d rejected due to %s"%(self.failure_modes[key], key)
+
+    checksum = self.n_accepted  + self.n_file_error \
+               + self.n_low_corr + self.n_low_signal \
+               + self.n_wrong_bravais + self.n_wrong_cell \
+               + sum([val for val in self.failure_modes.itervalues()])
+    assert checksum == len(self.integration_pickle_names)
+
+    high_res_count = (self.d_min_values <= self.params.d_min).count(True)
+    print >> self.log, "Of %d accepted images, %d accepted to %5.2f Angstrom resolution" % \
+      (self.n_accepted, high_res_count, self.params.d_min)
+
+    if self.params.raw_data.sdfac_refine:
+      self.scale_errors()
+
+    if self.params.raw_data.errors_from_sample_residuals:
+      self.errors_from_residuals()
+
+class run_manager(object):
+ def initialize(self,args):
+  import iotbx.phil
+  from xfel.command_line.cxi_merge import master_phil
+  if ("--help" in args) :
+    iotbx.phil.parse(master_phil).show(attributes_level=2)
+    return
+  phil = iotbx.phil.process_command_line(args=args, master_string=master_phil).show()
+  work_params = phil.work.extract()
+  from xfel.merging.phil_validation import application
+  application(work_params)
+
+  if ((work_params.d_min is None) or
+      (work_params.data is None) or
+      ( (work_params.model is None) and work_params.scaling.algorithm != "mark1") ) :
+    command_name = os.environ["LIBTBX_DISPATCHER_NAME"]
+    raise Usage(command_name + " "
+                "d_min=4.0 "
+                "data=~/scratch/r0220/006/strong/ "
+                "model=3bz1_3bz2_core.pdb")
+  if ((work_params.rescale_with_average_cell) and
+      (not work_params.set_average_unit_cell)) :
+    raise Usage("If rescale_with_average_cell=True, you must also specify "+
+      "set_average_unit_cell=True.")
+  if [work_params.raw_data.sdfac_auto, work_params.raw_data.sdfac_refine, work_params.raw_data.errors_from_sample_residuals].count(True) > 1:
+    raise Usage("Specify only one of sdfac_auto, sdfac_refine or errors_from_sample_residuals.")
+
+  # Read Nat's reference model from an MTZ file.  XXX The observation
+  # type is given as F, not I--should they be squared?  Check with Nat!
+  log = open("%s.log" % work_params.output.prefix, "w")
+  out = multi_out()
+  out.register("log", log, atexit_send_to=None)
+  out.register("stdout", sys.stdout)
+  print >> out, "I model"
+  if work_params.model is not None:
+    from xfel.merging.general_fcalc import run as run_fmodel
+    i_model = run_fmodel(work_params)
+    work_params.target_unit_cell = i_model.unit_cell()
+    work_params.target_space_group = i_model.space_group_info()
+    i_model.show_summary()
+  else:
+    i_model = None
+
+  print >> out, "Target unit cell and space group:"
+  print >> out, "  ", work_params.target_unit_cell
+  print >> out, "  ", work_params.target_space_group
+  from xfel.command_line.cxi_merge import consistent_set_and_model
+  self.miller_set, self.i_model = consistent_set_and_model(work_params,i_model)
+  self.work_params = work_params
+  self.frame_files = get_observations(work_params)
+  self.out = out
+
+ def other(self,scaler):
+  out = self.out
+  work_params = self.work_params
+  miller_set = self.miller_set
+  if scaler.n_accepted == 0:
+    return None
+  scaler.show_unit_cell_histograms()
+  if (work_params.rescale_with_average_cell) :
+    average_cell_abc = scaler.uc_values.get_average_cell_dimensions()
+    average_cell = uctbx.unit_cell(list(average_cell_abc) +
+      list(work_params.target_unit_cell.parameters()[3:]))
+    work_params.target_unit_cell = average_cell
+    print >> out, ""
+    print >> out, "#" * 80
+    print >> out, "RESCALING WITH NEW TARGET CELL"
+    print >> out, "  average cell: %g %g %g %g %g %g" % \
+      work_params.target_unit_cell.parameters()
+    print >> out, ""
+    assert False,"must do this step again with MPI"
+    scaler.reset()
+    scaler.scale_all(frame_files)
+    scaler.show_unit_cell_histograms()
+  print >> out, "\n"
+
+  # Sum the observations of I and I/sig(I) for each reflection.
+  sum_I = flex.double(miller_set.size(), 0.)
+  sum_I_SIGI = flex.double(miller_set.size(), 0.)
+  for i in xrange(miller_set.size()) :
+    index = miller_set.indices()[i]
+    if index in scaler.ISIGI :
+      for t in scaler.ISIGI[index]:
+        sum_I[i] += t[0]
+        sum_I_SIGI[i] += t[1]
+
+  miller_set_avg = miller_set.customized_copy(
+    unit_cell=work_params.target_unit_cell)
+  table1 = cxi_merge.show_overall_observations(
+    obs=miller_set_avg,
+    redundancy=scaler.completeness,
+    redundancy_to_edge=scaler.completeness_predictions,
+    summed_wt_I=scaler.summed_wt_I,
+    summed_weight=scaler.summed_weight,
+    ISIGI=scaler.ISIGI,
+    n_bins=work_params.output.n_bins,
+    title="Statistics for all reflections",
+    out=out,
+    work_params=work_params)
+  print >> out, ""
+  if work_params.model is not None:
+    n_refl, corr = scaler.get_overall_correlation(sum_I)
+  else:
+    n_refl, corr = ((scaler.completeness > 0).count(True), 0)
+  print >> out, "\n"
+  table2 = cxi_merge.show_overall_observations(
+    obs=miller_set_avg,
+    redundancy=scaler.summed_N,
+    redundancy_to_edge=scaler.completeness_predictions,
+    summed_wt_I=scaler.summed_wt_I,
+    summed_weight=scaler.summed_weight,
+    ISIGI=scaler.ISIGI,
+    n_bins=work_params.output.n_bins,
+    title="Statistics for reflections where I > 0",
+    out=out,
+    work_params=work_params)
+  #from libtbx import easy_pickle
+  #easy_pickle.dump(file_name="stats.pickle", obj=stats)
+  #stats.report(plot=work_params.plot)
+  #miller_counts = miller_set_p1.array(data=stats.counts.as_double()).select(
+  #  stats.counts != 0)
+  #miller_counts.as_mtz_dataset(column_root_label="NOBS").mtz_object().write(
+  #  file_name="nobs.mtz")
+  if work_params.data_subsubsets.subsubset is not None and work_params.data_subsubsets.subsubset_total is not None:
+    easy_pickle.dump("scaler_%d.pickle"%work_params.data_subsubsets.subsubset, scaler)
+  explanation = """
+Explanation:
+Completeness       = # unique Miller indices present in data / # Miller indices theoretical in asymmetric unit
+Asu. Multiplicity  = # measurements / # Miller indices theoretical in asymmetric unit
+Obs. Multiplicity  = # measurements / # unique Miller indices present in data
+Pred. Multiplicity = # predictions on all accepted images / # Miller indices theoretical in asymmetric unit"""
+  print >> out, explanation
+  mtz_file, miller_array = scaler.finalize_and_save_data()
+  #table_pickle_file = "%s_graphs.pkl" % work_params.output.prefix
+  #easy_pickle.dump(table_pickle_file, [table1, table2])
+  loggraph_file = os.path.abspath("%s_graphs.log" % work_params.output.prefix)
+  f = open(loggraph_file, "w")
+  f.write(table1.format_loggraph())
+  f.write("\n")
+  f.write(table2.format_loggraph())
+  f.close()
+  result = cxi_merge.scaling_result(
+    miller_array=miller_array,
+    plots=scaler.get_plot_statistics(),
+    mtz_file=mtz_file,
+    loggraph_file=loggraph_file,
+    obs_table=table1,
+    all_obs_table=table2,
+    n_reflections=n_refl,
+    overall_correlation=corr)
+  easy_pickle.dump("%s.pkl" % work_params.output.prefix, result)
+  return result
+
+
+if (__name__ == "__main__"):
+  from mpi4py import MPI
+  comm = MPI.COMM_WORLD
+  rank = comm.Get_rank()
+  size = comm.Get_size()
+  from time import time as tt
+
+  # set things up
+  if rank == 0:
+    print "SETUP START RANK=%d TIME=%f"%(rank,tt())
+    run = run_manager()
+    run.initialize(args=sys.argv[1:])
+    scaler_master = scaling_manager_mpi(
+      miller_set=run.miller_set,
+      i_model=run.i_model,
+      params=run.work_params,
+      log=run.out)
+    scaler_master.mpi_initialize(run.frame_files)
+
+    transmitted_info = dict(file_names=run.frame_files,
+                            miller_set=run.miller_set,
+                            model = run.i_model,
+                            params = run.work_params )
+    print "SETUP END RANK=%d TIME=%f"%(rank,tt())
+
+  else:
+    print "SETUP START RANK=%d TIME=%f"%(rank,tt())
+    transmitted_info = None
+    print "SETUP END RANK=%d TIME=%f"%(rank,tt())
+
+  print "BROADCAST START RANK=%d TIME=%f"%(rank,tt())
+  transmitted_info = comm.bcast(transmitted_info, root = 0)
+  print "BROADCAST END RANK=%d TIME=%f"%(rank,tt())
+
+  # now actually do the work
+  print "SCALER_WORKER_SETUP START RANK=%d TIME=%f"%(rank,tt())
+  scaler_worker = scaling_manager_mpi(transmitted_info["miller_set"],
+                                      transmitted_info["model"],
+                                      transmitted_info["params"],
+                                      log = sys.stdout)
+  print "SCALER_WORKER_SETUP END RANK=%d TIME=%f"%(rank,tt())
+
+  assert scaler_worker.params.backend == 'FS' # only option that makes sense
+  from xfel.cxi.merging_database_fs import manager2 as manager
+  db_mgr = manager(scaler_worker.params)
+  tar_file_names = transmitted_info["file_names"][0]
+
+  print "SCALER_WORKERS START RANK=%d TIME=%f"%(rank, tt())
+  for ix in xrange(len(tar_file_names)):
+    if ix%size == rank:
+      print "SCALER_WORKER START=%s RANK=%d TIME=%f"%(str([tar_file_names[ix],]), rank, tt())
+      scaler_worker.tar_to_scale_frame_adapter(tar_list=[tar_file_names[ix],], db_mgr=db_mgr)
+      print "SCALER_WORKER END=%s RANK=%d TIME=%f"%(str([tar_file_names[ix],]), rank, tt())
+  print "SCALER_WORKERS END RANK=%d TIME=%f"%(rank, tt())
+  scaler_worker.finished_db_mgr = db_mgr
+  # might want to clean up a bit before returning
+  del scaler_worker.log
+  del scaler_worker.params
+  del scaler_worker.miller_set
+  del scaler_worker.i_model
+  del scaler_worker.reverse_lookup
+
+  # gather reports and all add together
+  print "GATHER START RANK=%d TIME=%f"%(rank, tt())
+  reports = comm.gather(scaler_worker,root=0)
+  print "GATHER END RANK=%d TIME=%f"%(rank, tt())
+  if rank == 0:
+    print "Processing reports from %d ranks"%(len(reports))
+    ireport = 0
+    for item in reports:
+      print "SCALER_MASTER_ADD START RANK=%d TIME=%f"%(rank, tt())
+      scaler_master._add_all_frames(item)
+
+      print "SCALER_MASTER_ADD END RANK=%d TIME=%f"%(rank, tt())
+      print "processing %d calls from report %d"%(len(item.finished_db_mgr.sequencer),ireport); ireport += 1
+
+      for call_instance in item.finished_db_mgr.sequencer:
+        if call_instance["call"] == "insert_frame":
+          print "SCALER_MASTER_INSERT_FRAME START RANK=%d TIME=%f"%(rank, tt())
+          frame_id_zero_base = scaler_master.master_db_mgr.insert_frame(**call_instance["data"])
+          print "SCALER_MASTER_INSERT_FRAME END RANK=%d TIME=%f"%(rank, tt())
+        elif call_instance["call"] == "insert_observation":
+          print "SCALER_MASTER_INSERT_OBS START RANK=%d TIME=%f"%(rank, tt())
+          call_instance["data"]['frame_id_0_base'] = [frame_id_zero_base] * len(call_instance["data"]['frame_id_0_base'])
+          scaler_master.master_db_mgr.insert_observation(**call_instance["data"])
+          print "SCALER_MASTER_INSERT_OBS END RANK=%d TIME=%f"%(rank, tt())
+
+    print "SCALER_MASTER_FINALISE START RANK=%d TIME=%f"%(rank, tt())
+    scaler_master.master_db_mgr.join() # database written, finalize the manager
+    scaler_master.mpi_finalize()
+    print "SCALER_MASTER_FINALISE END RANK=%d TIME=%f"%(rank, tt())
+    print "OK"
+    run.other(scaler_master)

--- a/xfel/merging/command_line/mpi_cluster_two_merge_cs.py
+++ b/xfel/merging/command_line/mpi_cluster_two_merge_cs.py
@@ -1,0 +1,427 @@
+# LIBTBX_SET_DISPATCHER_NAME mpi.merge_cs
+from __future__ import division
+import sys,time,os
+from xfel.command_line import cxi_merge
+from libtbx.utils import Usage, multi_out
+from cctbx.array_family import flex
+from libtbx import easy_pickle
+
+from xfel.command_line.single_node_merge import get_observations
+
+from xfel.command_line.single_node_merge import scaling_manager as scaling_manager_base
+class scaling_manager_mpi(scaling_manager_base):
+  
+  def insert_frame(self, **kwargs):
+    order = []
+    if self.params.postrefinement.enable==True and \
+        self.params.postrefinement.algorithm in ["rs2","rs_hybrid"]:
+      order_dict = {'wavelength': 1,
+                  'beam_x': 2,
+                  'beam_y': 3,
+                  'distance': 4,
+                  'G': 5,
+                  'BFACTOR': 6,
+                  'RS': 7,
+                  'Astar_1': 8,
+                  'Astar_2': 9,
+                  'Astar_3': 10,
+                  'Astar_4': 11,
+                  'Astar_5': 12,
+                  'Astar_6': 13,
+                  'Astar_7': 14,
+                  'Astar_8': 15,
+                  'Astar_9': 16,
+                  'thetax': 17,
+                  'thetay': 18,
+                  'unique_file_name': 19,
+                  'c_c': 20}
+    else:
+      order_dict = {'wavelength': 1,
+                  'beam_x': 2,
+                  'beam_y': 3,
+                  'distance': 4,
+                  'c_c': 5,
+                  'slope': 6,
+                  'offset': 7,
+                  'res_ori_1': 8,
+                  'res_ori_2': 9,
+                  'res_ori_3': 10,
+                  'res_ori_4': 11,
+                  'res_ori_5': 12,
+                  'res_ori_6': 13,
+                  'res_ori_7': 14,
+                  'res_ori_8': 15,
+                  'res_ori_9': 16,
+                  'rotation100_rad': 17,
+                  'rotation010_rad': 18,
+                  'rotation001_rad': 19,
+                  'half_mosaicity_deg': 20,
+                  'wave_HE_ang': 21,
+                  'wave_LE_ang': 22,
+                  'domain_size_ang':23,
+                  'unique_file_name': 24}
+    for key in kwargs.keys():
+      order.append(order_dict[key])
+    parameters = [kwargs.values()]
+
+    # Pick up the index of the row just added.  The file name is
+    # assumed to to serve as a unique key.
+    lastrowid_key = kwargs['unique_file_name']
+    self._db_commands_queue.put(('frame', order, parameters, lastrowid_key))
+    while True:
+      item = self._db_results_queue.get()
+      self._db_results_queue.task_done()
+      if item[0] == kwargs['unique_file_name']:
+        # Entry in the observation table is zero-based.
+        return item[1] - 1
+      else:
+        # If the key does not match, put it back in the queue for
+        # someone else to pick up.
+        self._db_results_queue.put(item)
+
+  def insert_observation(self, **kwargs):
+    order = []
+    order_dict = {'hkl_id_0_base': 0,
+                  'i': 1,
+                  'sigi': 2,
+                  'detector_x': 3,
+                  'detector_y': 4,
+                  'frame_id_0_base': 5,
+                  'overload_flag': 6,
+                  'original_h': 7,
+                  'original_k': 8,
+                  'original_l': 9}
+    for key in kwargs.keys():
+      order.append(order_dict[key])
+    parameters = zip(*kwargs.values())
+    self._db_commands_queue.put(('observation', order, parameters, None))
+
+  def mpi_initialize (self, file_names) :
+    tar_list,self.integration_pickle_names = file_names
+    self.t1 = time.time()
+
+    assert self.params.backend == 'FS' # for prototyping rank=0 marshalling
+    from xfel.cxi.merging_database_fs import manager
+    db_mgr = manager(self.params)
+    db_mgr.initialize_db(self.miller_set.indices())
+    self.master_db_mgr = db_mgr
+
+  def mpi_finalize (self) :
+    t2 = time.time()
+    print >> self.log, ""
+    print >> self.log, "#" * 80
+    print >> self.log, "FINISHED MERGING"
+    print >> self.log, "  Elapsed time: %.1fs" % (t2 - self.t1)
+    print >> self.log, "  %d of %d integration files were accepted" % (
+      self.n_accepted, len(self.integration_pickle_names))
+    print >> self.log, "  %d rejected due to wrong Bravais group" % \
+      self.n_wrong_bravais
+    print >> self.log, "  %d rejected for unit cell outliers" % \
+      self.n_wrong_cell
+    print >> self.log, "  %d rejected for low signal" % \
+      self.n_low_signal
+    print >> self.log, "  %d rejected due to up-front poor correlation under min_corr parameter" % \
+      self.n_low_corr
+    print >> self.log, "  %d rejected for file errors or no reindex matrix" % \
+      self.n_file_error
+    for key in self.failure_modes.keys():
+      print >>self.log, "  %d rejected due to %s"%(self.failure_modes[key], key)
+
+    checksum = self.n_accepted  + self.n_file_error \
+               + self.n_low_corr + self.n_low_signal \
+               + self.n_wrong_bravais + self.n_wrong_cell \
+               + sum([val for val in self.failure_modes.itervalues()])
+    assert checksum == len(self.integration_pickle_names)
+
+    high_res_count = (self.d_min_values <= self.params.d_min).count(True)
+    print >> self.log, "Of %d accepted images, %d accepted to %5.2f Angstrom resolution" % \
+      (self.n_accepted, high_res_count, self.params.d_min)
+
+    if self.params.raw_data.sdfac_refine:
+      self.scale_errors()
+
+    if self.params.raw_data.errors_from_sample_residuals:
+      self.errors_from_residuals()
+
+  def iterate_instances(self,item,rank,tt):
+    count=0
+    n_insert_frame = self.master_db_mgr.insert_frame
+
+    for call_instance in item.finished_db_mgr.sequencer:
+      print "INSTANCE=%d START RANK=%d TIME=%f"%(count,rank,tt())
+      if call_instance["call"] == "insert_frame":        
+        print "insert_frame=%d START RANK=%d TIME=%f"%(count,rank,tt())
+        frame_id_zero_base = n_insert_frame(**call_instance["data"])
+        print "insert_frame=%d STOP RANK=%d TIME=%f"%(count,rank,tt())
+
+      elif call_instance["call"] == "insert_observation":
+        print "insert_observation=%d START RANK=%d TIME=%f"%(count,rank,tt())
+        call_instance["data"]['frame_id_0_base'] = [frame_id_zero_base] * len(call_instance["data"]['frame_id_0_base'])
+        self.master_db_mgr.insert_observation(**call_instance["data"])
+        print "insert_observation=%d STOP RANK=%d TIME=%f"%(count,rank,tt())
+      count+=1
+
+class run_manager(object):
+ def initialize(self,args):
+  import iotbx.phil
+  from xfel.command_line.cxi_merge import master_phil
+  if ("--help" in args) :
+    iotbx.phil.parse(master_phil).show(attributes_level=2)
+    return
+  phil = iotbx.phil.process_command_line(args=args, master_string=master_phil).show()
+  work_params = phil.work.extract()
+  from xfel.merging.phil_validation import application
+  application(work_params)
+
+  if ((work_params.d_min is None) or
+      (work_params.data is None) or
+      ( (work_params.model is None) and work_params.scaling.algorithm != "mark1") ) :
+    command_name = os.environ["LIBTBX_DISPATCHER_NAME"]
+    raise Usage(command_name + " "
+                "d_min=4.0 "
+                "data=~/scratch/r0220/006/strong/ "
+                "model=3bz1_3bz2_core.pdb")
+  if ((work_params.rescale_with_average_cell) and
+      (not work_params.set_average_unit_cell)) :
+    raise Usage("If rescale_with_average_cell=True, you must also specify "+
+      "set_average_unit_cell=True.")
+  if [work_params.raw_data.sdfac_auto, work_params.raw_data.sdfac_refine, work_params.raw_data.errors_from_sample_residuals].count(True) > 1:
+    raise Usage("Specify only one of sdfac_auto, sdfac_refine or errors_from_sample_residuals.")
+
+  # Read Nat's reference model from an MTZ file.  XXX The observation
+  # type is given as F, not I--should they be squared?  Check with Nat!
+  log = open("%s.log" % work_params.output.prefix, "w")
+  out = multi_out()
+  out.register("log", log, atexit_send_to=None)
+  out.register("stdout", sys.stdout)
+  print >> out, "I model"
+  if work_params.model is not None:
+    from xfel.merging.general_fcalc import run as run_fmodel
+    i_model = run_fmodel(work_params)
+    work_params.target_unit_cell = i_model.unit_cell()
+    work_params.target_space_group = i_model.space_group_info()
+    i_model.show_summary()
+  else:
+    i_model = None
+
+  print >> out, "Target unit cell and space group:"
+  print >> out, "  ", work_params.target_unit_cell
+  print >> out, "  ", work_params.target_space_group
+  from xfel.command_line.cxi_merge import consistent_set_and_model
+  self.miller_set, self.i_model = consistent_set_and_model(work_params,i_model)
+  self.work_params = work_params
+  self.frame_files = get_observations(work_params)
+  self.out = out
+
+ def other(self,scaler):
+  out = self.out
+  work_params = self.work_params
+  miller_set = self.miller_set
+  if scaler.n_accepted == 0:
+    return None
+  scaler.show_unit_cell_histograms()
+  if (work_params.rescale_with_average_cell) :
+    average_cell_abc = scaler.uc_values.get_average_cell_dimensions()
+    average_cell = uctbx.unit_cell(list(average_cell_abc) +
+      list(work_params.target_unit_cell.parameters()[3:]))
+    work_params.target_unit_cell = average_cell
+    print >> out, ""
+    print >> out, "#" * 80
+    print >> out, "RESCALING WITH NEW TARGET CELL"
+    print >> out, "  average cell: %g %g %g %g %g %g" % \
+      work_params.target_unit_cell.parameters()
+    print >> out, ""
+    assert False,"must do this step again with MPI"
+    scaler.reset()
+    scaler.scale_all(frame_files)
+    scaler.show_unit_cell_histograms()
+  print >> out, "\n"
+
+  # Sum the observations of I and I/sig(I) for each reflection.
+  sum_I = flex.double(miller_set.size(), 0.)
+  sum_I_SIGI = flex.double(miller_set.size(), 0.)
+  for i in xrange(miller_set.size()) :
+    index = miller_set.indices()[i]
+    if index in scaler.ISIGI :
+      for t in scaler.ISIGI[index]:
+        sum_I[i] += t[0]
+        sum_I_SIGI[i] += t[1]
+
+  miller_set_avg = miller_set.customized_copy(
+    unit_cell=work_params.target_unit_cell)
+  table1 = cxi_merge.show_overall_observations(
+    obs=miller_set_avg,
+    redundancy=scaler.completeness,
+    redundancy_to_edge=scaler.completeness_predictions,
+    summed_wt_I=scaler.summed_wt_I,
+    summed_weight=scaler.summed_weight,
+    ISIGI=scaler.ISIGI,
+    n_bins=work_params.output.n_bins,
+    title="Statistics for all reflections",
+    out=out,
+    work_params=work_params)
+  print >> out, ""
+  if work_params.model is not None:
+    n_refl, corr = scaler.get_overall_correlation(sum_I)
+  else:
+    n_refl, corr = ((scaler.completeness > 0).count(True), 0)
+  print >> out, "\n"
+  table2 = cxi_merge.show_overall_observations(
+    obs=miller_set_avg,
+    redundancy=scaler.summed_N,
+    redundancy_to_edge=scaler.completeness_predictions,
+    summed_wt_I=scaler.summed_wt_I,
+    summed_weight=scaler.summed_weight,
+    ISIGI=scaler.ISIGI,
+    n_bins=work_params.output.n_bins,
+    title="Statistics for reflections where I > 0",
+    out=out,
+    work_params=work_params)
+  #from libtbx import easy_pickle
+  #easy_pickle.dump(file_name="stats.pickle", obj=stats)
+  #stats.report(plot=work_params.plot)
+  #miller_counts = miller_set_p1.array(data=stats.counts.as_double()).select(
+  #  stats.counts != 0)
+  #miller_counts.as_mtz_dataset(column_root_label="NOBS").mtz_object().write(
+  #  file_name="nobs.mtz")
+  if work_params.data_subsubsets.subsubset is not None and work_params.data_subsubsets.subsubset_total is not None:
+    easy_pickle.dump("scaler_%d.pickle"%work_params.data_subsubsets.subsubset, scaler)
+  explanation = """
+Explanation:
+Completeness       = # unique Miller indices present in data / # Miller indices theoretical in asymmetric unit
+Asu. Multiplicity  = # measurements / # Miller indices theoretical in asymmetric unit
+Obs. Multiplicity  = # measurements / # unique Miller indices present in data
+Pred. Multiplicity = # predictions on all accepted images / # Miller indices theoretical in asymmetric unit"""
+  print >> out, explanation
+  mtz_file, miller_array = scaler.finalize_and_save_data()
+  #table_pickle_file = "%s_graphs.pkl" % work_params.output.prefix
+  #easy_pickle.dump(table_pickle_file, [table1, table2])
+  loggraph_file = os.path.abspath("%s_graphs.log" % work_params.output.prefix)
+  f = open(loggraph_file, "w")
+  f.write(table1.format_loggraph())
+  f.write("\n")
+  f.write(table2.format_loggraph())
+  f.close()
+  result = cxi_merge.scaling_result(
+    miller_array=miller_array,
+    plots=scaler.get_plot_statistics(),
+    mtz_file=mtz_file,
+    loggraph_file=loggraph_file,
+    obs_table=table1,
+    all_obs_table=table2,
+    n_reflections=n_refl,
+    overall_correlation=corr)
+  easy_pickle.dump("%s.pkl" % work_params.output.prefix, result)
+  return result
+
+if (__name__ == "__main__"):
+  from mpi4py import MPI
+  comm = MPI.COMM_WORLD
+  rank = comm.Get_rank()
+  size = comm.Get_size()
+  from time import time as tt
+
+  # set things up
+  if rank == 0:
+    print "SETUP START RANK=%d TIME=%f"%(rank,tt())
+    run = run_manager()
+    run.initialize(args=sys.argv[1:])
+    scaler_master = scaling_manager_mpi(
+      miller_set=run.miller_set,
+      i_model=run.i_model,
+      params=run.work_params,
+      log=run.out)
+    scaler_master.mpi_initialize(run.frame_files)
+
+    transmitted_info = dict(file_names=run.frame_files,
+                            miller_set=run.miller_set,
+                            model = run.i_model,
+                            params = run.work_params )
+    print "SETUP END RANK=%d TIME=%f"%(rank,tt())
+  else:
+    print "SETUP START RANK=%d TIME=%f"%(rank,tt())
+    transmitted_info = None
+    print "SETUP END RANK=%d TIME=%f"%(rank,tt())
+
+  print "BROADCAST START RANK=%d TIME=%f"%(rank,tt())
+  transmitted_info = comm.bcast(transmitted_info, root = 0)
+  print "BROADCAST END RANK=%d TIME=%f"%(rank,tt())
+
+  # now actually do the work
+  print "SCALER_WORKER_SETUP START RANK=%d TIME=%f"%(rank,tt())
+  scaler_worker = scaling_manager_mpi(transmitted_info["miller_set"],
+                                      transmitted_info["model"],
+                                      transmitted_info["params"],
+                                      log = sys.stdout)
+  print "SCALER_WORKER_SETUP END RANK=%d TIME=%f"%(rank,tt())
+
+  assert scaler_worker.params.backend == 'FS' # only option that makes sense
+  from xfel.cxi.merging_database_fs import manager2 as manager
+  db_mgr = manager(scaler_worker.params)
+  tar_file_names = transmitted_info["file_names"][0]
+
+  print "SCALER_WORKERS START RANK=%d TIME=%f"%(rank,tt())
+  if rank == 0:
+    for ix in xrange(len(tar_file_names)):
+      print "SCALER_WORKER_RECV START=%d RANK=%d TIME=%f"%(ix,rank,tt())
+      rankreq = comm.recv(source=MPI.ANY_SOURCE)
+      print "SCALER_WORKER_RECV START=%d RANK=%d TIME=%f"%(ix,rank,tt())
+      print "SCALER_WORKER_SEND START=%d RANK=%d,%d TIME=%f"%(ix,rank,rankreq,tt())
+      comm.send(ix,dest=rankreq)
+      print "SCALER_WORKER_SEND END=%d RANK=%d,%d TIME=%f"%(ix,rank,rankreq,tt())
+    for rankreq in range(size-1):
+      print "SCALER_WORKER_RECV_KILL START RANK=%d TIME=%f"%(rank,tt())
+      rankreq = comm.recv(source=MPI.ANY_SOURCE)
+      print "SCALER_WORKER_RECV_KILL END RANK=%d TIME=%f"%(rank,tt())
+      print "SCALER_WORKER_SEND_KILL START RANK=%d,%d TIME=%f"%(rank,rankreq,tt())
+      comm.send('endrun',dest=rankreq)
+      print "SCALER_WORKER_SEND_KILL END RANK=%d,%d TIME=%f"%(rank,rankreq,tt())
+    scaler_worker.finished_db_mgr = db_mgr
+
+  else:
+    while True:
+      print "SCALER_WORKER_RANKSEND START RANK=%d TIME=%f"%(rank,tt())
+      comm.send(rank,dest=0)
+      print "SCALER_WORKER_RANKSEND END RANK=%d TIME=%f"%(rank,tt())
+      print "SCALER_WORKER_IDXRECV START RANK=%d TIME=%f"%(rank,tt())
+      idx = comm.recv(source=0)
+      print "SCALER_WORKER_IDXRECV END  RANK=%d TIME=%f"%(rank,tt())
+
+      if idx == 'endrun': 
+        scaler_worker.finished_db_mgr = db_mgr
+        break
+      print "SCALER_WORKER START=%s RANK=%d TIME=%f"%(str([tar_file_names[idx],]), rank, tt())
+      scaler_worker.tar_to_scale_frame_adapter(tar_list=[tar_file_names[idx],], db_mgr=db_mgr)
+      print "SCALER_WORKER END=%s RANK=%d TIME=%f"%(str([tar_file_names[idx],]), rank, tt())
+
+  print "SCALER_WORKERS END RANK=%d TIME=%f"%(rank, tt())
+
+  # might want to clean up a bit before returning
+  del scaler_worker.log
+  del scaler_worker.params
+  del scaler_worker.miller_set
+  del scaler_worker.i_model
+  del scaler_worker.reverse_lookup
+
+  # gather reports and all add together
+  print "GATHER START RANK=%d TIME=%f"%(rank, tt())
+  reports = comm.gather(scaler_worker,root=0)
+  print "GATHER END RANK=%d TIME=%f"%(rank, tt())
+
+  if rank == 0:
+    print "Processing reports from %d ranks"%(len(reports))
+    ireport = 0
+    for item in reports:
+      print "SCALER_MASTER_ADD START RANK=%d TIME=%f"%(rank, tt())
+      scaler_master._add_all_frames(item)
+      print "SCALER_MASTER_ADD END RANK=%d TIME=%f"%(rank, tt())
+
+      print "processing %d calls from report %d"%(len(item.finished_db_mgr.sequencer),ireport); ireport += 1
+      scaler_master.iterate_instances(item,rank,tt)
+
+    print "SCALER_MASTER_FINALISE START RANK=%d TIME=%f"%(rank, tt())
+    scaler_master.master_db_mgr.join() # database written, finalize the manager
+    scaler_master.mpi_finalize()
+    print "SCALER_MASTER_FINALISE END RANK=%d TIME=%f"%(rank, tt())
+    print "OK"
+    run.other(scaler_master)

--- a/xfel/merging/command_line/mpi_merge.py
+++ b/xfel/merging/command_line/mpi_merge.py
@@ -1,0 +1,99 @@
+# LIBTBX_SET_DISPATCHER_NAME mpi.merge
+from __future__ import division
+import sys,time
+from xfel.command_line import cxi_merge
+
+from xfel.command_line.single_node_merge import get_observations
+cxi_merge.get_observations = get_observations
+
+from xfel.command_line.single_node_merge import scaling_manager as scaling_manager_base
+class scaling_manager_mpi(scaling_manager_base):
+
+  def scale_all (self, file_names) :
+    tar_list,integration_pickle_names = file_names
+    t1 = time.time()
+    if self.params.backend == 'MySQL':
+      from xfel.cxi.merging_database import manager
+    elif self.params.backend == 'SQLite':
+      from xfel.cxi.merging_database_sqlite3 import manager
+    else:
+      from xfel.cxi.merging_database_fs import manager
+
+    db_mgr = manager(self.params)
+    db_mgr.initialize_db(self.miller_set.indices())
+
+    # MPI
+    nproc = self.params.nproc
+    assert nproc >= 1
+    if nproc > 1:
+      self._scale_all_parallel(tar_list, db_mgr)
+    else:
+      self._scale_all_serial(tar_list, db_mgr)
+    # done
+    db_mgr.join()
+
+    t2 = time.time()
+    print >> self.log, ""
+    print >> self.log, "#" * 80
+    print >> self.log, "FINISHED MERGING"
+    print >> self.log, "  Elapsed time: %.1fs" % (t2 - t1)
+    print >> self.log, "  %d of %d integration files were accepted" % (
+      self.n_accepted, len(integration_pickle_names))
+    print >> self.log, "  %d rejected due to wrong Bravais group" % \
+      self.n_wrong_bravais
+    print >> self.log, "  %d rejected for unit cell outliers" % \
+      self.n_wrong_cell
+    print >> self.log, "  %d rejected for low signal" % \
+      self.n_low_signal
+    print >> self.log, "  %d rejected due to up-front poor correlation under min_corr parameter" % \
+      self.n_low_corr
+    print >> self.log, "  %d rejected for file errors or no reindex matrix" % \
+      self.n_file_error
+    for key in self.failure_modes.keys():
+      print >>self.log, "  %d rejected due to %s"%(self.failure_modes[key], key)
+
+    checksum = self.n_accepted  + self.n_file_error \
+               + self.n_low_corr + self.n_low_signal \
+               + self.n_wrong_bravais + self.n_wrong_cell \
+               + sum([val for val in self.failure_modes.itervalues()])
+    assert checksum == len(integration_pickle_names)
+
+    high_res_count = (self.d_min_values <= self.params.d_min).count(True)
+    print >> self.log, "Of %d accepted images, %d accepted to %5.2f Angstrom resolution" % \
+      (self.n_accepted, high_res_count, self.params.d_min)
+
+    if self.params.raw_data.sdfac_refine:
+      self.scale_errors()
+
+    if self.params.raw_data.errors_from_sample_residuals:
+      self.errors_from_residuals()
+
+  def _scale_all_parallel (self, file_names, db_mgr) :
+    from mpi4py import MPI
+    comm = MPI.COMM_SELF.Spawn("mpi.worker2", args=[], #libtbx.python",args=['worker2.py'],
+                           maxprocs=self.params.nproc)
+    transmitted_info = dict(file_names=file_names,
+                            miller_set=self.miller_set,
+                            model = self.i_model,
+                            params = self.params )
+    comm.bcast(transmitted_info, root = MPI.ROOT)
+    reports = comm.gather("no data",root=MPI.ROOT)
+    print "reports",reports
+    comm.Disconnect()
+    for worker_sm in reports:
+      self._add_all_frames(worker_sm)
+
+  def _scale_all_serial (self, tar_list, db_mgr) :
+    """
+    Scale frames sequentially (single-process).  The return value is
+    picked up by the callback.
+    """
+    self.tar_to_scale_frame_adapter(tar_list, db_mgr)
+    return (self)
+
+cxi_merge.scaling_manager = scaling_manager_mpi
+
+if (__name__ == "__main__"):
+  result = cxi_merge.run(args=sys.argv[1:])
+  if result is None:
+    sys.exit(1)

--- a/xfel/merging/command_line/single_node_merge.py
+++ b/xfel/merging/command_line/single_node_merge.py
@@ -1,0 +1,382 @@
+# LIBTBX_SET_DISPATCHER_NAME singlenode.merge
+from __future__ import division
+from xfel.command_line.cxi_merge import run
+from xfel.command_line.cxi_merge import OutlierCellError, WrongBravaisError
+import sys,glob,os,math,time
+from xfel.command_line import cxi_merge
+from cctbx.array_family import flex
+from cctbx.sgtbx.bravais_types import bravais_lattice
+from libtbx import Auto
+from cStringIO import StringIO
+from libtbx.utils import Sorry
+from scitbx import matrix
+from xfel.cxi.merging_utils import intensity_data, frame_data, null_data
+
+def get_observations (work_params):
+  try:
+    data_dirs = work_params.data
+    data_subset = work_params.data_subset
+    subsubset = work_params.data_subsubsets.subsubset
+    subsubset_total = work_params.data_subsubsets.subsubset_total
+    extension = work_params.filename_extension
+  except Exception,e:
+    exit("Changed the interface for get_observations, please contact authors "+str(e))
+
+  print "Step 1.  Get a list of all files"
+  assert work_params.a_list is None
+  integration_pickle_names = []
+  assert work_params.targlob is not None
+  tar_list = glob.glob(work_params.targlob)
+  for tarname in tar_list:
+      import tarfile
+      T = tarfile.open(name=tarname, mode='r')
+      K = T.getmembers()
+      NT = len(K)
+      for nt in xrange(NT):
+        k = os.path.basename(K[nt].path)
+        integration_pickle_names.append("%s;member%05d;timestamp%s"%(tarname,nt,k))
+      print tarname,NT
+  print "Number of pickle files found:", len(integration_pickle_names)
+  print
+  return tar_list,integration_pickle_names
+cxi_merge.get_observations = get_observations
+
+def load_result (file_hash,
+                 frame_obj,
+                 ref_bravais_type,
+                 reference_cell,
+                 params,
+                 reindex_op,
+                 out,
+                 get_predictions_to_edge=False,
+                 image_info=None,
+                 exclude_CSPAD_sensor=None) :
+
+  print >> out, "-" * 80
+  print >> out, "Step 2.  Load pickle file into dictionary obj and filter on lattice & cell with",reindex_op
+  print >> out, file_hash
+  """
+  Take a pickle file, confirm that it contains the appropriate data, and
+  check the lattice type and unit cell against the reference settings - if
+  rejected, raises an exception (for tracking statistics).
+  """
+
+  obj = frame_obj
+  if (not obj.has_key("observations")) :
+    return None
+  if params.isoform_name is not None:
+    if not "identified_isoform" in obj:
+      return None
+    if obj["identified_isoform"] != params.isoform_name:
+      return None
+  if reindex_op == "h,k,l":
+    pass
+    #raise WrongBravaisError("Skipping file with h,k,l")
+  else:
+    for idx in xrange(len(obj["observations"])):
+      obj["observations"][idx] = obj["observations"][idx].change_basis(reindex_op)
+    from cctbx.sgtbx import change_of_basis_op
+    cb_op = change_of_basis_op(reindex_op)
+    ORI = obj["current_orientation"][0]
+    Astar = matrix.sqr(ORI.reciprocal_matrix())
+    CB_OP_sqr = matrix.sqr(cb_op.c().r().as_double()).transpose()
+    from cctbx.crystal_orientation import crystal_orientation
+    ORI_new = crystal_orientation((Astar*CB_OP_sqr).elems, True)
+    obj["current_orientation"][0] = ORI_new
+    # unexpected, first since cxi_merge had a previous postrefinement implementation that
+    #  apparently failed to apply the reindex_op (XXX still must be fixed), and secondly
+    #  that the crystal_orientation.change basis() implementation fails to work because
+    #  it does not use the transpose:  obj["current_orientation"][0].change_basis(cb_op)
+    pass
+    #raise WrongBravaisError("Skipping file with alternate indexing %s"%reindex_op)
+
+  result_array = obj["observations"][0]
+  unit_cell = result_array.unit_cell()
+  sg_info = result_array.space_group_info()
+  print >> out, ""
+
+  print >> out, sg_info
+  print >> out, unit_cell
+
+  #Check for pixel size (at this point we are assuming we have square pixels, all experiments described in one
+  #refined_experiments.json file use the same detector, and all panels on the detector have the same pixel size)
+
+  if params.pixel_size is not None:
+    pixel_size = params.pixel_size
+  elif "pixel_size" in obj:
+    pixel_size = obj["pixel_size"]
+  else:
+    raise Sorry("Cannot find pixel size. Specify appropriate pixel size in mm for your detector in phil file.")
+
+  #Calculate displacements based on pixel size
+  assert obj['mapped_predictions'][0].size() == obj["observations"][0].size()
+  mm_predictions = pixel_size*(obj['mapped_predictions'][0])
+  mm_displacements = flex.vec3_double()
+  cos_two_polar_angle = flex.double()
+  for pred in mm_predictions:
+    mm_displacements.append((pred[0]-obj["xbeam"],pred[1]-obj["ybeam"],0.0))
+    cos_two_polar_angle.append( math.cos( 2. * math.atan2(pred[1]-obj["ybeam"],pred[0]-obj["xbeam"]) ) )
+  obj["cos_two_polar_angle"] = cos_two_polar_angle
+  #then convert to polar angle and compute polarization correction
+
+  if (not bravais_lattice(sg_info.type().number()) == ref_bravais_type) :
+    raise WrongBravaisError("Skipping cell in different Bravais type (%s)" %
+      str(sg_info))
+  if (not unit_cell.is_similar_to(
+      other=reference_cell,
+      relative_length_tolerance=params.unit_cell_length_tolerance,
+      absolute_angle_tolerance=params.unit_cell_angle_tolerance)) :
+    raise OutlierCellError(
+      "Skipping cell with outlier dimensions (%g %g %g %g %g %g" %
+      unit_cell.parameters())
+  # Illustrate how a unit cell filter would be implemented.
+  #ucparams = unit_cell.parameters()
+  #if not (130.21 < ucparams[2] < 130.61) or not (92.84 < ucparams[0] < 93.24):
+  #  print >> out, "DOES NOT PASS ERSATZ UNIT CELL FILTER"
+  #  return None
+  print >> out, "Integrated data:"
+  result_array.show_summary(f=out, prefix="  ")
+  # XXX don't force reference setting here, it will be done later, after the
+  # original unit cell is recorded
+
+  #Remove observations on a selected sensor if requested
+  if exclude_CSPAD_sensor is not None:
+    print >> out, "excluding CSPAD sensor %d" % exclude_CSPAD_sensor
+    fast_min1, slow_min1, fast_max1, slow_max1, \
+    fast_min2, slow_min2, fast_max2, slow_max2 = \
+      get_boundaries_from_sensor_ID(exclude_CSPAD_sensor)
+    fast_min = min(fast_min1, fast_min2)
+    slow_min = min(slow_min1, slow_min2)
+    fast_max = max(fast_max1, fast_max2)
+    slow_max = max(slow_max1, slow_max2)
+    accepted = flex.bool()
+    px_preds = obj['mapped_predictions'][0]
+    for idx in xrange(px_preds.size()):
+      pred_fast, pred_slow = px_preds[idx]
+      if (pred_fast < fast_min) or (pred_fast > fast_max) or (pred_slow < slow_min) or (pred_slow > slow_max):
+        accepted.append(True)
+      else:
+        accepted.append(False)
+    obj['mapped_predictions'][0] = obj['mapped_predictions'][0].select(accepted)
+    obj['observations'][0] = obj['observations'][0].select(accepted)
+    obj['cos_two_polar_angle'] = obj["cos_two_polar_angle"].select(accepted)
+  if not 'indices_to_edge' in obj.keys():
+    if get_predictions_to_edge:
+      from xfel.merging.predictions_to_edges import extend_predictions
+      extend_predictions(obj, file_name, image_info, dmin=1.5, dump=False)
+    else:
+      obj['indices_to_edge'] = None
+  return obj
+
+from cxi_merge import scaling_manager as scaling_manager_base
+class scaling_manager(scaling_manager_base):
+
+  def tar_to_scale_frame_adapter(self, tar_list, db_mgr):
+    for tarname in tar_list:
+      import tarfile
+      T = tarfile.open(name=tarname, mode='r')
+      K = T.getmembers()
+      NT = len(K)
+      for nt in xrange(NT):
+        k = os.path.basename(K[nt].path)
+        file_hash = "%s;member%05d;timestamp%s"%(tarname,nt,k)
+        this_member = K[nt]
+        fileIO = T.extractfile(member=this_member)
+        import cPickle as pickle
+        frame_obj = pickle.load(fileIO)
+        scaled = self.scale_frame(file_hash, frame_obj, db_mgr)
+        if (scaled is not None) :
+          self.add_frame(scaled)
+
+  def scale_all (self, file_names) :
+    tar_list,integration_pickle_names = file_names
+    t1 = time.time()
+    if self.params.backend == 'MySQL':
+      from xfel.cxi.merging_database import manager
+    elif self.params.backend == 'SQLite':
+      from xfel.cxi.merging_database_sqlite3 import manager
+    else:
+      from xfel.cxi.merging_database_fs import manager
+
+    db_mgr = manager(self.params)
+    db_mgr.initialize_db(self.miller_set.indices())
+
+    # Unless the number of requested processes is greater than one,
+    # try parallel multiprocessing on a parallel host.  Block until
+    # all database commands have been processed.
+    nproc = self.params.nproc
+    if (nproc is None) or (nproc is Auto):
+      import libtbx.introspection
+      nproc = libtbx.introspection.number_of_processors()
+    if nproc > 1:
+      try :
+        import multiprocessing
+        self._scale_all_parallel(tar_list, db_mgr)
+      except ImportError, e :
+        print >> self.log, \
+          "multiprocessing module not available (requires Python >= 2.6)\n" \
+          "will scale frames serially"
+        self._scale_all_serial(tar_list, db_mgr)
+    else:
+      self._scale_all_serial(tar_list, db_mgr)
+    db_mgr.join()
+
+    t2 = time.time()
+    print >> self.log, ""
+    print >> self.log, "#" * 80
+    print >> self.log, "FINISHED MERGING"
+    print >> self.log, "  Elapsed time: %.1fs" % (t2 - t1)
+    print >> self.log, "  %d of %d integration files were accepted" % (
+      self.n_accepted, len(integration_pickle_names))
+    print >> self.log, "  %d rejected due to wrong Bravais group" % \
+      self.n_wrong_bravais
+    print >> self.log, "  %d rejected for unit cell outliers" % \
+      self.n_wrong_cell
+    print >> self.log, "  %d rejected for low signal" % \
+      self.n_low_signal
+    print >> self.log, "  %d rejected due to up-front poor correlation under min_corr parameter" % \
+      self.n_low_corr
+    print >> self.log, "  %d rejected for file errors or no reindex matrix" % \
+      self.n_file_error
+    for key in self.failure_modes.keys():
+      print >>self.log, "  %d rejected due to %s"%(self.failure_modes[key], key)
+
+    checksum = self.n_accepted  + self.n_file_error \
+               + self.n_low_corr + self.n_low_signal \
+               + self.n_wrong_bravais + self.n_wrong_cell \
+               + sum([val for val in self.failure_modes.itervalues()])
+    assert checksum == len(integration_pickle_names)
+
+    high_res_count = (self.d_min_values <= self.params.d_min).count(True)
+    print >> self.log, "Of %d accepted images, %d accepted to %5.2f Angstrom resolution" % \
+      (self.n_accepted, high_res_count, self.params.d_min)
+
+    if self.params.raw_data.sdfac_refine:
+      self.scale_errors()
+
+    if self.params.raw_data.errors_from_sample_residuals:
+      self.errors_from_residuals()
+
+  def _scale_all_parallel (self, file_names, db_mgr) :
+    import multiprocessing
+    import libtbx.introspection
+
+    nproc = self.params.nproc
+    if (nproc is None) or (nproc is Auto) :
+      nproc = libtbx.introspection.number_of_processors()
+
+    # Input files are supplied to the scaling processes on demand by
+    # means of a queue.
+    #
+    # XXX The input queue may need to either allow non-blocking
+    # put():s or run in a separate process to prevent the procedure
+    # from blocking here if the list of file paths does not fit into
+    # the queue's buffer.
+    input_queue = multiprocessing.Manager().JoinableQueue()
+    for file_name in file_names:
+      print file_name
+      input_queue.put(file_name)
+    pool = multiprocessing.Pool(processes=nproc)
+    # Each process accumulates its own statistics in serial, and the
+    # grand total is eventually collected by the main process'
+    # _add_all_frames() function.
+    for i in xrange(nproc) :
+      sm = scaling_manager(self.miller_set, self.i_model, self.params)
+      pool.apply_async(
+        func=sm,
+        args=[input_queue, db_mgr],
+        callback=self._add_all_frames)
+    pool.close()
+    pool.join()
+
+    # Block until the input queue has been emptied.
+    input_queue.join()
+
+  def _scale_all_serial (self, tar_list, db_mgr) :
+    """
+    Scale frames sequentially (single-process).  The return value is
+    picked up by the callback.
+    """
+    self.tar_to_scale_frame_adapter(tar_list, db_mgr)
+    return (self)
+
+  def __call__ (self, input_queue, db_mgr) :
+    """ Scale frames sequentially within the current process.  The
+    return value is picked up by the callback.  See also
+    self.scale_all_serial()"""
+    from Queue import Empty
+
+    try :
+      while True:
+        try:
+          file_name = input_queue.get_nowait()
+        except Empty:
+          return self
+        self.tar_to_scale_frame_adapter(tar_list=[file_name,], db_mgr=db_mgr)
+        input_queue.task_done()
+
+    except Exception, e :
+      print >> self.log, str(e)
+      return None
+
+  def scale_frame (self, file_hash, frame_obj, db_mgr) :
+    """The scale_frame() function populates a back end database with
+    appropriately scaled intensities derived from a single frame.  The
+    mark0 scaling algorithm determines the scale factor by correlating
+    the frame's corrected intensities to those of a reference
+    structure, while the mark1 algorithm applies no scaling at all.
+    The scale_frame() function can be called either serially or via a
+    multiprocessing map() function.
+
+    @note This function must not modify any internal data or the
+          parallelization will not yield usable results!
+
+    @param file_name Path to integration pickle file
+    @param db_mgr    Back end database manager
+    @return          An intensity_data object
+    """
+
+    out = StringIO()
+    wrong_cell = wrong_bravais = False
+    reindex_op = self.params.data_reindex_op
+    if self.reverse_lookup is not None:
+      reindex_op = self.reverse_lookup.get(file_hash, None)
+      if reindex_op is None:
+        return null_data(file_name=file_hash, log_out=out.getvalue(), file_error=True)
+    if (self.params.predictions_to_edge.apply) and (self.params.predictions_to_edge.image is not None):
+      from xfel.merging.predictions_to_edges import ImageInfo
+      image_info = ImageInfo(self.params.predictions_to_edge.image, detector_phil=self.params.predictions_to_edge.detector_phil)
+    else:
+      image_info = None
+    try :
+      result = load_result(
+        file_hash,
+        frame_obj,
+        reference_cell=self.params.target_unit_cell,
+        ref_bravais_type=self.ref_bravais_type,
+        params=self.params,
+        reindex_op = reindex_op,
+        out=out,
+        get_predictions_to_edge=self.params.predictions_to_edge.apply,
+        image_info=image_info,
+        exclude_CSPAD_sensor=self.params.validation.exclude_CSPAD_sensor)
+      if result is None:
+        return null_data(
+          file_name=file_hash, log_out=out.getvalue(), file_error=True)
+    except OutlierCellError, e :
+      print >> out, str(e)
+      return null_data(
+        file_name=file_hash, log_out=out.getvalue(), wrong_cell=True)
+    except WrongBravaisError, e :
+      print >> out, str(e)
+      return null_data(
+        file_name=file_hash, log_out=out.getvalue(), wrong_bravais=True)
+    return self.scale_frame_detail(result, file_hash, db_mgr, out)
+
+cxi_merge.scaling_manager = scaling_manager
+
+if (__name__ == "__main__"):
+  result = run(args=sys.argv[1:])
+  if result is None:
+    sys.exit(1)
+

--- a/xfel/merging/command_line/worker2.py
+++ b/xfel/merging/command_line/worker2.py
@@ -1,0 +1,27 @@
+from __future__ import division
+# LIBTBX_SET_DISPATCHER_NAME mpi.worker2
+from mpi4py import MPI
+from xfel.command_line.mpi_merge import scaling_manager_mpi
+
+comm = MPI.Comm.Get_parent()
+size = comm.Get_size()
+rank = comm.Get_rank()
+
+received_info = {}
+received_info = comm.bcast(received_info, root=0)
+file_names = received_info["file_names"]
+sm = scaling_manager_mpi(received_info["miller_set"],
+                         received_info["model"],
+                         received_info["params"])
+
+assert sm.params.backend == 'MySQL' # only option that makes sense
+from xfel.cxi.merging_database import manager
+db_mgr = manager(sm.params)
+
+for ix in xrange(len(file_names)):
+  if ix%size == rank:
+    print "Rank %d processing %s"%(rank, file_names[ix])
+    sm.tar_to_scale_frame_adapter(tar_list=[file_names[ix],], db_mgr=db_mgr)
+
+comm.gather(sm, root=0)
+comm.Disconnect()


### PR DESCRIPTION
New directory structure for command_line scripts related to merging. Added exafel:sept_sprint MPI merging work scripts. 

mpi_merge.py: Use MPI spawn to create new MPI processes, and uses MySQL backend.
mpi_cluster_merge.py: Use MPI (non-spawn) to create new MPI processes, and uses MySQL backend.
mpi_cluster_two_merge.py: Use MPI (non-spawn) to create new MPI processes, and uses FS backend.
mpi_cluster_two_merge_cs.py: Use MPI (non-spawn) to create new MPI processes, and uses FS backend. Work distributed to processes using a client-server model.