### PR TITLE
Make understanding TimePix_SU in header file case insensitive

### DIFF
--- a/dxtbx/format/FormatSMVADSC.py
+++ b/dxtbx/format/FormatSMVADSC.py
@@ -31,7 +31,7 @@ class FormatSMVADSC(FormatSMV):
     if header.get('BEAMLINE') == 'fake': return False
 
     # do not understand Timepix_SU images
-    if header.get('BEAMLINE') == 'TimePix_SU': return False
+    if header.get('BEAMLINE').upper() == 'TIMEPIX_SU': return False
 
     # this used to include TIME
     wanted_header_items = ['BEAM_CENTER_X', 'BEAM_CENTER_Y',


### PR DESCRIPTION
Depending on how TimePix_SU SMV files are created they may have the line BEAMLINE=TimePix_SU as all upper case or as mixed case. When they are upper case there is sometimes a problem where Dials imports as the wrong SMV format. This should fix it.