### PR TITLE
Enable phil-scoped linear solver backend selection 

### DIFF
--- a/cctbx/examples/merging/data_subset.py
+++ b/cctbx/examples/merging/data_subset.py
@@ -79,7 +79,6 @@ def mapper_factory(base_class):
 
     def e_unpack_stddev(self):
       return self.expanded_stddev
-
   return mapper_unmapper
 
 def mapper_factory_with_explicit_B(base_class):

--- a/cctbx/examples/merging/samosa/scale.py
+++ b/cctbx/examples/merging/samosa/scale.py
@@ -164,8 +164,6 @@ def run(show_plots,args):
         filename = all_files[x]
         print >>out, filename, " ".join([str(a) for a in modified_A.elems])
 
-
-
     work_params.scaling.algorithm="levmar"
     from xfel.cxi.cxi_cc import run_cc
     run_cc(work_params,work_params.model_reindex_op,sys.stdout)

--- a/cctbx/examples/merging/test_levenberg_sparse.py
+++ b/cctbx/examples/merging/test_levenberg_sparse.py
@@ -28,7 +28,7 @@ def choice_as_bitflag(choices):
                   PartialityEtaDeff = p.PartialityEtaDeff)[choice]
   return flags
 
-def choice_as_helper_base(choices, linsolver):
+def choice_as_helper_base(choices, linsolver=lsb.ldlt):
   if "Deff" in choices or "Rxy" in choices:
     from cctbx.examples.merging import postrefine_base as base_class
   else:
@@ -45,9 +45,12 @@ def choice_as_helper_base(choices, linsolver):
       # do this outside the factory function pfh.set_cpp_data(fsim, NI, NG)
 
     #Overridden solve function to allow choice of solver algorithm. Default to Cholesky LDLT.
-    def solve(self,linsolver=lsb.ldlt):
-      #from IPython import embed; embed()
-      self.step_equations().solve(linsolver)
+    def solve(self,*args):
+      if len(args) >0:
+        base_class.linsolver = args[0]
+      if isinstance(base_class.linsolver, basestring):
+        base_class.linsolver = getattr(lsb,base_class.linsolver)
+      self.step_equations().solve(base_class.linsolver)
 
     def restart(pfh):
       pfh.x = pfh.x_0.deep_copy()

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -818,7 +818,7 @@ class eigen_module(SourceModule):
   module = 'eigen'
   anonymous = ['git',
                'git@github.com:eigenteam/eigen-git-mirror.git',
-               'https://github.com/eigenteam/eigen-git-mirror.git'
+               'https://github.com/eigenteam/eigen-git-mirror.git',
                'https://github.com/eigenteam/eigen-git-mirror/archive/master.zip']
 
 # Phenix repositories

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -816,9 +816,10 @@ class opt_resources_module(SourceModule):
 
 class eigen_module(SourceModule):
   module = 'eigen'
-  anonymous = ['curl', 'http://cci.lbl.gov/repositories/eigen.gz']
-  authentarfile = ['%(cciuser)s@cci.lbl.gov', 'eigen.tar.gz', '/net/cci/auto_build/repositories/eigen']
-  authenticated = ['rsync', '%(cciuser)s@cci.lbl.gov:/net/cci/auto_build/repositories/eigen/']
+  anonymous = ['git',
+               'git@github.com:eigenteam/eigen-git-mirror.git',
+               'https://github.com/eigenteam/eigen-git-mirror.git'
+               'https://github.com/eigenteam/eigen-git-mirror/archive/master.zip']
 
 # Phenix repositories
 class phenix_module(SourceModule):

--- a/scitbx/examples/bevington/bevington_ext.cpp
+++ b/scitbx/examples/bevington/bevington_ext.cpp
@@ -1,5 +1,5 @@
 #include <cctbx/boost_python/flex_fwd.h>
-
+#include <boost/python/enum.hpp>
 #include <boost/python/module.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
