### PR TITLE
Implementation of TLS-analysis in c++

### DIFF
--- a/mmtbx/regression/tls/tst_tls_decompose.py
+++ b/mmtbx/regression/tls/tst_tls_decompose.py
@@ -1,0 +1,244 @@
+from __future__ import division
+import libtbx.utils
+from libtbx.test_utils import approx_equal
+import scitbx.random
+from scitbx import matrix
+from scitbx.math import basic_statistics
+from scitbx.array_family import flex
+import itertools
+import math, time, sys
+
+from libtbx.utils import null_out, multi_out
+
+from mmtbx.tls import analysis as tls_analysis
+from mmtbx.tls.decompose import decompose_tls_matrices
+
+d2r = math.pi/180
+
+def dot(a,b):
+  return a[0]*b[0] + a[1]*b[1] + a[2]*b[2]
+
+def generate_random_tls_motions(g):
+  """Given a random number generator, return tls motions"""
+
+  # Generate random input
+  tx, ty, tz = sorted(abs(g(3))*2.00 + 0.10, reverse=True)      # on order of 1
+  dx, dy, dz = sorted(abs(g(3))*0.01 + 0.01, reverse=True) # on order of
+  sx, sy, sz = g(3)*5.0                             # on order of 5, don't need sorting, can be negative
+  # Generate three rotation axes
+  l_x = flex.vec3_double([tuple(g(3))])
+  l_y = flex.vec3_double([tuple(g(3))])
+  l_z = l_x.cross(l_y)
+  l_x = l_y.cross(l_z)
+  l_x = (l_x*(1.0/l_x.norm()))
+  l_y = (l_y*(1.0/l_y.norm()))
+  l_z = (l_z*(1.0/l_z.norm()))
+  assert approx_equal(l_x.dot(l_y)[0], 0.0)
+  assert approx_equal(l_y.dot(l_z)[0], 0.0)
+  assert approx_equal(l_x.dot(l_z)[0], 0.0)
+  assert approx_equal(l_x.dot(l_x)[0], 1.0)
+  assert approx_equal(l_y.dot(l_y)[0], 1.0)
+  assert approx_equal(l_z.dot(l_z)[0], 1.0)
+  l_x = l_x[0]
+  l_y = l_y[0]
+  l_z = l_z[0]
+  # Generate three points
+  w_lx = tuple(g(3)*10.0)
+  w_ly = tuple(g(3)*10.0)
+  w_lz = tuple(g(3)*10.0)
+  # Generate three vibration axes
+  v_x = flex.vec3_double([tuple(g(3))])
+  v_y = flex.vec3_double([tuple(g(3))])
+  v_z = v_x.cross(v_y)
+  v_x = v_y.cross(v_z)
+  v_x = (v_x*(1.0/v_x.norm()))
+  v_y = (v_y*(1.0/v_y.norm()))
+  v_z = (v_z*(1.0/v_z.norm()))
+  assert approx_equal(v_x.dot(v_y)[0], 0.0)
+  assert approx_equal(v_y.dot(v_z)[0], 0.0)
+  assert approx_equal(v_x.dot(v_z)[0], 0.0)
+  assert approx_equal(v_x.dot(v_x)[0], 1.0)
+  assert approx_equal(v_y.dot(v_y)[0], 1.0)
+  assert approx_equal(v_z.dot(v_z)[0], 1.0)
+  v_x = v_x[0]
+  v_y = v_y[0]
+  v_z = v_z[0]
+
+  return dx, dy, dz, l_x, l_y, l_z, sx, sy, sz, tx, ty, tz, v_x, v_y, v_z, w_lx, w_ly, w_lz
+
+def run_and_compare_dtm_and_tao(dx, dy, dz, l_x, l_y, l_z, sx, sy, sz, tx, ty, tz, v_x, v_y, v_z, w_M_lx, w_M_ly, w_M_lz):
+
+  o = tls_analysis.tls_from_motions(
+        dx=dx, dy=dy, dz=dz,
+        l_x=l_x, l_y=l_y, l_z=l_z,
+        sx=sx, sy=sy, sz=sz,
+        tx=tx, ty=ty, tz=tz,
+        v_x=v_x, v_y=v_y, v_z=v_z,
+        w_M_lx=w_M_lx, w_M_ly=w_M_ly, w_M_lz=w_M_lz)
+
+  # Add a bit of noise and convert to degrees
+  T = tuple(flex.double(o.T_M.as_sym_mat3()))
+  L = tuple(flex.double(o.L_M.as_sym_mat3()))
+  S = tuple(flex.double(o.S_M))
+
+  try:
+    dtm = decompose_tls_matrices(T=tuple(T),
+                                 L=tuple(L),
+                                 S=tuple(S),
+                                 l_and_s_in_degrees=False,
+                                 verbose=False)
+  except Exception as e:
+    print e
+    # Should never raise error
+    raise
+
+  try:
+    tao = tls_analysis.run(T=matrix.sym(sym_mat3=T),
+                           L=matrix.sym(sym_mat3=L),
+                           S=matrix.sqr(S),
+                           log=null_out())
+  except Exception as e:
+    # Raises error when invalid
+    print 'TAO error:', e
+    print 'DTM error:', dtm.error()
+    # Return failure status
+    return (dtm.is_valid(), False)
+
+  # One succeeded one failed
+  if not dtm.is_valid():
+    print 'TAO error:', 'none'
+    print 'DTM error:', dtm.error()
+    return (dtm.is_valid(), True)
+
+  # both suceeded
+  check_equal_dtm_and_tao_results(dtm=dtm, tao=tao)
+
+  return (True, True)
+
+def check_equal_dtm_and_tao_results(dtm, tao):
+
+  # tao orders axes by eigenvalues in INCREASING order.
+  # dtm orders axes by eigenvalues in DECREASING order.
+  # Therefore eigenvalues for x and z swap. As this is
+  # a non-cyclic permutation the direction of some axes
+  # changes as both systems are forced to be right-handed.
+
+  # extract reult object
+  tar = tao.result
+
+  # Swap x and z
+  assert approx_equal(dtm.l_amplitudes, (tar.dz, tar.dy, tar.dx))
+  assert approx_equal(dtm.s_amplitudes, (tar.sz, tar.sy, tar.sx))
+  assert approx_equal(dtm.v_amplitudes, (tar.tz, tar.ty, tar.tx))
+
+  # Always check the vibration axes
+  checklist = [(dtm.v_axis_directions[0], tar.v_z_M),
+               (dtm.v_axis_directions[1], tar.v_y_M),
+               (dtm.v_axis_directions[2], tar.v_x_M)]
+
+  # Special case where all eigenvalues are the same
+  if not (approx_equal(dtm.l_amplitudes[0], dtm.l_amplitudes[1], out=null_out()) and
+          approx_equal(dtm.l_amplitudes[1], dtm.l_amplitudes[2], out=null_out()) and
+          approx_equal(dtm.l_amplitudes[2], dtm.l_amplitudes[0], out=null_out())):
+      checklist.extend([(dtm.l_axis_directions[0], tar.l_z),
+                        (dtm.l_axis_directions[1], tar.l_y),
+                        (dtm.l_axis_directions[2], tar.l_x)])
+
+  # Check that each vector is the same (direction may be inverted)
+  for a,b in checklist:
+    d = dot(a,b) # calcuate normalised dot product
+    d = d/abs(d) # i.e. +/-1
+    assert approx_equal(abs(d), 1.0)
+    assert approx_equal(flex.double(a)*d, b)
+
+  # Check that intersection points of rotation axes are the same
+  assert approx_equal(dtm.l_axis_intersections, (tar.w_M_lz, tar.w_M_ly, tar.w_M_lx))
+
+def exercise_decompose_tls_matrices():
+
+  T = (9.598824505, 15.650977723, 8.860020860, -0.005192226, -1.725114669, -0.869540262)
+  L = (1.23001438881,4.61188308667,2.18102205791,0.435192109608,0.517157269537,-1.55699937912)
+  S = (-0.725668016697,-2.01548281778,0.431134160979,3.6329322896,-0.252099816856,-0.771964293756,-0.968895922456,1.70374138375,0.977767833552)
+
+  dtm_deg_input = decompose_tls_matrices(T=T, L=L, S=S, l_and_s_in_degrees=True, verbose=False)
+  dtm_rad_input = decompose_tls_matrices(T=T, L=tuple([v*d2r*d2r for v in L]), S=tuple([v*d2r for v in S]),
+                                         l_and_s_in_degrees=False, verbose=False)
+
+  for dtm in [dtm_deg_input,dtm_rad_input]:
+
+    assert dtm.is_valid()
+    assert dtm.error() == 'none'
+
+    assert approx_equal(dtm.v_amplitudes, (3.06921018016, 2.94143684759, 1.41201837191))
+    assert approx_equal(dtm.l_amplitudes, (0.0404764451411, 0.024588606101, 0.0141767022316))
+    assert approx_equal(dtm.s_amplitudes, (-2.8463226589406196, 13.419545390835827, -4.109522433370094))
+
+    assert approx_equal(dtm.l_axis_directions, [(0.04063819985118014,  0.9008939255667365, -0.4321327013659231),
+                                                (0.6515256136265412,   0.30400592381522407, 0.6950501946433874),
+                                                (0.7575373994077218,  -0.3097911121420477, -0.5746012141793462)])
+
+    assert approx_equal(dtm.v_axis_directions, [(0.5480708503205247,  -0.74962057386549,    0.3710624452386817),
+                                                (0.40867651787831666, -0.1470759298532635, -0.9007508948608665),
+                                                (0.7297957568825613,   0.6453198169089266,  0.22574429592093403)])
+
+    assert approx_equal(dtm.l_axis_intersections, [(-13.015849649869374, 35.879232351401456, -60.666685853674494),
+                                                   (-65.65635765706187, -50.022061840205446, -84.73832882566137),
+                                                   (-110.51255057376397, 51.16255655992905, -197.9357742701504)])
+
+  # Check that same as output from "mmtbx.tls.analysis.run"
+  # TAO needs input in radians
+  tao = tls_analysis.run(T=matrix.sym(sym_mat3=T),
+                         L=matrix.sym(sym_mat3=L)*d2r*d2r,
+                         S=matrix.sqr(S)*d2r,
+                         log=null_out())
+
+  check_equal_dtm_and_tao_results(dtm=dtm_rad_input, tao=tao)
+  check_equal_dtm_and_tao_results(dtm=dtm_deg_input, tao=tao)
+
+def exercise_tls_analysis_and_decompose_similar_results():
+  """Test random TLS matrices to see that different methods give same results"""
+
+  from scitbx.random import set_random_seed, variate, normal_distribution
+  set_random_seed(100)
+  g = variate(normal_distribution(0,1))
+
+  #for noise in (0.001, 0.1):
+  n_success = 0
+  n_run = 0
+  for i in xrange(24):
+    n_run += 1
+
+    dx, dy, dz, l_x, l_y, l_z, sx, sy, sz, tx, ty, tz, \
+            v_x, v_y, v_z, w_M_lx, w_M_ly, w_M_lz = generate_random_tls_motions(g=g)
+
+    ii = i//3
+
+    # Different tests (three of each)
+    if   ii==0:
+        pass
+    elif ii==1:
+        dx = 1e-9
+    elif ii==2:
+        dy = 1e-9
+    elif ii==3:
+        dz = 1e-9
+    elif ii==4:
+        dx = dy = 1e-9
+    elif ii==5:
+        dy = dz = 1e-9
+    elif ii==6:
+        dz = dx = 1e-9
+    elif ii==7:
+        dx = dy = dz = 1e-9
+
+    suc1, suc2 = run_and_compare_dtm_and_tao(dx, dy, dz, l_x, l_y, l_z, sx, sy, sz, tx, ty, tz, v_x, v_y, v_z, w_M_lx, w_M_ly, w_M_lz)
+
+    assert suc1 is suc2, 'DTM {} while TAO {}'.format(*[['failed', 'succeeded'][int(v)] for v in [suc1,suc2]])
+
+def run():
+  libtbx.utils.show_times_at_exit()
+  exercise_decompose_tls_matrices
+  exercise_tls_analysis_and_decompose_similar_results()
+
+if __name__ == '__main__':
+  run()

