### PR TITLE
Fix minor operator precedence error in rstbx

### DIFF
--- a/rstbx/apps/stills/simple_integration.h
+++ b/rstbx/apps/stills/simple_integration.h
@@ -420,11 +420,11 @@ namespace rstbx { namespace integration {
                bool pixels_are_active = true;
                for (mask_t::const_iterator k=spot_keys.begin();
                     k != spot_keys.end(); ++k){
-                 if ( check_tiles &&
-                      (k->first)[0] < tiling_boundaries_m[4*itile] ||
+                 if (check_tiles &&
+                     ((k->first)[0] < tiling_boundaries_m[4*itile] ||
                       (k->first)[0] >= tiling_boundaries_m[4*itile+2] ||
                       (k->first)[1] < tiling_boundaries_m[4*itile+1] ||
-                      (k->first)[1] >= tiling_boundaries_m[4*itile+3]) {
+                      (k->first)[1] >= tiling_boundaries_m[4*itile+3])) {
                    pixels_are_active = false;
                    break;
                  }
@@ -508,11 +508,11 @@ namespace rstbx { namespace integration {
             //Guard against background pixels off the active area
             if (check_tiles || use_mask_pixel_val) {
                int itile = tile_locations_m[i];
-               if ( check_tiles &&
-                    candidate_bkgd[0] < tiling_boundaries_m[4*itile] ||
+               if (check_tiles &&
+                   (candidate_bkgd[0] < tiling_boundaries_m[4*itile] ||
                     candidate_bkgd[0] >= tiling_boundaries_m[4*itile+2] ||
                     candidate_bkgd[1] < tiling_boundaries_m[4*itile+1] ||
-                    candidate_bkgd[1] >= tiling_boundaries_m[4*itile+3])
+                    candidate_bkgd[1] >= tiling_boundaries_m[4*itile+3]))
                   {continue;}
                if (use_mask_pixel_val) {
                   int ivalue(rawdata(candidate_bkgd[0],candidate_bkgd[1]));


### PR DESCRIPTION
Found what looks like a minor bug in RSTBX (via clang warning). Because && has higher precendence than ||, the
code reads:

    if ( check_tiles && condA   || condB || condC || candD )
        (            &&       )

where it looks like it should read:

    if ( check_tiles && ( condA || condB || condC || candD ) )

All tests seem to pass both with & without this change, so it's either not tested or this specific condition isn't tested.

@phyy-nx, I've tagged you as the most likely to look at this because you were the last person to touch this code (admittedly five years ago), but I'm reasonably certain about the change so if you don't have time to look over it I'll merge in a few days.