### PR TITLE
Add development version of cxi.merge that uses a reflection table

### DIFF
--- a/xfel/command_line/cxi_merge.py
+++ b/xfel/command_line/cxi_merge.py
@@ -1736,6 +1736,17 @@ class scaling_manager (intensity_data) :
     data.show_log_out(sys.stdout)
     return data
 
+  def sum_intensities(self):
+    sum_I = flex.double(self.miller_set.size(), 0.)
+    sum_I_SIGI = flex.double(self.miller_set.size(), 0.)
+    for i in xrange(self.miller_set.size()) :
+      index = self.miller_set.indices()[i]
+      if index in self.ISIGI :
+        for t in self.ISIGI[index]:
+          sum_I[i] += t[0]
+          sum_I_SIGI[i] += t[1]
+    return sum_I, sum_I_SIGI
+
 def consistent_set_and_model(work_params,i_model=None):
   # Adjust the minimum d-spacing of the generated Miller set to assure
   # that the desired high-resolution limit is included even if the
@@ -1859,14 +1870,7 @@ def run(args):
   print >> out, "\n"
 
   # Sum the observations of I and I/sig(I) for each reflection.
-  sum_I = flex.double(miller_set.size(), 0.)
-  sum_I_SIGI = flex.double(miller_set.size(), 0.)
-  for i in xrange(miller_set.size()) :
-    index = miller_set.indices()[i]
-    if index in scaler.ISIGI :
-      for t in scaler.ISIGI[index]:
-        sum_I[i] += t[0]
-        sum_I_SIGI[i] += t[1]
+  sum_I, sum_I_SIGI = scaler.sum_intensities()
 
   miller_set_avg = miller_set.customized_copy(
     unit_cell=work_params.target_unit_cell)
@@ -1935,6 +1939,33 @@ Pred. Multiplicity = # predictions on all accepted images / # Miller indices the
   easy_pickle.dump("%s.pkl" % work_params.output.prefix, result)
   return result
 
+def single_reflection_histograms(obs, ISIGI):
+  # Per-bin sum of I and I/sig(I) for each observation.
+  # R-merge statistics have been removed because
+  #  >> R-merge is defined on whole structure factor intensities, either
+  #     full observations or summed partials from the rotation method.
+  #     For XFEL data all reflections are assumed to be partial; no
+  #     method exists now to convert partials to fulls.
+  for i in obs.binner().array_indices(i_bin) :
+    import numpy as np
+    index = obs.indices()[i]
+    if (index in ISIGI) :
+      # Compute m, the "merged" intensity, as the average intensity
+      # of all observations of the reflection with the given index.
+      N = 0
+      m = 0
+      for t in ISIGI[index] :
+        N += 1
+        m += t[0]
+        print "Miller %20s n-obs=%4d  sum-I=%10.0f"%(index, N, m)
+        plot_n_bins = N//10
+        hist,bins = np.histogram([t[0] for t in ISIGI[index]],bins=25)
+        width = 0.7*(bins[1]-bins[0])
+        center = (bins[:-1]+bins[1:])/2
+        import matplotlib.pyplot as plt
+        plt.bar(center, hist, align="center", width=width)
+        plt.show()
+
 def show_overall_observations(
   obs, redundancy, redundancy_to_edge, summed_wt_I, summed_weight, ISIGI,
   n_bins=15, out=None, title=None, work_params=None):
