### PR TITLE
Retire pythonpath.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1708,8 +1708,6 @@ libtbx/program_utils/result.py -text
 libtbx/program_utils/statistics_info.py -text
 libtbx/progress.py -text
 libtbx/pyplot.py svneol=native#text/x-python
-libtbx/pythonpath/__init__.py -text
-libtbx/pythonpath/deep_thought.py svneol=native#text/x-python
 libtbx/queuing_system_utils/__init__.py svneol=native#text/x-python
 libtbx/queuing_system_utils/communication.py -text
 libtbx/queuing_system_utils/generic.py -text

--- a/dox.sphinx/conf.py
+++ b/dox.sphinx/conf.py
@@ -21,7 +21,6 @@ import sys, os, re
 #sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('./../bin'))
 sys.path.insert(0, os.path.abspath('./../lib'))
-sys.path.insert(0, os.path.abspath('./../../sources/cctbx_project/libtbx/pythonpath'))
 sys.path.insert(0, os.path.abspath('./../../sources/cctbx_project/boost_adaptbx'))
 sys.path.insert(0, os.path.abspath('./../../sources/cctbx_project/clipper_adaptbx'))
 sys.path.insert(0, os.path.abspath('./../../sources'))

--- a/libtbx/command_line/import_all_python.py
+++ b/libtbx/command_line/import_all_python.py
@@ -14,8 +14,6 @@ ignore_modules = set([
   "libtbx.start_print_trace",   # produces lots of output
   "libtbx.command_line.epydoc_run",
   "libtbx.command_line.ipython_shell_start",
-  "libtbx.pythonpath.deep_thought",
-  "libtbx.pythonpath.stdlib",
   "mmtbx.pdb_distances",        # too much executed code
   "gltbx.wx_viewer_leapmotion", # crashes if Leap installed
   # non-CCTBX modules

--- a/libtbx/configure.py
+++ b/libtbx/configure.py
@@ -1,23 +1,20 @@
-from __future__ import division
+from __future__ import absolute_import, division, print_function
 import sys, os
 
 def run():
-  if (not hasattr(sys, "version_info")
-      or sys.version_info[0] < 2
-      or (sys.version_info[0] == 2 and sys.version_info[1] < 3)):
-    print
-    print "*" * 78
-    print "FATAL: Python 2.3 or higher is required."
-    print "Version currently in use:", sys.version
-    print "*" * 78
+  if sys.hexversion < 0x02070000:
+    print()
+    print("*" * 78)
+    print("FATAL: Python 2.7 or higher is required.")
+    print("Version currently in use:", sys.version)
+    print("*" * 78)
     return False
-  sys.path.insert(1, os.path.join(sys.path[0], "pythonpath"))
   sys.path[0] = os.path.dirname(sys.path[0])
   import libtbx.env_config
   libtbx.env_config.cold_start(sys.argv)
-  print "Done."
+  print("Done.")
   return True
 
-if (__name__ == "__main__"):
+if __name__ == "__main__":
   if not run():
     sys.exit(1)

--- a/libtbx/pythonpath/deep_thought.py
+++ b/libtbx/pythonpath/deep_thought.py
@@ -1,6 +1,0 @@
-from __future__ import division
-s = set()
-for i in range(1,11):
-  for j in range(1,11):
-    s.add(i*j)
-print len(s)


### PR DESCRIPTION
We hardly knew ye.

Depends on #113. I'll merge this myself but want to leave it until after the Phenix release is done.

Removal of pythonpath should speed up initialization because there are now fewer places to look for imports. Plus nothing remains in there that is in some way required. Plus (nowadays) there should not be a need for such a feature in the first place.