### PR TITLE
dxtbx: add batch_offset to scan model (in the manner of MTZ batch number column)

### DIFF
--- a/dxtbx/model/scan.h
+++ b/dxtbx/model/scan.h
@@ -261,6 +261,7 @@ namespace dxtbx { namespace model {
       DXTBX_ASSERT(std::abs(oscillation_[1]) > 0.0);
       DXTBX_ASSERT(image_range_[1] + 1 == rhs.image_range_[0]);
       DXTBX_ASSERT(std::abs(oscillation_[1] - rhs.oscillation_[1]) < eps);
+      DXTBX_ASSERT(batch_offset_ == rhs.batch_offset_);
       // sometimes ticking through 0 the first difference is not helpful
       double diff_2pi = std::abs(mod_2pi(get_oscillation_range()[1]) -
                                  mod_2pi(rhs.get_oscillation_range()[0]));

--- a/dxtbx/model/scan.h
+++ b/dxtbx/model/scan.h
@@ -37,7 +37,8 @@ namespace dxtbx { namespace model {
     Scan() :
       image_range_(0, 0),
       oscillation_(0.0, 0.0),
-      num_images_(0) {}
+      num_images_(0),
+      batch_offset_(0) {}
 
     /**
      * Initialise the class
@@ -47,10 +48,12 @@ namespace dxtbx { namespace model {
      *                          image and the oscillation range of each frame
      */
     Scan(vec2 <int> image_range,
-         vec2 <double> oscillation)
+         vec2 <double> oscillation,
+         int batch_offset=0)
       : image_range_(image_range),
         oscillation_(oscillation),
         num_images_(1 + image_range_[1] - image_range_[0]),
+        batch_offset_(batch_offset),
         exposure_times_(num_images_, 0.0),
         epochs_(num_images_, 0.0) {
       DXTBX_ASSERT(num_images_ >= 0);
@@ -59,16 +62,19 @@ namespace dxtbx { namespace model {
     /**
      * Initialise the class
      * @param image_range The range of images covered by the scan
+     * @param batch_offset The batch offset for the scan
      * @param starting_angle The starting rotation angle
      * @param oscillation_range The oscillation range of each frame
      */
     Scan(vec2 <int> image_range,
          vec2 <double> oscillation,
          const scitbx::af::shared<double> &exposure_times,
-         const scitbx::af::shared<double> &epochs)
+         const scitbx::af::shared<double> &epochs,
+         int batch_offset=0)
       : image_range_(image_range),
         oscillation_(oscillation),
         num_images_(1 + image_range_[1] - image_range_[0]),
+        batch_offset_(batch_offset),
         exposure_times_(exposure_times),
         epochs_(epochs) {
       DXTBX_ASSERT(num_images_ >= 0);
@@ -91,6 +97,7 @@ namespace dxtbx { namespace model {
       : image_range_(rhs.image_range_),
         oscillation_(rhs.oscillation_),
         num_images_(rhs.num_images_),
+        batch_offset_(rhs.batch_offset_),
         exposure_times_(scitbx::af::reserve(rhs.exposure_times_.size())),
         epochs_(scitbx::af::reserve(rhs.epochs_.size())) {
       std::copy(rhs.epochs_.begin(), rhs.epochs_.end(),
@@ -105,6 +112,27 @@ namespace dxtbx { namespace model {
     /** Get the image range */
     vec2 <int> get_image_range() const {
       return image_range_;
+    }
+
+    /** Get the batch offset */
+    int get_batch_offset() const {
+      return batch_offset_;
+    }
+
+    /** Get the batch number for a given image index */
+    int get_batch_for_image_index(int index) const {
+      return index + batch_offset_;
+    }
+
+    /** Get the batch number for a given array index */
+    int get_batch_for_array_index(int index) const {
+      return index + batch_offset_ + 1;
+    }
+
+    /** Get the batch range */
+    vec2 <int> get_batch_range() const {
+      return vec2<int>(
+        image_range_[0] + batch_offset_, image_range_[1] + batch_offset_);
     }
 
     /** Get the array range (zero based) */
@@ -139,6 +167,11 @@ namespace dxtbx { namespace model {
       epochs_.resize(num_images_);
       exposure_times_.resize(num_images_);
       DXTBX_ASSERT(num_images_ > 0);
+    }
+
+    /** Set the batch_offset */
+    void set_batch_offset(int batch_offset) {
+      batch_offset_ = batch_offset;
     }
 
     /** Set the oscillation */
@@ -187,6 +220,7 @@ namespace dxtbx { namespace model {
     bool operator==(const Scan &rhs) const {
       double eps = 1e-7;
       return image_range_ == rhs.image_range_
+          && batch_offset_ == rhs.batch_offset_
           && std::abs(oscillation_[0] - rhs.oscillation_[0]) < eps
           && std::abs(oscillation_[1] - rhs.oscillation_[1]) < eps
           && exposure_times_.const_ref().all_approx_equal(rhs.exposure_times_.const_ref(), eps)
@@ -273,6 +307,12 @@ namespace dxtbx { namespace model {
     /** Check if the index is valid */
     bool is_image_index_valid(double index) const {
       return (image_range_[0] <= index && index <= image_range_[1]);
+    }
+
+    /** Check if a given batch is valid */
+    bool is_batch_valid(int batch) const {
+      vec2<int> batch_range = get_batch_range();
+      return (batch_range[0] <= batch && batch <= batch_range[1]);
     }
 
     /** Check if the array index is valid */
@@ -377,7 +417,8 @@ namespace dxtbx { namespace model {
       // Return scan
       return Scan(vec2<int>(image_index, image_index),
         get_image_oscillation(image_index ),
-        new_exposure_times, new_epochs);
+        new_exposure_times, new_epochs,
+        get_batch_offset());
     }
 
     friend std::ostream& operator<<(std::ostream &os, const Scan &s);
@@ -387,6 +428,7 @@ namespace dxtbx { namespace model {
     vec2 <int> image_range_;
     vec2 <double> oscillation_;
     int num_images_;
+    int batch_offset_;
     scitbx::af::shared<double> exposure_times_;
     scitbx::af::shared<double> epochs_;
   };

--- a/dxtbx/model/scan.py
+++ b/dxtbx/model/scan.py
@@ -38,6 +38,11 @@ scan_phil_scope = libtbx.phil.parse('''
       .type = floats(size=2)
       .help = "Override the image oscillation"
       .short_caption = "Oscillation"
+
+    batch_offset = None
+      .type = int(value_min=0)
+      .help = "Override the batch offset"
+      .short_caption = "Batch offset"
   }
 ''')
 
@@ -86,6 +91,9 @@ class ScanFactory:
       if params.scan.oscillation is not None:
         scan.set_oscillation(params.scan.oscillation)
 
+    if params.scan.batch_offset is not None:
+      scan.set_batch_offset(params.scan.batch_offset)
+
     # Return the model
     return scan
 
@@ -113,11 +121,14 @@ class ScanFactory:
     if not isinstance(d['exposure_time'], list):
       d['exposure_time'] = [d['exposure_time']]
 
+    d.setdefault('batch_offset', 0) # backwards compatibility 20180205
+
     # Create the model from the dictionary
     return Scan.from_dict(d)
 
   @staticmethod
-  def make_scan(image_range, exposure_times, oscillation, epochs, deg=True):
+  def make_scan(image_range, exposure_times, oscillation, epochs,
+                batch_offset=0, deg=True):
     from scitbx.array_family import flex
 
     if not isinstance(exposure_times, list):
@@ -140,6 +151,7 @@ class ScanFactory:
         tuple(map(float, oscillation)),
         flex.double(list(map(float, exposure_times))),
         flex.double(list(map(float, epoch_list))),
+        batch_offset,
         deg)
 
   @staticmethod

--- a/dxtbx/tests/model/tst_scan_data.py
+++ b/dxtbx/tests/model/tst_scan_data.py
@@ -77,6 +77,13 @@ def tst_scan_360_append():
   assert(abs(scan.get_oscillation()[1] - 1.0) < eps)
   assert(scan.get_image_range() == (1, 720))
   assert(scan.get_batch_range() == (1, 720))
+
+  from libtbx.test_utils import Exception_expected
+  scan2.set_batch_offset(10)
+  try: scan = scan1 + scan2
+  except Exception: pass
+  else: raise Exception_expected
+
   print 'OK'
 
 def tst_swap():

--- a/dxtbx/tests/model/tst_scan_data.py
+++ b/dxtbx/tests/model/tst_scan_data.py
@@ -2,6 +2,17 @@ from __future__ import absolute_import, division
 
 from dxtbx.model import Scan
 
+def tst_is_batch_valid(scan):
+  """Check that the is_angle_valid function behaves properly."""
+  br1, br2 = scan.get_batch_range()
+  for i in range(0, br1):
+    assert(scan.is_batch_valid(i) == False)
+  for i in range(br1, br2+1):
+    assert(scan.is_batch_valid(i) == True)
+  for i in range(br2+1, br2+100):
+    assert(scan.is_batch_valid(i) == False)
+  print "OK"
+
 def tst_is_angle_valid(scan):
   """Check that the is_angle_valid function behaves properly."""
   oscillation_range = scan.get_oscillation_range()
@@ -53,6 +64,7 @@ def tst_scan_360_append():
   assert(abs(scan.get_oscillation()[0] - 0.0) < eps)
   assert(abs(scan.get_oscillation()[1] - 1.0) < eps)
   assert(scan.get_image_range() == (1, 720))
+  assert(scan.get_batch_range() == (1, 720))
   print 'OK'
 
   scan1 = Scan((1, 360), (0.0, 1.0))
@@ -64,6 +76,7 @@ def tst_scan_360_append():
   assert(abs(scan.get_oscillation()[0] - 0.0) < eps)
   assert(abs(scan.get_oscillation()[1] - 1.0) < eps)
   assert(scan.get_image_range() == (1, 720))
+  assert(scan.get_batch_range() == (1, 720))
   print 'OK'
 
 def tst_swap():
@@ -93,12 +106,18 @@ def tst_from_phil():
   assert s1.get_num_images() == 10
   assert s1.get_image_range() == (1, 10)
   assert s1.get_oscillation() == (-4, 0.1)
+  assert s1.get_batch_offset() == 0
+  assert s1.get_batch_range() == s1.get_image_range()
+  for i in range(s1.get_image_range()[0], s1.get_image_range()[1]+1):
+    assert s1.get_batch_for_image_index(i) == i
+    assert s1.get_batch_for_array_index(i-1) == i
 
   params = scan_phil_scope.fetch(parse('''
     scan {
       image_range = 1, 20
       extrapolate_scan = True
       oscillation = (20, 0.01)
+      batch_offset = 10
     }
   ''')).extract()
 
@@ -106,6 +125,12 @@ def tst_from_phil():
   assert s2.get_num_images() == 20
   assert s2.get_image_range() == (1, 20)
   assert s2.get_oscillation() == (20, 0.01)
+  assert s2.get_batch_offset() == 10
+  assert s2.get_batch_range() == (11, 30)
+  ir1, ir2 = s2.get_image_range()
+  for i in range(ir1, ir2):
+    assert s2.get_batch_for_image_index(i) == i + s2.get_batch_offset()
+    assert s2.is_batch_valid(s2.get_batch_for_image_index(i))
 
   print 'OK'
 
@@ -113,8 +138,10 @@ def run():
   image_range = (0, 1000)
   oscillation = (0, 0.1)
   scan = Scan(image_range, oscillation)
+  scan.set_batch_offset(100)
   tst_scan_oscillation_recycle(scan)
   tst_is_angle_valid(scan)
+  tst_is_batch_valid(scan)
   tst_is_frame_valid(scan)
   tst_get_angle_from_frame(scan)
   tst_get_frame_from_angle(scan)

--- a/dxtbx/tests/serialize/tst_serialize.py
+++ b/dxtbx/tests/serialize/tst_serialize.py
@@ -78,13 +78,14 @@ class Test(object):
   def tst_scan(self):
     from dxtbx.model import Scan, ScanFactory
     from scitbx.array_family import flex
-    s1 = Scan((1, 3), (1.0, 0.2), flex.double([0.1, 0.1, 0.1]), flex.double([0.1, 0.2, 0.3]))
+    s1 = Scan((1, 3), (1.0, 0.2), flex.double([0.1, 0.1, 0.1]), flex.double([0.1, 0.2, 0.3]), 0)
     d = s1.to_dict()
     s2 = ScanFactory.from_dict(d)
     assert(d['image_range'] == (1, 3))
     assert(d['oscillation'] == (1.0, 0.2))
     assert(d['exposure_time'] == [0.1, 0.1, 0.1])
     assert(d['epochs'] == [0.1, 0.2, 0.3])
+    assert(d['batch_offset'] == 0)
     assert(s1 == s2)
 
     # Test with a template and partial dictionary
@@ -97,10 +98,15 @@ class Test(object):
     assert(s2 != s3)
 
     # Test with a partial epoch
-    d3 = { 'image_range' : (1, 10), 'epochs' : [0.1, 0.2] }
+    d3 = { 'image_range' : (1, 10), 'epochs' : [0.1, 0.2],}
     s4 = ScanFactory.from_dict(d3, d)
     assert(abs(s4.get_epochs()[2] - 0.3) < 1e-7)
     assert(abs(s4.get_epochs()[9] - 1.0) < 1e-7)
+
+    d4 = {'batch_offset': 100}
+    s5 = ScanFactory.from_dict(d4, d)
+    assert(s5.get_batch_offset() == 100)
+    assert(s5.get_batch_range() == (101, 103))
 
 if __name__ == '__main__':
   if libtbx.env.has_module("dials") and \


### PR DESCRIPTION
Add a batch_offset attribute to the dxtbx scan model.

This is to allow tracking/handling of unique batch numbers for multi-crystal datasets when interacting with CCP4 programs such as POINTLESS and AIMLESS.

Batch numbers are implemented as the image number plus an offset (default is zero).

See also:
http://www.ccp4.ac.uk/html/mtzformat.html
http://www.ccp4.ac.uk/html/aimless.html