### PR TITLE
Allow rotarama cache rebuild to fail gracefully on Python3

### DIFF
--- a/mmtbx/command_line/rebuild_rotarama_cache.py
+++ b/mmtbx/command_line/rebuild_rotarama_cache.py
@@ -5,10 +5,7 @@ import sys
 
 # NB:  this can be run from the command line as "mmtbx.rebuild_rotarama_cache"
 def run():
-  from libtbx import easy_pickle
   from libtbx.utils import format_cpu_times
-  from libtbx.str_utils import show_string
-  from mmtbx.rotamer.n_dim_table import NDimTable
   from mmtbx.rotamer import rotamer_eval
   from mmtbx.rotamer import ramachandran_eval
 
@@ -43,6 +40,9 @@ def run():
   print(format_cpu_times())
 
 def rebuild_pickle_files(data_dir, file_prefix, target_db, amino_acids):
+  from libtbx import easy_pickle
+  from libtbx.str_utils import show_string
+  from mmtbx.rotamer.n_dim_table import NDimTable
   os.chdir(data_dir)
   print("Processing data files in %s:" % show_string(data_dir))
   for aa, aafile in amino_acids.items():

--- a/mmtbx/command_line/rebuild_rotarama_cache.py
+++ b/mmtbx/command_line/rebuild_rotarama_cache.py
@@ -1,18 +1,21 @@
-from __future__ import division
-from libtbx import easy_pickle
-from libtbx.utils import format_cpu_times
-from libtbx.str_utils import show_string
-from mmtbx.rotamer.n_dim_table import NDimTable
-from mmtbx.rotamer import rotamer_eval
-from mmtbx.rotamer import ramachandran_eval
-import sys, os
+from __future__ import absolute_import, division, print_function
+
+import os
+import sys
 
 # NB:  this can be run from the command line as "mmtbx.rebuild_rotarama_cache"
 def run():
+  from libtbx import easy_pickle
+  from libtbx.utils import format_cpu_times
+  from libtbx.str_utils import show_string
+  from mmtbx.rotamer.n_dim_table import NDimTable
+  from mmtbx.rotamer import rotamer_eval
+  from mmtbx.rotamer import ramachandran_eval
+
   initial_current_working_directory = os.getcwd()
   rotamer_data_dir = rotamer_eval.find_rotarama_data_dir(optional=True)
   if rotamer_data_dir is None:
-    print '  Rebuilding rotarama library skipped. Needs rotamer library.'
+    print('  Rebuilding rotarama library skipped. Needs rotamer library.')
     return
   target_db = rotamer_eval.open_rotarama_dlite(
     rotarama_data_dir=rotamer_data_dir)
@@ -37,11 +40,11 @@ def run():
 #   target_db=target_db,
 #   amino_acids=ramachandran_eval.aminoAcids)
   os.chdir(initial_current_working_directory)
-  print format_cpu_times()
+  print(format_cpu_times())
 
 def rebuild_pickle_files(data_dir, file_prefix, target_db, amino_acids):
   os.chdir(data_dir)
-  print "Processing data files in %s:" % show_string(data_dir)
+  print("Processing data files in %s:" % show_string(data_dir))
   for aa, aafile in amino_acids.items():
     data_file = file_prefix+aafile+".data"
     pickle_file = file_prefix+aafile+".pickle"
@@ -49,19 +52,27 @@ def rebuild_pickle_files(data_dir, file_prefix, target_db, amino_acids):
       source_path=data_file,
       target_path=pickle_file,
       path_prefix=data_dir)
-    print "  %s -> %s:" % (data_file, pickle_file),
+    print("  %s -> %s:" % (data_file, pickle_file), end=' ')
     if not pair_info.needs_update:
-      print "already up to date."
+      print("already up to date.")
     else:
-      print "converting ...",
+      print("converting ...", end=' ')
       sys.stdout.flush()
       pair_info.start_building_target()
       ndt = NDimTable.createFromText(data_file)
       easy_pickle.dump(file_name=pickle_file, obj=ndt)
       pair_info.done_building_target()
-      print "done."
+      print("done.")
     sys.stdout.flush()
   target_db.write()
 
 if __name__ == "__main__":
+  if sys.hexversion < 0x03000000:
     run()
+  else:
+    try:
+      run()
+    except Exception:
+      print("Rebuilding rotorama failed with an exception. This is expected on Python3.")
+      import traceback
+      traceback.print_exc()


### PR DESCRIPTION
```mmtbx.rebuild_rotarama_cache``` is run as part of the bootstrap build stage and is currently the only blocked for Python3 builds. I tried converting the relevant files but doing this would affect too many files, so want to leave this for someone from the mmtbx crew to sort out.
To address the immediate issue this patch catches any exceptions on Python 3 only.
Nothing changes on Python 2