--- a/mmtbx/run_tests.py
+++ b/mmtbx/run_tests.py
@@ -20,6 +20,7 @@ tst_list = (
   # TLS
   "$D/regression/tls/tst_tls.py",
   "$D/regression/tls/tst_tls_analysis.py",
+  "$D/regression/tls/tst_tls_decompose.py",
   "$D/regression/tls/tst_get_t_scheme.py",
   "$D/regression/tls/tst_tls_refinement_fft.py",
   "$D/regression/tls/tst_u_tls_vs_u_ens_00.py",

--- a/mmtbx/tls/SConscript
+++ b/mmtbx/tls/SConscript
@@ -6,6 +6,8 @@ env_etc.include_registry.append(
 
 if (not env_etc.no_boost_python):
   Import("env_cctbx_boost_python_ext")
+
+  # original library imported in mmtbx/tls/__init__.py
   env_bpl = env_cctbx_boost_python_ext.Clone()
   env_etc.include_registry.append(
     env=env_bpl,
@@ -14,3 +16,14 @@ if (not env_etc.no_boost_python):
   env_bpl.SharedLibrary(
     target="#lib/mmtbx_tls_ext",
     source=["tls_ext.cpp"])
+
+  # add library to be imported in mmtbx/tls/decompose.py (adapted from above)
+  env_dec = env_cctbx_boost_python_ext.Clone()
+  env_etc.include_registry.append(
+    env=env_dec,
+    paths=env_etc.mmtbx_common_includes)
+  env_dec.Prepend(LIBS=["cctbx"])
+  env_dec.SharedLibrary(
+    target="#lib/mmtbx_tls_decompose_ext",
+    source=["decompose.cpp", "decompose_ext.cpp"])
+ 

--- a/mmtbx/tls/analysis.py
+++ b/mmtbx/tls/analysis.py
@@ -255,7 +255,7 @@ class run(object):
     show_vector(x=w_lz, title="w_lz, eq.(16)", log=self.log)
     #
     d11 = wz_ly**2*self.Lyy + wy_lz**2*self.Lzz
-    d22 = wz_lx**2*self.Lxx + wx_lz**2*self.Lzz
+    d22 = wx_lz**2*self.Lzz + wz_lx**2*self.Lxx
     d33 = wy_lx**2*self.Lxx + wx_ly**2*self.Lyy
     d12 = -wx_lz*wy_lz*self.Lzz
     d13 = -wx_ly*wz_ly*self.Lyy
@@ -404,8 +404,8 @@ class run(object):
         #
         tSs = []
         cauchy_conditions(i=0,j=4,k=8, tSs=tSs)
-        cauchy_conditions(i=4,j=0,k=8, tSs=tSs)
         cauchy_conditions(i=8,j=0,k=4, tSs=tSs)
+        cauchy_conditions(i=4,j=8,k=0, tSs=tSs)
         if(len(tSs)==1): self.t_S = tSs[0]
         elif(len(tSs)==0): raise RuntimeError
         else:
@@ -487,7 +487,7 @@ class run(object):
 
   def check_33_34_35(self, a_s, b_s, c_s):
     if(not ((a_s<0 or self.is_zero(a_s)) and
-            (b_s>0 or self.is_zero(a_s)) and
+            (b_s>0 or self.is_zero(b_s)) and
             (c_s<0 or self.is_zero(c_s)))):
       raise Sorry("Step C (right branch): Conditions 33-35 failed.")
 

--- a/mmtbx/tls/decompose.cpp
+++ b/mmtbx/tls/decompose.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <iostream>
 #include <iomanip>
+#include <algorithm>
 
 #include <scitbx/vec3.h>
 #include <scitbx/mat3.h>
@@ -12,7 +13,7 @@
 #include <scitbx/matrix/eigensystem.h>
 #include <scitbx/constants.h>
 
-#include "decompose.h"
+#include <mmtbx/tls/decompose.h>
 
 namespace mmtbx { namespace tls { namespace decompose {
 
@@ -28,23 +29,32 @@ typedef af::versa<double, af::c_grid<2> >   eigenvectors;
 
 decompose_tls_matrices::decompose_tls_matrices(
         scitbx::sym_mat3<double> const& T,
-        scitbx::sym_mat3<double> const& L_deg,
-        scitbx::mat3<double> const& S_deg,
-        scitbx::vec3<double> const& origin = (0.0,0.0,0.0) )
+        scitbx::sym_mat3<double> const& L,
+        scitbx::mat3<double> const& S,
+        bool l_and_s_in_degrees = true,
+        bool verbose = false,
+        double tol = 1.e-6,
+        double eps = 1.e-8) : verbose_(verbose), tol(tol), eps(eps)
 {
-    double deg2rad = scitbx::deg_as_rad(1.0);
-    double deg2radsq = deg2rad * deg2rad;
-
-    // Convert and store the input matrices
     T_M = T;
-    L_M = L_deg * deg2radsq;
-    S_M = S_deg * deg2rad;
+    L_M = L;
+    S_M = S;
 
-    std::cout << "--------------------------" << std::endl;
-    std::cout << "Input Matrices:" << std::endl;
-    print("T", T_M);
-    print("L", L_M);
-    print("S", S_M);
+    // Convert to radians
+    if (l_and_s_in_degrees) {
+        double deg2rad = scitbx::deg_as_rad(1.0);
+        double deg2radsq = deg2rad * deg2rad;
+        L_M *= deg2radsq;
+        S_M *= deg2rad;
+    }
+
+    if (verbose_) {
+        std::cout << "--------------------------" << std::endl;
+        std::cout << "Input Matrices:" << std::endl;
+        print("T", T_M);
+        print("L", L_M);
+        print("S", S_M);
+    }
 
     // Run decomposition
     run();
@@ -56,7 +66,7 @@ bool decompose_tls_matrices::is_pd(scitbx::sym_mat3<double> const& matrix) {
     // Create eigensystem object
     Eig es(matrix);
     // Extract eigenvalues
-    af::shared<double> ev = es.values();
+    eigenvalues ev = es.values();
     // Check all are positive
     for (int i=0; i<3; i++) {
         if (matrix[i] < (-1.0*tol)) { return false; }
@@ -66,15 +76,9 @@ bool decompose_tls_matrices::is_pd(scitbx::sym_mat3<double> const& matrix) {
 
 scitbx::vec3<double> decompose_tls_matrices::as_bs_cs(
         double t,
-        double Sxx,
-        double Syy,
-        double Szz,
-        double T11,
-        double T22,
-        double T33,
-        double T12,
-        double T13,
-        double T23) {
+        double Sxx, double Syy, double Szz,
+        double T11, double T22, double T33,
+        double T12, double T13, double T23) {
 
     double xx_ = (t-Sxx)*(t-Sxx) - T11;
     double yy_ = (t-Syy)*(t-Syy) - T22;
@@ -132,6 +136,15 @@ void decompose_tls_matrices::print(std::string const& label, scitbx::vec3<double
     std::cout << spacer << vector[0] << spacer << vector[1] << spacer << vector[2] << std::endl;
 }
 
+void decompose_tls_matrices::print(std::string const& label, af::shared<double> const& vector) {
+    std::cout << std::setprecision(6) << std::fixed << std::showpos;
+    std::cout << label << ": ";
+    for (int i=0; i < vector.size(); i++) {
+        std::cout << spacer << vector[i];
+    }
+    std::cout << std::endl;
+}
+
 // Small-value functions
 
 double decompose_tls_matrices::zero_filter(double value) {
@@ -167,10 +180,12 @@ void decompose_tls_matrices::zero_small_values(scitbx::vec3<double>& vector) {
 */
 void decompose_tls_matrices::stepA() {
 
-    std::cout << std::endl;
-    std::cout << " ######################################" << std::endl;
-    std::cout << " <-------        Step A        ------->" << std::endl;
-    std::cout << " ######################################" << std::endl << std::endl;
+    if (verbose_) {
+        std::cout << std::endl;
+        std::cout << " ######################################" << std::endl;
+        std::cout << " <-------        Step A        ------->" << std::endl;
+        std::cout << " ######################################" << std::endl << std::endl;
+    }
 
     // Bail if T not positive definite
     if (! is_pd(T_M)) {
@@ -186,13 +201,26 @@ void decompose_tls_matrices::stepA() {
     eigenvectors l_eig_vecs = l_eig.vectors();
     eigenvalues  l_eig_vals = l_eig.values();
 
+//x Code copied from the original python implementation but not "activated"
+//x I don't like this forcing of the eigenvectors because you it could propagate errors to further on
+//x    // Special case -- all eigenvalues are the same
+//x    if ( is_zero(l_eig_vals[0] - l_eig_vals[1]) and
+//x         is_zero(l_eig_vals[1] - l_eig_vals[2]) and
+//x         is_zero(l_eig_vals[2] - l_eig_vals[0]) ) {
+//x        l1_M = scitbx::vec3<double>(1.0,0.0,0.0);
+//x        l2_M = scitbx::vec3<double>(0.0,1.0,0.0);
+//x        l3_M = scitbx::vec3<double>(0.0,0.0,1.0);
+//x    } else {
     // Store the eigenvalues and eigenvectors of L
-    l_amplitudes = scitbx::vec3<double>(l_eig_vals[0], l_eig_vals[1], l_eig_vals[2]);
     l1_M = scitbx::vec3<double>(&l_eig_vecs[0]);
     l2_M = scitbx::vec3<double>(&l_eig_vecs[3]);
     l3_M = scitbx::vec3<double>(&l_eig_vecs[6]);
     // OVERWRITE - Choose l1 to be cross product of l2 and l3 (guaranteed righthanded system)
     l1_M = l2_M.cross(l3_M);
+//x    }
+
+    // Store ampltidues as the square root of the eigenvalue
+    for (int i=0; i<3; i++) { l_amplitudes.push_back(std::sqrt(l_eig_vals[i])); }
 
     // Extract the rotation matrix from the eigenvectors
     // Eigenvectors of L_M are ROWS of R_ML
@@ -206,40 +234,42 @@ void decompose_tls_matrices::stepA() {
 
     // Check that determinant is 1 and transpose is inverse
     double det = R_ML.determinant();
-    if ( std::abs(det-1.0) > tol ) {
+    if ( ! is_zero(det-1.0) ) {
         throw std::runtime_error("Step A: Rotation matrix R[ML] does not have unitary determinant");
     }
 
     // Print Eigenvalues of L
-    std::cout << "--------------------------" << std::endl;
-    std::cout << "Eigenvalues of L: " << std::endl;
-    print("1", l_amplitudes[0]);
-    print("2", l_amplitudes[1]);
-    print("3", l_amplitudes[2]);
-    std::cout << "Eigenvectors of L: " << std::endl;
-    print("1", l1_M);
-    print("2", l2_M);
-    print("3", l3_M);
-
-    // Print eigenvectors/rotation matrix
-    std::cout << "--------------------------" << std::endl;
-    print("R[M->L]", R_ML);
-
-    // Check eigenvectors are unitary
-    double mod1, mod2, mod3;
-    mod1 = R_ML(0,0)*R_ML(0,0) + R_ML(0,1)*R_ML(0,1) + R_ML(0,2)*R_ML(0,2);
-    mod2 = R_ML(1,0)*R_ML(1,0) + R_ML(1,1)*R_ML(1,1) + R_ML(1,2)*R_ML(1,2);
-    mod3 = R_ML(2,0)*R_ML(2,0) + R_ML(2,1)*R_ML(2,1) + R_ML(2,2)*R_ML(2,2);
-
-    // Sanity checks -- verbose only
-    std::cout << "--------------------------" << std::endl;
-    std::cout << "Modulus of the eigenvectors of the L_M matrix" << std::endl;
-    std::cout << "modulus 1st vector: " << mod1 << std::endl;
-    std::cout << "modulus 2nd vector: " << mod2 << std::endl;
-    std::cout << "modulus 3rd vector: " << mod3 << std::endl;
-
-    std::cout << "--------------------------" << std::endl;
-    print("R[ML] * L[M] * t(R[ML])", R_ML * L_M * R_ML_t);
+    if (verbose_) {
+        std::cout << "--------------------------" << std::endl;
+        std::cout << "Eigenvalues of L: " << std::endl;
+        print("1", l_eig_vals[0]);
+        print("2", l_eig_vals[1]);
+        print("3", l_eig_vals[2]);
+        std::cout << "Eigenvectors of L: " << std::endl;
+        print("1", l1_M);
+        print("2", l2_M);
+        print("3", l3_M);
+        std::cout << "RMS librational components: " << std::endl;
+        print("1", l_amplitudes[0]);
+        print("2", l_amplitudes[1]);
+        print("3", l_amplitudes[2]);
+        // Print eigenvectors/rotation matrix
+        std::cout << "--------------------------" << std::endl;
+        print("R[M->L]", R_ML);
+        // Check eigenvectors are unitary
+        double mod1, mod2, mod3;
+        mod1 = R_ML(0,0)*R_ML(0,0) + R_ML(0,1)*R_ML(0,1) + R_ML(0,2)*R_ML(0,2);
+        mod2 = R_ML(1,0)*R_ML(1,0) + R_ML(1,1)*R_ML(1,1) + R_ML(1,2)*R_ML(1,2);
+        mod3 = R_ML(2,0)*R_ML(2,0) + R_ML(2,1)*R_ML(2,1) + R_ML(2,2)*R_ML(2,2);
+        // Sanity checks -- verbose only
+        std::cout << "--------------------------" << std::endl;
+        std::cout << "Modulus of the eigenvectors of the L_M matrix" << std::endl;
+        std::cout << "modulus 1st vector: " << mod1 << std::endl;
+        std::cout << "modulus 2nd vector: " << mod2 << std::endl;
+        std::cout << "modulus 3rd vector: " << mod3 << std::endl;
+        std::cout << "--------------------------" << std::endl;
+        print("R[ML] * L[M] * t(R[ML])", R_ML * L_M * R_ML_t);
+    }
 
     // Transform the input matrices to the basis of L_M
     scitbx::mat3<double> T_L_ = R_ML * T_M * R_ML_t;
@@ -250,11 +280,13 @@ void decompose_tls_matrices::stepA() {
     // S is mat3 anyway
     S_L = R_ML * S_M * R_ML_t;
 
-    std::cout << "--------------------------" << std::endl;
-    std::cout << "Basis[L] Matrices" << std::endl;
-    print("T[L]", T_L);
-    print("L[L]", L_L);
-    print("S[L]", S_L);
+    if (verbose_) {
+        std::cout << "--------------------------" << std::endl;
+        std::cout << "Basis[L] Matrices" << std::endl;
+        print("T[L]", T_L);
+        print("L[L]", L_L);
+        print("S[L]", S_L);
+    }
 
 }
 
@@ -263,10 +295,12 @@ void decompose_tls_matrices::stepA() {
 */
 void decompose_tls_matrices::stepB() {
 
-    std::cout << std::endl;
-    std::cout << " ######################################" << std::endl;
-    std::cout << " <-------        Step B        ------->" << std::endl;
-    std::cout << " ######################################" << std::endl << std::endl;
+    if (verbose_) {
+        std::cout << std::endl;
+        std::cout << " ######################################" << std::endl;
+        std::cout << " <-------        Step B        ------->" << std::endl;
+        std::cout << " ######################################" << std::endl << std::endl;
+    }
 
     // Lxx component
     double Lxx{xx(L_L)};
@@ -306,11 +340,6 @@ void decompose_tls_matrices::stepB() {
     w_15.w_ly = scitbx::vec3<double>(w_15.wx_ly,        0.0, w_15.wz_ly);
     w_15.w_lz = scitbx::vec3<double>(w_15.wx_lz, w_15.wy_lz,        0.0);
 
-    std::cout << "--------------------------" << std::endl;
-    print("w_lx (eq.15)", w_15.w_lx);
-    print("w_ly (eq.15)", w_15.w_ly);
-    print("w_lz (eq.15)", w_15.w_lz);
-
     // But what is actually wanted:
     double wxx{(w.wx_ly+w.wx_lz)/2.0};
     double wyy{(w.wy_lz+w.wy_lx)/2.0};
@@ -319,21 +348,26 @@ void decompose_tls_matrices::stepB() {
     w.w_ly = scitbx::vec3<double>(w.wx_ly,     wyy, w.wz_ly);
     w.w_lz = scitbx::vec3<double>(w.wx_lz, w.wy_lz,     wzz);
 
-    std::cout << "--------------------------" << std::endl;
-    print("w_lx (eq.16)", w.w_lx);
-    print("w_ly (eq.16)", w.w_ly);
-    print("w_lz (eq.16)", w.w_lz);
-
     // Transform points on libration axes ... in M basis
     w1_M = R_ML_t * w.w_lx;
     w2_M = R_ML_t * w.w_ly;
     w3_M = R_ML_t * w.w_lz;
 
-    std::cout << "--------------------------" << std::endl;
-    std::cout << "Points on Libration axis (M-basis)" << std::endl;
-    print("w_lx[M]", w1_M);
-    print("w_ly[M]", w2_M);
-    print("w_lz[M]", w3_M);
+    if (verbose_) {
+        std::cout << "--------------------------" << std::endl;
+        print("w_lx (eq.15)", w_15.w_lx);
+        print("w_ly (eq.15)", w_15.w_ly);
+        print("w_lz (eq.15)", w_15.w_lz);
+        std::cout << "--------------------------" << std::endl;
+        print("w_lx (eq.16)", w.w_lx);
+        print("w_ly (eq.16)", w.w_ly);
+        print("w_lz (eq.16)", w.w_lz);
+        std::cout << "--------------------------" << std::endl;
+        std::cout << "Points on Libration axis (M-basis)" << std::endl;
+        print("w_lx[M]", w1_M);
+        print("w_ly[M]", w2_M);
+        print("w_lz[M]", w3_M);
+    }
 
     // Calculate D matrix
     double d11 = w.wz_ly * w.wz_ly * Lyy + w.wy_lz * w.wy_lz * Lzz;
@@ -355,20 +389,24 @@ void decompose_tls_matrices::stepB() {
         throw std::runtime_error("Step B: Matrix T_C[L] is not positive semidefinite.");
     }
 
-    // Print output matrices from this section
-    std::cout << "--------------------------" << std::endl;
-    print("D_W[L]", D_WL);
-    std::cout << "--------------------------" << std::endl;
-    print("T_C[L]", T_CL);
+    if (verbose_) {
+        // Print output matrices from this section
+        std::cout << "--------------------------" << std::endl;
+        print("D_W[L]", D_WL);
+        std::cout << "--------------------------" << std::endl;
+        print("T_C[L]", T_CL);
+    }
 
 }
 
 void decompose_tls_matrices::stepC() {
 
-    std::cout << std::endl;
-    std::cout << " ######################################" << std::endl;
-    std::cout << " <-------        Step C        ------->" << std::endl;
-    std::cout << " ######################################" << std::endl << std::endl;
+    if (verbose_) {
+        std::cout << std::endl;
+        std::cout << " ######################################" << std::endl;
+        std::cout << " <-------        Step C        ------->" << std::endl;
+        std::cout << " ######################################" << std::endl << std::endl;
+    }
 
     // Have not implemented FORCE_t_S or find_t_S_formula=="10"
 
@@ -405,9 +443,11 @@ void decompose_tls_matrices::stepC() {
     // All diagonal components of L are non-zero
     if ( ! (is_zero(Lxx) or is_zero(Lyy) or is_zero(Lzz)) ) {
 
-        std::cout << std::endl << "--------------------------" << std::endl;
-        std::cout << "TAKING THE LEFT BRANCH" << std::endl;
-        std::cout << "--------------------------" << std::endl << std::endl;
+        if (verbose_) {
+            std::cout << std::endl << "--------------------------" << std::endl;
+            std::cout << "TAKING THE LEFT BRANCH" << std::endl;
+            std::cout << "--------------------------" << std::endl << std::endl;
+        }
 
         double t_min_C = std::max({Sxx-rx, Syy-ry, Szz-rz});
         double t_max_C = std::min({Sxx+rx, Syy+ry, Szz+rz});
@@ -418,6 +458,7 @@ void decompose_tls_matrices::stepC() {
             throw std::runtime_error("Step C (left branch): Empty (tmin_c,tmax_c) interval.");
         }
 
+        // Calculate t_0 ("formula 11")
         double num = Sxx * Lyy*Lyy * Lzz*Lzz + \
                      Syy * Lzz*Lzz * Lxx*Lxx + \
                      Szz * Lxx*Lxx * Lyy*Lyy;
@@ -426,24 +467,25 @@ void decompose_tls_matrices::stepC() {
                      Lxx*Lxx * Lyy*Lyy;
         double t_0 = num/den;
 
-        std::cout << "--------------------------" << std::endl;
-        print("t_0", t_0);
-
         // Construct T_lambda matrix
         scitbx::sym_mat3<double> T_lambda{t11, t22, t33, t12, t13, t23};
 
-        std::cout << "--------------------------" << std::endl;
-        print("T_lambda", T_lambda);
-
         // Calculate eigenvalues & vectors of T_lambda
         Eig es(T_lambda);
-        eigenvalues  ev = es.values();
+        eigenvalues ev = es.values();
 
-        std::cout << "--------------------------" << std::endl;
-        print("Eigenvalues", scitbx::vec3<double>(ev.begin()));
+        if (verbose_) {
+            std::cout << "--------------------------" << std::endl;
+            print("t_0", t_0);
+            std::cout << "--------------------------" << std::endl;
+            print("T_lambda", T_lambda);
+            std::cout << "--------------------------" << std::endl;
+            print("Eigenvalues", scitbx::vec3<double>(ev.begin()));
+        }
 
         // Eigenvalues should be in decreasing order
         if ( ! (ev[0] >= ev[1] >= ev[2])) {
+            print("Eig", ev);
             throw std::logic_error("Eigenvalues are not in descending size order.");
         }
 
@@ -454,43 +496,47 @@ void decompose_tls_matrices::stepC() {
             throw std::runtime_error("Step C (left branch): Eq.(32): tau_max<0.");
         }
 
-        std::cout << "--------------------------" << std::endl;
-
-        // Print here for cleaness (even though calculated earlier)
-        print("t_min_C", t_min_C);
-        print("t_max_C", t_max_C);
-
         double t_min_tau = std::max({Sxx,Syy,Szz})-std::sqrt(tau_max);
         double t_max_tau = std::min({Sxx,Syy,Szz})+std::sqrt(tau_max);
 
-        print("t_min_tau", t_min_tau);
-        print("t_max_tau", t_max_tau);
-
         if(t_min_tau > t_max_tau) {
+            if (verbose_) {
+                print("t_min_tau", t_min_tau);
+                print("t_max_tau", t_max_tau);
+            }
             throw std::runtime_error("Step C (left branch): Empty (tmin_t,tmax_t) interval.");
         }
 
         double t_a_sq = t_0*t_0 + (t11+t22+t33)/3.0 - (Sxx*Sxx+Syy*Syy+Szz*Szz)/3.0;
         if(t_a_sq < 0.0) {
+            if (verbose_) {
+                print("t_a_sq", t_a_sq);
+            }
             throw std::runtime_error("Step C (left branch): Negative argument when estimating tmin_a.");
         }
 
         double t_a = std::sqrt(t_a_sq);
 
-        print("t_a", t_a);
-
         double t_min_a = t_0-t_a;
         double t_max_a = t_0+t_a;
-
-        print("t_min_a", t_min_a);
-        print("t_max_a", t_max_a);
 
         // compute t_min, t_max
         double t_min = std::max({t_min_C, t_min_tau, t_min_a});
         double t_max = std::min({t_max_C, t_max_tau, t_max_a});
 
-        print("t_min", t_min);
-        print("t_max", t_max);
+        if (verbose_) {
+            std::cout << "--------------------------" << std::endl;
+            print("t_min_C", t_min_C);
+            print("t_max_C", t_max_C);
+            print("t_min_tau", t_min_tau);
+            print("t_max_tau", t_max_tau);
+            print("t_a", t_a);
+            print("t_min_a", t_min_a);
+            print("t_max_a", t_max_a);
+            std::cout << "--------------------------" << std::endl;
+            print("t_min", t_min);
+            print("t_max", t_max);
+        }
 
         // Negative-size interval
         if (t_min > t_max) {
@@ -509,20 +555,20 @@ void decompose_tls_matrices::stepC() {
             bool found_solution = false;
             double step = (t_max-t_min)/1.e5;
             double target = 1.e+9;
-            double target_test;
+            double target_; // temporary variable to compare to current target
 
             // Find the closest valid t to t_0
             for (double t_test=t_min; (t_test<=t_max); t_test+=step) {
                 // How far is this from the target
-                target_test = std::abs(t_0-t_test);
+                target_ = std::abs(t_0-t_test);
                 // Check if closer than current best valid solution
-                if (target_test < target) {
+                if (target_ < target) {
                     // Extract multipliers for the quadratic expansion
                     abc = as_bs_cs(t_test, Sxx, Syy, Szz, t11, t22, t33, t12, t23, t13);
                     // Check linear component positive and quadratic component negative
                     if ( ! (is_negative(abc[1]) or is_positive(abc[2])) ) {
                         // Store the new values
-                        target = target_test;
+                        target = target_;
                         t_S = t_test;
                         // Note that a valid solution has been found
                         found_solution = true;
@@ -537,9 +583,11 @@ void decompose_tls_matrices::stepC() {
     // One or more diagonal components of L is zero
     } else {
 
-        std::cout << std::endl << "--------------------------" << std::endl;
-        std::cout << "TAKING THE RIGHT BRANCH" << std::endl;
-        std::cout << "--------------------------" << std::endl << std::endl;
+        if (verbose_) {
+            std::cout << std::endl << "--------------------------" << std::endl;
+            std::cout << "TAKING THE RIGHT BRANCH" << std::endl;
+            std::cout << "--------------------------" << std::endl << std::endl;
+        }
 
         // whether a solution was found for the cauchy
         bool found_solution(false);
@@ -549,9 +597,9 @@ void decompose_tls_matrices::stepC() {
             int s_i = (ii+0)%3;
             int s_j = (ii+1)%3;
             int s_k = (ii+2)%3;
-            int m_i = (4*ii+0)%12;
-            int m_j = (4*ii+4)%12;
-            int m_k = (4*ii+8)%12;
+            int m_i = 4*s_i;
+            int m_j = 4*s_j;
+            int m_k = 4*s_k;
 
             if ( is_zero(L_L[s_i]) ) {
                 double t_test = S_L[m_i];
@@ -563,7 +611,7 @@ void decompose_tls_matrices::stepC() {
                 }
                 // Check standard conditions
                 abc = as_bs_cs(t_test, Sxx, Syy, Szz, t11, t22, t33, t12, t23, t13);
-                if ( is_positive(abc[0]) or is_negative(abc[1]) or is_negative(abc[2]) ) {
+                if ( is_positive(abc[0]) or is_negative(abc[1]) or is_positive(abc[2]) ) {
                     throw std::runtime_error("Step C (right branch): Conditions 33-35 failed.");
                 }
                 // Checks passed -- does it agree with previous solutions?
@@ -572,6 +620,9 @@ void decompose_tls_matrices::stepC() {
                 } else {
                     // Store the found solution
                     t_S = t_test;
+                    if (verbose_) {
+                        print("Found solution:", t_test);
+                    }
                     // Note that a valid solution has been found
                     found_solution = true;
                 }
@@ -588,15 +639,17 @@ void decompose_tls_matrices::stepC() {
         throw std::runtime_error("Step C (left/right branch): Final t_S does not give positive semidefinite V.");
     }
 
-    std::cout << "--------------------------" << std::endl;
-    print("Final t_S", t_S);
-
     // Calculate the trace-corrected form of S_L
     S_C = S_L - scitbx::mat3<double>(t_S);
 
-    std::cout << "--------------------------" << std::endl;
-    print("S[L]", S_L);
-    print("S_C[L]", S_C);
+    if (verbose_) {
+        std::cout << "--------------------------" << std::endl;
+        print("Final t_S", t_S);
+        std::cout << "--------------------------" << std::endl;
+        print("diag(t_S)", scitbx::mat3<double>(t_S));
+        print("S[L]", S_L);
+        print("S_C[L]", S_C);
+    }
 
     double S_Cxx = xx(S_C);
     double S_Cyy = yy(S_C);
@@ -604,44 +657,46 @@ void decompose_tls_matrices::stepC() {
 
     double sx{0.0}, sy{0.0}, sz{0.0};
 
-    if ( is_zero(Lxx) and (! is_zero(S_Cxx)) ) {
-        throw std::runtime_error("Step C: incompatible L_L and S_C matrices.");
-    } else {
+    if ( ! is_zero(Lxx) ) {
         sx = S_Cxx/Lxx;
+    } else if ( ! is_zero(S_Cxx)) {
+        throw std::runtime_error("Step C: incompatible L_L and S_C matrices. (L{xx} & S_C{xx})");
     }
 
-    if ( is_zero(Lyy) and (! is_zero(S_Cyy)) ) {
-        throw std::runtime_error("Step C: incompatible L_L and S_C matrices.");
-    } else {
+    if ( ! is_zero(Lyy) ) {
         sy = S_Cyy/Lyy;
+    } else if ( ! is_zero(S_Cyy)) {
+        throw std::runtime_error("Step C: incompatible L_L and S_C matrices. (L{yy} & S_C{yy})");
     }
 
-    if ( is_zero(Lzz) and (! is_zero(S_Czz)) ) {
-        throw std::runtime_error("Step C: incompatible L_L and S_C matrices.");
-    } else {
+    if ( ! is_zero(Lzz) ) {
         sz = S_Czz/Lzz;
+    } else if ( ! is_zero(S_Czz)) {
+        throw std::runtime_error("Step C: incompatible L_L and S_C matrices. (L{zz} & S_C{zz})");
     }
-
-    std::cout << "--------------------------" << std::endl;
-    std::cout <<  "Screw parameters:" << std::endl;
-    print("sx", sx);
-    print("sy", sy);
-    print("sz", sz);
 
     // Store s-amplitudes
-    s_amplitudes = scitbx::vec3<double>(sx,sy,sz);
+    s_amplitudes.push_back(sx);
+    s_amplitudes.push_back(sy);
+    s_amplitudes.push_back(sz);
 
     // Calculate the contribution to the translation matrix
     C_L_t_S = scitbx::sym_mat3<double>(sx*S_Cxx, sy*S_Cyy, sz*S_Czz, 0.0, 0.0, 0.0);
 
-    std::cout << "--------------------------" << std::endl;
-    print("C[L](t=t_S)", C_L_t_S);
-
     // Calculate the vibration matrix
     V_L = T_CL - C_L_t_S;
 
-    std::cout << "--------------------------" << std::endl;
-    print("V[L]", V_L);
+    if (verbose_) {
+        std::cout << "--------------------------" << std::endl;
+        std::cout <<  "Screw parameters:" << std::endl;
+        print("sx", sx);
+        print("sy", sy);
+        print("sz", sz);
+        std::cout << "--------------------------" << std::endl;
+        print("C[L](t=t_S)", C_L_t_S);
+        std::cout << "--------------------------" << std::endl;
+        print("V[L]", V_L);
+    }
 
     if (! is_pd(V_L)) {
         throw std::runtime_error("Step C: Matrix V[L] is not positive semidefinite.");
@@ -651,10 +706,12 @@ void decompose_tls_matrices::stepC() {
 
 void decompose_tls_matrices::stepD() {
 
-    std::cout << std::endl;
-    std::cout << " ######################################" << std::endl;
-    std::cout << " <-------        Step D        ------->" << std::endl;
-    std::cout << " ######################################" << std::endl << std::endl;
+    if (verbose_) {
+        std::cout << std::endl;
+        std::cout << " ######################################" << std::endl;
+        std::cout << " <-------        Step D        ------->" << std::endl;
+        std::cout << " ######################################" << std::endl << std::endl;
+    }
 
     // Diagonalise V[L] matrix
     Eig v_eig(V_L);
@@ -662,33 +719,31 @@ void decompose_tls_matrices::stepD() {
     eigenvalues  v_eig_vals = v_eig.values();
 
     // Store the eigenvectors of V
-    v_amplitudes = scitbx::vec3<double>(v_eig_vals[0], v_eig_vals[1], v_eig_vals[2]);
     v1_L = scitbx::vec3<double>(&v_eig_vecs[0]);
     v2_L = scitbx::vec3<double>(&v_eig_vecs[3]);
     v3_L = scitbx::vec3<double>(&v_eig_vecs[6]);
     // OVERWRITE - Choose v1 to be cross product of v2 and v3 (guaranteed righthanded system)
     v1_L = v2_L.cross(v3_L);
 
-    // Print Eigenvalues of V
-    std::cout << "--------------------------" << std::endl;
-    std::cout << "Eigenvalues of V[L]: " << std::endl;
-    print("1", v_amplitudes[0]);
-    print("2", v_amplitudes[1]);
-    print("3", v_amplitudes[2]);
-    std::cout << "Eigenvectors of V[L]: " << std::endl;
-    print("1", v1_L);
-    print("2", v2_L);
-    print("3", v3_L);
+    // Store ampltidues as the square root of the eigenvalue
+    for (int i=0; i<3; i++) { v_amplitudes.push_back(std::sqrt(v_eig_vals[i])); }
 
-    // T values are sqrt of v
-    double t1 = std::sqrt(v_amplitudes[0]);
-    double t2 = std::sqrt(v_amplitudes[1]);
-    double t3 = std::sqrt(v_amplitudes[2]);
-
-    std::cout << "RMS vibrational components: " << std::endl;
-    print("1", t1);
-    print("2", t2);
-    print("3", t3);
+    if (verbose_) {
+        // Print Eigenvalues of V
+        std::cout << "--------------------------" << std::endl;
+        std::cout << "Eigenvalues of V[L]: " << std::endl;
+        print("1", v_eig_vals[0]);
+        print("2", v_eig_vals[1]);
+        print("3", v_eig_vals[2]);
+        std::cout << "Eigenvectors of V[L]: " << std::endl;
+        print("1", v1_L);
+        print("2", v2_L);
+        print("3", v3_L);
+        std::cout << "RMS vibrational components: " << std::endl;
+        print("1", v_amplitudes[0]);
+        print("2", v_amplitudes[1]);
+        print("3", v_amplitudes[2]);
+    }
 
     // Extract the rotation matrix from the eigenvectors
     //scitbx::mat3<double> R_LV = static_cast <scitbx::mat3<double>> (v_eig.vectors().begin());
@@ -699,28 +754,27 @@ void decompose_tls_matrices::stepD() {
     scitbx::mat3<double> V_V_ = R_LV * V_L * R_LV_t;
     V_V = scitbx::sym_mat3<double>((V_V_ + V_V_.transpose()) / 2.0);
 
-    std::cout << "--------------------------" << std::endl;
-    print("V[V]", V_V);
-
     // Return vibration axes to original basis
     v1_M = R_ML_t * v1_L;
     v2_M = R_ML_t * v2_L;
     v3_M = R_ML_t * v3_L;
 
-    std::cout << "--------------------------" << std::endl;
-    std::cout << "Vibrational axes (M-basis)" << std::endl;
-    print("1", v1_M);
-    print("2", v2_M);
-    print("3", v3_M);
-
     // Calculate full transformation
     R_MV = R_LV * R_ML;
 
-    std::cout << "--------------------------" << std::endl;
-    print("R[M->L]", R_ML);
-    print("R[L->V]", R_LV);
-    print("R[M->V]", R_MV);
-
+    if (verbose_) {
+        std::cout << "--------------------------" << std::endl;
+        print("V[V]", V_V);
+        std::cout << "--------------------------" << std::endl;
+        std::cout << "Vibrational axes (M-basis)" << std::endl;
+        print("1", v1_M);
+        print("2", v2_M);
+        print("3", v3_M);
+        std::cout << "--------------------------" << std::endl;
+        print("R[M->L]", R_ML);
+        print("R[L->V]", R_LV);
+        print("R[M->V]", R_MV);
+    }
 }
 
 void decompose_tls_matrices::run() {
@@ -734,40 +788,24 @@ void decompose_tls_matrices::run() {
     }
     catch (std::runtime_error e)
     {
-        std::cout << "Exception Caught: " << e.what() << std::endl;
         error_ = e.what();
-    }
-
-    // print result
-    std::cout << std::boolalpha << "TLS matrices are valid: " << is_valid() << std::endl;
-    if  (! is_valid() ) {
-        std::cout << "Result: " << error_ << std::endl;
+        valid_ = false;
     }
 }
 
 }}} // close mmtbx/tls/decompose
 
+// Example usage
 int main()
 {
     double one(1.0), nul(0.0), sml(1e-9);
 
-    // Simple test (no S)
-//    scitbx::sym_mat3<double> T (+0.280, +0.395, +0.234, +0.063, +0.118, +0.033);
-//    scitbx::sym_mat3<double> L (+0.106, +0.107, +0.696, -0.021, -0.014, -0.152);
-//    scitbx::mat3<double> S (0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-
-    // Test against python implementation
+    // Example input matrices
     scitbx::sym_mat3<double> T (0.0959882450545,0.156509777229,0.0886002086034,-5.19222597403e-05,-0.0172511466857,-0.00869540261855);
     scitbx::sym_mat3<double> L (0.0123001438881,0.0461188308667,0.0218102205791,0.00435192109608,0.00517157269537,-0.0155699937912);
     scitbx::mat3<double> S (-0.00725668016697,-0.0201548281778,0.00431134160979,0.036329322896,-0.00252099816856,-0.00771964293756,-0.00968895922456,0.0170374138375,0.00977767833552);
 
-    // Make matrices larger so can be seen after scaling to radians
-    double mult(100.0);
-    T *= mult;
-    L *= mult;
-    S *= mult;
-
-    mmtbx::tls::decompose::decompose_tls_matrices dtm(T, L, S);
+    mmtbx::tls::decompose::decompose_tls_matrices dtm(T, L, S, false, true);
 
     return 0;
 }

--- a/mmtbx/tls/decompose.cpp
+++ b/mmtbx/tls/decompose.cpp
@@ -1,0 +1,773 @@
+#include <cmath>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <iomanip>
+
+#include <scitbx/vec3.h>
+#include <scitbx/mat3.h>
+#include <scitbx/sym_mat3.h>
+#include <scitbx/array_family/versa.h>
+#include <scitbx/array_family/shared.h>
+#include <scitbx/matrix/eigensystem.h>
+#include <scitbx/constants.h>
+
+#include "decompose.h"
+
+namespace mmtbx { namespace tls { namespace decompose {
+
+namespace af = scitbx::af;
+typedef scitbx::matrix::eigensystem::real_symmetric<double> Eig;
+typedef af::shared<double>                  eigenvalues;
+typedef af::versa<double, af::c_grid<2> >   eigenvectors;
+
+// Template FloatType
+//template <typename FloatType>
+
+// Constructor
+
+decompose_tls_matrices::decompose_tls_matrices(
+        scitbx::sym_mat3<double> const& T,
+        scitbx::sym_mat3<double> const& L_deg,
+        scitbx::mat3<double> const& S_deg,
+        scitbx::vec3<double> const& origin = (0.0,0.0,0.0) )
+{
+    double deg2rad = scitbx::deg_as_rad(1.0);
+    double deg2radsq = deg2rad * deg2rad;
+
+    // Convert and store the input matrices
+    T_M = T;
+    L_M = L_deg * deg2radsq;
+    S_M = S_deg * deg2rad;
+
+    std::cout << "--------------------------" << std::endl;
+    std::cout << "Input Matrices:" << std::endl;
+    print("T", T_M);
+    print("L", L_M);
+    print("S", S_M);
+
+    // Run decomposition
+    run();
+}
+
+// linalg functions
+
+bool decompose_tls_matrices::is_pd(scitbx::sym_mat3<double> const& matrix) {
+    // Create eigensystem object
+    Eig es(matrix);
+    // Extract eigenvalues
+    af::shared<double> ev = es.values();
+    // Check all are positive
+    for (int i=0; i<3; i++) {
+        if (matrix[i] < (-1.0*tol)) { return false; }
+    }
+    return true;
+}
+
+scitbx::vec3<double> decompose_tls_matrices::as_bs_cs(
+        double t,
+        double Sxx,
+        double Syy,
+        double Szz,
+        double T11,
+        double T22,
+        double T33,
+        double T12,
+        double T13,
+        double T23) {
+
+    double xx_ = (t-Sxx)*(t-Sxx) - T11;
+    double yy_ = (t-Syy)*(t-Syy) - T22;
+    double zz_ = (t-Szz)*(t-Szz) - T33;
+
+    return scitbx::vec3<double>(
+            xx_ + yy_ + zz_,
+            xx_*yy_ + yy_*zz_ + zz_*xx_ - (T12*T12 + T23*T23 + T13*T13),
+            xx_*yy_*zz_ - T23*T23*xx_ - T13*T13*yy_ - T12*T12*zz_ - 2.0*T12*T23*T13);
+
+}
+
+// check functions
+
+bool decompose_tls_matrices::is_zero(double value) {
+    if (std::abs(value) < tol) { return true; }
+    return false;
+}
+
+bool decompose_tls_matrices::is_positive(double value) {
+    if ( value > tol ) { return true; }
+    return false;
+}
+
+bool decompose_tls_matrices::is_negative(double value) {
+    if ( value < -tol) { return true; }
+    return false;
+}
+
+// print functions
+
+void decompose_tls_matrices::print(std::string const& label, double value) {
+    std::cout << label << ": " << spacer << value << spacer << std::endl;
+}
+
+void decompose_tls_matrices::print(std::string const& label, scitbx::mat3<double> const& matrix) {
+    std::cout << std::setprecision(6) << std::fixed << std::showpos;
+    std::cout << label << ":" << std::endl;
+    std::cout << spacer << matrix[0] << spacer << matrix[1] << spacer << matrix[2] << std::endl;
+    std::cout << spacer << matrix[3] << spacer << matrix[4] << spacer << matrix[5] << std::endl;
+    std::cout << spacer << matrix[6] << spacer << matrix[7] << spacer << matrix[8] << std::endl;
+}
+
+void decompose_tls_matrices::print(std::string const& label, scitbx::sym_mat3<double> const& matrix) {
+    std::cout << std::setprecision(6) << std::fixed << std::showpos;
+    std::cout << label << ":" << std::endl;
+    std::cout << spacer << matrix[0]  << spacer << matrix[3]  << spacer << matrix[4] << std::endl;
+    std::cout << spacer << "+-.------" << spacer << matrix[1]  << spacer << matrix[5] << std::endl;
+    std::cout << spacer << "+-.------" << spacer << "+-.------" << spacer << matrix[2] << std::endl;
+}
+
+void decompose_tls_matrices::print(std::string const& label, scitbx::vec3<double> const& vector) {
+    std::cout << std::setprecision(6) << std::fixed << std::showpos;
+    std::cout << label << ": ";
+    std::cout << spacer << vector[0] << spacer << vector[1] << spacer << vector[2] << std::endl;
+}
+
+// Small-value functions
+
+double decompose_tls_matrices::zero_filter(double value) {
+    if (std::abs(value) < eps) { return 0.0; }
+    return value;
+}
+
+void decompose_tls_matrices::zero_small_values(scitbx::mat3<double>& matrix) {
+    //Iterate through values
+    for (int i=0; i<9; i++) {
+        if (std::abs(matrix[i]) < eps) { matrix[i] = 0.0; }
+    }
+}
+
+void decompose_tls_matrices::zero_small_values(scitbx::sym_mat3<double>& matrix) {
+    //Iterate through values
+    for (int i=0; i<6; i++) {
+        if (std::abs(matrix[i]) < eps) { matrix[i] = 0.0; }
+    }
+}
+
+void decompose_tls_matrices::zero_small_values(scitbx::vec3<double>& vector) {
+    //Iterate through values
+    for (int i=0; i<3; i++) {
+        if (std::abs(vector[i]) < eps) { vector[i] = 0.0; }
+    }
+}
+
+// Main functions
+
+/**
+ * Diagonalise the L matrix
+*/
+void decompose_tls_matrices::stepA() {
+
+    std::cout << std::endl;
+    std::cout << " ######################################" << std::endl;
+    std::cout << " <-------        Step A        ------->" << std::endl;
+    std::cout << " ######################################" << std::endl << std::endl;
+
+    // Bail if T not positive definite
+    if (! is_pd(T_M)) {
+        throw std::runtime_error("Step A: Input matrix T[M] is not positive semidefinite.");
+    }
+    // Bail if L not positive definite
+    if (! is_pd(L_M)) {
+        throw std::runtime_error("Step A: Input matrix L[M] is not positive semidefinite.");
+    }
+
+    // Find eigenvalues and eigenvectors of L-matrix
+    Eig l_eig(L_M);
+    eigenvectors l_eig_vecs = l_eig.vectors();
+    eigenvalues  l_eig_vals = l_eig.values();
+
+    // Store the eigenvalues and eigenvectors of L
+    l_amplitudes = scitbx::vec3<double>(l_eig_vals[0], l_eig_vals[1], l_eig_vals[2]);
+    l1_M = scitbx::vec3<double>(&l_eig_vecs[0]);
+    l2_M = scitbx::vec3<double>(&l_eig_vecs[3]);
+    l3_M = scitbx::vec3<double>(&l_eig_vecs[6]);
+    // OVERWRITE - Choose l1 to be cross product of l2 and l3 (guaranteed righthanded system)
+    l1_M = l2_M.cross(l3_M);
+
+    // Extract the rotation matrix from the eigenvectors
+    // Eigenvectors of L_M are ROWS of R_ML
+    // R_ML = ( e1_x, e1_y, e1_z )
+    //        ( e2_x, e2_y, e2_z )
+    //        ( e3_x, e3_y, e3_z )
+    // elements are R_ML(row, column)
+    //R_ML = static_cast <scitbx::mat3<double>> (l_eig.vectors().begin());
+    R_ML = scitbx::mat3<double>(l1_M[0], l1_M[1], l1_M[2], l2_M[0], l2_M[1], l2_M[2], l3_M[0], l3_M[1], l3_M[2]);
+    R_ML_t = R_ML.transpose();
+
+    // Check that determinant is 1 and transpose is inverse
+    double det = R_ML.determinant();
+    if ( std::abs(det-1.0) > tol ) {
+        throw std::runtime_error("Step A: Rotation matrix R[ML] does not have unitary determinant");
+    }
+
+    // Print Eigenvalues of L
+    std::cout << "--------------------------" << std::endl;
+    std::cout << "Eigenvalues of L: " << std::endl;
+    print("1", l_amplitudes[0]);
+    print("2", l_amplitudes[1]);
+    print("3", l_amplitudes[2]);
+    std::cout << "Eigenvectors of L: " << std::endl;
+    print("1", l1_M);
+    print("2", l2_M);
+    print("3", l3_M);
+
+    // Print eigenvectors/rotation matrix
+    std::cout << "--------------------------" << std::endl;
+    print("R[M->L]", R_ML);
+
+    // Check eigenvectors are unitary
+    double mod1, mod2, mod3;
+    mod1 = R_ML(0,0)*R_ML(0,0) + R_ML(0,1)*R_ML(0,1) + R_ML(0,2)*R_ML(0,2);
+    mod2 = R_ML(1,0)*R_ML(1,0) + R_ML(1,1)*R_ML(1,1) + R_ML(1,2)*R_ML(1,2);
+    mod3 = R_ML(2,0)*R_ML(2,0) + R_ML(2,1)*R_ML(2,1) + R_ML(2,2)*R_ML(2,2);
+
+    // Sanity checks -- verbose only
+    std::cout << "--------------------------" << std::endl;
+    std::cout << "Modulus of the eigenvectors of the L_M matrix" << std::endl;
+    std::cout << "modulus 1st vector: " << mod1 << std::endl;
+    std::cout << "modulus 2nd vector: " << mod2 << std::endl;
+    std::cout << "modulus 3rd vector: " << mod3 << std::endl;
+
+    std::cout << "--------------------------" << std::endl;
+    print("R[ML] * L[M] * t(R[ML])", R_ML * L_M * R_ML_t);
+
+    // Transform the input matrices to the basis of L_M
+    scitbx::mat3<double> T_L_ = R_ML * T_M * R_ML_t;
+    scitbx::mat3<double> L_L_ = R_ML * L_M * R_ML_t;
+    // Make symmetric and recast
+    T_L = scitbx::sym_mat3<double>((T_L_ + T_L_.transpose()) / 2.0);
+    L_L = scitbx::sym_mat3<double>((L_L_ + L_L_.transpose()) / 2.0);
+    // S is mat3 anyway
+    S_L = R_ML * S_M * R_ML_t;
+
+    std::cout << "--------------------------" << std::endl;
+    std::cout << "Basis[L] Matrices" << std::endl;
+    print("T[L]", T_L);
+    print("L[L]", L_L);
+    print("S[L]", S_L);
+
+}
+
+/**
+ * Find the libration axes in the L-basis
+*/
+void decompose_tls_matrices::stepB() {
+
+    std::cout << std::endl;
+    std::cout << " ######################################" << std::endl;
+    std::cout << " <-------        Step B        ------->" << std::endl;
+    std::cout << " ######################################" << std::endl << std::endl;
+
+    // Lxx component
+    double Lxx{xx(L_L)};
+    double Sxy{xy(S_L)};
+    double Sxz{xz(S_L)};
+    if ( ! is_zero(Lxx) ) {
+        w.wz_lx = w_15.wz_lx =   Sxy / Lxx;       // xy is     cyclic permutation >  plus sign
+        w.wy_lx = w_15.wy_lx = - Sxz / Lxx;       // xz is anticyclic permutation > minus sign
+    } else if ( ! (is_zero(Sxy) and is_zero(Sxz)) ) {
+        throw std::runtime_error("Step B: Non-zero off-diagonal S[L] and zero L[L] elements.");
+    }
+
+    // Lyy Component
+    double Lyy{yy(L_L)};
+    double Syz{yz(S_L)};
+    double Syx{yx(S_L)};
+    if ( ! is_zero(Lyy) ) {
+        w.wx_ly = w_15.wx_ly =   Syz / Lyy;       // yz is     cyclic permutation >  plus sign
+        w.wz_ly = w_15.wz_ly = - Syx / Lyy;       // yx is anticyclic permutation > minus sign
+    } else if ( ! (is_zero(Syz) and is_zero(Syx)) ) {
+        throw std::runtime_error("Step B: Non-zero off-diagonal S[L] and zero L[L] elements.");
+    }
+
+    // Lzz component
+    double Lzz{zz(L_L)};
+    double Szx{zx(S_L)};
+    double Szy{zy(S_L)};
+    if ( ! is_zero(Lzz) ) {
+        w.wy_lz = w_15.wy_lz =   Szx / Lzz;       // zx is     cyclic permutation >  plus sign
+        w.wx_lz = w_15.wx_lz = - Szy / Lzz;       // zy is anticyclic permutation > minus sign
+    } else if ( ! (is_zero(Szx) and is_zero(Szy)) ) {
+        throw std::runtime_error("Step B: Non-zero off-diagonal S[L] and zero L[L] elements.");
+    }
+
+    // Combine to create vectors
+    w_15.w_lx = scitbx::vec3<double>(       0.0, w_15.wy_lx, w_15.wz_lx);
+    w_15.w_ly = scitbx::vec3<double>(w_15.wx_ly,        0.0, w_15.wz_ly);
+    w_15.w_lz = scitbx::vec3<double>(w_15.wx_lz, w_15.wy_lz,        0.0);
+
+    std::cout << "--------------------------" << std::endl;
+    print("w_lx (eq.15)", w_15.w_lx);
+    print("w_ly (eq.15)", w_15.w_ly);
+    print("w_lz (eq.15)", w_15.w_lz);
+
+    // But what is actually wanted:
+    double wxx{(w.wx_ly+w.wx_lz)/2.0};
+    double wyy{(w.wy_lz+w.wy_lx)/2.0};
+    double wzz{(w.wz_lx+w.wz_ly)/2.0};
+    w.w_lx = scitbx::vec3<double>(    wxx, w.wy_lx, w.wz_lx);
+    w.w_ly = scitbx::vec3<double>(w.wx_ly,     wyy, w.wz_ly);
+    w.w_lz = scitbx::vec3<double>(w.wx_lz, w.wy_lz,     wzz);
+
+    std::cout << "--------------------------" << std::endl;
+    print("w_lx (eq.16)", w.w_lx);
+    print("w_ly (eq.16)", w.w_ly);
+    print("w_lz (eq.16)", w.w_lz);
+
+    // Transform points on libration axes ... in M basis
+    w1_M = R_ML_t * w.w_lx;
+    w2_M = R_ML_t * w.w_ly;
+    w3_M = R_ML_t * w.w_lz;
+
+    std::cout << "--------------------------" << std::endl;
+    std::cout << "Points on Libration axis (M-basis)" << std::endl;
+    print("w_lx[M]", w1_M);
+    print("w_ly[M]", w2_M);
+    print("w_lz[M]", w3_M);
+
+    // Calculate D matrix
+    double d11 = w.wz_ly * w.wz_ly * Lyy + w.wy_lz * w.wy_lz * Lzz;
+    double d22 = w.wx_lz * w.wx_lz * Lzz + w.wz_lx * w.wz_lx * Lxx;
+    double d33 = w.wy_lx * w.wy_lx * Lxx + w.wx_ly * w.wx_ly * Lyy;
+    double d12 = - w.wx_lz * w.wy_lz * Lzz;
+    double d13 = - w.wz_ly * w.wx_ly * Lyy;
+    double d23 = - w.wy_lx * w.wz_lx * Lxx;
+
+    // Find the apparent translation caused by offset of libration axes
+    D_WL = scitbx::sym_mat3<double>(d11,d22,d33,d12,d13,d23);
+    // Subtract from translation matrix
+    T_CL = T_L - D_WL;
+    // Convert small values to zero in-place
+    zero_small_values(T_CL);
+
+    // Check PD
+    if (! is_pd(T_CL)) {
+        throw std::runtime_error("Step B: Matrix T_C[L] is not positive semidefinite.");
+    }
+
+    // Print output matrices from this section
+    std::cout << "--------------------------" << std::endl;
+    print("D_W[L]", D_WL);
+    std::cout << "--------------------------" << std::endl;
+    print("T_C[L]", T_CL);
+
+}
+
+void decompose_tls_matrices::stepC() {
+
+    std::cout << std::endl;
+    std::cout << " ######################################" << std::endl;
+    std::cout << " <-------        Step C        ------->" << std::endl;
+    std::cout << " ######################################" << std::endl << std::endl;
+
+    // Have not implemented FORCE_t_S or find_t_S_formula=="10"
+
+    double Lxx{zero_filter(xx(L_L))};
+    double Lyy{zero_filter(yy(L_L))};
+    double Lzz{zero_filter(zz(L_L))};
+
+    double Sxx{xx(S_L)};
+    double Syy{yy(S_L)};
+    double Szz{zz(S_L)};
+
+    double T_CLxx = xx(T_CL);
+    double T_CLyy = yy(T_CL);
+    double T_CLzz = zz(T_CL);
+
+    double t11 = T_CLxx * Lxx;
+    double t22 = T_CLyy * Lyy;
+    double t33 = T_CLzz * Lzz;
+
+    double rx = std::sqrt(t11);
+    double ry = std::sqrt(t22);
+    double rz = std::sqrt(t33);
+
+    double t12 = xy(T_CL) * std::sqrt(Lxx*Lyy);
+    double t13 = xz(T_CL) * std::sqrt(Lxx*Lzz);
+    double t23 = yz(T_CL) * std::sqrt(Lyy*Lzz);
+
+    // Coefficients of the quadratic
+    scitbx::vec3<double> abc;
+
+    //
+    //  LEFT BRANCH
+    //
+    // All diagonal components of L are non-zero
+    if ( ! (is_zero(Lxx) or is_zero(Lyy) or is_zero(Lzz)) ) {
+
+        std::cout << std::endl << "--------------------------" << std::endl;
+        std::cout << "TAKING THE LEFT BRANCH" << std::endl;
+        std::cout << "--------------------------" << std::endl << std::endl;
+
+        double t_min_C = std::max({Sxx-rx, Syy-ry, Szz-rz});
+        double t_max_C = std::min({Sxx+rx, Syy+ry, Szz+rz});
+
+        if (t_min_C > t_max_C) {
+            print("t_min_C", t_min_C);
+            print("t_max_C", t_max_C);
+            throw std::runtime_error("Step C (left branch): Empty (tmin_c,tmax_c) interval.");
+        }
+
+        double num = Sxx * Lyy*Lyy * Lzz*Lzz + \
+                     Syy * Lzz*Lzz * Lxx*Lxx + \
+                     Szz * Lxx*Lxx * Lyy*Lyy;
+        double den = Lyy*Lyy * Lzz*Lzz + \
+                     Lzz*Lzz * Lxx*Lxx + \
+                     Lxx*Lxx * Lyy*Lyy;
+        double t_0 = num/den;
+
+        std::cout << "--------------------------" << std::endl;
+        print("t_0", t_0);
+
+        // Construct T_lambda matrix
+        scitbx::sym_mat3<double> T_lambda{t11, t22, t33, t12, t13, t23};
+
+        std::cout << "--------------------------" << std::endl;
+        print("T_lambda", T_lambda);
+
+        // Calculate eigenvalues & vectors of T_lambda
+        Eig es(T_lambda);
+        eigenvalues  ev = es.values();
+
+        std::cout << "--------------------------" << std::endl;
+        print("Eigenvalues", scitbx::vec3<double>(ev.begin()));
+
+        // Eigenvalues should be in decreasing order
+        if ( ! (ev[0] >= ev[1] >= ev[2])) {
+            throw std::logic_error("Eigenvalues are not in descending size order.");
+        }
+
+        double tau_max = ev[0];
+
+        // Largest eigenvalue must be positive
+        if(tau_max < 0.0) {
+            throw std::runtime_error("Step C (left branch): Eq.(32): tau_max<0.");
+        }
+
+        std::cout << "--------------------------" << std::endl;
+
+        // Print here for cleaness (even though calculated earlier)
+        print("t_min_C", t_min_C);
+        print("t_max_C", t_max_C);
+
+        double t_min_tau = std::max({Sxx,Syy,Szz})-std::sqrt(tau_max);
+        double t_max_tau = std::min({Sxx,Syy,Szz})+std::sqrt(tau_max);
+
+        print("t_min_tau", t_min_tau);
+        print("t_max_tau", t_max_tau);
+
+        if(t_min_tau > t_max_tau) {
+            throw std::runtime_error("Step C (left branch): Empty (tmin_t,tmax_t) interval.");
+        }
+
+        double t_a_sq = t_0*t_0 + (t11+t22+t33)/3.0 - (Sxx*Sxx+Syy*Syy+Szz*Szz)/3.0;
+        if(t_a_sq < 0.0) {
+            throw std::runtime_error("Step C (left branch): Negative argument when estimating tmin_a.");
+        }
+
+        double t_a = std::sqrt(t_a_sq);
+
+        print("t_a", t_a);
+
+        double t_min_a = t_0-t_a;
+        double t_max_a = t_0+t_a;
+
+        print("t_min_a", t_min_a);
+        print("t_max_a", t_max_a);
+
+        // compute t_min, t_max
+        double t_min = std::max({t_min_C, t_min_tau, t_min_a});
+        double t_max = std::min({t_max_C, t_max_tau, t_max_a});
+
+        print("t_min", t_min);
+        print("t_max", t_max);
+
+        // Negative-size interval
+        if (t_min > t_max) {
+            throw std::runtime_error("Step C (left branch): Intersection of the intervals for t_S is empty.");
+        // Zero-sized interval
+        } else if (is_zero(t_min-t_max)) {
+            abc = as_bs_cs(t_min, Sxx, Syy, Szz, t11, t22, t33, t12, t23, t13);
+            if ( ! (is_negative(abc[1]) or is_positive(abc[2])) ) {
+                t_S = t_min;
+            } else {
+                throw std::runtime_error("Step C (left branch): t_min=t_max gives non-positive semidefinite V.");
+            }
+        // Positive-size interval
+        } else {
+            // Initialise loop variables
+            bool found_solution = false;
+            double step = (t_max-t_min)/1.e5;
+            double target = 1.e+9;
+            double target_test;
+
+            // Find the closest valid t to t_0
+            for (double t_test=t_min; (t_test<=t_max); t_test+=step) {
+                // How far is this from the target
+                target_test = std::abs(t_0-t_test);
+                // Check if closer than current best valid solution
+                if (target_test < target) {
+                    // Extract multipliers for the quadratic expansion
+                    abc = as_bs_cs(t_test, Sxx, Syy, Szz, t11, t22, t33, t12, t23, t13);
+                    // Check linear component positive and quadratic component negative
+                    if ( ! (is_negative(abc[1]) or is_positive(abc[2])) ) {
+                        // Store the new values
+                        target = target_test;
+                        t_S = t_test;
+                        // Note that a valid solution has been found
+                        found_solution = true;
+                    }
+                }
+            }
+            // No valid solution found in interval
+            if (! found_solution) {
+                throw std::runtime_error("Step C (left branch): Interval (t_min,t_max) has no t giving positive semidefinite V.");
+            }
+        }
+    // One or more diagonal components of L is zero
+    } else {
+
+        std::cout << std::endl << "--------------------------" << std::endl;
+        std::cout << "TAKING THE RIGHT BRANCH" << std::endl;
+        std::cout << "--------------------------" << std::endl << std::endl;
+
+        // whether a solution was found for the cauchy
+        bool found_solution(false);
+
+        for (int ii=0; ii<3; ii++) {
+            // Generate matrix indices for diagonals (sym and non-sym)
+            int s_i = (ii+0)%3;
+            int s_j = (ii+1)%3;
+            int s_k = (ii+2)%3;
+            int m_i = (4*ii+0)%12;
+            int m_j = (4*ii+4)%12;
+            int m_k = (4*ii+8)%12;
+
+            if ( is_zero(L_L[s_i]) ) {
+                double t_test = S_L[m_i];
+                // Check cauchy conditions
+                double cp1 = (S_L[m_j]-t_test)*(S_L[m_j]-t_test) - T_CL[s_j]*L_L[s_j];
+                double cp2 = (S_L[m_k]-t_test)*(S_L[m_k]-t_test) - T_CL[s_k]*L_L[s_k];
+                if ( is_positive(cp1) or is_positive(cp2) ) {
+                    throw std::runtime_error("Step C (right branch): Cauchy condition failed (23).");
+                }
+                // Check standard conditions
+                abc = as_bs_cs(t_test, Sxx, Syy, Szz, t11, t22, t33, t12, t23, t13);
+                if ( is_positive(abc[0]) or is_negative(abc[1]) or is_negative(abc[2]) ) {
+                    throw std::runtime_error("Step C (right branch): Conditions 33-35 failed.");
+                }
+                // Checks passed -- does it agree with previous solutions?
+                if ( found_solution and (! is_zero(t_S-t_test)) ) {
+                    throw std::runtime_error("Step C (right branch): different solutions do not agree (should not happen?)");
+                } else {
+                    // Store the found solution
+                    t_S = t_test;
+                    // Note that a valid solution has been found
+                    found_solution = true;
+                }
+            }
+        }
+        if ( ! found_solution ) {
+            throw std::runtime_error("Step C (right branch): No valid solutions found.");
+        }
+    }
+
+    // Check the final solution
+    abc = as_bs_cs(t_S, Sxx, Syy, Szz, t11, t22, t33, t12, t23, t13);
+    if ( is_negative(abc[1]) or is_positive(abc[2]) ) {
+        throw std::runtime_error("Step C (left/right branch): Final t_S does not give positive semidefinite V.");
+    }
+
+    std::cout << "--------------------------" << std::endl;
+    print("Final t_S", t_S);
+
+    // Calculate the trace-corrected form of S_L
+    S_C = S_L - scitbx::mat3<double>(t_S);
+
+    std::cout << "--------------------------" << std::endl;
+    print("S[L]", S_L);
+    print("S_C[L]", S_C);
+
+    double S_Cxx = xx(S_C);
+    double S_Cyy = yy(S_C);
+    double S_Czz = zz(S_C);
+
+    double sx{0.0}, sy{0.0}, sz{0.0};
+
+    if ( is_zero(Lxx) and (! is_zero(S_Cxx)) ) {
+        throw std::runtime_error("Step C: incompatible L_L and S_C matrices.");
+    } else {
+        sx = S_Cxx/Lxx;
+    }
+
+    if ( is_zero(Lyy) and (! is_zero(S_Cyy)) ) {
+        throw std::runtime_error("Step C: incompatible L_L and S_C matrices.");
+    } else {
+        sy = S_Cyy/Lyy;
+    }
+
+    if ( is_zero(Lzz) and (! is_zero(S_Czz)) ) {
+        throw std::runtime_error("Step C: incompatible L_L and S_C matrices.");
+    } else {
+        sz = S_Czz/Lzz;
+    }
+
+    std::cout << "--------------------------" << std::endl;
+    std::cout <<  "Screw parameters:" << std::endl;
+    print("sx", sx);
+    print("sy", sy);
+    print("sz", sz);
+
+    // Store s-amplitudes
+    s_amplitudes = scitbx::vec3<double>(sx,sy,sz);
+
+    // Calculate the contribution to the translation matrix
+    C_L_t_S = scitbx::sym_mat3<double>(sx*S_Cxx, sy*S_Cyy, sz*S_Czz, 0.0, 0.0, 0.0);
+
+    std::cout << "--------------------------" << std::endl;
+    print("C[L](t=t_S)", C_L_t_S);
+
+    // Calculate the vibration matrix
+    V_L = T_CL - C_L_t_S;
+
+    std::cout << "--------------------------" << std::endl;
+    print("V[L]", V_L);
+
+    if (! is_pd(V_L)) {
+        throw std::runtime_error("Step C: Matrix V[L] is not positive semidefinite.");
+    }
+
+}
+
+void decompose_tls_matrices::stepD() {
+
+    std::cout << std::endl;
+    std::cout << " ######################################" << std::endl;
+    std::cout << " <-------        Step D        ------->" << std::endl;
+    std::cout << " ######################################" << std::endl << std::endl;
+
+    // Diagonalise V[L] matrix
+    Eig v_eig(V_L);
+    eigenvectors v_eig_vecs = v_eig.vectors();
+    eigenvalues  v_eig_vals = v_eig.values();
+
+    // Store the eigenvectors of V
+    v_amplitudes = scitbx::vec3<double>(v_eig_vals[0], v_eig_vals[1], v_eig_vals[2]);
+    v1_L = scitbx::vec3<double>(&v_eig_vecs[0]);
+    v2_L = scitbx::vec3<double>(&v_eig_vecs[3]);
+    v3_L = scitbx::vec3<double>(&v_eig_vecs[6]);
+    // OVERWRITE - Choose v1 to be cross product of v2 and v3 (guaranteed righthanded system)
+    v1_L = v2_L.cross(v3_L);
+
+    // Print Eigenvalues of V
+    std::cout << "--------------------------" << std::endl;
+    std::cout << "Eigenvalues of V[L]: " << std::endl;
+    print("1", v_amplitudes[0]);
+    print("2", v_amplitudes[1]);
+    print("3", v_amplitudes[2]);
+    std::cout << "Eigenvectors of V[L]: " << std::endl;
+    print("1", v1_L);
+    print("2", v2_L);
+    print("3", v3_L);
+
+    // T values are sqrt of v
+    double t1 = std::sqrt(v_amplitudes[0]);
+    double t2 = std::sqrt(v_amplitudes[1]);
+    double t3 = std::sqrt(v_amplitudes[2]);
+
+    std::cout << "RMS vibrational components: " << std::endl;
+    print("1", t1);
+    print("2", t2);
+    print("3", t3);
+
+    // Extract the rotation matrix from the eigenvectors
+    //scitbx::mat3<double> R_LV = static_cast <scitbx::mat3<double>> (v_eig.vectors().begin());
+    scitbx::mat3<double> R_LV = scitbx::mat3<double>(v1_L[0], v1_L[1], v1_L[2], v2_L[0], v2_L[1], v2_L[2], v3_L[0], v3_L[1], v3_L[2]);
+    scitbx::mat3<double> R_LV_t = R_LV.transpose();
+
+    // Calculate V in own basis
+    scitbx::mat3<double> V_V_ = R_LV * V_L * R_LV_t;
+    V_V = scitbx::sym_mat3<double>((V_V_ + V_V_.transpose()) / 2.0);
+
+    std::cout << "--------------------------" << std::endl;
+    print("V[V]", V_V);
+
+    // Return vibration axes to original basis
+    v1_M = R_ML_t * v1_L;
+    v2_M = R_ML_t * v2_L;
+    v3_M = R_ML_t * v3_L;
+
+    std::cout << "--------------------------" << std::endl;
+    std::cout << "Vibrational axes (M-basis)" << std::endl;
+    print("1", v1_M);
+    print("2", v2_M);
+    print("3", v3_M);
+
+    // Calculate full transformation
+    R_MV = R_LV * R_ML;
+
+    std::cout << "--------------------------" << std::endl;
+    print("R[M->L]", R_ML);
+    print("R[L->V]", R_LV);
+    print("R[M->V]", R_MV);
+
+}
+
+void decompose_tls_matrices::run() {
+
+    try
+    {
+        stepA();
+        stepB();
+        stepC();
+        stepD();
+    }
+    catch (std::runtime_error e)
+    {
+        std::cout << "Exception Caught: " << e.what() << std::endl;
+        error_ = e.what();
+    }
+
+    // print result
+    std::cout << std::boolalpha << "TLS matrices are valid: " << is_valid() << std::endl;
+    if  (! is_valid() ) {
+        std::cout << "Result: " << error_ << std::endl;
+    }
+}
+
+}}} // close mmtbx/tls/decompose
+
+int main()
+{
+    double one(1.0), nul(0.0), sml(1e-9);
+
+    // Simple test (no S)
+//    scitbx::sym_mat3<double> T (+0.280, +0.395, +0.234, +0.063, +0.118, +0.033);
+//    scitbx::sym_mat3<double> L (+0.106, +0.107, +0.696, -0.021, -0.014, -0.152);
+//    scitbx::mat3<double> S (0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
+
+    // Test against python implementation
+    scitbx::sym_mat3<double> T (0.0959882450545,0.156509777229,0.0886002086034,-5.19222597403e-05,-0.0172511466857,-0.00869540261855);
+    scitbx::sym_mat3<double> L (0.0123001438881,0.0461188308667,0.0218102205791,0.00435192109608,0.00517157269537,-0.0155699937912);
+    scitbx::mat3<double> S (-0.00725668016697,-0.0201548281778,0.00431134160979,0.036329322896,-0.00252099816856,-0.00771964293756,-0.00968895922456,0.0170374138375,0.00977767833552);
+
+    // Make matrices larger so can be seen after scaling to radians
+    double mult(100.0);
+    T *= mult;
+    L *= mult;
+    S *= mult;
+
+    mmtbx::tls::decompose::decompose_tls_matrices dtm(T, L, S);
+
+    return 0;
+}

--- a/mmtbx/tls/decompose.h
+++ b/mmtbx/tls/decompose.h
@@ -1,0 +1,198 @@
+#ifndef MMTBX_TLS_DECOMPOSE_H
+#define MMTBX_TLS_DECOMPOSE_H
+
+#include <string>
+#include <iostream>
+
+#include <scitbx/vec3.h>
+#include <scitbx/mat3.h>
+#include <scitbx/sym_mat3.h>
+
+namespace mmtbx { namespace tls { namespace decompose {
+
+// Actual validation functions
+class decompose_tls_matrices {
+
+  public:
+    // Constructor with origin
+    decompose_tls_matrices(scitbx::sym_mat3<double> const& T,
+                           scitbx::sym_mat3<double> const& L_deg,
+                           scitbx::mat3<double> const& S_deg,
+                           scitbx::vec3<double> const& origin); 
+
+    bool is_valid() { return valid_; }
+    std::string error() { return error_; }
+
+  private:
+
+    // Response variables 
+    bool valid_{true};
+    std::string error_{"none"};
+
+    // Define analysis precision (for determining positive-definiteness, etc).
+    double tol {1.e-6};
+    // Define floating point boundary (for determining when something is zero)
+    double eps {1.e-8};
+
+    // printing
+    std::string spacer{"   "};
+
+    // --------------------
+    // Decomposition functions
+    // --------------------
+    void run();
+    void stepA();
+    void stepB();
+    void stepC();
+    void stepD();
+    // Apply origin shifts, etc
+    void tidy();
+
+    // --------------------
+    // Input variables
+    // --------------------
+    // Input matrices 
+    scitbx::sym_mat3<double> T_M; 
+    scitbx::sym_mat3<double> L_M;
+    scitbx::mat3<double>     S_M;
+    // Origin -- only used for manipulating the output axes, does not affect decomposition
+    // TODO NOT IMPLEMENTED TODO
+    scitbx::vec3<double> const origin;
+
+    // --------------------
+    // Output variables (set throughout and grouped here for clarity)
+    // --------------------
+    // Amplitudes of libration
+    scitbx::vec3<double> l_amplitudes;
+    // Libration axes ... in the M basis
+    scitbx::vec3<double> l1_M, l2_M, l3_M;
+    // Points on libration axes ... in M basis
+    scitbx::vec3<double> w1_M, w2_M, w3_M;
+    // Amplitudes of screw motions (along librational axes)
+    scitbx::vec3<double> s_amplitudes;
+    // Amplitudes of vibration
+    scitbx::vec3<double> v_amplitudes;
+    // Vibration axes ... in the L basis
+    scitbx::vec3<double> v1_L, v2_L, v3_L;
+    // Vibration axes ... in the M basis
+    scitbx::vec3<double> v1_M, v2_M, v3_M;
+
+    // --------------------
+    // Coordinate transformation
+    // --------------------
+    // Rotation matrix to transform between original and libration coordinate frames (M -> L)
+    // R_ML * a_M = a_L
+    scitbx::mat3<double> R_ML;
+    scitbx::mat3<double> R_ML_t;
+    // Rotation matrix to transform between original and vibrational coordinate frames 
+    // R_MV * a_M = a_V
+    scitbx::mat3<double> R_MV;
+    scitbx::mat3<double> R_MV_t;
+
+    // Matrices at various stages during the decomposition and internal variables 
+    // --------------------
+    // Set at step A
+    // --------------------
+    // Matrices in the basis of the libration matrix
+    scitbx::sym_mat3<double> T_L; 
+    scitbx::sym_mat3<double> L_L;
+    scitbx::mat3<double> S_L;
+    // --------------------
+    // Set at step B
+    // --------------------
+    // Store information about the position of the libration axes
+    struct W {
+        double wy_lx{0.0}, wz_lx{0.0}; 
+        double wz_ly{0.0}, wx_ly{0.0};
+        double wx_lz{0.0}, wy_lz{0.0};
+        scitbx::vec3<double> w_lx,  w_ly,  w_lz;
+    } w_15, w;
+    // Translational components from offset of librational axes from origin 
+    scitbx::sym_mat3<double> D_WL; 
+    // Translational components in the L-basis 
+    // T_CL = T_L - D_WL
+    scitbx::sym_mat3<double> T_CL;
+    // --------------------
+    // Set at step C
+    // --------------------
+    // Amount to subtract from the trace of the S-matrix
+    double t_S{0.0};
+    // S-matrix after subtraction of t_S
+    // S_C = S_L - diag(t_S)
+    scitbx::mat3<double> S_C;
+    // Screw contributions to translation matrix
+    scitbx::sym_mat3<double> C_L_t_S;
+    // Vibrational component in the L-basis
+    // V_L = T_CL - C_L_t_S
+    scitbx::sym_mat3<double> V_L;
+    // --------------------
+    // Set at step D
+    // --------------------
+    // (Pure) Vibrations in the vibration basis
+    scitbx::sym_mat3<double> V_V;
+
+    // --------------------
+    // Eigen-analysis functions
+    // --------------------
+    bool is_pd(scitbx::sym_mat3<double> const& matrix);
+    // Quadratic equation coefficients for determinant of V-matrix from T+S matrices
+    scitbx::vec3<double> as_bs_cs(
+            double t,
+            double Sxx, double Syy, double Szz,
+            double T11, double T22, double T33, double T12, double T13, double T23);
+
+    // --------------------
+    // Logic/zero functions
+    // --------------------
+    // Dealing with small values
+    bool is_zero(double value);
+    bool is_positive(double value);
+    bool is_negative(double value);
+    // Return value or zero
+    double zero_filter(double value);
+    // Set small values to zero
+    void zero_small_values(scitbx::vec3<double>& vector);
+    void zero_small_values(scitbx::mat3<double>& matrix);
+    void zero_small_values(scitbx::sym_mat3<double>& matrix);
+
+    // --------------------
+    // Matrix Helper functions 
+    // --------------------
+    // Normal matrices
+    // xx, xy, xz      0, 1, 2
+    // yx, yy, yz  ->  3, 4, 5
+    // zx, zy, zz      6, 7, 8
+    double xx(scitbx::mat3<double> const& matrix) { return matrix[0]; }
+    double xy(scitbx::mat3<double> const& matrix) { return matrix[1]; }
+    double xz(scitbx::mat3<double> const& matrix) { return matrix[2]; }
+    double yx(scitbx::mat3<double> const& matrix) { return matrix[3]; }
+    double yy(scitbx::mat3<double> const& matrix) { return matrix[4]; }
+    double yz(scitbx::mat3<double> const& matrix) { return matrix[5]; }
+    double zx(scitbx::mat3<double> const& matrix) { return matrix[6]; }
+    double zy(scitbx::mat3<double> const& matrix) { return matrix[7]; }
+    double zz(scitbx::mat3<double> const& matrix) { return matrix[8]; }
+    // Symmetric matrices
+    // 0, 3, 4
+    // -, 1, 5
+    // -, -, 2
+    double xx(scitbx::sym_mat3<double> const& matrix) { return matrix[0]; }
+    double xy(scitbx::sym_mat3<double> const& matrix) { return matrix[3]; }
+    double xz(scitbx::sym_mat3<double> const& matrix) { return matrix[4]; }
+    double yx(scitbx::sym_mat3<double> const& matrix) { return xy(matrix); }
+    double yy(scitbx::sym_mat3<double> const& matrix) { return matrix[1]; }
+    double yz(scitbx::sym_mat3<double> const& matrix) { return matrix[5]; }
+    double zx(scitbx::sym_mat3<double> const& matrix) { return xz(matrix); }
+    double zy(scitbx::sym_mat3<double> const& matrix) { return yz(matrix); }
+    double zz(scitbx::sym_mat3<double> const& matrix) { return matrix[2]; }
+
+    // Print matrices 
+    void print(std::string const& label, double value);
+    void print(std::string const& label, scitbx::mat3<double> const& matrix);
+    void print(std::string const& label, scitbx::sym_mat3<double> const& matrix);
+    void print(std::string const& label, scitbx::vec3<double> const& vector);
+};
+                            
+}}} // close mmtbx/tls/decompose
+
+#endif
+

--- a/mmtbx/tls/decompose.py
+++ b/mmtbx/tls/decompose.py
@@ -1,0 +1,7 @@
+from __future__ import division
+# Not sure if the next line is needed (copied this script from mmtbx/tls/__init__.py)
+#import cctbx.array_family.flex # import dependency
+
+import boost.python
+ext = boost.python.import_ext("mmtbx_tls_decompose_ext")
+from mmtbx_tls_decompose_ext import *

--- a/mmtbx/tls/decompose_ext.cpp
+++ b/mmtbx/tls/decompose_ext.cpp
@@ -1,0 +1,42 @@
+#include <cctbx/boost_python/flex_fwd.h>
+
+#include <boost/python/module.hpp>
+#include <boost/python/class.hpp>
+#include <boost/python/def.hpp>
+#include <boost/python/args.hpp>
+#include <mmtbx/tls/tls.h>
+#include <scitbx/array_family/boost_python/shared_wrapper.h>
+#include <scitbx/boost_python/is_polymorphic_workaround.h>
+#include <boost/python/return_value_policy.hpp>
+#include <boost/python/return_by_value.hpp>
+#include <boost/python.hpp>
+
+SCITBX_BOOST_IS_POLYMORPHIC_WORKAROUND(mmtbx::tls::common)
+
+namespace mmtbx { namespace tls { namespace decompose {
+  namespace bp = boost::python;
+
+namespace {
+
+  void init_module()
+  {
+    using namespace boost::python;
+    using boost::python::arg;
+
+   class_<decompose_tls_matrices>("decompose_tls_matrices",
+           init< sym_mat3<double> const&,
+                 sym_mat3<double> const&,
+                 mat3<double> const&,
+                 vec3<double> const& >())
+       .def("is_valid", &decompose_tls_matrices::is_valid)
+   ;
+
+  }
+
+} // namespace <anonymous>
+}}} // namespace mmtbx::tls::decompose
+
+BOOST_PYTHON_MODULE(mmtbx_tls_decompose_ext)
+{
+  mmtbx::tls::decompose::init_module();
+}

--- a/mmtbx/tls/decompose_ext.cpp
+++ b/mmtbx/tls/decompose_ext.cpp
@@ -4,32 +4,89 @@
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/args.hpp>
-#include <mmtbx/tls/tls.h>
 #include <scitbx/array_family/boost_python/shared_wrapper.h>
 #include <scitbx/boost_python/is_polymorphic_workaround.h>
 #include <boost/python/return_value_policy.hpp>
 #include <boost/python/return_by_value.hpp>
 #include <boost/python.hpp>
 
+#include <scitbx/array_family/shared.h>
+#include <mmtbx/tls/decompose.h>
+
 SCITBX_BOOST_IS_POLYMORPHIC_WORKAROUND(mmtbx::tls::common)
 
 namespace mmtbx { namespace tls { namespace decompose {
   namespace bp = boost::python;
+  namespace af = scitbx::af;
 
 namespace {
+
+  boost::python::tuple get_v_amplitudes(const decompose_tls_matrices& a)
+  { return boost::python::tuple(a.v_amplitudes); }
+
+  boost::python::tuple get_l_amplitudes(const decompose_tls_matrices& a)
+  { return boost::python::tuple(a.l_amplitudes); }
+
+  boost::python::tuple get_s_amplitudes(const decompose_tls_matrices& a)
+  { return boost::python::tuple(a.s_amplitudes); }
+
+  af::shared<scitbx::vec3<double>> get_v_axis_directions(const decompose_tls_matrices& a)
+  {
+      af::shared<scitbx::vec3<double>> s(3);
+      s[0] = a.v1_M;
+      s[1] = a.v2_M;
+      s[2] = a.v3_M;
+      return s;
+  }
+
+  af::shared<scitbx::vec3<double>> get_l_axis_directions(const decompose_tls_matrices& a)
+  {
+      af::shared<scitbx::vec3<double>> s(3);
+      s[0] = a.l1_M;
+      s[1] = a.l2_M;
+      s[2] = a.l3_M;
+      return s;
+  }
+
+  af::shared<scitbx::vec3<double>> get_l_axis_intersections(const decompose_tls_matrices& a)
+  {
+      af::shared<scitbx::vec3<double>> s(3);
+      s[0] = a.w1_M;
+      s[1] = a.w2_M;
+      s[2] = a.w3_M;
+      return s;
+  }
 
   void init_module()
   {
     using namespace boost::python;
     using boost::python::arg;
 
-   class_<decompose_tls_matrices>("decompose_tls_matrices",
-           init< sym_mat3<double> const&,
-                 sym_mat3<double> const&,
-                 mat3<double> const&,
-                 vec3<double> const& >())
-       .def("is_valid", &decompose_tls_matrices::is_valid)
-   ;
+    class_<decompose_tls_matrices>("decompose_tls_matrices",
+            init< scitbx::sym_mat3<double> const&,
+                  scitbx::sym_mat3<double> const&,
+                  scitbx::mat3<double> const&,
+                  bool, bool,
+                  double, double>(
+                      (arg("T"),
+                       arg("L"),
+                       arg("S"),
+                       arg("l_and_s_in_degrees")=true,
+                       arg("verbose")=false,
+                       arg("tol")=1.e-6,
+                       arg("eps")=1.e-8)))
+        .def("is_valid", &decompose_tls_matrices::is_valid)
+        .def("error", &decompose_tls_matrices::error)
+
+        .add_property("v_amplitudes", get_v_amplitudes)
+        .add_property("l_amplitudes", get_l_amplitudes)
+        .add_property("s_amplitudes", get_s_amplitudes)
+
+        .add_property("v_axis_directions",    get_v_axis_directions)
+        .add_property("l_axis_directions",    get_l_axis_directions)
+        .add_property("l_axis_intersections", get_l_axis_intersections)
+
+    ;
 
   }
 


### PR DESCRIPTION
Reimplementation of the tis-analysis of mmtbx/tls/analysis.py in c++ for speed. Compares at ~0.6s in python to 0.002s in c++. Tests implemented against the original mmtbx/tls/analysis.py. Also identified and fixed an error in the original mmtbx/tls/analysis.py.

This is my first commit to the cctbx so you may wish to check this code more thoroughly than you might do for others -- feedback is appreciated to make sure I'm doing things properly.

