### PR TITLE
Changes to be consistent with the current nexus format.

### DIFF
--- a/dxtbx/format/FormatHDFEigerNearlyNexus.py
+++ b/dxtbx/format/FormatHDFEigerNearlyNexus.py
@@ -156,7 +156,7 @@ class EigerNXmxFixer(object):
       handle['/entry/instrument/detector/x_pixel_size'].value)
     group['fast_pixel_direction'].attrs['transformation_type'] = 'translation'
     group['fast_pixel_direction'].attrs['vector'] = fast_axis
-    group['fast_pixel_direction'].attrs['offset'] = 0
+    group['fast_pixel_direction'].attrs['offset'] = (0, 0, 0)
     group['fast_pixel_direction'].attrs['units'] = "m"
     group['fast_pixel_direction'].attrs['depends_on'] = '/entry/instrument/detector/transformations/translation'
 
@@ -168,7 +168,7 @@ class EigerNXmxFixer(object):
       handle['/entry/instrument/detector/y_pixel_size'].value)
     group['slow_pixel_direction'].attrs['transformation_type'] = 'translation'
     group['slow_pixel_direction'].attrs['vector'] = slow_axis
-    group['slow_pixel_direction'].attrs['offset'] = 0
+    group['slow_pixel_direction'].attrs['offset'] = (0, 0, 0)
     group['slow_pixel_direction'].attrs['units'] = "m"
     group['slow_pixel_direction'].attrs['depends_on'] = '/entry/instrument/detector/transformations/translation'
 
@@ -181,7 +181,7 @@ class EigerNXmxFixer(object):
       0)
     group['module_offset'].attrs['transformation_type'] = 'translation'
     group['module_offset'].attrs['vector'] = (0, 0, 0)
-    group['module_offset'].attrs['offset'] = 0
+    group['module_offset'].attrs['offset'] = (0, 0, 0)
     group['module_offset'].attrs['units'] = "m"
     group['module_offset'].attrs['depends_on'] = '/entry/instrument/detector/transformations/translation'
 


### PR DESCRIPTION
Implementing these changes and bringing nexus.py in line with the NeXus format. 
1. Drop _F, _S vectors (including the depends_on list and transformations)
2. Use fast/slow_pixel_direction instead (single entry equal to pixel size) and use module_offset to position these vectors
3. Drop fast_pixel_size
4. Flatten module list

Concurrent changes have been made to dials_regression/test.py to skip testing of LCLS_cspad_nexus master file which is currently inconsistent with the NeXus format. Thus you would need to update dials_regression repository to pass all tests there. 
Work done with @phyy-nx 