### PR TITLE
boost.python changes for python 3

### DIFF
--- a/boost/python.py
+++ b/boost/python.py
@@ -222,6 +222,35 @@ class injector(object):
           setattr_from_dict(b.__dict__)
       return type.__init__(self, name, (), {})
 
+def inject(target_class, *mixin_classes):
+  '''Add entries from python class dictionaries to a boost extension class.
+
+     It is used as follows:
+
+           class _():
+             def method(...):
+               ...
+           boost.python.inject(extension_class, _)
+
+     instead of the previous mechanism of
+
+           class _(boost.python.injector, extension_class):
+             def method(...):
+               ...
+
+     which does not work in python 3.
+  '''
+  def setattr_from_dict(d):
+    for key, value in d.items():
+      if key not in ("__init__",
+                     "__del__",
+                     "__module__",
+                     "__file__",
+                     "__dict__") and (key != '__doc__' or value):
+        setattr(target_class, key, value)
+  for m in mixin_classes:
+    setattr_from_dict(m.__dict__)
+
 def process_docstring_options(env_var="BOOST_ADAPTBX_DOCSTRING_OPTIONS"):
   from_env = os.environ.get(env_var)
   if from_env is None: return None

--- a/scitbx/array_family/flex.py
+++ b/scitbx/array_family/flex.py
@@ -209,8 +209,7 @@ def condense_as_ranges(integer_array):
   store_range()
   return result
 
-class _(boost.python.injector, mersenne_twister):
-
+class _():
   def random_selection(self, population_size, sample_size):
     assert population_size >= 0
     assert sample_size >= 0
@@ -218,6 +217,7 @@ class _(boost.python.injector, mersenne_twister):
     perm = self.random_permutation(size=population_size)
     perm.resize(sample_size)
     return sorted(perm)
+boost.python.inject(mersenne_twister, _)
 
 random_generator = ext.mersenne_twister(scitbx.random.mt19937)
 


### PR DESCRIPTION
The first commit 82633df is simply syntax rewriting.

The second commit 10f4e8ad  adds a new ```boost.python``` injection function. 
The ```boost.python.injector``` currently depends on the behaviour of ```__metaclass__```. This has changed in python 3, so boost injections using the class constructor will no longer happen. There are no error messages or anything - the code is simply never executed.

Injections in the form of
```python
class _(boost.python.injector, extension_class):
  def method(...):
     ...
```
will not work.

I have added a ```boost.python.inject``` function to achieve the same goal which works on python 2 and 3. The example above then changes to
```python
class _():
  def method(...):
    ...
boost.python.inject(extension_class, _)
```

The commit contains an example in ```scitbx/array_family/flex.py``` (which is required for the python 3 bootstrap build step).

@luc-j-bourhis since you did the most recent work on boost.python could you please take a look?