### PR TITLE
prime: Convert pool_map to parallel_map in solve_indexing_ambiguity, #139.

### DIFF
--- a/prime/command_line/solve_indexing_ambiguity.py
+++ b/prime/command_line/solve_indexing_ambiguity.py
@@ -5,7 +5,7 @@ Created     : 8/15/2016
 Description : Command line for solving indexing ambiguity
 '''
 import numpy as np
-from libtbx.easy_mp import pool_map
+from libtbx.easy_mp import parallel_map
 from prime.index_ambiguity.mod_indexing_ambiguity import indamb_handler
 import cPickle as pickle
 from prime.index_ambiguity.mod_kmeans import kmeans_handler
@@ -89,7 +89,7 @@ class indexing_ambiguity_handler(object):
           return None, iparams
         else:
           frames = [(i, frame_files[i], iparams, miller_array_ref) for i in range(n_frames)]
-          cc_results = pool_map(
+          cc_results = parallel_map(
             iterable=frames,
             func=solve_with_mtz_mproc,
             processes=iparams.n_processors)
@@ -104,7 +104,7 @@ class indexing_ambiguity_handler(object):
     frames = [(i, frame_files[i], iparams) for i in random.sample(range(n_frames), iparams.indexing_ambiguity.n_sample_frames)]
     #get observations list
     print "Reading observations"
-    alt_dict_results = pool_map(
+    alt_dict_results = parallel_map(
           iterable=frames,
           func=get_obs_mproc,
           processes=iparams.n_processors)
@@ -121,7 +121,7 @@ class indexing_ambiguity_handler(object):
     frames = [(i, frame_dup_files[i], frame_keys[i], obs_list[i], obs_list) for i in range(len(frame_dup_files))]
     #calculate r
     print "Calculating R"
-    calc_r_results = pool_map(
+    calc_r_results = parallel_map(
           iterable=frames,
           func=calculate_r_mproc,
           processes=iparams.n_processors)
@@ -156,7 +156,7 @@ class indexing_ambiguity_handler(object):
     frames = [(i, frame_dup_files_sel[i], iparams) for i in range(len(frame_dup_files_sel))]
     #get observations list
     print "Re-reading observations"
-    alt_dict_results = pool_map(
+    alt_dict_results = parallel_map(
           iterable=frames,
           func=get_obs_mproc,
           processes=iparams.n_processors)
@@ -173,7 +173,7 @@ class indexing_ambiguity_handler(object):
     frames = [(i, frame_dup_files[i], frame_keys[i], obs_list[i], obs_list) for i in range(len(frame_dup_files))]
     #calculate r
     print "Re-calculating R"
-    calc_r_results = pool_map(
+    calc_r_results = parallel_map(
           iterable=frames,
           func=calculate_r_mproc,
           processes=iparams.n_processors)
@@ -220,7 +220,7 @@ class indexing_ambiguity_handler(object):
       #setup a list of remaining frames
       frame_files_remain = [frame for frame in frame_files if frame not in sol_pickle]
       frames = [(i, frame_files_remain[i], iparams, miller_array_ref) for i in range(len(frame_files_remain))]
-      cc_results = pool_map(
+      cc_results = parallel_map(
           iterable=frames,
           func=solve_with_mtz_mproc,
           processes=iparams.n_processors)


### PR DESCRIPTION
Hi Monarin,

Many thanks for looking into #139 and fixing it. I found that the fix didn't apply to the ambiguity solving step, so this patch applys the same logic from your commit 39adfa20f865e240eb38a54b6a82fd889a59cd51 to solve_indexing_ambiguity.py. Is seems to work for my test case, but thought you should sign it off.

(If you're happy with the patch, can you please click the triangle next to the big green button, and pick "Rebase and merge" to avoid inserting a merge commit? Thanks)
![image](https://user-images.githubusercontent.com/2102431/36950750-880bd68a-1ff2-11e8-9026-ca67dbe40880.png)
