### PR TITLE
Xtc speedup

### DIFF
--- a/dxtbx/format/FormatMultiImage.py
+++ b/dxtbx/format/FormatMultiImage.py
@@ -153,7 +153,7 @@ class FormatMultiImage(object):
                    format_kwargs=None,
                    template=None,
                    check_format=True,
-                   just_in_time=False):
+                   lazy=False):
     '''
     Factory method to create an imageset
 
@@ -229,7 +229,7 @@ class FormatMultiImage(object):
       else:
         is_sweep = False
 
-    assert not (as_sweep and just_in_time), 'No Just-in-Time support for sweeps'
+    assert not (as_sweep and lazy), 'No lazy support for sweeps'
 
     if single_file_indices is not None:
       single_file_indices = flex.size_t(single_file_indices)
@@ -237,11 +237,11 @@ class FormatMultiImage(object):
     # Create an imageset or sweep
     if not is_sweep:
 
-      # Use imagesetJIT
-      # Setup ImageSetJIT and just return it. No models are set.
-      if just_in_time:
-        from dxtbx.imageset import ImageSetJIT
-        iset = ImageSetJIT(
+      # Use imagesetlazy
+      # Setup ImageSetLazy and just return it. No models are set.
+      if lazy:
+        from dxtbx.imageset import ImageSetLazy
+        iset = ImageSetLazy(
           ImageSetData(
             reader = reader,
             masker = masker,

--- a/dxtbx/format/FormatMultiImage.py
+++ b/dxtbx/format/FormatMultiImage.py
@@ -175,9 +175,8 @@ class FormatMultiImage(object):
     if format_kwargs is None:
       format_kwargs = {}
 
-    # If we have no specific format class, we need indices for number of images
-    from dxtbx.format.FormatMultiImageJIT import FormatMultiImageJIT
-    if Class in [FormatMultiImage, FormatMultiImageJIT]:
+    # If get_num_images hasn't been implemented, we need indices for number of images
+    if Class.get_num_images == FormatMultiImage.get_num_images:
       assert single_file_indices is not None
       assert min(single_file_indices) >= 0
       num_images = max(single_file_indices) + 1

--- a/dxtbx/format/FormatMultiImage.py
+++ b/dxtbx/format/FormatMultiImage.py
@@ -176,8 +176,8 @@ class FormatMultiImage(object):
       format_kwargs = {}
 
     # If we have no specific format class, we need indices for number of images
-    import inspect
-    if FormatMultiImage in inspect.getmro(Class):
+    from dxtbx.format.FormatMultiImageLazy import FormatMultiImageLazy
+    if Class in [FormatMultiImage, FormatMultiImageLazy]:
       assert single_file_indices is not None
       assert min(single_file_indices) >= 0
       num_images = max(single_file_indices) + 1

--- a/dxtbx/format/FormatMultiImage.py
+++ b/dxtbx/format/FormatMultiImage.py
@@ -153,7 +153,7 @@ class FormatMultiImage(object):
                    format_kwargs=None,
                    template=None,
                    check_format=True,
-                   lazy=False):
+                   just_in_time=False):
     '''
     Factory method to create an imageset
 
@@ -176,8 +176,8 @@ class FormatMultiImage(object):
       format_kwargs = {}
 
     # If we have no specific format class, we need indices for number of images
-    from dxtbx.format.FormatMultiImageLazy import FormatMultiImageLazy
-    if Class in [FormatMultiImage, FormatMultiImageLazy]:
+    from dxtbx.format.FormatMultiImageJIT import FormatMultiImageJIT
+    if Class in [FormatMultiImage, FormatMultiImageJIT]:
       assert single_file_indices is not None
       assert min(single_file_indices) >= 0
       num_images = max(single_file_indices) + 1
@@ -230,7 +230,7 @@ class FormatMultiImage(object):
       else:
         is_sweep = False
 
-    assert not (as_sweep and lazy), 'No lazy support for sweeps'
+    assert not (as_sweep and just_in_time), 'No Just-in-Time support for sweeps'
 
     if single_file_indices is not None:
       single_file_indices = flex.size_t(single_file_indices)
@@ -238,11 +238,11 @@ class FormatMultiImage(object):
     # Create an imageset or sweep
     if not is_sweep:
 
-      # Use imagesetlazy
-      # Setup ImageSetLazy and just return it. No models are set.
-      if lazy:
-        from dxtbx.imageset import ImageSetLazy
-        iset = ImageSetLazy(
+      # Use imagesetJIT
+      # Setup ImageSetJIT and just return it. No models are set.
+      if just_in_time:
+        from dxtbx.imageset import ImageSetJIT
+        iset = ImageSetJIT(
           ImageSetData(
             reader = reader,
             masker = masker,

--- a/dxtbx/format/FormatMultiImageJIT.py
+++ b/dxtbx/format/FormatMultiImageJIT.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 
 class FormatMultiImageJIT(FormatMultiImage):
@@ -24,15 +24,15 @@ class FormatMultiImageJIT(FormatMultiImage):
                    check_format=True,
                    just_in_time=True):
 
-    return super(FormatMultiImageJIT, Class).get_imageset(filenames,
-                                                           beam,
-                                                           detector,
-                                                           goniometer,
-                                                           scan,
-                                                           as_sweep,
-                                                           as_imageset,
-                                                           single_file_indices,
-                                                           format_kwargs,
-                                                           template,
-                                                           check_format,
-                                                           just_in_time)
+    return super(FormatMultiImageJIT, Class).get_imageset(filenames=filenames,
+                                                          beam=beam,
+                                                          detector=detector,
+                                                          goniometer=goniometer,
+                                                          scan=scan,
+                                                          as_sweep=as_sweep,
+                                                          as_imageset=as_imageset,
+                                                          single_file_indices=single_file_indices,
+                                                          format_kwargs=format_kwargs,
+                                                          template=template,
+                                                          check_format=check_format,
+                                                          just_in_time=just_in_time)

--- a/dxtbx/format/FormatMultiImageJIT.py
+++ b/dxtbx/format/FormatMultiImageJIT.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 
-class FormatMultiImageLazy(FormatMultiImage):
+class FormatMultiImageJIT(FormatMultiImage):
 
   '''
-  Lazy version of FormatMultiImage that does not instantiate the models ahead of time.
-  It creates an ImageSetLazy class and returns it. Saves time when image file contains
+  Just-in-Time version of FormatMultiImage that does not instantiate the models ahead of time.
+  It creates an ImageSetJIT class and returns it. Saves time when image file contains
   too many images to setup before processing.
   '''
 
@@ -22,9 +22,9 @@ class FormatMultiImageLazy(FormatMultiImage):
                    format_kwargs=None,
                    template=None,
                    check_format=True,
-                   lazy=True):
+                   just_in_time=True):
 
