### PR TITLE
Virtualenv issues

### DIFF
--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -1559,8 +1559,8 @@ selfx:
     else:
       # fallback in case of virtualenv
       # https://github.com/pypa/virtualenv/issues/355
-      pythonpath = [self.as_relocatable_path(
-        op.join(sys.prefix,'lib',self.python_exe.basename(),'site-packages'))]
+      from distutils.sysconfig import get_python_lib
+      pythonpath = [self.as_relocatable_path(get_python_lib())]
     pythonpath.append(self.lib_path)
     for module in self.module_list:
       pythonpath.extend(module.assemble_pythonpath())


### PR DESCRIPTION
Another solution for b46e27a is to set PYTHONPATH to include python lib for python used to create the virtualenv (__future__.py is not present in virtualenv's lib/python27).