@@ -25,12 +25,20 @@ namespace boost_python { namespace {
     typedef return_value_policy<return_by_value> rbv;
     typedef default_call_policies dcp;
 
+    enum_<linear_ls_eigen_wrapper::SolverAlgo>("linsolver_backend")
+      .value("ldlt", linear_ls_eigen_wrapper::LDLT)
+      .value("llt", linear_ls_eigen_wrapper::LLT)
+      .value("cg", linear_ls_eigen_wrapper::CG)
+      .value("bicgstab", linear_ls_eigen_wrapper::BICGSTAB)
+      .export_values()
+    ;
+
     class_<linear_ls_eigen_wrapper>("linear_ls_eigen_wrapper", no_init)
       .def(init<int>(arg("n_parameters")))
       .def("n_parameters", &linear_ls_eigen_wrapper::n_parameters)
       .def("reset", &linear_ls_eigen_wrapper::reset)
       .def("right_hand_side", &linear_ls_eigen_wrapper::right_hand_side)
-      .def("solve", &linear_ls_eigen_wrapper::solve)
+      .def("solve", &linear_ls_eigen_wrapper::solve, ( arg("solverIdx")=linear_ls_eigen_wrapper::LDLT ) )
       .def("solved", &linear_ls_eigen_wrapper::solved)
       .def("normal_matrix", &linear_ls_eigen_wrapper::normal_matrix)
       .def("solution", &linear_ls_eigen_wrapper::solution)

--- a/scitbx/examples/bevington/prototype_core.h
+++ b/scitbx/examples/bevington/prototype_core.h
@@ -101,22 +101,22 @@ class linear_ls_eigen_wrapper
         Eigen::SparseMatrix<double> eigen_normal_matrix_full = eigen_normal_matrix.selfadjointView<Eigen::Upper>();
         Eigen::ConjugateGradient<sparse_matrix_t, Eigen::Lower|Eigen::Upper > cg_solver(eigen_normal_matrix_full);
         x = cg_solver.solve(b);
-        //Full matrix used here.
-        last_computed_matrixL_nonZeros_ = cg_solver.nonZeros();
+        //CG method can used upper or lower matrix. Value taken from input matrix..
+        last_computed_matrixL_nonZeros_ = eigen_normal_matrix.nonZeros();
       }
       else if( solverIdx == BICGSTAB ){
         Eigen::SparseMatrix<double> eigen_normal_matrix_full = eigen_normal_matrix.selfadjointView<Eigen::Upper>();
         //Eigen::BiCGSTAB<sparse_matrix_t, Eigen::RowMajor> solver(eigen_normal_matrix_full);
         Eigen::BiCGSTAB<sparse_matrix_t> bicgstab_solver(eigen_normal_matrix_full);
         x = bicgstab_solver.solve(b);
-        //Full matrix used here.
-        last_computed_matrixL_nonZeros_ = bicgstab_solver.nonZeros();
+        //Full matrix used here. -1 used to indicate N/A
+        last_computed_matrixL_nonZeros_ = -1;//bicgstab_solver.nonZeros();
       }
       else{
         Eigen::SimplicialLDLT<sparse_matrix_t> ldlt_solver(eigen_normal_matrix.transpose());
         x = ldlt_solver.solve(b);
-        sparse_matrix_t lower = llt_solver.matrixL();
-        last_computed_matrixL_nonZeros_ = ldlt_solver.nonZeros();
+        sparse_matrix_t lower = ldlt_solver.matrixL();
+        last_computed_matrixL_nonZeros_ = lower.nonZeros();
       }
 
       //Try to record state of lower Cholesky factor without incurring cost of computing # non-Zeros again

--- a/scitbx/examples/bevington/prototype_core.h
+++ b/scitbx/examples/bevington/prototype_core.h
@@ -48,6 +48,7 @@ class linear_ls_eigen_wrapper
 
   public:
     typedef Eigen::SparseMatrix<double> sparse_matrix_t;
+    enum SolverAlgo { LDLT=0, CG=1, LLT=2, BICGSTAB=3 };
 
     /// Construct a least-squares problem with the given number of unknowns.
     linear_ls_eigen_wrapper(int n_parameters)
@@ -79,22 +80,48 @@ class linear_ls_eigen_wrapper
       return right_hand_side_;
     }
 