-    return super(FormatMultiImageLazy, Class).get_imageset(filenames,
+    return super(FormatMultiImageJIT, Class).get_imageset(filenames,
                                                            beam,
                                                            detector,
                                                            goniometer,
@@ -35,4 +35,4 @@ class FormatMultiImageLazy(FormatMultiImage):
                                                            format_kwargs,
                                                            template,
                                                            check_format,
-                                                           lazy)
+                                                           just_in_time)

--- a/dxtbx/format/FormatMultiImageLazy.py
+++ b/dxtbx/format/FormatMultiImageLazy.py
@@ -4,12 +4,17 @@ from dxtbx.imageset import ImageSet
 
 class ImageSetLazy(ImageSet):
 
+  '''
+  Lazy ImageSet class that doesn't necessitate setting the models ahead of time.
+  Only when a particular model (like detector or beam) for an image is requested,
+  it sets the model using the format class and then returns the model
+  '''
+
   def get_detector(self, index=None):
     if index is None: index=0
     detector = super(ImageSetLazy,self).get_detector(index)
     if detector is None:
       format_instance = self.get_format_class()._current_instance_
-      #format_instance = self.get_format_class()(self.paths()[self.indices()[index]])
       detector = format_instance.get_detector(self.indices()[index])
       self.set_detector(detector,index)
     return detector
@@ -20,7 +25,6 @@ class ImageSetLazy(ImageSet):
     beam = super(ImageSetLazy,self).get_beam(index)
     if beam is None:
       format_instance = self.get_format_class()._current_instance_
-      #format_instance = self.get_format_class()(self.paths()[self.indices()[index]])
       beam = format_instance.get_beam(self.indices()[index])
       self.set_beam(beam,index)
     return beam
@@ -30,7 +34,6 @@ class ImageSetLazy(ImageSet):
     goniometer = super(ImageSetLazy,self).get_goniometer(index)
     if goniometer is None:
       format_instance = self.get_format_class()._current_instance_
-      #format_instance = self.get_format_class()(self.paths()[self.indices()[index]])
       goniometer = format_instance.get_goniometer(self.indices()[index])
       self.set_goniometer(goniometer,index)
     return goniometer
@@ -40,7 +43,6 @@ class ImageSetLazy(ImageSet):
     scan = super(ImageSetLazy,self).get_scan(index)
     if scan is None:
       format_instance = self.get_format_class()._current_instance_
-      #format_instance = self.get_format_class()(self.paths()[self.indices()[index]])
       scan = format_instance.get_scan(self.indices()[index])
       self.set_scan(scan,index)
     return scan
@@ -58,17 +60,11 @@ class ImageSetLazy(ImageSet):
 
 class FormatMultiImageLazy(FormatMultiImage):
 
-  def get_goniometer(self, index=None):
-    return self._goniometer_instance
-
-  def get_detector(self, index=None):
-    return self._detector_instance
-
-  def get_beam(self, index=None):
-    return self._beam_instance
-
-  def get_scan(self, index=None):
-    return self._scan_instance
+  '''
+  Lazy version of FormatMultiImage that does not instantiate the models ahead of time.
+  It creates an ImageSetLazy class and returns it. Saves time when image file contains
+  too many images to setup before processing.
+  '''
 
   @classmethod
   def get_imageset(Class,
@@ -165,6 +161,7 @@ class FormatMultiImageLazy(FormatMultiImage):
     if not is_sweep:
 
       # Create the imageset
+      # Do not read and then set the models
       iset = ImageSetLazy(
         ImageSetData(
           reader = reader,
@@ -173,30 +170,6 @@ class FormatMultiImageLazy(FormatMultiImage):
           params = params,
           format = Class),
         indices=single_file_indices)
-
-      # If any are None then read from format
-#      if [beam, detector, goniometer, scan].count(None) != 0:
-#
-#        # Get list of models
-#        beam = []
-#        detector = []
-#        goniometer = []
-#        scan = []
-#        for i in range(format_instance.get_num_images()):
-#          beam.append(format_instance.get_beam(i))
-#          detector.append(format_instance.get_detector(i))
-#          goniometer.append(format_instance.get_goniometer(i))
-#          scan.append(format_instance.get_scan(i))
-#
-#      if single_file_indices is None:
-#        single_file_indices = list(range(format_instance.get_num_images()))
-#
-#      # Set the list of models
-#      for i in range(len(single_file_indices)):
-#        iset.set_beam(beam[single_file_indices[i]], i)
-#        iset.set_detector(detector[single_file_indices[i]], i)
-#        iset.set_goniometer(goniometer[single_file_indices[i]], i)
-#        iset.set_scan(scan[single_file_indices[i]], i)
 
     else:
 

--- a/dxtbx/format/FormatMultiImageLazy.py
+++ b/dxtbx/format/FormatMultiImageLazy.py
@@ -1,62 +1,5 @@
 from __future__ import absolute_import, division
 from dxtbx.format.FormatMultiImage import FormatMultiImage
-from dxtbx.imageset import ImageSet
-
-class ImageSetLazy(ImageSet):
-
-  '''
-  Lazy ImageSet class that doesn't necessitate setting the models ahead of time.
-  Only when a particular model (like detector or beam) for an image is requested,
-  it sets the model using the format class and then returns the model
-  '''
-
-  def get_detector(self, index=None):
-    if index is None: index=0
-    detector = super(ImageSetLazy,self).get_detector(index)
-    if detector is None:
-      format_instance = self.get_format_class()._current_instance_
-      detector = format_instance.get_detector(self.indices()[index])
-      self.set_detector(detector,index)
-    return detector
-
-
-  def get_beam(self, index=None):
-    if index is None: index=0
-    beam = super(ImageSetLazy,self).get_beam(index)
-    if beam is None:
-      format_instance = self.get_format_class()._current_instance_
-      beam = format_instance.get_beam(self.indices()[index])
-      self.set_beam(beam,index)
-    return beam
-
-  def get_goniometer(self, index=None):
-    if index is None: index=0
-    goniometer = super(ImageSetLazy,self).get_goniometer(index)
-    if goniometer is None:
-      format_instance = self.get_format_class()._current_instance_
-      goniometer = format_instance.get_goniometer(self.indices()[index])
-      self.set_goniometer(goniometer,index)
-    return goniometer
-
-  def get_scan(self, index=None):
-    if index is None: index=0
-    scan = super(ImageSetLazy,self).get_scan(index)
-    if scan is None:
-      format_instance = self.get_format_class()._current_instance_
-      scan = format_instance.get_scan(self.indices()[index])
-      self.set_scan(scan,index)
-    return scan
-
-  def __getitem__(self, item):
-    if isinstance(item, slice):
-      return ImageSetLazy(self.data(), indices = self.indices()[item])
-    else:
-      # Sets the list for detector, beam etc before being accessed by functions in imageset.h
-      self.get_detector(item)
-      self.get_beam(item)
-      self.get_goniometer(item)
-      self.get_scan(item)
-    return super(ImageSetLazy,self).__getitem__(item)
 
 class FormatMultiImageLazy(FormatMultiImage):
 
@@ -78,148 +21,20 @@ class FormatMultiImageLazy(FormatMultiImage):
                    single_file_indices=None,
                    format_kwargs=None,
                    template=None,
-                   check_format=True):
-    '''
-    Factory method to create an imageset
+                   check_format=True,
+                   lazy=True):
 
-    '''
-    from dxtbx.imageset import ImageSetData
-    from dxtbx.imageset import ImageSweep
-    from os.path import abspath
-    from dials.array_family import flex
-    if isinstance(filenames, str):
-      filenames = [filenames]
-    elif len(filenames) > 1:
-      assert len(set(filenames)) == 1
-      filenames = filenames[0:1]
+    return super(FormatMultiImageLazy,self).get_imageset(Class,
+                                                         filenames,
+                                                         beam,
+                                                         detector,
+                                                         goniometer,
+                                                         scan,
+                                                         as_sweep,
+                                                         as_imageset,
+                                                         single_file_indices,
+                                                         format_kwargs,
+                                                         template,
+                                                         check_format,
+                                                         lazy)
 
