### PR TITLE
Get radial lengths of all spotfinder spots.

### DIFF
--- a/xfel/ui/command_line/plot_spotfinder_stats_in_gui.py
+++ b/xfel/ui/command_line/plot_spotfinder_stats_in_gui.py
@@ -8,8 +8,8 @@ from xfel.ui.components.spotfinder_plotter import plot_spotfinder_stats
 def easy_run_plot_spotfinder_stats(pickle):
   from libtbx import easy_pickle
   contents = easy_pickle.load(pickle)
-  stats_tuple, run_tags, run_statuses, minimalist, interactive, xsize, ysize, high_vis, title = contents
-  print plot_spotfinder_stats(stats_tuple, run_tags=run_tags, run_statuses=run_statuses, minimalist=minimalist,
+  stats_tuple, spot_length_stats_tuple, run_tags, run_statuses, minimalist, interactive, xsize, ysize, high_vis, title = contents
+  print plot_spotfinder_stats(stats_tuple, spot_length_stats_tuple, run_tags=run_tags, run_statuses=run_statuses, minimalist=minimalist,
     interactive=interactive, xsize=xsize, ysize=ysize, high_vis=high_vis, title=title)
 
 if __name__ == "__main__":

--- a/xfel/ui/components/spotfinder_plotter.py
+++ b/xfel/ui/components/spotfinder_plotter.py
@@ -46,7 +46,11 @@ def plot_spotfinder_stats(stats,
     spot_ratio = plot_ratio*2
     text_ratio = plot_ratio*3
   t, n_strong, enough_rate, n_min, window, lengths, boundaries, run_numbers = stats
-  t_lengths, spot_lengths = spot_length_stats
+  t_lengths, spot_lengths, spot_intensities = spot_length_stats
+  # set up coloring of spot lengths by intensities
+  from matplotlib.cm import ScalarMappable
+  mappable = ScalarMappable(cmap="plasma")
+  cmap = mappable.to_rgba(spot_intensities)
   if len(t) == 0:
     return None
   n_runs = len(boundaries)//2
@@ -72,7 +76,7 @@ def plot_spotfinder_stats(stats,
   ax1_twin.set_ylim(ymin=0)
   ax1_twin.set_ylabel("%% images with\n>=%d spots" % n_min, fontsize=text_ratio)
   if spot_length_stats:
-    ax2.scatter(t_lengths, spot_lengths, edgecolors="none", color='navy', s=spot_ratio)
+    ax2.scatter(t_lengths, spot_lengths, edgecolors="none", color=cmap, s=spot_ratio)
   ax2.set_ylim(ymin=0)
   ax2.axis('tight')
   ax2.set_ylabel("spot lengths\n(pixels)", fontsize=text_ratio)
@@ -112,7 +116,7 @@ def plot_spotfinder_stats(stats,
       ax3.text(start_t, .85, "run %d" % run_numbers[idx], fontsize=text_ratio)
       ax3.text(start_t, .65, "%d images" % lengths[idx], fontsize=text_ratio)
       ax3.text(start_t, .45, "%d n>=%d" % (slice_enough.count(True), n_min), fontsize=text_ratio)
-      if spot_length_stats:
+      if spot_length_stats and len(spot_lengths) > 0:
         ax3.text(start_t, .25, "avg %d px" % int(flex.sum(spot_lengths)/len(spot_lengths)), fontsize=text_ratio)
       ax3.set_xlabel("timestamp (s)", fontsize=text_ratio)
       ax3.set_yticks([])
@@ -145,6 +149,7 @@ def plot_multirun_spotfinder_stats(runs,
   nset = flex.int()
   l_tset = flex.double() # lengths timestamp
   lset = flex.double() # lengths
+  iset = flex.double() # intensities
   boundaries = []
   lengths = []
   runs_with_data = []
@@ -167,6 +172,7 @@ def plot_multirun_spotfinder_stats(runs,
       lengths.append(len(tslice))
       runs_with_data.append(run_numbers[idx])
       lset.extend(spot_length_stats[idx][1])
+      iset.extend(spot_length_stats[idx][2])
     else:
       boundaries.extend([None]*2)
   stats_tuple = get_spotfinder_stats(tset,
@@ -175,7 +181,7 @@ def plot_multirun_spotfinder_stats(runs,
                                      tuple(boundaries),
                                      tuple(lengths),
                                      runs_with_data)
-  spot_length_stats_tuple = (l_tset, lset)
+  spot_length_stats_tuple = (l_tset, lset, iset)
   if easy_run:
     from libtbx import easy_run, easy_pickle
     easy_pickle.dump("plot_spotfinder_stats_tmp.pickle", (stats_tuple, spot_length_stats_tuple, run_tags, run_statuses, minimalist, interactive, xsize, ysize, high_vis, title))

--- a/xfel/ui/components/spotfinder_scraper.py
+++ b/xfel/ui/components/spotfinder_scraper.py
@@ -1,0 +1,32 @@
+from __future__ import division
+
+from xfel.util.reflection_length import ReflectionsRadialLengthsFromFiles
+from dials.array_family import flex
+import os
+
+def get_spot_length_stats(outdir, ref_stats=None):
+  def join(filename):
+    return os.path.join(outdir, str(filename))
+  files = map(join, os.listdir(outdir))
+  datablocks = sorted([f for f in files if 'datablock' in f])
+  strong = sorted([f for f in files if 'strong' in f])
+  if ref_stats:
+    timestamps, n_strong = ref_stats
+    ts_strong = timestamps.select(n_strong > 0)
+    assert len(strong) == len(datablocks), \
+      "Mismatch between n_strong: %d, n_datablocks: %d" % (len(strong), len(datablocks))
+    assert len(strong) == len(timestamps), \
+      "Mismatch between n_strong: %d, n_timestamps: %d" % (len(strong), len(timestamps))
+    strong_spot_timestamps = flex.double()
+    strong_spot_lengths = flex.double()
+    for i in xrange(len(datablocks)):
+      ts, s, db = timestamps[i], strong[i], datablocks[i]
+      lengths = ReflectionsRadialLengthsFromFiles([s, db]).get_spot_lengths_px()
+      for length in lengths:
+        strong_spot_lengths.append(length)
+        strong_spot_timestamps.append(ts)
+    return strong_spot_timestamps, strong_spot_lengths
+  else:
+    strong_spot_lengths = ReflectionsRadialLengthsFromFiles(
+      datablocks + strong).get_spot_lengths_px()
+    return (flex.double(), strong_spot_lengths)

--- a/xfel/ui/components/spotfinder_scraper.py
+++ b/xfel/ui/components/spotfinder_scraper.py
@@ -7,26 +7,48 @@ import os
 def get_spot_length_stats(outdir, ref_stats=None):
   def join(filename):
     return os.path.join(outdir, str(filename))
+
   files = map(join, os.listdir(outdir))
   datablocks = sorted([f for f in files if 'datablock' in f])
   strong = sorted([f for f in files if 'strong' in f])
+  strong_spot_timestamps = flex.double()
+  strong_spot_lengths = flex.double()
+  strong_spot_intensities = flex.double()
+
+  def process_pair(refl, block, ts=None):
+    measurer = ReflectionsRadialLengthsFromFiles([refl, block])
+    lengths = measurer.get_spot_lengths_px()
+    intensities = measurer.get_intensities()
+    assert len(lengths) == len(intensities)
+    for i, length in enumerate(lengths):
+      strong_spot_lengths.append(length)
+      strong_spot_intensities.append(intensities[i])
+      if ts:
+        strong_spot_timestamps.append(ts)
+
   if ref_stats:
     timestamps, n_strong = ref_stats
-    ts_strong = timestamps.select(n_strong > 0)
-    assert len(strong) == len(datablocks), \
-      "Mismatch between n_strong: %d, n_datablocks: %d" % (len(strong), len(datablocks))
-    assert len(strong) == len(timestamps), \
+    # Can't use reference timestamps at all if there are fewer datablocks than timestamps.
+    assert len(datablocks) == len(timestamps), \
       "Mismatch between n_strong: %d, n_timestamps: %d" % (len(strong), len(timestamps))
-    strong_spot_timestamps = flex.double()
-    strong_spot_lengths = flex.double()
-    for i in xrange(len(datablocks)):
+    # In case of unanticipated errors during spotfinding, strong.pickle may not be written.
+    # Get a list strong of the same length as datablocks with placeholder None values.
+    if len(strong) != len(datablocks):
+      strong = [db.split("datablock.json")[0] + "strong.pickle"
+        if db.split("datablock.json")[0] + "strong.pickle" in strong
+        else None
+        for db in datablocks]
+    for i in xrange(len(timestamps)):
       ts, s, db = timestamps[i], strong[i], datablocks[i]
-      lengths = ReflectionsRadialLengthsFromFiles([s, db]).get_spot_lengths_px()
-      for length in lengths:
-        strong_spot_lengths.append(length)
-        strong_spot_timestamps.append(ts)
-    return strong_spot_timestamps, strong_spot_lengths
+      if s is not None:
+        process_pair(s, db, ts=ts)
   else:
-    strong_spot_lengths = ReflectionsRadialLengthsFromFiles(
-      datablocks + strong).get_spot_lengths_px()
-    return (flex.double(), strong_spot_lengths)
+    if len(strong) != len(datablocks):
+      for pickle in strong:
+        matching_json = pickle.split("_strong.pickle")[0] + "_datablock.json"
+        if matching_json in datablocks:
+          process_pair(pickle, matching_json)
+    else: # Looks redundant but doesn't depend on file naming conventions
+      for s, db in zip(strong, datablocks):
+        process_pair(s, db)
+  return strong_spot_timestamps, strong_spot_lengths, strong_spot_intensities

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -633,6 +633,10 @@ class SpotfinderSentinel(Thread):
               self.spot_length_stats.append(get_spot_length_stats(run_outdir, ref_stats=sf_stats))
             except OSError:
               print "Outdir %s no longer accessible." % run_outdir
+            except Exception as e:
+              print e
+              from dials.array_family import flex
+              self.spot_length_stats.append((flex.double(), flex.double(), flex.double()))
 
       jobs = self.db.get_all_jobs()
       for idx in xrange(len(self.run_numbers)):

--- a/xfel/util/reflection_length.py
+++ b/xfel/util/reflection_length.py
@@ -48,9 +48,9 @@ class ReflectionsRadialLengths(object):
     return flex.double([self.get_one_spot_length(id) for id in xrange(len(self.strong))])
 
 class ReflectionsRadialLengthsFromFiles(ReflectionsRadialLengths):
-  def __init__(self, *files):
+  def __init__(self, files):
     from dials.util.options import Importer, flatten_reflections, flatten_experiments, flatten_datablocks
-    importer = Importer(list(files), read_experiments=True, read_datablocks=True,
+    importer = Importer(files, read_experiments=True, read_datablocks=True,
       read_reflections=True, check_format=False)
     if importer.unhandled:
       print "Unable to handle one or more files:", importer.unhandled
@@ -75,3 +75,4 @@ if __name__ == "__main__":
   assert len(sys.argv) == 3
   strong_spot_lengths = ReflectionsRadialLengthsFromFiles(sys.argv[1:]).get_spot_lengths_px()
   easy_pickle.dump("spot_lengths_px.pickle", strong_spot_lengths)
+  print list(strong_spot_lengths)

--- a/xfel/util/reflection_length.py
+++ b/xfel/util/reflection_length.py
@@ -46,6 +46,8 @@ class ReflectionsRadialLengths(object):
     return length
   def get_spot_lengths_px(self):
     return flex.double([self.get_one_spot_length(id) for id in xrange(len(self.strong))])
+  def get_intensities(self):
+    return self.strong['intensity.sum.value']
 
 class ReflectionsRadialLengthsFromFiles(ReflectionsRadialLengths):
   def __init__(self, files):

--- a/xfel/util/reflection_length.py
+++ b/xfel/util/reflection_length.py
@@ -1,0 +1,77 @@
+from __future__ import division
+
+from libtbx import easy_pickle
+from dials.array_family import flex
+from scitbx import matrix
+from dials.algorithms.shoebox import MaskCode
+
+class ReflectionsRadialLengths(object):
+  """Compute the length of each spotfinder spot in the radial direction."""
+  valid_code = MaskCode.Valid | MaskCode.Foreground
+  def __init__(self, strong_spots, experiment=None, datablock=None):
+    self.strong = strong_spots
+    assert 'bbox' in self.strong and 'shoebox' in self.strong, \
+      "Spotfinder shoeboxes are required for spot length calculations."
+    assert experiment or datablock, \
+      "Supply one experiment or datablock object."
+    if datablock:
+      imgset = datablock._imagesets[0]
+      self.det = imgset.get_detector()
+      self.beam = imgset.get_beam()
+    else:
+      self.det = experiment.detector
+      self.beam = experiment.beam
+    s0 = self.beam.get_unit_s0()
+    self.panel_s0_intersections = flex.vec2_double(
+      [self.det[i].get_ray_intersection_px(s0) for i in xrange(len(self.det))])
+  def get_one_spot_length(self, id):
+    # the radial direction is along the vector from the beam center to
+    # the spot centroid for each spot
+    shoebox = self.strong['shoebox'][id]
+    s0_position = self.panel_s0_intersections[shoebox.panel]
+    centroid = shoebox.centroid_strong().px_xy
+    dx, dy = [centroid[i] - s0_position[i] for i in (0, 1)]
+    radial = matrix.col((dx, dy)).normalize()
+    mask = flex.bool([(m & self.valid_code) != 0 for m in shoebox.mask])
+    bbox = self.strong['bbox'][id]
+    x_start, y_start = bbox[0], bbox[2]
+    x_range, y_range = bbox[1] - bbox[0], bbox[3] - bbox[2]
+    radial_distances = flex.double()
+    for i, valid_foreground in enumerate(mask):
+      if valid_foreground:
+        position = matrix.col((x_start + i%x_range, y_start + i//y_range))
+        projection = position.dot(radial)
+        radial_distances.append(projection)
+    length = flex.max(radial_distances) - flex.min(radial_distances)
+    return length
+  def get_spot_lengths_px(self):
+    return flex.double([self.get_one_spot_length(id) for id in xrange(len(self.strong))])
+
+class ReflectionsRadialLengthsFromFiles(ReflectionsRadialLengths):
+  def __init__(self, *files):
+    from dials.util.options import Importer, flatten_reflections, flatten_experiments, flatten_datablocks
+    importer = Importer(list(files), read_experiments=True, read_datablocks=True,
+      read_reflections=True, check_format=False)
+    if importer.unhandled:
+      print "Unable to handle one or more files:", importer.unhandled
+      return
+    reflections = flatten_reflections(importer.reflections)
+    assert len(reflections) == 1, "Implemented only for one reflection table at a time presently"
+    datablock = None
+    experiment = None
+    if importer.experiments:
+      experiments = flatten_experiments(importer.experiments)
+      assert len(experiments) == 1, "Implemented only for one experiment at a time presently"
+      experiment = experiments[0]
+    if importer.datablocks:
+      datablocks  = flatten_datablocks(importer.datablocks)
+      assert len(datablocks) == 1, "Implemented only for one datablock at a time presently"
+      datablock = datablocks[0]
+    super(ReflectionsRadialLengthsFromFiles, self).__init__(
+      reflections[0], datablock=datablock, experiment=experiment)
+
+if __name__ == "__main__":
+  import sys
+  assert len(sys.argv) == 3
+  strong_spot_lengths = ReflectionsRadialLengthsFromFiles(sys.argv[1:]).get_spot_lengths_px()
+  easy_pickle.dump("spot_lengths_px.pickle", strong_spot_lengths)


### PR DESCRIPTION
Early version of a tool to get radial components of the lengths of all
spotfinder spots in a strong.pickle file or spotfinder reflection table.
Should be useful for monitoring the LS49 Jungfrau spot shapes.

I have a test ready to commit to xfel_regression.