### PR TITLE
Option to install mpi4py during base step

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -1045,6 +1045,7 @@ class Builder(object):
       skip_base="",
       force_base_build=False,
       enable_shared=False,
+      mpi_build=False,
       python3=False,
     ):
     if nproc is None:
@@ -1084,6 +1085,7 @@ class Builder(object):
     self.download_only = download_only
     self.skip_base = skip_base
     self.force_base_build = force_base_build
+    self.mpi_build=mpi_build
     self.add_init()
 
     # Cleanup
@@ -1806,6 +1808,8 @@ class XFELBuilder(CCIBuilder):
   ]
 
   def add_base(self, extra_opts=[]):
+    if self.mpi_build:
+      extra_opts=['--mpi-build']+extra_opts
     super(XFELBuilder, self).add_base(
       extra_opts=['--labelit'] + extra_opts)
 
@@ -2300,6 +2304,11 @@ def run(root=None):
                     dest="enable_shared",
                     action="store_true",
                     default=False)
+  parser.add_option("--mpi-build",
+                    dest="mpi_build",
+                    help="Builds software with mpi functionality",
+                    action="store_true",
+                    default=False)
   parser.add_option("--python3",
                     dest="python3",
                     help="Install a Python3 interpreter. This is unsupported and purely for development purposes.",
@@ -2374,6 +2383,7 @@ def run(root=None):
     skip_base=options.skip_base,
     force_base_build=options.force_base_build,
     enable_shared=options.enable_shared,
+    mpi_build=options.mpi_build
     python3=options.python3,
   ).run()
   print "\nBootstrap success: %s" % ", ".join(actions)

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -1085,7 +1085,6 @@ class Builder(object):
     self.download_only = download_only
     self.skip_base = skip_base
     self.force_base_build = force_base_build
-    self.mpi_build=mpi_build
     self.add_init()
 
     # Cleanup
@@ -1116,6 +1115,8 @@ class Builder(object):
       extra_opts = ["--nproc=%s" % str(self.nproc)]
       if enable_shared:
         extra_opts.append("--python-shared")
+      if mpi_build:
+        extra_opts.append("--mpi-build")
       self.add_base(extra_opts=extra_opts)
 
     # Configure, make, get revision numbers
@@ -1808,10 +1809,8 @@ class XFELBuilder(CCIBuilder):
   ]
 
   def add_base(self, extra_opts=[]):
-    if self.mpi_build:
-      extra_opts=['--mpi-build']+extra_opts
     super(XFELBuilder, self).add_base(
-      extra_opts=['--labelit'] + extra_opts)
+      extra_opts=['--labelit', '--mpi-build'] + extra_opts)
 
   def add_tests(self):
     self.add_test_command('cctbx_regression.test_nightly')
@@ -2383,7 +2382,7 @@ def run(root=None):
     skip_base=options.skip_base,
     force_base_build=options.force_base_build,
     enable_shared=options.enable_shared,
-    mpi_build=options.mpi_build
+    mpi_build=options.mpi_build,
     python3=options.python3,
   ).run()
   print "\nBootstrap success: %s" % ", ".join(actions)

--- a/libtbx/auto_build/install_base_packages.py
+++ b/libtbx/auto_build/install_base_packages.py
@@ -70,7 +70,7 @@ class installer (object) :
     parser.add_option("--python3", dest="python3", action="store_true", default=False,
       help="Install a Python3 interpreter. This is unsupported and purely for development purposes.")
     parser.add_option("--mpi-build", dest="mpi_build", action="store_true", default=False,
-      help="Installs software with MPI functionality. Currently for testing purposes only.")
+      help="Installs software with MPI functionality")
     parser.add_option("-g", "--debug", dest="debug", action="store_true",
       help="Build in debugging mode", default=False)
     # Package set options.

--- a/libtbx/auto_build/install_base_packages.py
+++ b/libtbx/auto_build/install_base_packages.py
@@ -69,6 +69,8 @@ class installer (object) :
       help="Use the system Python interpreter", action="store_true")
     parser.add_option("--python3", dest="python3", action="store_true", default=False,
       help="Install a Python3 interpreter. This is unsupported and purely for development purposes.")
+    parser.add_option("--mpi-build", dest="mpi_build", action="store_true", default=False,
+      help="Installs software with MPI functionality. Currently for testing purposes and only for DIALS.")
     parser.add_option("-g", "--debug", dest="debug", action="store_true",
       help="Build in debugging mode", default=False)
     # Package set options.
@@ -318,6 +320,10 @@ class installer (object) :
     # Package dependencies.
     if 'pillow' in packages:
       packages += ['freetype']
+
+    # mpi4py installation
+    if options.mpi_build:
+      packages +=['mpi4py']
 
     return set(packages)
 
@@ -697,6 +703,7 @@ Installation of Python packages may fail.
       'ipython',
       'pyopengl',
       'scipy',
+      'mpi4py',
       'py2app',
       'misc',
       'lz4_plugin',
@@ -1064,6 +1071,12 @@ _replace_sysconfig_paths(build_time_vars)
       pkg_name=SCIPY_PKG,
       pkg_name_label="SciPy",
       confirm_import_module="scipy")
+
+  def build_mpi4py(self):
+    self.build_python_module_pip(
+      package_name='mpi4py',
+      package_version=MPI4PY_VERSION,
+      confirm_import_module="mpi4py")
 
   def build_py2app(self):
     self.build_python_module_simple(

--- a/libtbx/auto_build/install_base_packages.py
+++ b/libtbx/auto_build/install_base_packages.py
@@ -70,7 +70,7 @@ class installer (object) :
     parser.add_option("--python3", dest="python3", action="store_true", default=False,
       help="Install a Python3 interpreter. This is unsupported and purely for development purposes.")
     parser.add_option("--mpi-build", dest="mpi_build", action="store_true", default=False,
-      help="Installs software with MPI functionality. Currently for testing purposes and only for DIALS.")
+      help="Installs software with MPI functionality. Currently for testing purposes only.")
     parser.add_option("-g", "--debug", dest="debug", action="store_true",
       help="Build in debugging mode", default=False)
     # Package set options.

--- a/libtbx/auto_build/package_defs.py
+++ b/libtbx/auto_build/package_defs.py
@@ -69,6 +69,7 @@ PILLOW_VERSION = "4.2.1"
 PYTEST_VERSION="3.2.3"
 SIX_VERSION="1.11.0"
 SPHINX_VERSION="1.4.4" # for documentation
+MPI4PY_VERSION="3.0.0"
 
 # HDF5
 BASE_HDF5_PKG_URL = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/"


### PR DESCRIPTION
This pull request provides an option to install mpi4py during the base step. The flag required is --mpi-build when bootstrap.py is run. In order for the installation to be successful, MPI libraries should be available on your machine. 
If there are no objections within the next 1-2 days to this pull request, I can merge this.