-    # Make filenames absolute
-    filenames = map(abspath, filenames)
-
-    # Make it a dictionary
-    if format_kwargs is None:
-      format_kwargs = {}
-
-    # If we have no specific format class, we need indices for number of images
-    if Class == FormatMultiImageLazy:
-      assert single_file_indices is not None
-      assert min(single_file_indices) >= 0
-      num_images = max(single_file_indices) + 1
-    else:
-      num_images = None
-
-    # Get some information from the format class
-    reader = Class.get_reader()(filenames, num_images=num_images, **format_kwargs)
-    masker = Class.get_masker()(filenames, num_images=num_images, **format_kwargs)
-
-    # Get the format instance
-    assert len(filenames) == 1
-    if check_format is True:
-      format_instance = Class(filenames[0], **format_kwargs)
-    else:
-      format_instance = None
-
-    # Read the vendor type
-    if check_format is True:
-      vendor = format_instance.get_vendortype()
-    else:
-      vendor = ""
-
-    # Get the format kwargs
-    params = format_kwargs
-
-    # Check if we have a sweep
-
-    # Make sure only 1 or none is set
-    assert [as_imageset, as_sweep].count(True) < 2
-    if as_imageset:
-      is_sweep = False
-    elif as_sweep:
-      is_sweep = True
-    else:
-      if scan is None and format_instance is None:
-        raise RuntimeError('''
-          One of the following needs to be set
-            - as_imageset=True
-            - as_sweep=True
-            - scan
-            - check_format=True
-      ''')
-      if scan is None:
-        test_scan = format_instance.get_scan()
-      else:
-        test_scan = scan
-      if test_scan is not None and test_scan.get_oscillation()[1] != 0:
-        is_sweep = True
-      else:
-        is_sweep = False
-
-    if single_file_indices is not None:
-      single_file_indices = flex.size_t(single_file_indices)
-
-    # Create an imageset or sweep
-    if not is_sweep:
-
-      # Create the imageset
-      # Do not read and then set the models
-      iset = ImageSetLazy(
-        ImageSetData(
-          reader = reader,
-          masker = masker,
-          vendor = vendor,
-          params = params,
-          format = Class),
-        indices=single_file_indices)
-
-    else:
-
-      # Get the template
-      template = filenames[0]
-
-      # Check indices are sequential
-      if single_file_indices is not None:
-        assert all(i + 1== j for i, j in zip(
-          single_file_indices[:-1],
-          single_file_indices[1:]))
-        num_images = len(single_file_indices)
-      else:
-        num_images = format_instance.get_num_images()
-
-      # Check the scan makes sense - we must want to use <= total images
-      if scan is not None:
-        assert scan.get_num_images() <= num_images
-
-      # If any are None then read from format
-      if beam is None:
-        beam = format_instance.get_beam()
-      if detector is None:
-        detector = format_instance.get_detector()
-      if goniometer is None:
-        goniometer = format_instance.get_goniometer()
-      if scan is None:
-        scan = format_instance.get_scan()
-        if scan is not None:
-          # TODO change this to lazy read of models
-          for f in filenames[1:]:
-            format_instance = Class(f, **format_kwargs)
-            scan += format_instance.get_scan()
-
-      isetdata = ImageSetData(
-          reader     = reader,
-          masker     = masker,
-          vendor     = vendor,
-          params     = params,
-          format     = Class,
-          template   = template)
-
-      # Create the sweep
-      iset = ImageSweep(
-        isetdata,
-        beam       = beam,
-        detector   = detector,
-        goniometer = goniometer,
-        scan       = scan,
-        indices    = single_file_indices)
-
-    # Return the imageset
-    return iset

--- a/dxtbx/format/FormatMultiImageLazy.py
+++ b/dxtbx/format/FormatMultiImageLazy.py
@@ -46,11 +46,12 @@ class ImageSetLazy(ImageSet):
     return scan
 
   def __getitem__(self, item):
-    # Sets the list for detector, beam etc before being accessed by functions in imageset.h
-    self.get_detector(item)
-    self.get_beam(item)
-    self.get_goniometer(item)
-    self.get_scan(item)
+    if not isinstance(item, slice):
+      # Sets the list for detector, beam etc before being accessed by functions in imageset.h
+      self.get_detector(item)
+      self.get_beam(item)
+      self.get_goniometer(item)
+      self.get_scan(item)
     return super(ImageSetLazy,self).__getitem__(item)
 
 class FormatMultiImageLazy(FormatMultiImage):

--- a/dxtbx/format/FormatMultiImageLazy.py
+++ b/dxtbx/format/FormatMultiImageLazy.py
@@ -46,7 +46,9 @@ class ImageSetLazy(ImageSet):
     return scan
 
   def __getitem__(self, item):
-    if not isinstance(item, slice):
+    if isinstance(item, slice):
+      return ImageSetLazy(self.data(), indices = self.indices()[item])
+    else:
       # Sets the list for detector, beam etc before being accessed by functions in imageset.h
       self.get_detector(item)
       self.get_beam(item)

--- a/dxtbx/format/FormatMultiImageLazy.py
+++ b/dxtbx/format/FormatMultiImageLazy.py
@@ -25,14 +25,35 @@ class ImageSetLazy(ImageSet):
       self.set_beam(beam,index)
     return beam
 