-    void solve() {
+    void solve(SolverAlgo solverIdx) {
       SCITBX_ASSERT(formed_normal_matrix());
       int N = n_parameters();
-      Eigen::SimplicialLDLT<sparse_matrix_t> chol(eigen_normal_matrix.transpose());
       // XXX pack the right hand side in a eigen vector type
       Eigen::VectorXd b(n_parameters());
+      Eigen::VectorXd x(n_parameters());
       double* rhsptr = right_hand_side_.begin();
       for (int i = 0; i<N; ++i){
         b[i] = *rhsptr++;
       }
 
-      Eigen::VectorXd x = chol.solve(b);
+      if( solverIdx == LLT ){
+        Eigen::SimplicialLLT<sparse_matrix_t> llt_solver(eigen_normal_matrix.transpose());
+        x = llt_solver.solve(b);
+        sparse_matrix_t lower = llt_solver.matrixL();
+        last_computed_matrixL_nonZeros_ = lower.nonZeros();
+      }
+      else if( solverIdx == CG ){
+        Eigen::SparseMatrix<double> eigen_normal_matrix_full = eigen_normal_matrix.selfadjointView<Eigen::Upper>();
+        Eigen::ConjugateGradient<sparse_matrix_t, Eigen::Lower|Eigen::Upper > cg_solver(eigen_normal_matrix_full);
+        x = cg_solver.solve(b);
+        //Full matrix used here.
+        last_computed_matrixL_nonZeros_ = cg_solver.nonZeros();
+      }
+      else if( solverIdx == BICGSTAB ){
+        Eigen::SparseMatrix<double> eigen_normal_matrix_full = eigen_normal_matrix.selfadjointView<Eigen::Upper>();
+        //Eigen::BiCGSTAB<sparse_matrix_t, Eigen::RowMajor> solver(eigen_normal_matrix_full);
+        Eigen::BiCGSTAB<sparse_matrix_t> bicgstab_solver(eigen_normal_matrix_full);
+        x = bicgstab_solver.solve(b);
+        //Full matrix used here.
+        last_computed_matrixL_nonZeros_ = bicgstab_solver.nonZeros();
+      }
+      else{
+        Eigen::SimplicialLDLT<sparse_matrix_t> ldlt_solver(eigen_normal_matrix.transpose());
+        x = ldlt_solver.solve(b);
+        sparse_matrix_t lower = llt_solver.matrixL();
+        last_computed_matrixL_nonZeros_ = ldlt_solver.nonZeros();
+      }
 
       //Try to record state of lower Cholesky factor without incurring cost of computing # non-Zeros again
-      sparse_matrix_t lower = chol.matrixL();
-      last_computed_matrixL_nonZeros_ = lower.nonZeros();
+     /* sparse_matrix_t lower = chol.matrixL();
+      last_computed_matrixL_nonZeros_ = lower.nonZeros();*/
       // XXX Not sure if this adds measurable time, if so it should be refactored to a separate function
 
       //  XXX put the solution in the solution_ variable

--- a/scitbx/lstbx/normal_eqns.py
+++ b/scitbx/lstbx/normal_eqns.py
@@ -43,9 +43,13 @@ class non_linear_ls_mixin(object):
 
   def normal_matrix_packed_u(self):
     return self.step_equations().normal_matrix_packed_u()
-
-  def solve(self):
-    self.step_equations().solve()
+  
+  #Solver can be used to specify LS backend, hence *args. Defaults to pre-existing no-argument solvers no argument given
+  def solve(self,*args):
+    try:
+      self.step_equations().solve(args[1])
+    except:
+      self.step_equations().solve()
 
   def solve_and_step_forward(self):
     self.solve()

--- a/scitbx/lstbx/normal_eqns_solving.py
+++ b/scitbx/lstbx/normal_eqns_solving.py
@@ -122,21 +122,19 @@ class iterations(object):
     self.non_linear_ls = journaled_non_linear_ls(non_linear_ls, self,
                                                  self.track_gradient,
                                                  self.track_step)
-    linsolver_param = non_linear_ls.linsolver
+    try: 
+      linsolver_param = non_linear_ls.linsolver
+    except:
+      linsolver_param = None
     if linsolver_param == 'ldlt' or linsolver_param == None:
-      print "Using Cholesky LDLT direct linear solver."
       self.linsolver = lsb.ldlt
     elif linsolver_param == 'llt':
-      print "Using Cholesky LLT direct linear solver."
       self.linsolver = lsb.llt
     elif linsolver_param == 'cg':
-      print "Using conjugate gradient iterative linear solver"
       self.linsolver = lsb.cg
     elif linsolver_param == 'bicgstab':
-      print "Using bi-conjugate gradient stabilised (BiCGSTAB) iterative linear solver"
       self.linsolver = lsb.bicgstab
     else:
-      print "Unrecognised solver. Defaulting to Cholesky LDLT."
       self.linsolver = lsb.ldlt
     self.do()
 
@@ -170,7 +168,6 @@ class iterations(object):
 
   def do(self):
     raise NotImplementedError
-
 
 class naive_iterations(iterations):
 

--- a/scitbx/lstbx/tests/test_problems.py
+++ b/scitbx/lstbx/tests/test_problems.py
@@ -4,6 +4,7 @@ from __future__ import division
 from scitbx.array_family import flex
 from scitbx.lstbx import normal_eqns
 import libtbx
+from scitbx.examples.bevington import linsolver_backend as lsb
 
 class polynomial_fit(normal_eqns.non_linear_ls_with_separable_scale_factor,
                      normal_eqns.non_linear_ls_mixin):
@@ -97,6 +98,9 @@ class exponential_fit(
       ))
     assert len(self.y) == len(self.t)
     self.restart()
+
+  def solve(self,*args):
+    self.step_equations().solve()
 
   def restart(self):
     self.x = self.x_0.deep_copy()

--- a/xfel/command_line/cxi_merge.py
+++ b/xfel/command_line/cxi_merge.py
@@ -347,6 +347,10 @@ levmar {
     .help = Others are refineable parameters to choose from, default is only refine G and I.
     .type = choice
     .multiple = True
+  linsolver = *ldlt llt cg bicgstab
+    .type = choice
+    .help = Linear solver backend algorithm for LevMar
+    .help = ldlt and llt are Cholesky direct methods, cg and bicgstab are iterative methods
 }
 cell_rejection {
   unit_cell = Auto


### PR DESCRIPTION
The Eigen sparse linear solver backend of the LevenbergMarquardt algorithm can be chosen using the phil parameter `levmar.linsolver=*ldlt llt cg bicgstab`

- `ldlt` = Direct Cholesky LDLT
- `llt` = Direct Cholesky LLT
- `cg` = Iterative conjugate gradient
- `bicgstab` = Iterative biconjugate gradient stabilised
