### PR TITLE
phil: add allow_none (default=True) attribute for int/float types

### DIFF
--- a/libtbx/phil/tst.py
+++ b/libtbx/phil/tst.py
@@ -231,7 +231,7 @@ d=a b c # 1 {2} 3 \\
   .expert_level = 1
 {
   !a = b
-    .type = int
+    .type = int(allow_none=True)
   c = d
     .expert_level = 2
 }
@@ -318,7 +318,7 @@ t {
     attributes_level=2,
     expected_out="""\
 a = None
-  .type = int
+  .type = int(allow_none=True)
 s
   .optional = False
   .multiple = True
@@ -330,7 +330,7 @@ t
 {
   d = None
     .optional = True
-    .type = float
+    .type = float(allow_none=True)
   e = x
     .type = str
 }
@@ -1769,7 +1769,7 @@ c {
     x = 1
       .expert_level = 6
     y = 3
-      .type = int
+      .type = int(allow_none=True)
       .expert_level = 7
     t
       .expert_level = 8
@@ -4276,7 +4276,7 @@ s
   a = None
     .type = str
   b = 0
-    .type = float
+    .type = float(allow_none=True)
   c = *x *y
     .optional = True
     .type = choice(multi=True)
@@ -4307,7 +4307,7 @@ s
   a = None
     .type = str
   b = 0
-    .type = float
+    .type = float(allow_none=True)
   c = *x *y
     .optional = True
     .type = choice(multi=True)
@@ -4319,7 +4319,7 @@ s
   a = None
     .type = str
   b = 1
-    .type = float
+    .type = float(allow_none=True)
   c = *x *y
     .optional = True
     .type = choice(multi=True)
@@ -4389,12 +4389,12 @@ s
   a = x
     .type = str
   b = 2
-    .type = int
+    .type = int(allow_none=True)
   c = x *y
     .optional = True
     .type = choice(multi=True)
   d = None
-    .type = float
+    .type = float(allow_none=True)
 }
 """)
   #
@@ -4809,26 +4809,26 @@ h = 10
   work_phil = master_phil.format(python_object=work_params)
   assert not show_diff(work_phil.as_str(attributes_level=2),"""\
 a = None
-  .type = float
+  .type = float(allow_none=True)
 b = 1
-  .type = int
+  .type = int(allow_none=True)
 c = 1.5
-  .type = float(value_min=1)
+  .type = float(value_min=1, allow_none=True)
 d = 4.5
-  .type = float(value_max=5)
+  .type = float(value_max=5, allow_none=True)
 e = 6.2
-  .type = float(value_min=3.2, value_max=7.6)
+  .type = float(value_min=3.2, value_max=7.6, allow_none=True)
 f = 5
-  .type = int(value_min=0)
+  .type = int(value_min=0, allow_none=True)
 g = 3
-  .type = int(value_max=4)
+  .type = int(value_max=4, allow_none=True)
 h = 10
-  .type = int(value_min=4, value_max=12)
+  .type = int(value_min=4, value_max=12, allow_none=True)
 """)
   #
   master_phil = phil.parse(input_string="""\
 a=-1.5
-  .type=float(value_min=1.0)
+  .type=float(value_min=1.0, allow_none=True)
 """)
   try: master_phil.extract()
   except RuntimeError, e:
@@ -4868,6 +4868,16 @@ d=-6
     assert not show_diff(str(e),
       "d element is less than the minimum allowed value:"
       " -6 < 3 (input line 1)")
+  else: raise Exception_expected
+  #
+  master_phil = phil.parse(input_string="""\
+d=None
+  .type=int(allow_none=False)
+""")
+  try: master_phil.extract()
+  except RuntimeError, e:
+    assert not show_diff(str(e),
+      "d cannot be None")
   else: raise Exception_expected
 
 def exercise_ints_and_floats():


### PR DESCRIPTION
This commit adds the "allow_none" attribute for int/float types (c.f. allow_none_elements for ints/floats).

This would allow a developer to explicitly prevent a user from setting "None" as an allowable value for a given phil parameter. See e.g.:

https://github.com/dials/dials/issues/516

```
$ git diff
diff --git a/algorithms/spot_finding/factory.py b/algorithms/spot_finding/factory.py
index 9420d6e..930fa38 100644
--- a/algorithms/spot_finding/factory.py
+++ b/algorithms/spot_finding/factory.py
@@ -73,7 +73,7 @@ def generate_phil_scope():
       max_spot_size = 100
         .help = "The maximum number of contiguous pixels for a spot"
                 "to be accepted by the filtering algorithm."
-        .type = int(value_min=1)
+        .type = int(value_min=1, allow_none=False)
 
       max_separation = 2
         .help = "The maximum peak-to-centroid separation (in pixels)"
```

```
$ dials.find_spots $(libtbx.find_in_repositories dials_regression)/centroid_test_data/centroid_0001.cbf max_spot_size=None
Traceback (most recent call last):
...
RuntimeError: Please report this error to dials-support@lists.sourceforge.net: spotfinder.filter.max_spot_size cannot be None
```