+  def get_goniometer(self, index=None):
+    if index is None: index=0
+    goniometer = super(ImageSetLazy,self).get_goniometer(index)
+    if goniometer is None:
+      format_instance = self.get_format_class()._current_instance_
+      #format_instance = self.get_format_class()(self.paths()[self.indices()[index]])
+      goniometer = format_instance.get_goniometer(self.indices()[index])
+      self.set_goniometer(goniometer,index)
+    return goniometer
+
+  def get_scan(self, index=None):
+    if index is None: index=0
+    scan = super(ImageSetLazy,self).get_scan(index)
+    if scan is None:
+      format_instance = self.get_format_class()._current_instance_
+      #format_instance = self.get_format_class()(self.paths()[self.indices()[index]])
+      scan = format_instance.get_scan(self.indices()[index])
+      self.set_scan(scan,index)
+    return scan
+
   def __getitem__(self, item):
+    # Sets the list for detector, beam etc before being accessed by functions in imageset.h
     self.get_detector(item)
     self.get_beam(item)
+    self.get_goniometer(item)
+    self.get_scan(item)
     return super(ImageSetLazy,self).__getitem__(item)
 
-
 class FormatMultiImageLazy(FormatMultiImage):
-
 
   def get_goniometer(self, index=None):
     return self._goniometer_instance
@@ -202,6 +223,7 @@ class FormatMultiImageLazy(FormatMultiImage):
       if scan is None:
         scan = format_instance.get_scan()
         if scan is not None:
+          # TODO change this to lazy read of models
           for f in filenames[1:]:
             format_instance = Class(f, **format_kwargs)
             scan += format_instance.get_scan()

--- a/dxtbx/format/FormatMultiImageLazy.py
+++ b/dxtbx/format/FormatMultiImageLazy.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 
-class FormatMultiImageJIT(FormatMultiImage):
+class FormatMultiImageLazy(FormatMultiImage):
 
   '''
-  Just-in-Time version of FormatMultiImage that does not instantiate the models ahead of time.
-  It creates an ImageSetJIT class and returns it. Saves time when image file contains
+  Lazy version of FormatMultiImage that does not instantiate the models ahead of time.
+  It creates an ImageSetLazy class and returns it. Saves time when image file contains
   too many images to setup before processing.
   '''
 
@@ -22,9 +22,9 @@ class FormatMultiImageJIT(FormatMultiImage):
                    format_kwargs=None,
                    template=None,
                    check_format=True,
-                   just_in_time=True):
+                   lazy=True):
 
-    return super(FormatMultiImageJIT, Class).get_imageset(filenames=filenames,
+    return super(FormatMultiImageLazy, Class).get_imageset(filenames=filenames,
                                                           beam=beam,
                                                           detector=detector,
                                                           goniometer=goniometer,
@@ -35,4 +35,4 @@ class FormatMultiImageJIT(FormatMultiImage):
                                                           format_kwargs=format_kwargs,
                                                           template=template,
                                                           check_format=check_format,
-                                                          just_in_time=just_in_time)
+                                                          lazy=lazy)

--- a/dxtbx/format/FormatMultiImageLazy.py
+++ b/dxtbx/format/FormatMultiImageLazy.py
@@ -24,17 +24,15 @@ class FormatMultiImageLazy(FormatMultiImage):
                    check_format=True,
                    lazy=True):
 
-    return super(FormatMultiImageLazy,self).get_imageset(Class,
-                                                         filenames,
-                                                         beam,
-                                                         detector,
-                                                         goniometer,
-                                                         scan,
-                                                         as_sweep,
-                                                         as_imageset,
-                                                         single_file_indices,
-                                                         format_kwargs,
-                                                         template,
-                                                         check_format,
-                                                         lazy)
-
+    return super(FormatMultiImageLazy, Class).get_imageset(filenames,
+                                                           beam,
+                                                           detector,
+                                                           goniometer,
+                                                           scan,
+                                                           as_sweep,
+                                                           as_imageset,
+                                                           single_file_indices,
+                                                           format_kwargs,
+                                                           template,
+                                                           check_format,
+                                                           lazy)

--- a/dxtbx/format/FormatXTC.py
+++ b/dxtbx/format/FormatXTC.py
@@ -102,7 +102,7 @@ class FormatXTC(FormatMultiImageLazy,FormatStill,Format):
     self.times = []
     self.run_mapping = {}
     for run in self._ds.runs():
-      times = run.times()[0:100]
+      times = run.times()
       self.run_mapping[run.run()] = len(self.times), len(self.times)+len(times),run
       self.times.extend(times)
 

--- a/dxtbx/format/FormatXTC.py
+++ b/dxtbx/format/FormatXTC.py
@@ -38,9 +38,9 @@ class FormatXTC(FormatMultiImageJIT,FormatStill,Format):
     self.current_event = None
 
     if 'locator_scope' in kwargs:
-      self.params = FormatXTC.params_from_phil(kwargs['locator_scope'],image_file)
+      self.params = FormatXTC.params_from_phil(kwargs['locator_scope'],image_file,strict=True)
     else:
-      self.params = FormatXTC.params_from_phil(locator_scope,image_file)
+      self.params = FormatXTC.params_from_phil(locator_scope,image_file,strict=True)
     assert self.params.mode == 'idx', 'idx mode should be used for analysis'
     self._initialized = True
 
@@ -89,11 +89,17 @@ class FormatXTC(FormatMultiImageJIT,FormatStill,Format):
     return True
 
   @staticmethod
-  def params_from_phil(master_phil, user_phil):
+  def params_from_phil(master_phil, user_phil,strict=False):
     """ Read the locator file """
     try:
       user_input = parse(file_name = user_phil)
-      working_phil = master_phil.fetch(sources = [user_input])
+      working_phil, unused = master_phil.fetch(sources = [user_input], track_unused_definitions=True)
+      unused_args = ["%s=%s"%(u.path,u.object.words[0].value) for u in unused]
+      if len(unused_args) > 0 and strict:
+        for unused_arg in unused_args:
+          print(unused_arg)
+        print('Incorrect of unused parameter in locator file. Please check and retry')
+        return None
       params = working_phil.extract()
       return params
     except Exception:

--- a/dxtbx/format/FormatXTC.py
+++ b/dxtbx/format/FormatXTC.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatStill import FormatStill
-from dxtbx.format.FormatMultiImageLazy import FormatMultiImageLazy
+from dxtbx.format.FormatMultiImageJIT import FormatMultiImageJIT
 from libtbx.phil import parse
 
 locator_str = """
@@ -25,13 +25,13 @@ locator_str = """
 """
 locator_scope = parse(locator_str)
 
-class FormatXTC(FormatMultiImageLazy,FormatStill,Format):
+class FormatXTC(FormatMultiImageJIT,FormatStill,Format):
 
   def __init__(self, image_file, **kwargs):
     from dxtbx import IncorrectFormatError
     if not self.understand(image_file):
       raise IncorrectFormatError(self, image_file)
-    FormatMultiImageLazy.__init__(self, **kwargs)
+    FormatMultiImageJIT.__init__(self, **kwargs)
     FormatStill.__init__(self, image_file, **kwargs)
     Format.__init__(self, image_file, **kwargs)
     self.current_index = None

--- a/dxtbx/format/FormatXTC.py
+++ b/dxtbx/format/FormatXTC.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatStill import FormatStill
-from dxtbx.format.FormatMultiImageJIT import FormatMultiImageJIT
+from dxtbx.format.FormatMultiImageLazy import FormatMultiImageLazy
 from libtbx.phil import parse
 
 locator_str = """
