### PR TITLE
Replace deprecated boost::python numpy interface

### DIFF
--- a/scitbx/array_family/boost_python/flex_bool.cpp
+++ b/scitbx/array_family/boost_python/flex_bool.cpp
@@ -375,7 +375,7 @@ namespace {
         default_call_policies(),
         (arg("size"), arg("iselection"))))
       .def("__init__", make_constructor(
-        flex_bool_from_numpy_array, default_call_policies()))
+        flex_from_numpy_array<bool>, default_call_policies()))
       .def("__eq__", eq)
       .def("__ne__", ne)
       .def("__eq__", eq)
@@ -420,7 +420,7 @@ namespace {
            af::const_ref<bool> const&,
            af::const_ref<std::size_t> const&)) filter_indices, (
              arg("indices")))
-      .def("as_numpy_array", flex_bool_as_numpy_array, (
+      .def("as_numpy_array", flex_as_numpy_array<bool>, (
         arg("optional")=false))
     ;
     def("order", f_w::order_a_a, (arg("other")));

--- a/scitbx/array_family/boost_python/flex_complex_double.cpp
+++ b/scitbx/array_family/boost_python/flex_complex_double.cpp
@@ -1,7 +1,6 @@
 #include <scitbx/array_family/boost_python/flex_wrapper.h>
 #include <scitbx/array_family/boost_python/flex_pickle_single_buffered.h>
 #include <scitbx/array_family/boost_python/flex_wrapper_complex.h>
-#include <scitbx/array_family/boost_python/numpy_bridge.hpp>
 #include <scitbx/array_family/versa_matrix.h>
 #include <scitbx/matrix/move.h>
 #include <boost/python/make_constructor.hpp>
@@ -119,8 +118,6 @@ namespace {
       .def("__init__", make_constructor(
         from_pair_of_flex_double, default_call_policies(), (
           arg("reals"), arg("imags"))))
-      .def("__init__", make_constructor(
-        flex_complex_double_from_numpy_array, default_call_policies()))
       .def("part_names", part_names)
       .staticmethod("part_names")
       .def("parts", parts)
@@ -175,8 +172,6 @@ namespace {
               arg("block"),
               arg("i_row"),
               arg("i_column")))
-      .def("as_numpy_array", flex_complex_double_as_numpy_array, (
-        arg("optional")=false))
     ;
     def("mean", f_w::mean_a);
     def("mean_sq", f_w::mean_sq_a);

--- a/scitbx/array_family/boost_python/flex_double.cpp
+++ b/scitbx/array_family/boost_python/flex_double.cpp
@@ -2,7 +2,6 @@
 #include <scitbx/array_family/boost_python/flex_pickle_single_buffered.h>
 #include <scitbx/array_family/boost_python/byte_str.h>
 #include <scitbx/array_family/boost_python/range_wrappers.h>
-#include <scitbx/array_family/boost_python/numpy_bridge.hpp>
 #include <scitbx/math/utils.h>
 #include <scitbx/matrix/norms.h>
 #include <boost/python/args.hpp>
@@ -488,8 +487,6 @@ namespace boost_python {
         from_list_of_lists_or_tuples, default_call_policies()))
       .def("__init__", make_constructor(
         from_tuple_of_lists_or_tuples, default_call_policies()))
-      .def("__init__", make_constructor(
-        flex_double_from_numpy_array, default_call_policies()))
       .def("__mul__", mul_ar_sc)
       .def("__rmul__", mul_ar_sc)
       .def("__mul__", f_w::mul_a_s) // re-define so it is found first
@@ -530,8 +527,6 @@ namespace boost_python {
       .def("select", select_stl_iterable<std::set<unsigned> >, (
         arg("selection")))
       .def("norm_1", norm_1_a)
-      .def("as_numpy_array", flex_double_as_numpy_array, (
-        arg("optional")=false))
     ;
     def(
       "double_from_byte_str",

--- a/scitbx/array_family/boost_python/flex_ext.cpp
+++ b/scitbx/array_family/boost_python/flex_ext.cpp
@@ -12,6 +12,7 @@
 #include <scitbx/array_family/boost_python/c_grid_flex_conversions.h>
 #include <scitbx/array_family/boost_python/owning_ref_conversions.h>
 #include <scitbx/array_family/boost_python/passing_flex_by_reference.h>
+#include <scitbx/array_family/boost_python/numpy_bridge.hpp>
 #include <scitbx/boost_python/container_conversions.h>
 #include <scitbx/boost_python/slice.h>
 #include <boost_adaptbx/optional_conversions.h>
@@ -31,7 +32,6 @@
 
 namespace scitbx { namespace af { namespace boost_python {
 
-  void import_numpy_api_if_available();
   void wrap_flex_grid();
   void wrap_flex_bool();
   void wrap_flex_size_t();

--- a/scitbx/array_family/boost_python/flex_float.cpp
+++ b/scitbx/array_family/boost_python/flex_float.cpp
@@ -1,7 +1,6 @@
 #include <scitbx/array_family/boost_python/flex_wrapper.h>
 #include <scitbx/array_family/boost_python/flex_pickle_single_buffered.h>
 #include <scitbx/array_family/boost_python/range_wrappers.h>
-#include <scitbx/array_family/boost_python/numpy_bridge.hpp>
 #include <boost/python/make_constructor.hpp>
 
 namespace scitbx { namespace af { namespace boost_python {
@@ -11,10 +10,6 @@ namespace scitbx { namespace af { namespace boost_python {
     using namespace boost::python;
     flex_wrapper<float>::numeric("float", boost::python::scope())
       .def_pickle(flex_pickle_single_buffered<float>())
-      .def("__init__", make_constructor(
-        flex_float_from_numpy_array, default_call_policies()))
-      .def("as_numpy_array", flex_float_as_numpy_array, (
-        boost::python::arg("optional")=false))
     ;
     range_wrappers<float, int>::wrap("float_range");
   }

--- a/scitbx/array_family/boost_python/flex_int.cpp
+++ b/scitbx/array_family/boost_python/flex_int.cpp
@@ -2,7 +2,6 @@
 #include <scitbx/array_family/boost_python/flex_pickle_single_buffered.h>
 #include <scitbx/array_family/boost_python/byte_str.h>
 #include <scitbx/array_family/boost_python/range_wrappers.h>
-#include <scitbx/array_family/boost_python/numpy_bridge.hpp>
 #include <scitbx/array_family/counts.h>
 #include <scitbx/array_family/versa_matrix.h>
 #include <scitbx/matrix/packed.h>
@@ -201,8 +200,6 @@ namespace scitbx { namespace af { namespace boost_python {
       .def_pickle(flex_pickle_single_buffered<int>())
       .def("__init__", make_constructor(
         from_std_string, default_call_policies()))
-      .def("__init__", make_constructor(
-        flex_int_from_numpy_array, default_call_policies()))
       .def("copy_to_byte_str", copy_to_byte_str<versa<int, flex_grid<> > >)
       .def("slice_to_byte_str",
         slice_to_byte_str<versa<int, flex_grid<> > >)
@@ -255,8 +252,6 @@ namespace scitbx { namespace af { namespace boost_python {
               arg("block"),
               arg("i_row"),
               arg("i_column")))
-      .def("as_numpy_array", flex_int_as_numpy_array, (
-        arg("optional")=false))
       .def("__invert__", &bitwise_not)
       .def("__or__", &bitwise_or_single)
       .def("__or__", &bitwise_or_array)

--- a/scitbx/array_family/boost_python/flex_long.cpp
+++ b/scitbx/array_family/boost_python/flex_long.cpp
@@ -1,7 +1,6 @@
 #include <scitbx/array_family/boost_python/flex_wrapper.h>
 #include <scitbx/array_family/boost_python/flex_pickle_single_buffered.h>
 #include <scitbx/array_family/boost_python/range_wrappers.h>
-#include <scitbx/array_family/boost_python/numpy_bridge.hpp>
 #include <scitbx/array_family/counts.h>
 #include <scitbx/array_family/versa_matrix.h>
 #include <scitbx/matrix/move.h>
@@ -18,8 +17,6 @@ namespace scitbx { namespace af { namespace boost_python {
     using boost::python::arg;
     flex_wrapper<long>::signed_integer("long", boost::python::scope())
       .def_pickle(flex_pickle_single_buffered<long>())
-      .def("__init__", make_constructor(
-        flex_long_from_numpy_array, default_call_policies()))
       .def("counts", counts<long, std::map<long, long> >::unlimited)
       .def("counts", counts<long, std::map<long, long> >::limited, (
         arg("max_keys")))
@@ -41,8 +38,6 @@ namespace scitbx { namespace af { namespace boost_python {
               arg("block"),
               arg("i_row"),
               arg("i_column")))
-      .def("as_numpy_array", flex_long_as_numpy_array, (
-        arg("optional")=false))
     ;
     range_wrappers<long, long>::wrap("long_range");
   }

--- a/scitbx/array_family/boost_python/flex_size_t.cpp
+++ b/scitbx/array_family/boost_python/flex_size_t.cpp
@@ -87,8 +87,10 @@ namespace {
       .def_pickle(flex_pickle_single_buffered<std::size_t>())
       .def("__init__", make_constructor(
         from_stl_vector_unsigned, default_call_policies()))
+      // numpy deliberately respecified here because for some unknown
+      // reason relying on flex_wrapper::numeric fails TypeConversion
       .def("__init__", make_constructor(
-        flex_size_t_from_numpy_array, default_call_policies()))
+        flex_from_numpy_array<std::size_t>, default_call_policies()))
       .def("copy_to_byte_str",
         copy_to_byte_str<versa<std::size_t, flex_grid<> > >)
       .def("as_int", as_int)
@@ -106,8 +108,6 @@ namespace {
       .def("inverse_permutation", inverse_permutation)
       .def("increment_and_track_up_from_zero",
         increment_and_track_up_from_zero, (arg("iselection")))
-      .def("as_numpy_array", flex_size_t_as_numpy_array, (
-        arg("optional")=false))
     ;
     def(
       "size_t_from_byte_str",

--- a/scitbx/array_family/boost_python/flex_wrapper.h
+++ b/scitbx/array_family/boost_python/flex_wrapper.h
@@ -23,6 +23,7 @@
 #include <scitbx/array_family/boost_python/ref_flex_conversions.h>
 #include <scitbx/array_family/boost_python/passing_flex_by_reference.h>
 #include <scitbx/array_family/boost_python/selections_wrapper.h>
+#include <scitbx/array_family/boost_python/numpy_bridge.hpp>
 #include <scitbx/misc/positive_getitem_index.h>
 
 namespace scitbx { namespace af { namespace boost_python {
@@ -904,6 +905,10 @@ namespace scitbx { namespace af { namespace boost_python {
         boost::python::def("product", product_a);
       }
       return plain(python_name)
+        .def("__init__", make_constructor(
+          flex_from_numpy_array<ElementType>, boost::python::default_call_policies()))
+        .def("as_numpy_array", flex_as_numpy_array<ElementType>, (
+          boost::python::arg("optional")=false))
         .def("count", count)
         .def("__neg__", neg_a)
         .def("__add__", add_a_a)

--- a/scitbx/array_family/boost_python/numpy_bridge.hpp
+++ b/scitbx/array_family/boost_python/numpy_bridge.hpp
@@ -1,27 +1,52 @@
-#include <boost/python/numeric.hpp>
+#ifndef NUMPY_BRIDGE_H
+#define NUMPY_BRIDGE_H
 
-namespace scitbx { namespace af { namespace boost_python {
+#include <boost/python/numpy.hpp>
+#include <scitbx/array_family/accessors/flex_grid.h>
+#include <scitbx/array_family/versa.h>
 
-#define SCITBX_LOC(pyname, ElementType) \
-  boost::python::object \
-  flex_##pyname##_as_numpy_array( \
-    ref<ElementType, flex_grid<> > const& O, \
-    bool optional=false); \
- \
-  versa<ElementType, flex_grid<> >* \
-  flex_##pyname##_from_numpy_array( \
-    boost::python::numeric::array const& arr_obj);
+namespace scitbx {
+namespace af {
+namespace boost_python {
 
-  SCITBX_LOC(bool, bool)
-  SCITBX_LOC(int, int)
-  SCITBX_LOC(long, long)
-  SCITBX_LOC(float, float)
-  SCITBX_LOC(double, double)
-#define SCITBX_LOC2 std::complex<double>
-  SCITBX_LOC(complex_double, SCITBX_LOC2)
-#undef SCITBX_LOC2
-  SCITBX_LOC(size_t, std::size_t)
+/// Do any numpy API imports that might be required (only call once)
+void import_numpy_api_if_available();
 
-#undef SCITBX_LOC
+/// Convert a flex versa-grid object to a numpy array
+///
+/// @tparam ElementType   The value-type for the flex array. A numpy datatype
+///                       will be searched for to match this type.
+/// @param  from          The versa-grid array to convert from
+/// @param  optional      Ignored if numpy is available. If numpy is missing,
+///                       and optional is True, the returned python object is
+///                       None. Otherwise, if optional is False then an
+///                       std::invalid_argument exception is thrown.
+/// @returns A new numpy array object
+///
+/// @throws std::runtime_error      If no matching numpy type could be found,
+///                                 or numpy unavailable and optional=false
+template <typename ElementType>
+boost::python::object
+flex_as_numpy_array(ref<ElementType, flex_grid<> > const &from, bool optional);
 
-}}} // namespace scitbx::af::boost_python
+/// Convert a numpy array to a flex object.
+///
+/// The contents of the numpy array will be converted to a numpy datatype
+/// matching the target flex array before copying.
+///
+/// @tparam   ElementType         The value-type for the output flex array
+/// @param    array               A numpy array wrapped by boost::python
+/// @returns  A flex versa-grid array
+///
+/// @throws std::runtime_error    If numpy is not available, or if no
+///                               matching numpy data type could be found.
+/// @throws std::invalid_argument If the numpy array is non-contiguous
+template <typename ElementType>
+versa<ElementType, flex_grid<> > *
+flex_from_numpy_array(boost::python::numpy::ndarray const &array);
+
+} // namespace boost_python
+} // namespace af
+} // namespace scitbx
+
+#endif

--- a/scitbx/array_family/boost_python/tst_numpy_bridge.py
+++ b/scitbx/array_family/boost_python/tst_numpy_bridge.py
@@ -2,7 +2,13 @@ from __future__ import division
 from scitbx.array_family import flex
 from libtbx.test_utils import Exception_expected, show_diff
 
-def exercise_basic(flex_type, verbose):
+try:
+  import numpy as np
+except ImportError:
+  numpy = None
+
+def exercise_type_conversions(flex_type, verbose):
+  """Test converting various flex array types"""
   if (flex_type is flex.bool):
     z = False
   else:
@@ -17,7 +23,8 @@ def exercise_basic(flex_type, verbose):
     fna = flex_type(na)
     assert fna.all_eq(fa)
 
-def exercise_int():
+def test_int_conversions():
+  """More exhaustive tests for converting int-type arrays"""
   fa = flex.int_range(1,7)
   na = fa.as_numpy_array()
   assert na.tolist() == list(fa)
@@ -29,7 +36,8 @@ def exercise_int():
   fa[0] = 99
   assert na[0] == 1
   fa[0] = 1
-  #
+
+  # Test that a 2D gridded versa gets properly converted
   fa.reshape(flex.grid(2,3))
   na = fa.as_numpy_array()
   assert na.tolist() == [[1, 2, 3], [4, 5, 6]]
@@ -38,7 +46,8 @@ def exercise_int():
   assert fna.origin() == (0,0)
   assert fna.focus() == (2,3)
   assert fna.all_eq(fa)
-  #
+
+  # Test that a gridded versa gets converted properly
   fa = flex.int_range(4*2*3) + 1
   fa.reshape(flex.grid(4,2,3))
   na = fa.as_numpy_array()
@@ -52,6 +61,20 @@ def exercise_int():
   assert fna.origin() == (0,0,0)
   assert fna.focus() == (4,2,3)
   assert fna.all_eq(fa)
+
+  # Test converting a numpy array of a different type
+  fa = flex.int(np.array([1,2], dtype=np.int64))
+  assert fa[0] == 1
+  assert fa[1] == 2
+
+  # Test converting a very large array (memory leaks)
+  bigarray = np.ones(1000000)
+  fa = flex.int(bigarray)
+  assert (fa == 1).count(True)
+  # And, back to numpy
+  bigarray = fa.as_numpy_array()
+  assert np.sum(bigarray == 1) == len(bigarray)
+
 
 def run(args):
   assert args in [[], ["--forever"]]
@@ -73,8 +96,8 @@ def run(args):
             flex.double,
             flex.complex_double,
             flex.size_t]:
-        exercise_basic(flex_type, verbose)
-      exercise_int()
+        exercise_type_conversions(flex_type, verbose)
+      test_int_conversions()
     if (len(args) == 0):
       break
     verbose = False


### PR DESCRIPTION
This is the work to deprecate the old numeric interface and add compatibility with the new `boost::python::numpy` API, so that we can upgrade to and past Boost 1.65.

The parts of the API which rely on boost for numpy is relatively thin and can be removed completely to get rid of the dependency on this package, if we should desire to.

---

Boost 1.63 deprecated boost::python::numeric and added ::numpy. In order to update to 1.65 (#172), which drops the numeric API, we needed to move to the new ::numpy.

Because the numpy bridge code is mainly written in plain numpy C-API, the opportunity has been taken to update the API syntax (to remove warnings about using the old API).

The old macro-based declaration scheme has been removed in favor of C++ templates, which means the numpy conversion routines can be specified more centrally for flex arrays, though for some reason this appears to fail for std::size (which is why that is overridden specifically in flex_size_t.cpp)