### PR TITLE
Do not compress MacOS .pkg installers

### DIFF
--- a/libtbx/auto_build/create_mac_pkg.py
+++ b/libtbx/auto_build/create_mac_pkg.py
@@ -6,7 +6,7 @@ Phenix (or any other derived software).
 
 from __future__ import division
 from installer_utils import *
-from optparse import OptionParser
+from optparse import SUPPRESS_HELP, OptionParser
 import os.path as op
 import shutil
 import time
@@ -45,7 +45,8 @@ def run (args, out=sys.stdout) :
   parser.add_option("--overwrite", dest="overwrite", action="store_true",
     help="Overwrite temporary files")
   parser.add_option("--no_compression", dest="no_compression",
-    action="store_true", help="Skip final compression step")
+    action="store_true", help=SUPPRESS_HELP) # legacy parameter
+    # .pkg files are already compressed. Double-compressing is pointless.
   options, args = parser.parse_args(args)
   arch_type = os.uname()[-1]
   system_type = "64-bit Intel Macs"
@@ -205,13 +206,6 @@ our website).""" % { "package" : options.package_name,
   print >> out, "Calling productbuild:", product_args
   call(product_args, out)
   assert op.exists(pkg_name)
-  if (not options.no_compression) :
-    print >> out, "  compressing installer. . ."
-    zip_args = [ "ditto", "-c", "-k", "-rsrc", pkg_name, pkg_name + ".zip" ]
-    call(zip_args, out)
-    assert op.isfile(pkg_name + ".zip")
-    # Remove uncompressed .pkg.
-    os.unlink(pkg_name)
   return True
 
 if (__name__ == "__main__") :


### PR DESCRIPTION
WIll merge this myself after phenix release.

No space to be saved by compressing .pkg installers, but user now has to decompress before installation.
We in fact always unzip the file again before we upload the installer for a release, because the --no-compression flag can't be used via create_installer.py. Avoiding the compression in the first place would save some time.