@@ -25,13 +25,13 @@ locator_str = """
 """
 locator_scope = parse(locator_str)
 
-class FormatXTC(FormatMultiImageJIT,FormatStill,Format):
+class FormatXTC(FormatMultiImageLazy,FormatStill,Format):
 
   def __init__(self, image_file, **kwargs):
     from dxtbx import IncorrectFormatError
     if not self.understand(image_file):
       raise IncorrectFormatError(self, image_file)
-    FormatMultiImageJIT.__init__(self, **kwargs)
+    FormatMultiImageLazy.__init__(self, **kwargs)
     FormatStill.__init__(self, image_file, **kwargs)
     Format.__init__(self, image_file, **kwargs)
     self.current_index = None

--- a/dxtbx/format/FormatXTCCspad.py
+++ b/dxtbx/format/FormatXTCCspad.py
@@ -28,9 +28,8 @@ class FormatXTCCspad(FormatXTC):
     FormatXTC.__init__(self, image_file, locator_scope = cspad_locator_scope, **kwargs)
     self._ds = self._get_datasource(image_file)
     self._env = self._ds.env()
-    self.events_list = []
     self.populate_events()
-    self.n_images = len(self.events_list)
+    self.n_images = len(self.times)
 
   @staticmethod
   def understand(image_file):
@@ -49,7 +48,7 @@ class FormatXTCCspad(FormatXTC):
     from scitbx.array_family import flex
     import numpy as np
     det = psana.Detector(self._src, self._env)
