### PR TITLE
Retire stdlib top level module.

### DIFF
--- a/cctbx/eltbx/distance_based_connectivity.py
+++ b/cctbx/eltbx/distance_based_connectivity.py
@@ -1,5 +1,5 @@
-from __future__ import division
-from stdlib import math as smath
+from __future__ import absolute_import, division, print_function
+import math
 
 expected_bond_lengths_by_element_pair = {
   # based on elbow/chemistry/BondLengths.py rev. 42
@@ -61,7 +61,7 @@ def build_edge_list(sites_cart, elements,slop=0.2):
       x2 = x2-x1
       y2 = y2-y1
       z2 = z2-z1
-      dd = smath.sqrt( x2*x2+y2*y2+z2*z2 )
+      dd = math.sqrt( x2*x2+y2*y2+z2*z2 )
       expected_dist =  expected_bond_lengths_by_element_pair.get(
         (elements[ii], elements[jj]), False )
       if not expected_dist:

--- a/libtbx/forward_compatibility.py
+++ b/libtbx/forward_compatibility.py
@@ -1,36 +1,11 @@
-from __future__ import division
-from __future__ import generators
+from __future__ import absolute_import, division
 import sys, os
-
-def stdlib_import(name):
-  "Work around undesired behavior of Python's relative import feature."
-  try:
-    return sys.modules[name]
-  except KeyError:
-    pass
-  import imp
-  if (imp.is_builtin(name)):
-    try: return imp.init_builtin(name)
-    except Exception: pass
-  sys_path = sys.path[:]
-  sys_path.reverse()
-  for path in sys_path:
-    try:
-      fp, pathname, description = imp.find_module(name, [path])
-    except ImportError:
-      pass
-    else:
-      try:
-        return imp.load_module(name, fp, pathname, description)
-      finally:
-        if (fp is not None): fp.close()
-  raise RuntimeError("Cannot import %s module." % name)
 
 vers_info = sys.version_info[:2]
 
 if (vers_info < (2,6)):
   import cmath
-  math = stdlib_import("math")
+  import math
   cmath.phase = lambda z: math.atan2(z.imag, z.real)
   cmath.polar = lambda z: (abs(z), cmath.phase(z))
   cmath.rect = lambda r, phi: (r*math.cos(phi), r*math.sin(phi))

--- a/scitbx/differential_evolution.py
+++ b/scitbx/differential_evolution.py
@@ -1,6 +1,6 @@
-from __future__ import division
+from __future__ import absolute_import, division
 from scitbx.array_family import flex
-from stdlib import random
+from scitbx.stdlib import random
 class differential_evolution_optimizer(object):
   """
 This is a python implementation of differential evolution

--- a/scitbx/direct_search_simulated_annealing.py
+++ b/scitbx/direct_search_simulated_annealing.py
@@ -1,9 +1,8 @@
-from __future__ import division
+from __future__ import absolute_import, division
 from scitbx.array_family import flex
-from stdlib import math
+from scitbx.stdlib import math, random
 from libtbx.utils import Sorry
 from copy import deepcopy
-from stdlib import random
 from scitbx import simplex
 
 class dssa(object):

--- a/scitbx/math/spe.py
+++ b/scitbx/math/spe.py
@@ -1,6 +1,6 @@
-from __future__ import division
+from __future__ import absolute_import, division
 from scitbx.array_family import flex
-from stdlib import math as smath
+from scitbx.stdlib import math
 
 """
 This is a python implementation of the
@@ -54,7 +54,7 @@ class classic_spe_engine(object):
         td = jj_info[1]
         xi = x[ii]
         xj = x[jj]
-        cd = smath.sqrt( flex.sum( (xi-xj)*(xi-xj) ) )
+        cd = math.sqrt( flex.sum( (xi-xj)*(xi-xj) ) )
         new_xi = xi + l*0.5*(td-cd)/(cd+self.eps)*(xi-xj)
         new_xj = xj + l*0.5*(td-cd)/(cd+self.eps)*(xj-xi)
         strain += abs(cd-td)
@@ -69,9 +69,9 @@ def tst():
   xy = []
   for ii in range(M):
     r=10.0
-    phi = ii*(smath.pi*2/M)
-    x = r*smath.cos(phi)
-    y = r*smath.sin(phi)
+    phi = ii*(math.pi*2/M)
+    x = r*math.cos(phi)
+    y = r*math.sin(phi)
     xy.append( flex.double([x,y]) )
   # build distance matrix
   dmat = []
@@ -85,7 +85,7 @@ def tst():
       y1=xy[ii][1]
       y2=xy[jj][1]
 
-      dd = smath.sqrt( (x1-x2)**2.0 +(y1-y2)**2.0  )
+      dd = math.sqrt( (x1-x2)**2.0 +(y1-y2)**2.0  )
       if jj != ii:
           tmp.append( (jj,dd) )
     dmat.append( tmp )

--- a/scitbx/math/superpose.py
+++ b/scitbx/math/superpose.py
@@ -1,10 +1,9 @@
-from __future__ import division
+from __future__ import absolute_import, division
 from scitbx.linalg import eigensystem
 from scitbx.math import superpose_kearsley_rotation
 from scitbx import matrix
-from stdlib import math
+from scitbx.stdlib import math, random
 from scitbx.array_family import flex
-from stdlib import math as smath
 from scitbx import differential_evolution as de
 from scitbx.math import euler_angles as euler
 
@@ -161,7 +160,7 @@ class nsd_engine(object):
       tot_rho_fm+=dd
     tot_rho_fm = tot_rho_fm / (self.fixed.size()*self.d_fixed )
     tot_rho_mf = tot_rho_mf / (moving.size()*self.d_moving )
-    result = smath.sqrt((tot_rho_fm+tot_rho_mf)/2.0)
+    result = math.sqrt((tot_rho_fm+tot_rho_mf)/2.0)
     return result
 
 
@@ -172,8 +171,8 @@ class nsd_rigid_body_fitter(object):
 
     self.nsde = nsd_engine(self.fixed)
 
-    self.d_fixed  = smath.sqrt(self.nsde.d_fixed)
-    self.d_moving = smath.sqrt(self.nsde.get_mean_distance( self.moving ) )
+    self.d_fixed  = math.sqrt(self.nsde.d_fixed)
+    self.d_moving = math.sqrt(self.nsde.get_mean_distance( self.moving ) )
 
     self.m_com = self.moving.mean()
     self.f_com = self.fixed.mean()
@@ -182,7 +181,7 @@ class nsd_rigid_body_fitter(object):
     self.d = (self.d_fixed+self.d_moving)/12
 
     self.n = 6
-    pi = smath.pi
+    pi = math.pi
     self.domain = [ (-pi,pi),(-pi,pi), (-pi,pi), (-self.d,self.d),(-self.d,self.d), (-self.d,self.d) ]
     self.x = None
     self.optimizer = de.differential_evolution_optimizer(self, population_size=12,f=0.85,cr=0.95, n_cross=2,eps=1e-2,
@@ -244,7 +243,6 @@ def tst_nsd():
 
 
 if __name__ == "__main__":
-  from stdlib import random
   random.seed(0)
   flex.set_random_seed(0)
   for ii in range(10):

--- a/scitbx/math/tests/tst_bessel.py
+++ b/scitbx/math/tests/tst_bessel.py
@@ -1,32 +1,32 @@
-from __future__ import division
-from scitbx import math
-from stdlib import math as smath
+from __future__ import absolute_import, division
+import scitbx.math
+from scitbx.stdlib import math
 from scitbx.array_family import flex
 from libtbx.test_utils import approx_equal
 import sys
 
 def exercise_interfaces():
-  assert approx_equal(math.spherical_bessel(1, 2), 0.43539777498)
-  assert approx_equal(math.spherical_bessel_array(1, flex.double([2])),
+  assert approx_equal(scitbx.math.spherical_bessel(1, 2), 0.43539777498)
+  assert approx_equal(scitbx.math.spherical_bessel_array(1, flex.double([2])),
     [0.43539777498])
 
 def j0(x):
-  result = smath.sin(x)/x
+  result = math.sin(x)/x
   return result
 
 def j1(x):
-  result =  smath.sin(x)/(x*x) - smath.cos(x)/x
+  result =  math.sin(x)/(x*x) - math.cos(x)/x
   return result
 
 def j2(x):
-  result = (3.0/(x*x) -1.0)*(smath.sin(x)/x) - 3.0*smath.cos(x)/(x*x)
+  result = (3.0/(x*x) -1.0)*(math.sin(x)/x) - 3.0*math.cos(x)/(x*x)
   return result
 
 def exercise_results():
   x = flex.double( range(1,100) )/99.0
-  f0 = math.spherical_bessel_array(0,x)
-  f1 = math.spherical_bessel_array(1,x)
-  f2 = math.spherical_bessel_array(2,x)
+  f0 = scitbx.math.spherical_bessel_array(0,x)
+  f1 = scitbx.math.spherical_bessel_array(1,x)
+  f2 = scitbx.math.spherical_bessel_array(2,x)
   for xx, ff,fff,ffff in zip(x,f0,f1,f2):
     assert abs(ff-j0(xx))/ff < 1e-5
     assert abs(fff-j1(xx))/fff < 1e-5
@@ -34,7 +34,7 @@ def exercise_results():
 
 def tst_sph_bessel_j1():
   x = flex.double( range(1,200) )/199.0+7.5
-  f1 = math.spherical_bessel_array(1,x)
+  f1 = scitbx.math.spherical_bessel_array(1,x)
   for xx,ff in zip(x,f1):
     assert abs( ff-j1(xx) )/abs(ff) < 1e-5
     #print xx, ff, j1(xx), abs( ff-j1(xx) )/abs(ff)
@@ -43,15 +43,15 @@ def tst_sph_bessel_j1():
 def tst_bessel_J():
   x1 = 5.00000000e-02
   f1 = [9.99375098e-01, 2.49921883e-02, 3.12434901e-04]
-  g1 = [ math.bessel_J(0,x1), math.bessel_J(1,x1), math.bessel_J(2,x1)]
+  g1 = [ scitbx.math.bessel_J(0,x1), scitbx.math.bessel_J(1,x1), scitbx.math.bessel_J(2,x1)]
 
   x2 = 5.00000000e-01
   f2 = [9.38469807e-01, 2.42268458e-01, 3.06040235e-02]
-  g2 = [ math.bessel_J(0,x2), math.bessel_J(1,x2), math.bessel_J(2,x2) ]
+  g2 = [ scitbx.math.bessel_J(0,x2), scitbx.math.bessel_J(1,x2), scitbx.math.bessel_J(2,x2) ]
 
   x3 = 5.00000000e+00
   f3 = [-1.77596771e-01, -3.27579138e-01, 4.65651163e-02]
-  g3 = [ math.bessel_J(0,x3), math.bessel_J(1,x3), math.bessel_J(2,x3) ]
+  g3 = [ scitbx.math.bessel_J(0,x3), scitbx.math.bessel_J(1,x3), scitbx.math.bessel_J(2,x3) ]
 
   for a,b in zip(f1,g1):
     assert (a-b)/abs(a)< 1e-5
@@ -63,7 +63,7 @@ def tst_bessel_J():
 
 
 def exercise():
-  if (not hasattr(math, "spherical_bessel")):
+  if (not hasattr(scitbx.math, "spherical_bessel")):
     print "Skipping tst_bessel.py: functions not available."
     return
   exercise_interfaces()

--- a/scitbx/math/tests/tst_dmatrix.py
+++ b/scitbx/math/tests/tst_dmatrix.py
@@ -1,6 +1,6 @@
-from __future__ import division
+from __future__ import absolute_import, division
 from scitbx.math import dmatrix
-from stdlib import math as smath
+from scitbx.stdlib import math
 
 def tst_dmatrix():
   # expected values are the d_jmn at beta=1.0 and j=2, m=-2, -2<=n<=2
@@ -20,13 +20,13 @@ def tst_dmatrix():
 
   # check agains d(2,2,1) = -(1+cos(beta))*sin(beta)/2.0
   for ii in range(10):
-    expt = -(1.0+smath.cos(ii))*smath.sin(ii)/2.0
+    expt = -(1.0+math.cos(ii))*math.sin(ii)/2.0
     assert abs( dmatrix(2,ii).djmn(2,2,1) - expt ) < eps
   # check beta= multiple of pi/2
 
-  assert abs( dmatrix( 20, smath.pi ).djmn(2,2,0) )< eps
-  assert abs( dmatrix( 2, smath.pi*2 ).djmn(2,2,0) )< eps
-  assert abs( dmatrix( 20, smath.pi*0.5 ).djmn(2,2,0)-smath.sqrt(6.0)/4.0 )< eps
+  assert abs( dmatrix( 20, math.pi ).djmn(2,2,0) )< eps
+  assert abs( dmatrix( 2, math.pi*2 ).djmn(2,2,0) )< eps
+  assert abs( dmatrix( 20, math.pi*0.5 ).djmn(2,2,0)-math.sqrt(6.0)/4.0 )< eps
 
 
 if __name__ == "__main__":

--- a/scitbx/math/tst_2d_zernike.py
+++ b/scitbx/math/tst_2d_zernike.py
@@ -1,11 +1,11 @@
-from __future__ import division
-from scitbx import math
+from __future__ import absolute_import, division
+import scitbx.math
 from scitbx import differential_evolution as de
 from scitbx import simplex
 from scitbx import lbfgs
 from scitbx import direct_search_simulated_annealing as dssa
 from scitbx.array_family import flex
-from stdlib import math as smath
+from scitbx.stdlib import math
 import time, sys
 from fractions import Fraction
 
@@ -24,10 +24,10 @@ def read_data(filename):
 
 def generate_image(n,l, N=100):
   nmax = max(20,n)
-  lfg =  math.log_factorial_generator(nmax)
-  #rzfa = math.zernike_2d_radial(n,l,lfg)
-  #rap = math.zernike_2d_polynome(n,l,rzfa)
-  rap = math.zernike_2d_polynome(n,l)#,rzfa)
+  lfg =  scitbx.math.log_factorial_generator(nmax)
+  #rzfa = scitbx.math.zernike_2d_radial(n,l,lfg)
+  #rap = scitbx.math.zernike_2d_polynome(n,l,rzfa)
+  rap = scitbx.math.zernike_2d_polynome(n,l)#,rzfa)
 
   image = flex.vec3_double()
 
@@ -35,11 +35,11 @@ def generate_image(n,l, N=100):
   count = 0
   for x in range(-N, N+1):
     for y in range(-N, N+1):
-      rr = smath.sqrt(x*x+y*y)/N
+      rr = math.sqrt(x*x+y*y)/N
       if rr>1.0:
         value=0.0
       else:
-        tt = smath.atan2(y,x)
+        tt = math.atan2(y,x)
         value = rap.f(rr,tt)
         value = value.real
         count = count + 1
@@ -57,14 +57,14 @@ def tst_2d_zernike_mom(n,l, N=100, filename=None):
   else:
     image=generate_image(n,l)
 
-  NP=int(smath.sqrt( image.size() ))
+  NP=int(math.sqrt( image.size() ))
   N=NP/2
-  grid_2d = math.two_d_grid(N, nmax)
+  grid_2d = scitbx.math.two_d_grid(N, nmax)
   grid_2d.clean_space( image )
   grid_2d.construct_space_sum()
   tt2=time.time()
   print "time used: ", tt2-tt1
-  zernike_2d_mom = math.two_d_zernike_moments( grid_2d, nmax )
+  zernike_2d_mom = scitbx.math.two_d_zernike_moments( grid_2d, nmax )
 
   moments = zernike_2d_mom.moments()
 
@@ -72,10 +72,10 @@ def tst_2d_zernike_mom(n,l, N=100, filename=None):
   print "time used: ", tt2-tt1
 
   coefs = flex.real( moments )
-  nl_array = math.nl_array( nmax )
+  nl_array = scitbx.math.nl_array( nmax )
   nls = nl_array.nl()
   nl_array.load_coefs( nls, coefs )
-  lfg =  math.log_factorial_generator(nmax)
+  lfg =  scitbx.math.log_factorial_generator(nmax)
 
   print nl_array.get_coef(n,l)*2
 
@@ -91,18 +91,18 @@ def tst_2d_zernike_mom(n,l, N=100, filename=None):
     l=nl[1]
     if(l>0):
       c=c*2
-    #rzfa = math.zernike_2d_radial(n,l,lfg)
-    rap = math.zernike_2d_polynome(n,l) #,rzfa)
+    #rzfa = scitbx.math.zernike_2d_radial(n,l,lfg)
+    rap = scitbx.math.zernike_2d_polynome(n,l) #,rzfa)
     i=0
     for x in range(0,NP):
       x=x-N
       for y in range(0,NP):
         y=y-N
-        rr = smath.sqrt(x*x+y*y)/N
+        rr = math.sqrt(x*x+y*y)/N
         if rr>1.0:
           value=0.0
         else:
-          tt = smath.atan2(y,x)
+          tt = math.atan2(y,x)
           value = rap.f(rr,tt)
         reconst[i]=reconst[i]+value*c
         i=i+1
@@ -123,14 +123,14 @@ def tst_2d_poly(n,l):
   nmax=max(n,20)
   np=50
   x,y=0.1,0.9
-  r,t=smath.sqrt(x*x+y*y),smath.atan2(y,x)
-  lfg =  math.log_factorial_generator(nmax)
-  #rzfa = math.zernike_2d_radial(n,l,lfg)
-  #rap = math.zernike_2d_polynome(n,l,rzfa)
-  rap = math.zernike_2d_polynome(n,l)#,rzfa)
+  r,t=math.sqrt(x*x+y*y),math.atan2(y,x)
+  lfg =  scitbx.math.log_factorial_generator(nmax)
+  #rzfa = scitbx.math.zernike_2d_radial(n,l,lfg)
+  #rap = scitbx.math.zernike_2d_polynome(n,l,rzfa)
+  rap = scitbx.math.zernike_2d_polynome(n,l)#,rzfa)
   rt_value=rap.f(r,t)
-  grid = math.two_d_grid(np, nmax)
-  zm2d = math.two_d_zernike_moments(grid, nmax)
+  grid = scitbx.math.two_d_grid(np, nmax)
+  zm2d = scitbx.math.two_d_zernike_moments(grid, nmax)
   xy_value=zm2d.zernike_poly(n,l,x,y)
 
   print rt_value, xy_value, abs(rt_value), abs(xy_value)
@@ -139,15 +139,15 @@ def tst_2d_zm(n,l):
   nmax=max(n,20)
   np=100
   points=flex.double(range(-np,np+1))/np
-  grid = math.two_d_grid(np, nmax)
-  zm2d = math.two_d_zernike_moments(grid, nmax)
+  grid = scitbx.math.two_d_grid(np, nmax)
+  zm2d = scitbx.math.two_d_zernike_moments(grid, nmax)
   image = flex.vec3_double()
 
   output=file('testmap.dat','w')
 
   for x in points:
     for y in points:
-      r=smath.sqrt(x*x+y*y)
+      r=math.sqrt(x*x+y*y)
       if(r>1.0):
         value=0.0
       else:
@@ -156,12 +156,12 @@ def tst_2d_zm(n,l):
 
   grid.clean_space( image )
   grid.construct_space_sum()
-  zernike_2d_mom = math.two_d_zernike_moments( grid, nmax )
+  zernike_2d_mom = scitbx.math.two_d_zernike_moments( grid, nmax )
 
   moments = zernike_2d_mom.moments()
 
   coefs = flex.real( moments )
-  nl_array = math.nl_array( nmax )
+  nl_array = scitbx.math.nl_array( nmax )
   nls = nl_array.nl()
 
   for nl, c in zip( nls, moments):
@@ -203,7 +203,7 @@ class Bnmk (object):
   "Bnmk coefficient object hold 2d zernike expansion coefs"
   def __init__(self, nmax):
     self.nmax=nmax
-    self.Bnmk=math.nmk_array(nmax)
+    self.Bnmk=scitbx.math.nmk_array(nmax)
     self.initialize_bnmk()
 
   def initialize_bnmk(self):
@@ -232,7 +232,7 @@ def tst_integral_triple_zernike2d(nmax):
   coef_table = []
 
   for m in range(nmax+1):
-    C_m_3n = math.nmk_array(nmax)
+    C_m_3n = scitbx.math.nmk_array(nmax)
     for n1 in range(m,nmax+1,2):
       for n2 in range(m,n1+1,2):
         for n3 in range(m,n2+1,2):
@@ -257,7 +257,7 @@ def calc_Cnm_4m_from_Inm(m, nmax, Inm, coef_table_m):
 
 
 def calc_Cnm_from_Inm( Inm, coef_table, nmax ):
-  Cnm=math.nl_array(nmax)
+  Cnm=scitbx.math.nl_array(nmax)
   for n in range( 0,nmax+1,2 ): # only even number (n,m)
     for m in range(0,n+1,2 ):
       temp = 0
@@ -273,7 +273,7 @@ def calc_Cnm_from_Inm( Inm, coef_table, nmax ):
 
 
 def comp_Cnm_calculations(nmax):
-  Inm=math.nl_array(nmax)
+  Inm=scitbx.math.nl_array(nmax)
   nls = Inm.nl()
   size = nls.size()
   coefs = flex.random_double(size)
@@ -297,7 +297,7 @@ def comp_Cnm_calculations(nmax):
 
 
 def tst_solving_Inm(nmax):
-  Inm=math.nl_array(nmax)
+  Inm=scitbx.math.nl_array(nmax)
   nls = Inm.nl()
   size = nls.size()
   coefs = flex.random_double(size)
@@ -306,13 +306,13 @@ def tst_solving_Inm(nmax):
   coef_table = tst_integral_triple_zernike2d(nmax)
   Cnm = calc_Cnm_from_Inm( Inm, coef_table, nmax )
 
-  new_Inm=math.nl_array(nmax)
+  new_Inm=scitbx.math.nl_array(nmax)
 
   for n in range( nmax+1 ):
     for m in range(n,-1,-2):
       Cnm_value = Cnm.get_coef( n, m )
       coef = coef_table[m].get_coef(n,n,n).real
-#      value = smath.sqrt( Cnm_value/coef )
+#      value = math.sqrt( Cnm_value/coef )
       if(coef != 0):
         value = ( Cnm_value/coef )
         print n,m,Inm.get_coef(n,m)**2, value
@@ -323,7 +323,7 @@ class inm_refine(object):
     self.nmax=nmax
     self.Cnm = Cnm
     self.coef_table = coef_table
-    self.Inm = math.nl_array(nmax)
+    self.Inm = scitbx.math.nl_array(nmax)
 
     self.m=m ## testing the most populated cases
     self.coef_table_m = self.coef_table[self.m]
@@ -430,7 +430,7 @@ class inm_refine(object):
     return Cnm
 
 def test_solving(nmax, m):
-  Inm=math.nl_array(nmax)
+  Inm=scitbx.math.nl_array(nmax)
   nls = Inm.nl()
   size = nls.size()
   coefs = flex.random_double(size)

--- a/scitbx/math/zernike_align_fft.py
+++ b/scitbx/math/zernike_align_fft.py
@@ -1,14 +1,14 @@
-from __future__ import division
+from __future__ import absolute_import, division
 from scitbx.array_family import flex
 from scitbx.math import correlation
-from stdlib import math as smath
+from scitbx.stdlib import math
 from scitbx import fftpack, simplex
 
 def get_mean_sigma( nlm_array ):
   coef = nlm_array.coefs()
   mean = abs( coef[0] )
   var = flex.sum( flex.norm(coef) )
-  sigma = smath.sqrt( var-mean*mean )
+  sigma = math.sqrt( var-mean*mean )
   return mean, sigma
 
 
@@ -17,11 +17,11 @@ class align(object):
     self.nmax = nmax
     self.fixed = fixed
     self.moving = moving
-    self.beta = smath.pi*2.0/float(n_beta-1)*flex.double( range(n_beta) )
+    self.beta = math.pi*2.0/float(n_beta-1)*flex.double( range(n_beta) )
     self.nb = n_beta
     self.pad = max(0, (ngrid-1)//2 - nmax )
     self.ngrid = (self.pad+nmax) * 2 + 1
-    self.dx = smath.pi*2.0/(self.ngrid*10)
+    self.dx = math.pi*2.0/(self.ngrid*10)
     self.topn = topn
     self.refine = refine
     self.check_inversion = check_inversion
@@ -59,7 +59,7 @@ class align(object):
       scores = fft.backward( fft_input ).as_1d()
       self.scores = self.scores.concatenate( -flex.norm( scores )  )
     self.best_indx = flex.min_index( self.scores )
-    self.best_score = smath.sqrt( -self.scores[ self.best_indx ])
+    self.best_score = math.sqrt( -self.scores[ self.best_indx ])
 
 
     if self.check_inversion:
@@ -75,7 +75,7 @@ class align(object):
         scores = fft.backward( fft_input ).as_1d()
         inversion_scores = inversion_scores.concatenate( -flex.norm( scores )  )
       inv_best_indx = flex.min_index( inversion_scores )
-      inv_best_score = smath.sqrt(-inversion_scores[ inv_best_indx ] )
+      inv_best_score = math.sqrt(-inversion_scores[ inv_best_indx ] )
 
       if( inv_best_score < self.best_score ):
         self.score = inversion_scores
@@ -92,8 +92,8 @@ class align(object):
     g=self.best_indx - self.ngrid*self.ngrid*b - self.ngrid*a
 
     b = self.beta[b]
-    g = smath.pi*2.0 *( float(g)/(self.ngrid-1) )
-    a = smath.pi*2.0 *( float(a)/(self.ngrid-1) )
+    g = math.pi*2.0 *( float(g)/(self.ngrid-1) )
+    a = math.pi*2.0 *( float(a)/(self.ngrid-1) )
 
     self.best_ea = (a, b, g )
 
@@ -132,8 +132,8 @@ class align(object):
       g=o - self.ngrid*self.ngrid*b - self.ngrid*a
 
       b = self.beta[b]
-      g = smath.pi*2.0 *( float(g)/(self.ngrid-1) )
-      a = smath.pi*2.0 *( float(a)/(self.ngrid-1) )
+      g = math.pi*2.0 *( float(g)/(self.ngrid-1) )
+      a = math.pi*2.0 *( float(a)/(self.ngrid-1) )
       self.top_align.append( flex.double( (a, b, g) ) )
       self.top_scores.append( self.scores[o] )
       #print ii, ":", a, b, g, ":", self.scores[o]

--- a/scitbx/regular_grid_on_unit_sphere.py
+++ b/scitbx/regular_grid_on_unit_sphere.py
@@ -1,6 +1,6 @@
-from __future__ import division
+from __future__ import absolute_import, division
 from scitbx.array_family import flex
-from stdlib import math
+from scitbx.stdlib import math
 
 def rosca(m=9, hemisphere=True):
   """

--- a/scitbx/restraints.py
+++ b/scitbx/restraints.py
@@ -3,8 +3,8 @@
 Handling for normalized target and gradients.
 """
 
-from __future__ import division
-from stdlib import math
+from __future__ import absolute_import, division
+from scitbx.stdlib import math
 from libtbx.utils import Sorry
 
 class energies(object):

--- a/scitbx/stdlib.py
+++ b/scitbx/stdlib.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import absolute_import, division, print_function
 from libtbx.forward_compatibility import stdlib_import
 
 math = stdlib_import("math")

--- a/scitbx/tst_smoothing.py
+++ b/scitbx/tst_smoothing.py
@@ -1,13 +1,10 @@
-from __future__ import division
-from stdlib import math
-from stdlib import random
-
+from __future__ import absolute_import, division
+from scitbx.stdlib import math, random
 from libtbx.utils import frange
 from libtbx.test_utils import approx_equal, is_below_limit
 from scitbx.array_family import flex
-import scitbx.math
+import scitbx.math.curve_fitting
 import scitbx.random
-from scitbx.math import curve_fitting
 from scitbx.smoothing import savitzky_golay_filter, savitzky_golay_coefficients
 from scitbx.smoothing import convolve
 
@@ -72,7 +69,7 @@ def exercise_savitzky_golay_smoothing():
     mean = random.randint(-5,5)
     scale = flex.random_double() * 10
     sigma = flex.random_double() * 5 + 1
-    gaussian = curve_fitting.gaussian(scale, mean, sigma)
+    gaussian = scitbx.math.curve_fitting.gaussian(scale, mean, sigma)
 
     x = flex.double(frange(-20,20,0.1))
     y = gaussian(x)


### PR DESCRIPTION
Before this can be merged the following files need to be refactored:
* [x] phenix/refinement/weight_xray_chem.py
* [x] phenix/ligands/invariant_generator.py

**I'll merge this myself but want to leave it until after the Phenix release is done.**

This was used as a workaround in scitbx because scitbx is shadowing two system library modules (math, random), but relies on being able to import the system libraries as well.
Scitbx could be refactored to remove this stdlib hack entirely, but here I've opted to move the stdlib hack from libtbx/pythonpath into scitbx. This frees up another item from libtbx/pythonpath.

Code was refactored to make explicit whether it refers to python math vs scitbx.math.