### PR TITLE
simTBX dxtbx fixes

### DIFF
--- a/simtbx/nanoBragg/brunger_example/run_example.py
+++ b/simtbx/nanoBragg/brunger_example/run_example.py
@@ -61,9 +61,9 @@ with open(stolfile, "rb") as fp:
 # open the existing diffraction image: we need it for the background profile
 import dxtbx
 img = dxtbx.load(imgfile)
-panel = img.get_detector().to_dict()['panels'][0]
-pixel_size_mm = panel['pixel_size'][0]
-distance_mm = -panel['origin'][2]
+panel = img.get_detector()[0]
+pixel_size_mm = panel.get_pixel_size[0]
+distance_mm = panel.get_distance()
 #beam_center_mm =
 
 # create the simulation

--- a/simtbx/nanoBragg/nanoBragg.cpp
+++ b/simtbx/nanoBragg/nanoBragg.cpp
@@ -96,6 +96,10 @@ nanoBragg::nanoBragg(
     Sclose = Yclose = -dot_product(pix0_vector,sdet_vector);
     close_distance = distance =  dot_product(pix0_vector,odet_vector);
 
+    /* set beam centre */
+    scitbx::vec2<double> dials_bc = detector[0].get_beam_centre(beam.get_s0());
+    Xbeam = dials_bc[0]/1000.0;
+    Ybeam = dials_bc[1]/1000.0;
 
     /* detector sensor layer properties */
     detector_thick   = detector[0].get_thickness();

--- a/simtbx/nanoBragg/nanoBragg.cpp
+++ b/simtbx/nanoBragg/nanoBragg.cpp
@@ -107,6 +107,14 @@ nanoBragg::nanoBragg(
 
     //adc_offset = detector[0].ADC_OFFSET;
 
+    /* SPINDLE properties */
+
+    /* By default align the rotation axis with the detector fast direction */
+    spindle_vector[1] = fdet_vector[1];
+    spindle_vector[2] = fdet_vector[2];
+    spindle_vector[3] = fdet_vector[3];
+    unitize(spindle_vector,spindle_vector);
+
     /* NOT IMPLEMENTED: read in any other stuff?  */
     show_params();
 

--- a/simtbx/nanoBragg/nanoBragg.cpp
+++ b/simtbx/nanoBragg/nanoBragg.cpp
@@ -28,8 +28,7 @@ nanoBragg::nanoBragg(
     /* BEAM properties first */
 
     /* direction in 3-space of beam vector */
-    /* is this positive or negative? */
-    xyz = beam.get_direction();
+    xyz = beam.get_unit_s0();
     beam_vector[1] = xyz[0];
     beam_vector[2] = xyz[1];
     beam_vector[3] = xyz[2];
@@ -84,17 +83,17 @@ nanoBragg::nanoBragg(
     sdet_vector[2] = detector[0].get_slow_axis()[1];
     sdet_vector[3] = detector[0].get_slow_axis()[2];
     unitize(sdet_vector,sdet_vector);
-    /* must form an orthonormal system, but dxtbx distance is negative?  */
-    cross_product(sdet_vector,fdet_vector,odet_vector);
+    /* set orthogonal vector to the detector pixel array */
+    cross_product(fdet_vector,sdet_vector,odet_vector);
     unitize(odet_vector,odet_vector);
 
-    /* dxtbx origin is location of the first pixel? */
-    pix0_vector[1] = -detector[0].get_origin()[0]/1000.0;
-    pix0_vector[2] = -detector[0].get_origin()[1]/1000.0;
-    pix0_vector[3] = -detector[0].get_origin()[2]/1000.0;
+    /* dxtbx origin is location of outer corner of the first pixel */
+    pix0_vector[1] = detector[0].get_origin()[0]/1000.0;
+    pix0_vector[2] = detector[0].get_origin()[1]/1000.0;
+    pix0_vector[3] = detector[0].get_origin()[2]/1000.0;
     /* what is the point of closest approach between sample and detector? */
-    Fclose = Xclose = dot_product(pix0_vector,fdet_vector);
-    Sclose = Yclose = dot_product(pix0_vector,sdet_vector);
+    Fclose = Xclose = -dot_product(pix0_vector,fdet_vector);
+    Sclose = Yclose = -dot_product(pix0_vector,sdet_vector);
     close_distance = distance =  dot_product(pix0_vector,odet_vector);
 
 


### PR DESCRIPTION
This branch contains changes to the nanoBragg constructor from dxtbx Detector and Beam models. Previously the code appeared to invert the direction of beam propagation, due to an idiosyncrasy of the Beam class. After fixing that, other definitions had to change (`odet_vector`, `pix0_vector` and point of closest approach). I want to request a review from @jmholton to check I have fixed everything required. 

The direction of the rotation axis is also now set, as `init_defaults` sets this along the beam direction for typical dxtbx models.

The other commit makes a minor change to the brunger_example test script.