@@ -1990,35 +2021,11 @@ def show_overall_observations(
     I_sigI_sum = flex.sum(intensity * flex.sqrt(summed_weight.select(sel_o)))
     I_n = sel_o.count(True)
 
-    # Per-bin sum of I and I/sig(I) for each observation.
-    # R-merge statistics have been removed because
-    #  >> R-merge is defined on whole structure factor intensities, either
-    #     full observations or summed partials from the rotation method.
-    #     For XFEL data all reflections are assumed to be partial; no
-    #     method exists now to convert partials to fulls.
-    if work_params.plot_single_index_histograms: import numpy as np
-    for i in obs.binner().array_indices(i_bin) :
-      index = obs.indices()[i]
-      if (index in ISIGI) :
-        # Compute m, the "merged" intensity, as the average intensity
-        # of all observations of the reflection with the given index.
-        N = 0
-        m = 0
-        for t in ISIGI[index] :
-          N += 1
-          m += t[0]
-        if work_params is not None and \
-           (work_params.plot_single_index_histograms and \
-            N >= 30 and \
-            work_params.data_subset == 0):
-          print "Miller %20s n-obs=%4d  sum-I=%10.0f"%(index, N, m)
-          plot_n_bins = N//10
-          hist,bins = np.histogram([t[0] for t in ISIGI[index]],bins=25)
-          width = 0.7*(bins[1]-bins[0])
-          center = (bins[:-1]+bins[1:])/2
-          import matplotlib.pyplot as plt
-          plt.bar(center, hist, align="center", width=width)
-          plt.show()
+    if work_params is not None and \
+     (work_params.plot_single_index_histograms and \
+      N >= 30 and \
+      work_params.data_subset == 0):
+      single_reflection_histograms(obs, ISIGI)
 
     if sel_measurements > 0:
       mean_I = mean_I_sigI = 0

--- a/xfel/command_line/cxi_merge.py
+++ b/xfel/command_line/cxi_merge.py
@@ -1770,6 +1770,181 @@ class scaling_manager (intensity_data) :
           sum_I_SIGI[i] += t[1]
     return sum_I, sum_I_SIGI
 
+  @staticmethod
+  def show_overall_observations(
+    obs, redundancy, redundancy_to_edge, summed_wt_I, summed_weight, ISIGI,
+    n_bins=15, out=None, title=None, work_params=None):
+    if out is None:
+      out = sys.stdout
+    obs.setup_binner(d_max=100000, d_min=work_params.d_min, n_bins=n_bins)
+    result = []
+
+    cumulative_unique = 0
+    cumulative_meas   = 0
+    cumulative_n_pred = 0
+    cumulative_pred   = 0
+    cumulative_theor  = 0
+    cumulative_In     = 0
+    cumulative_I      = 0.0
+    cumulative_Isigma = 0.0
+
+    for i_bin in obs.binner().range_used():
+      sel_w = obs.binner().selection(i_bin)
+      sel_fo_all = obs.select(sel_w)
+      obs.binner()._have_format_strings=True
+      obs.binner().fmt_bin_range_used ="%6.3f -%6.3f"
+      d_range = obs.binner().bin_legend(
+        i_bin=i_bin, show_bin_number=False, show_counts=False)
+      sel_redundancy = redundancy.select(sel_w)
+      if redundancy_to_edge is not None:
+        sel_redundancy_pred = redundancy_to_edge.select(sel_w)
+      else:
+        sel_redundancy_pred = None
+      sel_absent = sel_redundancy.count(0)
+      n_present = sel_redundancy.size() - sel_absent
+      sel_complete_tag = "[%d/%d]" % (n_present, sel_redundancy.size())
+      sel_measurements = flex.sum(sel_redundancy)
+
+      # Alternatively, redundancy (or multiplicity) is calculated as the
+      # average number of observations for the observed
+      # reflections--missing reflections do not affect the redundancy
+      # adversely, and the reported value becomes
+      # completeness-independent.
+      val_redundancy_obs = 0
+      if n_present > 0:
+        val_redundancy_obs = flex.sum(sel_redundancy) / n_present
+      # Repeat on the full set of predictions, calculated w.r.t. the asymmetric unit
+      val_redundancy_pred = 0
+      if redundancy_to_edge is not None and n_present > 0:
+        val_redundancy_pred = flex.sum(sel_redundancy_pred) / sel_redundancy.size()
+
+      # Per-bin sum of I and I/sig(I).  For any reflection, the weight
+      # of the merged intensity must be positive for this to make sense.
+      sel_o = (sel_w & (summed_weight > 0))
+      intensity = summed_wt_I.select(sel_o) / summed_weight.select(sel_o)
+      I_sum = flex.sum(intensity)
+      I_sigI_sum = flex.sum(intensity * flex.sqrt(summed_weight.select(sel_o)))
+      I_n = sel_o.count(True)
+
+      if work_params is not None and \
+       (work_params.plot_single_index_histograms and \
+        N >= 30 and \
+        work_params.data_subset == 0):
+        scaling_manager.single_reflection_histograms(obs, ISIGI)
+
+      if sel_measurements > 0:
+        mean_I = mean_I_sigI = 0
+        if I_n > 0:
+          mean_I = I_sum / I_n
+          mean_I_sigI = I_sigI_sum / I_n
+        bin = resolution_bin(
+          i_bin=i_bin,
+          d_range=d_range,
+          d_min=obs.binner().bin_d_min(i_bin),
+          redundancy_asu=flex.mean(sel_redundancy.as_double()),
+          redundancy_obs=val_redundancy_obs,
+          redundancy_to_edge=val_redundancy_pred,
+          complete_tag=sel_complete_tag,
+          completeness=n_present / sel_redundancy.size(),
+          measurements=sel_measurements,
+          predictions=sel_redundancy_pred,
+          mean_I=mean_I,
+          mean_I_sigI=mean_I_sigI)
+        result.append(bin)
+      cumulative_unique += n_present
+      cumulative_meas   += sel_measurements
+      if redundancy_to_edge is not None:
+        cumulative_n_pred += flex.sum(sel_redundancy_pred)
+        cumulative_pred   += redundancy_to_edge
+      cumulative_theor  += sel_redundancy.size()
+      cumulative_In     += I_n
+      cumulative_I      += I_sum
+      cumulative_Isigma += I_sigI_sum
+
+    if (title is not None) :
+      print >> out, title
+    from libtbx import table_utils
+    table_header = ["","","","","<asu","<obs","<pred","","","",""]
+    table_header2 = ["Bin","Resolution Range","Completeness","%","multi>","multi>","multi>",
+      "n_meas", "n_pred","<I>","<I/sig(I)>"]
+    use_preds = (redundancy_to_edge is not None and flex.sum(redundancy_to_edge) > 0)
+    include_columns = [True, True, True, True, True, True, use_preds, True, use_preds, True, True]
+    table_data = []
+    table_data.append(table_header)
+    table_data.append(table_header2)
+    for bin in result:
+      table_row = []
+      table_row.append("%3d" % bin.i_bin)
+      table_row.append("%-13s" % bin.d_range)
+      table_row.append("%13s" % bin.complete_tag)
+      table_row.append("%5.2f" % (100*bin.completeness))
+      table_row.append("%6.2f" % bin.redundancy_asu)
+      table_row.append("%6.2f" % bin.redundancy_obs)
+      table_row.append("%6.2f" % (0 if redundancy_to_edge is None else bin.redundancy_to_edge))
+      table_row.append("%6d" % bin.measurements)
+      table_row.append("%6d" % (0 if redundancy_to_edge is None else flex.sum(bin.predictions)))
+      table_row.append("%8.0f" % bin.mean_I)
+      table_row.append("%8.3f" % bin.mean_I_sigI)
+      table_data.append(table_row)
+    if len(table_data) <= 2:
+      print >>out,"Table could not be constructed -- no bins accepted."
+      return
+    table_data.append([""]*len(table_header))
+    table_data.append(  [
+        format_value("%3s",   "All"),
+        format_value("%-13s", "                 "),
+        format_value("%13s",  "[%d/%d]"%(cumulative_unique,cumulative_theor)),
+        format_value("%5.2f", 100*(cumulative_unique/cumulative_theor)),
+        format_value("%6.2f", cumulative_meas/cumulative_theor),
+        format_value("%6.2f", cumulative_meas/cumulative_unique),
+        format_value("%6.2f", (0 if redundancy_to_edge is None else cumulative_n_pred/cumulative_theor)),
+        format_value("%6d",   cumulative_meas),
+        format_value("%6d",   (0 if redundancy_to_edge is None else flex.sum(redundancy_to_edge))),
+        format_value("%8.0f", cumulative_I/cumulative_In),
+        format_value("%8.3f", cumulative_Isigma/cumulative_In),
+    ])
+    table_data = table_utils.manage_columns(table_data, include_columns)
+
+    print
+    print >>out,table_utils.format(table_data,has_header=2,justify='center',delim=" ")
+
+    # XXX generate table object for displaying plots
+    if (title is None) :
+      title = "Data statistics by resolution"
+    table = data_plots.table_data(
+      title=title,
+      x_is_inverse_d_min=True,
+      force_exact_x_labels=True)
+    table.add_column(
+      column=[1 / bin.d_min**2 for bin in result],
+      column_name="d_min",
+      column_label="Resolution")
+    table.add_column(
+      column=[bin.redundancy_asu for bin in result],
+      column_name="redundancy",
+      column_label="Redundancy")
+    table.add_column(
+      column=[bin.completeness for bin in result],
+      column_name="completeness",
+      column_label="Completeness")
+    table.add_column(
+      column=[bin.mean_I_sigI for bin in result],
+      column_name="mean_i_over_sigI",
+      column_label="<I/sig(I)>")
+    table.add_graph(
+      name="Redundancy vs. resolution",
+      type="GRAPH",
+      columns=[0,1])
+    table.add_graph(
+      name="Completeness vs. resolution",
+      type="GRAPH",
+      columns=[0,2])
+    table.add_graph(
+      name="<I/sig(I)> vs. resolution",
+      type="GRAPH",
+      columns=[0,3])
+    return table
+
 def consistent_set_and_model(work_params,i_model=None):
   # Adjust the minimum d-spacing of the generated Miller set to assure
   # that the desired high-resolution limit is included even if the
@@ -1897,7 +2072,7 @@ def run(args):
 
   miller_set_avg = miller_set.customized_copy(
     unit_cell=work_params.target_unit_cell)
-  table1 = show_overall_observations(
+  table1 = scaling_manager.show_overall_observations(
     obs=miller_set_avg,
     redundancy=scaler.completeness,
     redundancy_to_edge=scaler.completeness_predictions,
@@ -1914,7 +2089,7 @@ def run(args):
   else:
     n_refl, corr = ((scaler.completeness > 0).count(True), 0)
   print >> out, "\n"
-  table2 = show_overall_observations(
+  table2 = scaling_manager.show_overall_observations(
     obs=miller_set_avg,
     redundancy=scaler.summed_N,
     redundancy_to_edge=scaler.completeness_predictions,
@@ -1961,180 +2136,6 @@ Pred. Multiplicity = # predictions on all accepted images / # Miller indices the
     overall_correlation=corr)
   easy_pickle.dump("%s.pkl" % work_params.output.prefix, result)
   return result
-
-def show_overall_observations(
-  obs, redundancy, redundancy_to_edge, summed_wt_I, summed_weight, ISIGI,
-  n_bins=15, out=None, title=None, work_params=None):
-  if out is None:
-    out = sys.stdout
-  obs.setup_binner(d_max=100000, d_min=work_params.d_min, n_bins=n_bins)
-  result = []
-
-  cumulative_unique = 0
-  cumulative_meas   = 0
-  cumulative_n_pred = 0
-  cumulative_pred   = 0
-  cumulative_theor  = 0
-  cumulative_In     = 0
-  cumulative_I      = 0.0
-  cumulative_Isigma = 0.0
-
-  for i_bin in obs.binner().range_used():
-    sel_w = obs.binner().selection(i_bin)
-    sel_fo_all = obs.select(sel_w)
-    obs.binner()._have_format_strings=True
-    obs.binner().fmt_bin_range_used ="%6.3f -%6.3f"
-    d_range = obs.binner().bin_legend(
-      i_bin=i_bin, show_bin_number=False, show_counts=False)
-    sel_redundancy = redundancy.select(sel_w)
-    if redundancy_to_edge is not None:
-      sel_redundancy_pred = redundancy_to_edge.select(sel_w)
-    else:
-      sel_redundancy_pred = None
-    sel_absent = sel_redundancy.count(0)
-    n_present = sel_redundancy.size() - sel_absent
-    sel_complete_tag = "[%d/%d]" % (n_present, sel_redundancy.size())
-    sel_measurements = flex.sum(sel_redundancy)
-
-    # Alternatively, redundancy (or multiplicity) is calculated as the
-    # average number of observations for the observed
-    # reflections--missing reflections do not affect the redundancy
-    # adversely, and the reported value becomes
-    # completeness-independent.
-    val_redundancy_obs = 0
-    if n_present > 0:
-      val_redundancy_obs = flex.sum(sel_redundancy) / n_present
-    # Repeat on the full set of predictions, calculated w.r.t. the asymmetric unit
-    val_redundancy_pred = 0
-    if redundancy_to_edge is not None and n_present > 0:
-      val_redundancy_pred = flex.sum(sel_redundancy_pred) / sel_redundancy.size()
-
-    # Per-bin sum of I and I/sig(I).  For any reflection, the weight
-    # of the merged intensity must be positive for this to make sense.
-    sel_o = (sel_w & (summed_weight > 0))
-    intensity = summed_wt_I.select(sel_o) / summed_weight.select(sel_o)
-    I_sum = flex.sum(intensity)
-    I_sigI_sum = flex.sum(intensity * flex.sqrt(summed_weight.select(sel_o)))
-    I_n = sel_o.count(True)
-
-    if work_params is not None and \
-     (work_params.plot_single_index_histograms and \
-      N >= 30 and \
-      work_params.data_subset == 0):
-      scaling_manager.single_reflection_histograms(obs, ISIGI)
-
-    if sel_measurements > 0:
-      mean_I = mean_I_sigI = 0
-      if I_n > 0:
-        mean_I = I_sum / I_n
-        mean_I_sigI = I_sigI_sum / I_n
-      bin = resolution_bin(
-        i_bin=i_bin,
-        d_range=d_range,
-        d_min=obs.binner().bin_d_min(i_bin),
-        redundancy_asu=flex.mean(sel_redundancy.as_double()),
-        redundancy_obs=val_redundancy_obs,
-        redundancy_to_edge=val_redundancy_pred,
-        complete_tag=sel_complete_tag,
-        completeness=n_present / sel_redundancy.size(),
-        measurements=sel_measurements,
-        predictions=sel_redundancy_pred,
-        mean_I=mean_I,
-        mean_I_sigI=mean_I_sigI)
-      result.append(bin)
-    cumulative_unique += n_present
-    cumulative_meas   += sel_measurements
-    if redundancy_to_edge is not None:
-      cumulative_n_pred += flex.sum(sel_redundancy_pred)
-      cumulative_pred   += redundancy_to_edge
-    cumulative_theor  += sel_redundancy.size()
-    cumulative_In     += I_n
-    cumulative_I      += I_sum
-    cumulative_Isigma += I_sigI_sum
-
-  if (title is not None) :
-    print >> out, title
-  from libtbx import table_utils
-  table_header = ["","","","","<asu","<obs","<pred","","","",""]
-  table_header2 = ["Bin","Resolution Range","Completeness","%","multi>","multi>","multi>",
-    "n_meas", "n_pred","<I>","<I/sig(I)>"]
-  use_preds = (redundancy_to_edge is not None and flex.sum(redundancy_to_edge) > 0)
-  include_columns = [True, True, True, True, True, True, use_preds, True, use_preds, True, True]
-  table_data = []
-  table_data.append(table_header)
-  table_data.append(table_header2)
-  for bin in result:
-    table_row = []
-    table_row.append("%3d" % bin.i_bin)
-    table_row.append("%-13s" % bin.d_range)
-    table_row.append("%13s" % bin.complete_tag)
-    table_row.append("%5.2f" % (100*bin.completeness))
-    table_row.append("%6.2f" % bin.redundancy_asu)
-    table_row.append("%6.2f" % bin.redundancy_obs)
-    table_row.append("%6.2f" % (0 if redundancy_to_edge is None else bin.redundancy_to_edge))
-    table_row.append("%6d" % bin.measurements)
-    table_row.append("%6d" % (0 if redundancy_to_edge is None else flex.sum(bin.predictions)))
-    table_row.append("%8.0f" % bin.mean_I)
-    table_row.append("%8.3f" % bin.mean_I_sigI)
-    table_data.append(table_row)
-  if len(table_data) <= 2:
-    print >>out,"Table could not be constructed -- no bins accepted."
-    return
-  table_data.append([""]*len(table_header))
-  table_data.append(  [
-      format_value("%3s",   "All"),
-      format_value("%-13s", "                 "),
-      format_value("%13s",  "[%d/%d]"%(cumulative_unique,cumulative_theor)),
-      format_value("%5.2f", 100*(cumulative_unique/cumulative_theor)),
-      format_value("%6.2f", cumulative_meas/cumulative_theor),
-      format_value("%6.2f", cumulative_meas/cumulative_unique),
-      format_value("%6.2f", (0 if redundancy_to_edge is None else cumulative_n_pred/cumulative_theor)),
-      format_value("%6d",   cumulative_meas),
-      format_value("%6d",   (0 if redundancy_to_edge is None else flex.sum(redundancy_to_edge))),
-      format_value("%8.0f", cumulative_I/cumulative_In),
-      format_value("%8.3f", cumulative_Isigma/cumulative_In),
-  ])
-  table_data = table_utils.manage_columns(table_data, include_columns)
-
-  print
-  print >>out,table_utils.format(table_data,has_header=2,justify='center',delim=" ")
-
-  # XXX generate table object for displaying plots
-  if (title is None) :
-    title = "Data statistics by resolution"
-  table = data_plots.table_data(
-    title=title,
-    x_is_inverse_d_min=True,
-    force_exact_x_labels=True)
-  table.add_column(
-    column=[1 / bin.d_min**2 for bin in result],
-    column_name="d_min",
-    column_label="Resolution")
-  table.add_column(
-    column=[bin.redundancy_asu for bin in result],
-    column_name="redundancy",
-    column_label="Redundancy")
-  table.add_column(
-    column=[bin.completeness for bin in result],
-    column_name="completeness",
-    column_label="Completeness")
-  table.add_column(
-    column=[bin.mean_I_sigI for bin in result],
-    column_name="mean_i_over_sigI",
-    column_label="<I/sig(I)>")
-  table.add_graph(
-    name="Redundancy vs. resolution",
-    type="GRAPH",
-    columns=[0,1])
-  table.add_graph(
-    name="Completeness vs. resolution",
-    type="GRAPH",
-    columns=[0,2])
-  table.add_graph(
-    name="<I/sig(I)> vs. resolution",
-    type="GRAPH",
-    columns=[0,3])
-  return table
 
 class resolution_bin(object):
   def __init__(self,

--- a/xfel/command_line/cxi_xmerge.py
+++ b/xfel/command_line/cxi_xmerge.py
@@ -17,7 +17,7 @@ import time
 import sys
 
 from xfel.command_line.cxi_merge import master_phil,scaling_manager
-from xfel.command_line.cxi_merge import unit_cell_distribution,show_overall_observations
+from xfel.command_line.cxi_merge import unit_cell_distribution
 from xfel.command_line.cxi_merge import scaling_result
 from xfel.command_line.cxi_merge import consistent_set_and_model
 from xfel import column_parser
@@ -342,7 +342,7 @@ def run(args):
     miller_set_avg = miller_set.customized_copy(
       unit_cell=work_params.target_unit_cell)
 
-    table1 = show_overall_observations(
+    table1 = scaling_manager.show_overall_observations(
       obs=miller_set_avg,
       redundancy=scaler.completeness,
       redundancy_to_edge=None,
@@ -361,7 +361,7 @@ def run(args):
     else:
       n_refl, corr = ((scaler.completeness > 0).count(True), 0)
     print >> out, "\n"
-    table2 = show_overall_observations(
+    table2 = scaling_manager.show_overall_observations(
       obs=miller_set_avg,
       redundancy=scaler.summed_N,
       redundancy_to_edge=None,

--- a/xfel/merging/command_line/dev_cxi_merge.py
+++ b/xfel/merging/command_line/dev_cxi_merge.py
@@ -10,7 +10,6 @@ from xfel.command_line.cxi_merge import master_phil
 from libtbx.utils import Usage, multi_out
 import sys,os
 from xfel.command_line.cxi_merge import get_observations, scaling_manager, show_overall_observations, scaling_result
-from cctbx.array_family import flex
 from libtbx import easy_pickle
 
 
@@ -126,15 +125,7 @@ class Script(object):
         print "  %s" % str(e)
     print >> self.out, "\n"
 
-    # Sum the observations of I and I/sig(I) for each reflection.
-    sum_I = flex.double(self.miller_set.size(), 0.)
-    sum_I_SIGI = flex.double(self.miller_set.size(), 0.)
-    for i in xrange(self.miller_set.size()) :
-      index = self.miller_set.indices()[i]
-      if index in scaler.ISIGI :
-        for t in scaler.ISIGI[index]:
-          sum_I[i] += t[0]
-          sum_I_SIGI[i] += t[1]
+    sum_I, sum_I_SIGI = scaler.sum_intensities()
 
     miller_set_avg = self.miller_set.customized_copy(
       unit_cell=self.params.target_unit_cell)

--- a/xfel/merging/command_line/dev_cxi_merge.py
+++ b/xfel/merging/command_line/dev_cxi_merge.py
@@ -9,7 +9,7 @@ from iotbx.phil import parse
 from xfel.command_line.cxi_merge import master_phil
 from libtbx.utils import Usage, multi_out
 import sys,os
-from xfel.command_line.cxi_merge import get_observations, scaling_manager, show_overall_observations, scaling_result
+from xfel.command_line.cxi_merge import get_observations, scaling_manager, scaling_result
 from libtbx import easy_pickle
 
 
@@ -129,7 +129,7 @@ class Script(object):
 
     miller_set_avg = self.miller_set.customized_copy(
       unit_cell=self.params.target_unit_cell)
-    table1 = show_overall_observations(
+    table1 = scaling_manager.show_overall_observations(
       obs=miller_set_avg,
       redundancy=scaler.completeness,
       redundancy_to_edge=scaler.completeness_predictions,
@@ -146,7 +146,7 @@ class Script(object):
     else:
       n_refl, corr = ((scaler.completeness > 0).count(True), 0)
     print >> self.out, "\n"
-    table2 = show_overall_observations(
+    table2 = scaling_manager.show_overall_observations(
       obs=miller_set_avg,
       redundancy=scaler.summed_N,
       redundancy_to_edge=scaler.completeness_predictions,

--- a/xfel/merging/command_line/dev_cxi_merge_refltable.py
+++ b/xfel/merging/command_line/dev_cxi_merge_refltable.py
@@ -1,0 +1,209 @@
+# -*- mode: python; coding: utf-8; indent-tabs-mode: nil; python-indent: 2 -*-
+#
+# LIBTBX_SET_DISPATCHER_NAME dev.cxi.merge_refltable
+#
+# $Id$
+from __future__ import division
+
+from xfel.command_line.cxi_merge import scaling_manager
+from dials.array_family import flex
+from xfel.merging.command_line.dev_cxi_merge import Script as MergingScript
+from xfel.cxi.merging_utils import null_data
+from libtbx import Auto
+
+def merging_reflection_table():
+  table = flex.reflection_table()
+  table['miller_index'] = flex.miller_index()
+  table['scaled_intensity'] = flex.double()
+  table['isigi'] = flex.double()
+  table['slope'] = flex.double()
+  table['miller_id'] = flex.size_t()
+  return table
+
+def single_reflection_histograms(obs, ISIGI):
+  # Per-bin sum of I and I/sig(I) for each observation.
+  # R-merge statistics have been removed because
+  #  >> R-merge is defined on whole structure factor intensities, either
+  #     full observations or summed partials from the rotation method.
+  #     For XFEL data all reflections are assumed to be partial; no
+  #     method exists now to convert partials to fulls.
+  import numpy as np
+  for i in obs.binner().array_indices(i_bin) :
+    index = obs.indices()[i]
+    refls = ISIGI.select(ISIGI['miller_index'] == index)
+    if (len(refls) > 0) :
+      # Compute m, the "merged" intensity, as the average intensity
+      # of all observations of the reflection with the given index.
+      N = 0
+      m = 0
+      for j in xrange(len(refls)):
+        N += 1
+        m += refls['isigi'][j]
+
+        print "Miller %20s n-obs=%4d  sum-I=%10.0f"%(index, N, m)
+        plot_n_bins = N//10
+        hist,bins = np.histogram(refls['intensity'],bins=25)
+        width = 0.7*(bins[1]-bins[0])
+        center = (bins[:-1]+bins[1:])/2
+        import matplotlib.pyplot as plt
+        plt.bar(center, hist, align="center", width=width)
+        plt.show()
+
+class refltable_scaling_manager(scaling_manager):
+  def initialize (self) :
+    super(refltable_scaling_manager, self).initialize()
+    self.ISIGI = merging_reflection_table()
+
+  def scale_frame_detail(self, result, file_name, db_mgr, out):
+    data = super(refltable_scaling_manager, self).scale_frame_detail(result, file_name, db_mgr, out)
+    reflections = merging_reflection_table()
+    for i, hkl in enumerate(self.miller_set.indices()):
+      if hkl not in data.ISIGI: continue
+      for refl in data.ISIGI[hkl]:
+        reflections.append({'miller_index':hkl,
+                            'scaled_intensity': refl[0],
+                            'isigi': refl[1],
+                            'slope': refl[2],
+                            'miller_id':i})
+    data.ISIGI = reflections
+    return data
+
+  def _scale_all_parallel (self, file_names, db_mgr) :
+    import multiprocessing
+    import libtbx.introspection
+
+    nproc = self.params.nproc
+    if (nproc is None) or (nproc is Auto) :
+      nproc = libtbx.introspection.number_of_processors()
+
+    # Input files are supplied to the scaling processes on demand by
+    # means of a queue.
+    #
+    # XXX The input queue may need to either allow non-blocking
+    # put():s or run in a separate process to prevent the procedure
+    # from blocking here if the list of file paths does not fit into
+    # the queue's buffer.
+    input_queue = multiprocessing.Manager().JoinableQueue()
+    for file_name in file_names:
+      input_queue.put(file_name)
+
+    pool = multiprocessing.Pool(processes=nproc)
+    # Each process accumulates its own statistics in serial, and the
+    # grand total is eventually collected by the main process'
+    # _add_all_frames() function.
+    for i in xrange(nproc) :
+      sm = refltable_scaling_manager(self.miller_set, self.i_model, self.params)
+      pool.apply_async(
+        func=sm,
+        args=[input_queue, db_mgr],
+        callback=self._add_all_frames)
+    pool.close()
+    pool.join()
+
+    # Block until the input queue has been emptied.
+    input_queue.join()
+
+  def add_frame (self, data) :
+    """
+    Combine the scaled data from a frame with the current overall dataset.
+    Also accepts None or null_data objects, when data are unusable but we
+    want to record the file as processed.
+    """
+    self.n_processed += 1
+    if (data is None) :
+      return None
+    if (isinstance(data, null_data)) :
+      if (data.file_error) :
+        self.n_file_error += 1
+      elif (data.low_signal) :
+        self.n_low_signal += 1
+      elif (data.wrong_bravais) :
+        self.n_wrong_bravais += 1
+      elif (data.wrong_cell) :
+        self.n_wrong_cell += 1
+      elif (getattr(data,"reason",None) is not None):
+        if str(data.reason)!="":
+          self.failure_modes[str(data.reason)] = self.failure_modes.get(str(data.reason),0) + 1
+        elif repr(type(data.reason))!="":
+          self.failure_modes[repr(type(data.reason))] = self.failure_modes.get(repr(type(data.reason)),0) + 1
+        else:
+          self.failure_modes["other reasons"] = self.failure_modes.get("other reasons",0) + 1
+      return
+    if (data.accept) :
+      self.n_accepted    += 1
+      self.completeness  += data.completeness
+      self.completeness_predictions += data.completeness_predictions
+      self.summed_N      += data.summed_N
+      self.summed_weight += data.summed_weight
+      self.summed_wt_I   += data.summed_wt_I
+      self.ISIGI.extend(data.ISIGI)
+    else :
+      self.n_low_corr += 1
+    self.uc_values.add_cell(data.indexed_cell,
+      rejected=(not data.accept))
+    if not self.params.short_circuit:
+      self.observations.append(data.n_obs)
+    if (data.n_obs > 0) :
+      frac_rejected = data.n_rejected / data.n_obs
+      self.rejected_fractions.append(frac_rejected)
+      self.d_min_values.append(data.d_min)
+    self.corr_values.append(data.corr)
+    self.wavelength.append(data.wavelength)
+
+  def _add_all_frames (self, data) :
+    """The _add_all_frames() function collects the statistics accumulated
+    in @p data by the individual scaling processes in the process
+    pool.  This callback function is run in serial, so it does not
+    need a lock.
+    """
+    self.n_accepted += data.n_accepted
+    self.n_file_error += data.n_file_error
+    self.n_low_corr += data.n_low_corr
+    self.n_low_signal += data.n_low_signal
+    self.n_processed += data.n_processed
+    self.n_wrong_bravais += data.n_wrong_bravais
+    self.n_wrong_cell += data.n_wrong_cell
+    for key in data.failure_modes.keys():
+      self.failure_modes[key] = self.failure_modes.get(key,0) + data.failure_modes[key]
+
+    self.ISIGI.extend(data.ISIGI)
+
+    self.completeness += data.completeness
+    self.completeness_predictions += data.completeness_predictions
+    self.summed_N += data.summed_N
+    self.summed_weight += data.summed_weight
+    self.summed_wt_I += data.summed_wt_I
+
+    self.corr_values.extend(data.corr_values)
+    self.d_min_values.extend(data.d_min_values)
+    if not self.params.short_circuit:
+      self.observations.extend(data.observations)
+    self.rejected_fractions.extend(data.rejected_fractions)
+    self.wavelength.extend(data.wavelength)
+
+    self.uc_values.add_cells(data.uc_values)
+
+  def sum_intensities(self):
+    # Sum the observations of I and I/sig(I) for each reflection.
+    sum_I = flex.double(self.miller_set.size(), 0.)
+    sum_I_SIGI = flex.double(self.miller_set.size(), 0.)
+    for i in xrange(len(self.ISIGI)):
+      j = self.ISIGI['miller_id'][i]
+      sum_I[j] += self.ISIGI['scaled_intensity'][i]
+      sum_I_SIGI[j] += self.ISIGI['isigi'][i]
+    return sum_I, sum_I_SIGI
+
+class Script(MergingScript):
+  '''A class for running the script.'''
+  def scale_all(self):
+    scaler = refltable_scaling_manager(
+      miller_set=self.miller_set,
+      i_model=self.i_model,
+      params=self.params,
+      log=self.out)
+    scaler.scale_all(self.frame_files)
+    return scaler
+
+if __name__ == '__main__':
+  script = Script()
+  script.run()

--- a/xfel/merging/command_line/dev_cxi_merge_refltable.py
+++ b/xfel/merging/command_line/dev_cxi_merge_refltable.py
@@ -20,39 +20,35 @@ def merging_reflection_table():
   table['miller_id'] = flex.size_t()
   return table
 
-def single_reflection_histograms(obs, ISIGI):
-  # Per-bin sum of I and I/sig(I) for each observation.
-  # R-merge statistics have been removed because
-  #  >> R-merge is defined on whole structure factor intensities, either
-  #     full observations or summed partials from the rotation method.
-  #     For XFEL data all reflections are assumed to be partial; no
-  #     method exists now to convert partials to fulls.
-  import numpy as np
-  for i in obs.binner().array_indices(i_bin) :
-    index = obs.indices()[i]
-    refls = ISIGI.select(ISIGI['miller_index'] == index)
-    if (len(refls) > 0) :
-      # Compute m, the "merged" intensity, as the average intensity
-      # of all observations of the reflection with the given index.
-      N = 0
-      m = 0
-      for j in xrange(len(refls)):
-        N += 1
-        m += refls['isigi'][j]
-
-        print "Miller %20s n-obs=%4d  sum-I=%10.0f"%(index, N, m)
-        plot_n_bins = N//10
-        hist,bins = np.histogram(refls['intensity'],bins=25)
-        width = 0.7*(bins[1]-bins[0])
-        center = (bins[:-1]+bins[1:])/2
-        import matplotlib.pyplot as plt
-        plt.bar(center, hist, align="center", width=width)
-        plt.show()
-
 class refltable_scaling_manager(scaling_manager):
   def initialize (self) :
     super(refltable_scaling_manager, self).initialize()
     self.ISIGI = merging_reflection_table()
+
+  @staticmethod
+  def single_reflection_histograms(obs, ISIGI):
+    # Per-bin sum of I and I/sig(I) for each observation.
+    import numpy as np
+    for i in obs.binner().array_indices(i_bin) :
+      index = obs.indices()[i]
+      refls = ISIGI.select(ISIGI['miller_index'] == index)
+      if (len(refls) > 0) :
+        # Compute m, the "merged" intensity, as the average intensity
+        # of all observations of the reflection with the given index.
+        N = 0
+        m = 0
+        for j in xrange(len(refls)):
+          N += 1
+          m += refls['isigi'][j]
+
+          print "Miller %20s n-obs=%4d  sum-I=%10.0f"%(index, N, m)
+          plot_n_bins = N//10
+          hist,bins = np.histogram(refls['intensity'],bins=25)
+          width = 0.7*(bins[1]-bins[0])
+          center = (bins[:-1]+bins[1:])/2
+          import matplotlib.pyplot as plt
+          plt.bar(center, hist, align="center", width=width)
+          plt.show()
 
   def scale_frame_detail(self, result, file_name, db_mgr, out):
     data = super(refltable_scaling_manager, self).scale_frame_detail(result, file_name, db_mgr, out)

--- a/xfel/merging/command_line/mpi_cluster_merge.py
+++ b/xfel/merging/command_line/mpi_cluster_merge.py
@@ -145,7 +145,7 @@ class run_manager(object):
 
   miller_set_avg = miller_set.customized_copy(
     unit_cell=work_params.target_unit_cell)
-  table1 = cxi_merge.show_overall_observations(
+  table1 = cxi_merge.scaling_manager.show_overall_observations(
     obs=miller_set_avg,
     redundancy=scaler.completeness,
     redundancy_to_edge=scaler.completeness_predictions,
@@ -162,7 +162,7 @@ class run_manager(object):
   else:
     n_refl, corr = ((scaler.completeness > 0).count(True), 0)
   print >> out, "\n"
-  table2 = cxi_merge.show_overall_observations(
+  table2 = cxi_merge.scaling_manager.show_overall_observations(
     obs=miller_set_avg,
     redundancy=scaler.summed_N,
     redundancy_to_edge=scaler.completeness_predictions,

--- a/xfel/merging/command_line/mpi_cluster_two_merge.py
+++ b/xfel/merging/command_line/mpi_cluster_two_merge.py
@@ -146,7 +146,7 @@ class run_manager(object):
 
   miller_set_avg = miller_set.customized_copy(
     unit_cell=work_params.target_unit_cell)
-  table1 = cxi_merge.show_overall_observations(
+  table1 = cxi_merge.scaling_manager.show_overall_observations(
     obs=miller_set_avg,
     redundancy=scaler.completeness,
     redundancy_to_edge=scaler.completeness_predictions,
@@ -163,7 +163,7 @@ class run_manager(object):
   else:
     n_refl, corr = ((scaler.completeness > 0).count(True), 0)
   print >> out, "\n"
-  table2 = cxi_merge.show_overall_observations(
+  table2 = cxi_merge.scaling_manager.show_overall_observations(
     obs=miller_set_avg,
     redundancy=scaler.summed_N,
     redundancy_to_edge=scaler.completeness_predictions,

--- a/xfel/merging/command_line/mpi_cluster_two_merge_cs.py
+++ b/xfel/merging/command_line/mpi_cluster_two_merge_cs.py
@@ -249,7 +249,7 @@ class run_manager(object):
 
   miller_set_avg = miller_set.customized_copy(
     unit_cell=work_params.target_unit_cell)
-  table1 = cxi_merge.show_overall_observations(
+  table1 = cxi_merge.scaling_manager.show_overall_observations(
     obs=miller_set_avg,
     redundancy=scaler.completeness,
     redundancy_to_edge=scaler.completeness_predictions,
@@ -266,7 +266,7 @@ class run_manager(object):
   else:
     n_refl, corr = ((scaler.completeness > 0).count(True), 0)
   print >> out, "\n"
-  table2 = cxi_merge.show_overall_observations(
+  table2 = cxi_merge.scaling_manager.show_overall_observations(
     obs=miller_set_avg,
     redundancy=scaler.summed_N,
     redundancy_to_edge=scaler.completeness_predictions,


### PR DESCRIPTION
Two changes to cxi.merge:
  Move summation code out of run method into method of the scaling manager
  Move plot single reflection histograms to own function

Concurrent changes to dev.cxi.merge

New program dev.cxi.merge_refltable that uses a dials reflection table as the underlying data structure for holding reflections during merging.