### PR TITLE
retire unused helper functions numstr7 and real_imag

### DIFF
--- a/libtbx/__init__.py
+++ b/libtbx/__init__.py
@@ -31,13 +31,6 @@ def _numstr(
   return brackets[0] + sep.join(flds) + brackets[1]
 __builtins__["numstr"] = _numstr
 
-def _numstr7(values): return numstr(values=values, fmt="%.7g")
-__builtins__["numstr7"] = _numstr7
-
-def _real_imag(complex_number):
-  return (complex_number.real, complex_number.imag)
-__builtins__["real_imag"] = _real_imag
-
 class AutoType(object):
   """
   Class for creating the Auto instance, which mimics the behavior of None

--- a/libtbx/tst_utils.py
+++ b/libtbx/tst_utils.py
@@ -56,8 +56,6 @@ def exercise_misc():
   #
   s = "[0.143139, -0.125121, None, -0.308607]"
   assert numstr(values=eval(s)) == s
-  s = "[0.1431391, -0.1251212, None, -0.3086073]"
-  assert numstr7(values=eval(s)) == s
   #
   for s,i in {"2000000" : 2000000,
               "2k" : 2048,


### PR DESCRIPTION
keeping the global namespace clean

Will merge this myself after phenix release.