-    d = self.get_detector()
+    d = self.get_detector(index)
     data = cspad_cbf_tbx.get_psana_corrected_data(det, self._get_event(index),
                                                   use_default=False,
                                                   dark=self.params.cspad.dark_correction,

--- a/dxtbx/format/FormatXTCJungfrau.py
+++ b/dxtbx/format/FormatXTCJungfrau.py
@@ -28,7 +28,7 @@ class FormatXTCJungfrau(FormatXTC):
     self.populate_events()
     self.n_images = len(self.times)
     self._cached_detector = {}
-    self._cached_corrections = {}
+    self._cached_psana_detectors = {}
 
   @staticmethod
   def understand(image_file):
@@ -44,15 +44,13 @@ class FormatXTCJungfrau(FormatXTC):
   def get_raw_data(self,index):
     import psana
     from scitbx.array_family import flex
-    det = psana.Detector(self._src, self._env)
     d = self.get_detector(index)
     evt = self._get_event(index)
     run = self.get_run_from_index(index)
-    if run.run() not in self._cached_corrections:
-      self._cached_corrections[run.run()] = \
-        det.gain(evt), det.offset(evt), det.pedestals(evt)
-    gain, offs, peds = self._cached_corrections[run.run()]
-    data = det.calib(evt, gain = gain, offs = offs, peds = peds)
+    if run.run() not in self._cached_psana_detectors:
+      self._cached_psana_detectors[run.run()] = psana.Detector(self._src, self._env)
+    det = self._cached_psana_detectors[run.run()]
+    data = det.calib(evt)
     data = data.astype(np.float64)
     self._raw_data = []
     for quad_count, quad in enumerate(d.hierarchy()):

--- a/dxtbx/format/FormatXTCJungfrau.py
+++ b/dxtbx/format/FormatXTCJungfrau.py
@@ -28,6 +28,7 @@ class FormatXTCJungfrau(FormatXTC):
     self.populate_events()
     self.n_images = len(self.times)
     self._cached_detector = {}
+    self._cached_corrections = {}
 
   @staticmethod
   def understand(image_file):
@@ -46,7 +47,12 @@ class FormatXTCJungfrau(FormatXTC):
     det = psana.Detector(self._src, self._env)
     d = self.get_detector(index)
     evt = self._get_event(index)
-    data = det.raw(evt)
+    run = self.get_run_from_index(index)
+    if run.run() not in self._cached_corrections:
+      self._cached_corrections[run.run()] = \
+        det.gain(evt), det.offset(evt), det.pedestals(evt)
+    gain, offs, peds = self._cached_corrections[run.run()]
+    data = det.calib(evt, gain = gain, offs = offs, peds = peds)
     data = data.astype(np.float64)
     self._raw_data = []
     for quad_count, quad in enumerate(d.hierarchy()):

--- a/dxtbx/format/FormatXTCJungfrau.py
+++ b/dxtbx/format/FormatXTCJungfrau.py
@@ -25,9 +25,8 @@ class FormatXTCJungfrau(FormatXTC):
     FormatXTC.__init__(self, image_file, locator_scope = jungfrau_locator_scope, **kwargs)
     self._ds = self._get_datasource(image_file)
     self._env = self._ds.env()
-    self.events_list = []
     self.populate_events()
-    self.n_images = len(self.events_list)
+    self.n_images = len(self.times)
 
   @staticmethod
   def understand(image_file):
@@ -46,7 +45,7 @@ class FormatXTCJungfrau(FormatXTC):
     det = psana.Detector(self._src, self._env)
     d = self.get_detector()
     evt = self._get_event(index)
-    data = det.calib(evt)
+    data = det.raw(evt)
     data = data.astype(np.float64)
     self._raw_data = []
     for quad_count, quad in enumerate(d.hierarchy()):
@@ -57,6 +56,8 @@ class FormatXTCJungfrau(FormatXTC):
         asic_data = data[quad_count][sensor_id*sdim:(sensor_id+1)*sdim,asic_in_sensor_id*fdim:(asic_in_sensor_id+1)*fdim] # 8 sensors per quad
         self._raw_data.append(flex.double(np.array(asic_data)))
     assert len(d) == len(self._raw_data)
+    #from IPython import embed; embed();
+    #import pdb; pdb.set_trace()
     return tuple(self._raw_data)
 
   def get_num_images(self):

--- a/dxtbx/format/FormatXTCRayonix.py
+++ b/dxtbx/format/FormatXTCRayonix.py
@@ -26,9 +26,8 @@ class FormatXTCRayonix(FormatXTC):
     FormatXTC.__init__(self, image_file, locator_scope = rayonix_locator_scope, **kwargs)
     self._ds = self._get_datasource(image_file)
     self._env = self._ds.env()
-    self.events_list = []
     self.populate_events()
-    self.n_images = len(self.events_list)
+    self.n_images = len(self.times)
 
   @staticmethod
   def understand(image_file):

--- a/dxtbx/imageset.py
+++ b/dxtbx/imageset.py
@@ -608,3 +608,14 @@ class ImageSetFactory(object):
 
     # Return the sweep
     return sweep
+
+  @staticmethod
+  def imageset_from_anyset(imageset):
+    ''' Create a new ImageSet object from an imageset object. Converts ImageSweep to ImageSet. '''
+    from dxtbx.imageset import ImageSet, ImageSweep, ImageSetLazy
+    if isinstance(imageset, ImageSetLazy):
+      return ImageSetLazy(imageset.data(), imageset.indices())
+    elif isinstance(imageset, ImageSweep) or isinstance(imageset, ImageSet):
+      return ImageSet(imageset.data(), imageset.indices())
+    else:
+      assert False, "Unrecognized imageset type: %s"%str(type(imageset))

--- a/dxtbx/imageset.py
+++ b/dxtbx/imageset.py
@@ -148,17 +148,17 @@ class ImageSetAux(boost.python.injector, ImageSet):
     return [self.get_path(i) for i in range(len(self))]
 
 
-class ImageSetLazy(ImageSet):
+class ImageSetJIT(ImageSet):
 
   '''
-  Lazy ImageSet class that doesn't necessitate setting the models ahead of time.
+  Just-in-Time ImageSet class that doesn't necessitate setting the models ahead of time.
   Only when a particular model (like detector or beam) for an image is requested,
   it sets the model using the format class and then returns the model
   '''
 
   def get_detector(self, index=None):
     if index is None: index=0
-    detector = super(ImageSetLazy,self).get_detector(index)
+    detector = super(ImageSetJIT,self).get_detector(index)
     if detector is None:
       format_instance = self.get_format_class()._current_instance_
       detector = format_instance.get_detector(self.indices()[index])
@@ -168,7 +168,7 @@ class ImageSetLazy(ImageSet):
 
   def get_beam(self, index=None):
     if index is None: index=0
-    beam = super(ImageSetLazy,self).get_beam(index)
+    beam = super(ImageSetJIT,self).get_beam(index)
     if beam is None:
       format_instance = self.get_format_class()._current_instance_
       beam = format_instance.get_beam(self.indices()[index])
@@ -177,7 +177,7 @@ class ImageSetLazy(ImageSet):
 
   def get_goniometer(self, index=None):
     if index is None: index=0
-    goniometer = super(ImageSetLazy,self).get_goniometer(index)
+    goniometer = super(ImageSetJIT,self).get_goniometer(index)
     if goniometer is None:
       format_instance = self.get_format_class()._current_instance_
       goniometer = format_instance.get_goniometer(self.indices()[index])
@@ -186,7 +186,7 @@ class ImageSetLazy(ImageSet):
 
   def get_scan(self, index=None):
     if index is None: index=0
-    scan = super(ImageSetLazy,self).get_scan(index)
+    scan = super(ImageSetJIT,self).get_scan(index)
     if scan is None:
       format_instance = self.get_format_class()._current_instance_
       scan = format_instance.get_scan(self.indices()[index])
@@ -195,14 +195,14 @@ class ImageSetLazy(ImageSet):
 
   def __getitem__(self, item):
     if isinstance(item, slice):
-      return ImageSetLazy(self.data(), indices = self.indices()[item])
+      return ImageSetJIT(self.data(), indices = self.indices()[item])
     else:
       # Sets the list for detector, beam etc before being accessed by functions in imageset.h
       self.get_detector(item)
       self.get_beam(item)
       self.get_goniometer(item)
       self.get_scan(item)
-    return super(ImageSetLazy,self).__getitem__(item)
+    return super(ImageSetJIT,self).__getitem__(item)
 
 class ImageSweepAux(boost.python.injector, ImageSweep):
 

--- a/dxtbx/imageset.py
+++ b/dxtbx/imageset.py
@@ -148,6 +148,61 @@ class ImageSetAux(boost.python.injector, ImageSet):
     return [self.get_path(i) for i in range(len(self))]
 
 
+class ImageSetLazy(ImageSet):
+
+  '''
+  Lazy ImageSet class that doesn't necessitate setting the models ahead of time.
+  Only when a particular model (like detector or beam) for an image is requested,
+  it sets the model using the format class and then returns the model
+  '''
+
+  def get_detector(self, index=None):
+    if index is None: index=0
+    detector = super(ImageSetLazy,self).get_detector(index)
+    if detector is None:
+      format_instance = self.get_format_class()._current_instance_
+      detector = format_instance.get_detector(self.indices()[index])
+      self.set_detector(detector,index)
+    return detector
+
+
+  def get_beam(self, index=None):
+    if index is None: index=0
+    beam = super(ImageSetLazy,self).get_beam(index)
+    if beam is None:
+      format_instance = self.get_format_class()._current_instance_
+      beam = format_instance.get_beam(self.indices()[index])
+      self.set_beam(beam,index)
+    return beam
+
+  def get_goniometer(self, index=None):
+    if index is None: index=0
+    goniometer = super(ImageSetLazy,self).get_goniometer(index)
+    if goniometer is None:
+      format_instance = self.get_format_class()._current_instance_
+      goniometer = format_instance.get_goniometer(self.indices()[index])
+      self.set_goniometer(goniometer,index)
+    return goniometer
+
+  def get_scan(self, index=None):
+    if index is None: index=0
+    scan = super(ImageSetLazy,self).get_scan(index)
+    if scan is None:
+      format_instance = self.get_format_class()._current_instance_
+      scan = format_instance.get_scan(self.indices()[index])
+      self.set_scan(scan,index)
+    return scan
+
+  def __getitem__(self, item):
+    if isinstance(item, slice):
+      return ImageSetLazy(self.data(), indices = self.indices()[item])
+    else:
+      # Sets the list for detector, beam etc before being accessed by functions in imageset.h
+      self.get_detector(item)
+      self.get_beam(item)
+      self.get_goniometer(item)
+      self.get_scan(item)
+    return super(ImageSetLazy,self).__getitem__(item)
 
 class ImageSweepAux(boost.python.injector, ImageSweep):
 

--- a/dxtbx/imageset.py
+++ b/dxtbx/imageset.py
@@ -148,17 +148,17 @@ class ImageSetAux(boost.python.injector, ImageSet):
     return [self.get_path(i) for i in range(len(self))]
 
 
-class ImageSetJIT(ImageSet):
+class ImageSetLazy(ImageSet):
 
   '''
-  Just-in-Time ImageSet class that doesn't necessitate setting the models ahead of time.
+  Lazy ImageSet class that doesn't necessitate setting the models ahead of time.
   Only when a particular model (like detector or beam) for an image is requested,
   it sets the model using the format class and then returns the model
   '''
 
   def get_detector(self, index=None):
     if index is None: index=0
-    detector = super(ImageSetJIT,self).get_detector(index)
+    detector = super(ImageSetLazy,self).get_detector(index)
     if detector is None:
       format_instance = self.get_format_class()._current_instance_
       detector = format_instance.get_detector(self.indices()[index])
@@ -168,7 +168,7 @@ class ImageSetJIT(ImageSet):
 
   def get_beam(self, index=None):
     if index is None: index=0
-    beam = super(ImageSetJIT,self).get_beam(index)
+    beam = super(ImageSetLazy,self).get_beam(index)
     if beam is None:
       format_instance = self.get_format_class()._current_instance_
       beam = format_instance.get_beam(self.indices()[index])
@@ -177,7 +177,7 @@ class ImageSetJIT(ImageSet):
 
   def get_goniometer(self, index=None):
     if index is None: index=0
-    goniometer = super(ImageSetJIT,self).get_goniometer(index)
+    goniometer = super(ImageSetLazy,self).get_goniometer(index)
     if goniometer is None:
       format_instance = self.get_format_class()._current_instance_
       goniometer = format_instance.get_goniometer(self.indices()[index])
@@ -186,7 +186,7 @@ class ImageSetJIT(ImageSet):
 
   def get_scan(self, index=None):
     if index is None: index=0
-    scan = super(ImageSetJIT,self).get_scan(index)
+    scan = super(ImageSetLazy,self).get_scan(index)
     if scan is None:
       format_instance = self.get_format_class()._current_instance_
       scan = format_instance.get_scan(self.indices()[index])
@@ -195,14 +195,14 @@ class ImageSetJIT(ImageSet):
 
   def __getitem__(self, item):
     if isinstance(item, slice):
-      return ImageSetJIT(self.data(), indices = self.indices()[item])
+      return ImageSetLazy(self.data(), indices = self.indices()[item])
     else:
       # Sets the list for detector, beam etc before being accessed by functions in imageset.h
       self.get_detector(item)
       self.get_beam(item)
       self.get_goniometer(item)
       self.get_scan(item)
-    return super(ImageSetJIT,self).__getitem__(item)
+    return super(ImageSetLazy,self).__getitem__(item)
 
 class ImageSweepAux(boost.python.injector, ImageSweep):
 

--- a/dxtbx/tests/tst_imageset.py
+++ b/dxtbx/tests/tst_imageset.py
@@ -595,12 +595,12 @@ class Test_SACLA_MPCCD_Cheetah_File(object):
     self.filename = join(dials_regression,
                     "./image_examples/SACLA_MPCCD_Cheetah/run266702-0-subset.h5")
 
-  def run(self, just_in_time=False):
+  def run(self, lazy=False):
 
     from dxtbx.format.Registry import Registry
     format_class = Registry.find(self.filename)
 
-    iset = format_class.get_imageset([self.filename], just_in_time=just_in_time)
+    iset = format_class.get_imageset([self.filename], lazy=lazy)
 
     assert len(iset) == 4
     for i in range(len(iset)):
@@ -611,7 +611,7 @@ class Test_SACLA_MPCCD_Cheetah_File(object):
       assert iset.get_goniometer(i) is None
       assert iset.get_scan(i) is None
 
-    iset = format_class.get_imageset([self.filename], single_file_indices=[1], just_in_time=just_in_time)
+    iset = format_class.get_imageset([self.filename], single_file_indices=[1], lazy=lazy)
     assert len(iset) == 1
 
     for i in range(len(iset)):
@@ -740,7 +740,7 @@ def run():
   TestImageSweep().run()
 #  TestNexusFile().run()
   Test_SACLA_MPCCD_Cheetah_File().run()
-  Test_SACLA_MPCCD_Cheetah_File().run(just_in_time=True)
+  Test_SACLA_MPCCD_Cheetah_File().run(lazy=True)
   TestImageSetFactory().run()
   TestPickleImageSet().run()
 

--- a/dxtbx/tests/tst_imageset.py
+++ b/dxtbx/tests/tst_imageset.py
@@ -588,39 +588,37 @@ class TestNexusFile(object):
       g = iset.get_goniometer(i)
       s = iset.get_scan(i)
 
-class Test_SACLA_MPCCD_Cheetah_File(object):
+def test_SACLA_MPCCD_Cheetah_File(lazy=False):
 
-  def __init__(self):
-    from os.path import join
-    self.filename = join(dials_regression,
+  from os.path import join
+  filename = join(dials_regression,
                     "./image_examples/SACLA_MPCCD_Cheetah/run266702-0-subset.h5")
 
-  def run(self, lazy=False):
 
-    from dxtbx.format.Registry import Registry
-    format_class = Registry.find(self.filename)
+  from dxtbx.format.Registry import Registry
+  format_class = Registry.find(filename)
 
-    iset = format_class.get_imageset([self.filename], lazy=lazy)
+  iset = format_class.get_imageset([filename], lazy=lazy)
 
-    assert len(iset) == 4
-    for i in range(len(iset)):
-      assert iset.get_raw_data(i)
-#      assert iset.get_mask(i)
-      assert iset.get_beam(i)
-      assert iset.get_detector(i)
-      assert iset.get_goniometer(i) is None
-      assert iset.get_scan(i) is None
+  assert len(iset) == 4
+  for i in range(len(iset)):
+    assert iset.get_raw_data(i)
+#   assert iset.get_mask(i)
+    assert iset.get_beam(i)
+    assert iset.get_detector(i)
+    assert iset.get_goniometer(i) is None
+    assert iset.get_scan(i) is None
 
-    iset = format_class.get_imageset([self.filename], single_file_indices=[1], lazy=lazy)
-    assert len(iset) == 1
+  iset = format_class.get_imageset([filename], single_file_indices=[1], lazy=lazy)
+  assert len(iset) == 1
 
-    for i in range(len(iset)):
-      assert iset.get_raw_data(i)
-#      assert iset.get_mask(i)
-      assert iset.get_beam(i)
-      assert iset.get_detector(i)
-      assert iset.get_goniometer(i) is None
-      assert iset.get_scan(i) is None
+  for i in range(len(iset)):
+    assert iset.get_raw_data(i)
+#   assert iset.get_mask(i)
+    assert iset.get_beam(i)
+    assert iset.get_detector(i)
+    assert iset.get_goniometer(i) is None
+    assert iset.get_scan(i) is None
 
 class TestImageSetFactory(object):
   def get_file_list(self):
@@ -739,10 +737,10 @@ def run():
   TestImageSet().run()
   TestImageSweep().run()
 #  TestNexusFile().run()
-  Test_SACLA_MPCCD_Cheetah_File().run()
-  Test_SACLA_MPCCD_Cheetah_File().run(lazy=True)
   TestImageSetFactory().run()
   TestPickleImageSet().run()
+  test_SACLA_MPCCD_Cheetah_File()
+  test_SACLA_MPCCD_Cheetah_File(lazy=True)
 
 
 if __name__ == '__main__':

--- a/dxtbx/tests/tst_imageset.py
+++ b/dxtbx/tests/tst_imageset.py
@@ -588,7 +588,41 @@ class TestNexusFile(object):
       g = iset.get_goniometer(i)
       s = iset.get_scan(i)
 
+class Test_SACLA_MPCCD_Cheetah_File(object):
 
+  def __init__(self):
+    from os.path import join
+    self.filename = join(dials_regression,
+                    "./image_examples/SACLA_MPCCD_Cheetah/run266702-0-subset.h5")
+
+  def run(self, just_in_time=False):
+
+    from dxtbx.format.Registry import Registry
+    format_class = Registry.find(self.filename)
+
+    iset = format_class.get_imageset([self.filename], just_in_time=just_in_time)
+
+    assert len(iset) == 4
+    for i in range(len(iset)):
+      data = iset.get_raw_data(i)
+#      mask = iset.get_mask(i)
+      b = iset.get_beam(i)
+      d = iset.get_detector(i)
+      g = iset.get_goniometer(i)
+      s = iset.get_scan(i)
+
+    print 'OK'
+
+    iset = format_class.get_imageset([self.filename], single_file_indices=[1], just_in_time=just_in_time)
+    assert len(iset) == 1
+
+    for i in range(len(iset)):
+      data = iset.get_raw_data(i)
+#      mask = iset.get_mask(i)
+      b = iset.get_beam(i)
+      d = iset.get_detector(i)
+      g = iset.get_goniometer(i)
+      s = iset.get_scan(i)
 
 class TestImageSetFactory(object):
   def get_file_list(self):
@@ -707,6 +741,8 @@ def run():
   TestImageSet().run()
   TestImageSweep().run()
 #  TestNexusFile().run()
+  Test_SACLA_MPCCD_Cheetah_File().run()
+  Test_SACLA_MPCCD_Cheetah_File().run(just_in_time=True)
   TestImageSetFactory().run()
   TestPickleImageSet().run()
 

--- a/dxtbx/tests/tst_imageset.py
+++ b/dxtbx/tests/tst_imageset.py
@@ -604,25 +604,23 @@ class Test_SACLA_MPCCD_Cheetah_File(object):
 
     assert len(iset) == 4
     for i in range(len(iset)):
-      data = iset.get_raw_data(i)
-#      mask = iset.get_mask(i)
-      b = iset.get_beam(i)
-      d = iset.get_detector(i)
-      g = iset.get_goniometer(i)
-      s = iset.get_scan(i)
-
-    print 'OK'
+      assert iset.get_raw_data(i)
+#      assert iset.get_mask(i)
+      assert iset.get_beam(i)
+      assert iset.get_detector(i)
+      assert iset.get_goniometer(i) is None
+      assert iset.get_scan(i) is None
 
     iset = format_class.get_imageset([self.filename], single_file_indices=[1], just_in_time=just_in_time)
     assert len(iset) == 1
 
     for i in range(len(iset)):
-      data = iset.get_raw_data(i)
-#      mask = iset.get_mask(i)
-      b = iset.get_beam(i)
-      d = iset.get_detector(i)
-      g = iset.get_goniometer(i)
-      s = iset.get_scan(i)
+      assert iset.get_raw_data(i)
+#      assert iset.get_mask(i)
+      assert iset.get_beam(i)
+      assert iset.get_detector(i)
+      assert iset.get_goniometer(i) is None
+      assert iset.get_scan(i) is None
 
 class TestImageSetFactory(object):
   def get_file_list(self):

--- a/xfel/ui/db/frame_logging.py
+++ b/xfel/ui/db/frame_logging.py
@@ -68,6 +68,7 @@ class DialsProcessorWithLogging(Processor):
       self.log_frame(experiments, indexed, run, len(indexed), timestamp = timestamp,
                      two_theta_low = self.tt_low, two_theta_high = self.tt_high,
                      db_event = self.db_event)
+    return experiments, indexed
 
   def integrate(self, experiments, indexed):
     # Results should always be logged after integration even if it fails.

--- a/xfel/ui/db/frame_logging.py
+++ b/xfel/ui/db/frame_logging.py
@@ -30,9 +30,9 @@ class DialsProcessorWithLogging(Processor):
     imageset = sets[0]
     assert len(imageset) == 1
     format_obj = imageset.data().reader().format_class._current_instance_ # XXX
-    run = format_obj.get_run(imageset.indices()[0])
+    run = format_obj.get_run_from_index(imageset.indices()[0])
     timestamp = format_obj.get_psana_timestamp(imageset.indices()[0])
-    return run, timestamp
+    return run.run(), timestamp
 
   def pre_process(self, datablock):
     super(DialsProcessorWithLogging, self).pre_process(datablock)


### PR DESCRIPTION
This pull request introduces and modifies the following features in dxtbx to speed up processing of XTC streams at LCLS - 

1. Add FormatMultiImageJIT (JIT = Just-in-Time) and change FormatXTC to inherit from that class. This allows us to process large XTC streams without loading/setting all the models upfront as is the case with FormatMultiImage. The models are set only when requested by a process. Because of this, a new imageset, ImageSetJIT is necessary since some of the ImageSet features need to be overriden (eg. get_detector etc). The __getitem__ function for ImageSetJIT is also defined since a model (detector,beam etc) for an image needs to be set before further action takes place in imageset.h
Most of the features introduced have little to no duplication of code. The class method get_imageset() function in FormatMultiImage has a new flag **just_in_time** that allows us to implement FormatMultiImageJIT without duplicating code. 

Note, to do this change, in ImageSetJIT, get_format_class(). __current_instance__ has been used. 

2. Incorporate functionality for handling multiple LCLS runs with FormatXTC by using a dictionary to map runs to their events (through the run.times() method)

3. idx mode is made default in all XTC readers. This allows better parallelism when using dials.stills_process

4. Caching has been used to improve FormatXTC code speed. The PSANA detector object from within a run is cached, so is the FormatXTCJungfrau detector object (currently no information is available about parallax effects of the Jungfrau). 

5. New test in dxtbx/test/tst_imageset.py to test the imageset obtained from loading a multiimage file. The tests are done both with and without **just_in_time**=True. 

6. A concomitant pull request has been created in the dials source for utilizing these changes.

By 
Asmit Bhowmick & Aaron Brewster  

