### PR TITLE
Fix MosaicCrystal(Sauter2014|Kabsch2010) warning messages

### DIFF
--- a/dxtbx/model/boost_python/crystal.cc
+++ b/dxtbx/model/boost_python/crystal.cc
@@ -352,6 +352,16 @@ namespace dxtbx { namespace model { namespace boost_python {
             arg("space_group_symbol"))))
       .def_pickle(CrystalPickleSuite());
 
+    // Create member-function pointers to specific is_simiar_to overloads
+    // - each of these crystals has a custom implementation along with the
+    //   inherited interface, and we want to expose these explicitly
+    bool (MosaicCrystalKabsch2010::*kabsch_is_similar_to)(
+        const CrystalBase &, double, double, double, double) const =
+        &MosaicCrystalKabsch2010::is_similar_to;
+    bool (MosaicCrystalSauter2014::*sauter_is_similar_to)(
+        const CrystalBase &, double, double, double, double, double) const =
+        &MosaicCrystalSauter2014::is_similar_to;
+
     class_ <MosaicCrystalKabsch2010, bases <Crystal> > ("MosaicCrystalKabsch2010", no_init)
       .def(init<const MosaicCrystalKabsch2010&>())
       .def(init<const Crystal&>())
@@ -371,7 +381,7 @@ namespace dxtbx { namespace model { namespace boost_python {
             arg("real_space_b"),
             arg("real_space_c"),
             arg("space_group_symbol"))))
-      .def("is_similar_to", &MosaicCrystalKabsch2010::is_similar_to, (
+      .def("is_similar_to", kabsch_is_similar_to, (
             arg("other"),
             arg("angle_tolerance")=0.01,
             arg("uc_rel_length_tolerance")=0.01,
@@ -403,7 +413,7 @@ namespace dxtbx { namespace model { namespace boost_python {
             arg("real_space_b"),
             arg("real_space_c"),
             arg("space_group_symbol"))))
-      .def("is_similar_to", &MosaicCrystalSauter2014::is_similar_to, (
+      .def("is_similar_to", sauter_is_similar_to, (
             arg("other"),
             arg("angle_tolerance")=0.01,
             arg("uc_rel_length_tolerance")=0.01,

--- a/dxtbx/model/crystal.h
+++ b/dxtbx/model/crystal.h
@@ -1011,10 +1011,10 @@ namespace dxtbx { namespace model {
      */
     bool is_similar_to(
         const CrystalBase &other,
-        double angle_tolerance=0.01,
-        double uc_rel_length_tolerance=0.01,
-        double uc_abs_angle_tolerance=1.0,
-        double mosaicity_tolerance=0.8) const {
+        double angle_tolerance,
+        double uc_rel_length_tolerance,
+        double uc_abs_angle_tolerance,
+        double mosaicity_tolerance) const {
 
       // mosaicity test
       const MosaicCrystalKabsch2010* mosaic_other = dynamic_cast<const MosaicCrystalKabsch2010*>(&other);
@@ -1033,6 +1033,15 @@ namespace dxtbx { namespace model {
       }
 
       return Crystal::is_similar_to(other, angle_tolerance, uc_rel_length_tolerance, uc_abs_angle_tolerance);
+    }
+
+    bool is_similar_to(
+        const CrystalBase &other,
+        double angle_tolerance=0.01,
+        double uc_rel_length_tolerance=0.01,
+        double uc_abs_angle_tolerance=1.0) const /* override */ {
+      // Call with a default mosaicity tolerance
+      return is_similar_to(other, angle_tolerance, uc_rel_length_tolerance, uc_abs_angle_tolerance, 0.8);
     }
 
     /**
@@ -1135,10 +1144,10 @@ namespace dxtbx { namespace model {
      */
     bool is_similar_to(
         const CrystalBase &other,
-        double angle_tolerance=0.01,
-        double uc_rel_length_tolerance=0.01,
-        double uc_abs_angle_tolerance=1.0,
-        double half_mosaicity_tolerance=0.4,
+        double angle_tolerance,
+        double uc_rel_length_tolerance,
+        double uc_abs_angle_tolerance,
+        double half_mosaicity_tolerance,
         double domain_size_tolerance=1.0) const {
 
       // mosaicity test
@@ -1162,6 +1171,17 @@ namespace dxtbx { namespace model {
       }
 
       return Crystal::is_similar_to(other, angle_tolerance, uc_rel_length_tolerance, uc_abs_angle_tolerance);
+    }
+
+    /// Check if models are similar
+    bool is_similar_to(
+        const CrystalBase &other,
+        double angle_tolerance=0.01,
+        double uc_rel_length_tolerance=0.01,
+        double uc_abs_angle_tolerance=1.0) const /* override */ {
+      // Call with a default half-mosaicity tolerance
+      // Use the function-default domain_size_tolerance
+      return is_similar_to(other, angle_tolerance, uc_rel_length_tolerance, uc_abs_angle_tolerance, 0.4);
     }
 
     /**


### PR DESCRIPTION
The `dxtbx::model::Crystal` subclasses `MosaicCrystalKabsch2010` and `MosaicCrystalSauter2014` both defined their [own](https://github.com/cctbx/cctbx_project/blob/99ffd3c3d4483e83c6466b1803775d40ce12baec/dxtbx/model/crystal.h#L1012-L1017), [extended](https://github.com/cctbx/cctbx_project/blob/99ffd3c3d4483e83c6466b1803775d40ce12baec/dxtbx/model/crystal.h#L1136-L1142) function signatures for the virtual [is_similar_to](https://github.com/cctbx/cctbx_project/blob/99ffd3c3d4483e83c6466b1803775d40ce12baec/dxtbx/model/crystal.h#L214-L218). This appears to hide the superclass implementation, breaking polymorphism, and clang indeed emits warnings for this (_"hides overloaded virtual function"_).

This moves the default instantiation to an inheritance override function, to resolve the warning, and passes explicit member-function pointers into the boost::python bindings (required to resolve the overload).

The slightly obscure pointer dance seems to be required to get Boost::Python to choose a specific overload - otherwise the `def` line errors. I don't know another way around this.