### PR TITLE
Syntax changes for Python 3 bootstrap build step

### DIFF
--- a/cctbx/array_family/flex.py
+++ b/cctbx/array_family/flex.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import absolute_import, division, print_function
 import scitbx.array_family.flex
 
 import boost.python

--- a/iotbx/phil.py
+++ b/iotbx/phil.py
@@ -1,11 +1,14 @@
-from __future__ import division
+from __future__ import absolute_import, division, print_function
+
+import os
+import sys
+
 from cctbx import sgtbx
 from cctbx import uctbx
 import libtbx.phil.command_line
 from libtbx.utils import Sorry, Usage, import_python_object
 from libtbx.phil import tokenizer
 from libtbx import Auto
-import sys, os
 
 class unit_cell_converters(object):
 
@@ -209,14 +212,14 @@ Full parameters:
       if (self.integer_def is not None) :
         try :
           int_value = int(arg)
-        except ValueError, e :
+        except ValueError:
           pass
         else :
           return libtbx.phil.parse("%s=%d" % (self.integer_def, int_value))
       if (self.float_def is not None) :
         try :
           float_value = float(arg)
-        except ValueError, e :
+        except ValueError:
           pass
         else :
           return libtbx.phil.parse("%s=%g" % (self.float_def, float_value))
@@ -296,13 +299,13 @@ class setup_app_generic (object) :
         try :
           user_phil = parse(file_name=arg)
           sources.append(user_phil)
-        except Exception, e :
+        except Exception as e :
           unused_args.append(os.path.abspath(arg))
       elif arg != "" and not arg.startswith("-") :
         try :
           params = interpreter.process(arg=arg)
         except RuntimeError :
-          print >> log, "%s does not appear to be a parameter definition" % arg
+          print("%s does not appear to be a parameter definition" % arg, file=log)
           unused_args.append(arg)
         else :
           sources.append(params)
@@ -311,10 +314,10 @@ class setup_app_generic (object) :
     try :
       working_phil = master_phil.fetch(sources=sources,
          skip_incompatible_objects=True)
-    except Exception, e :
-      print >> log, "Error incorporating parameters from user-specified file(s):"
-      print >> log, str(e)
-      print >> log, "Will revert to default parameters for this run."
+    except Exception as e :
+      print("Error incorporating parameters from user-specified file(s):", file=log)
+      print(str(e), file=log)
+      print("Will revert to default parameters for this run.", file=log)
       working_phil = master_phil.fetch()
 
     assert working_phil is not None

--- a/libtbx/easy_pickle.py
+++ b/libtbx/easy_pickle.py
@@ -5,10 +5,12 @@ file_name ends with .gz. Also provides functions to read that object back.
 """
 
 from __future__ import absolute_import, division, print_function
-import cPickle
+
 import os
+
 from libtbx.str_utils import show_string
 from libtbx import smart_open
+from six.moves import cPickle
 
 def _open(file_name, mode):
   """

--- a/libtbx/smart_open.py
+++ b/libtbx/smart_open.py
@@ -1,25 +1,28 @@
-from __future__ import division
+from __future__ import absolute_import, division, print_function
+
+import io
+import os
+
 from libtbx.utils import escape_sh_double_quoted, gzip_open, bz2_open
 from libtbx import easy_run
 from libtbx.str_utils import show_string
-from cStringIO import StringIO
-import os
+from six import BytesIO
 
 def for_reading(file_name, mode="r", gzip_mode="rb"):
   assert mode in ["r", "rb"]
   assert gzip_mode in ["r", "rb"]
   file_name = os.path.expanduser(file_name)
-  if (file_name.endswith(".gz")):
+  if file_name.endswith(".gz"):
     return gzip_open(file_name=file_name, mode=gzip_mode)
-  if (file_name.endswith(".Z")):
-    return StringIO(easy_run.fully_buffered(
+  if file_name.endswith(".Z"):
+    return BytesIO(easy_run.fully_buffered(
       command='gunzip -c "%s"' % escape_sh_double_quoted(file_name),
       stdout_splitlines=False).raise_if_errors().stdout_buffer)
   if file_name.endswith('.bz2'):
     return bz2_open(file_name=file_name, mode=mode)
   try:
     return open(file_name, mode)
-  except IOError, e:
+  except IOError as e:
     raise IOError(
       "Cannot open file for reading: %s\n" % show_string(file_name)
       + "  "+str(e))
@@ -28,13 +31,13 @@ def for_writing(file_name, mode="w", gzip_mode="wb"):
   assert mode in ["w", "wb", "a", "ab"]
   assert gzip_mode in ["w", "wb", "a", "ab"]
   file_name = os.path.expanduser(file_name)
-  if (file_name.endswith(".gz")):
+  if file_name.endswith(".gz"):
     return gzip_open(file_name=file_name, mode=gzip_mode)
-  elif (file_name.endswith(".bz2")):
+  elif file_name.endswith(".bz2"):
     return bz2_open(file_name=file_name, mode=mode)
   try:
     return open(file_name, mode)
-  except IOError, e:
+  except IOError as e:
     raise IOError(
       "Cannot open file for writing: %s\n" % show_string(file_name)
       + "  "+str(e))
@@ -42,7 +45,7 @@ def for_writing(file_name, mode="w", gzip_mode="wb"):
 def file(file_name, mode):
   assert mode in ["r", "rb", "w", "wb", "a", "ab"]
   file_name = os.path.expanduser(file_name)
-  if (mode[0] == "r"):
+  if mode[0] in ("r", "rb"):
     return for_reading(file_name=file_name, mode=mode)
   return for_writing(file_name=file_name, mode=mode)
 
@@ -51,9 +54,9 @@ def exercise():
   for file_name in sys.argv[1:]:
     assert for_reading(file_name=file_name).read().splitlines() \
         == ["line 1", "line 2", "the end"]
-  print >> for_writing(file_name="tmp_plain"), "line 1"
-  print >> for_writing(file_name="tmp.gz"), "line 1"
-  print "OK"
+  print("line 1", file=for_writing(file_name="tmp_plain"))
+  print("line 1", file=for_writing(file_name="tmp.gz"))
+  print("OK")
 
-if (__name__ == "__main__"):
+if __name__ == "__main__":
   exercise()

--- a/scitbx/array_family/flex.py
+++ b/scitbx/array_family/flex.py
@@ -1,7 +1,10 @@
-from __future__ import division
+from __future__ import absolute_import, division, print_function
+
+import hashlib
+import sys
+
 import boost.optional # import dependency
 import boost.std_pair # import dependency
-
 import boost.python
 boost.python.import_ext("scitbx_array_family_flex_ext")
 from scitbx_array_family_flex_ext import *
@@ -11,23 +14,19 @@ import scitbx.stl.map # import dependency
 import scitbx.random
 from scitbx.random import get_random_seed, set_random_seed
 from libtbx.str_utils import format_value
-from libtbx.utils import hashlib_md5
-import sys
 
 def bool_md5(self):
-  result = hashlib_md5()
-  result.update(self.__getstate__()[1])
-  return result
+  return hashlib.md5(self.__getstate__()[1])
 bool.md5 = bool_md5
 
 class _(boost.python.injector, grid):
 
   def show_summary(self, f=None):
     if (f is None): f = sys.stdout
-    print >> f, "origin:", self.origin()
-    print >> f, "last:", self.last()
-    print >> f, "focus:", self.focus()
-    print >> f, "all:", self.all()
+    print("origin:", self.origin(), file=f)
+    print("last:", self.last(), file=f)
+    print("focus:", self.focus(), file=f)
+    print("all:", self.all(), file=f)
     return self
 
 def sorted(data, reverse=False, stable=False):
@@ -42,7 +41,7 @@ def as_scitbx_matrix(a):
   return scitbx.matrix.rec(tuple(a), a.focus())
 
 def show(a):
-  print as_scitbx_matrix(a).mathematica_form(one_row_per_line=True)
+  print(as_scitbx_matrix(a).mathematica_form(one_row_per_line=True))
 
 def rows(a):
   assert a.nd() == 2
@@ -144,14 +143,14 @@ def _format_mean(values, format):
 class _(boost.python.injector, ext.min_max_mean_double):
 
   def show(self, out=None, prefix="", format="%.6g", show_n=True):
-    if (out is None): out = sys.stdout
-    if (show_n):
-      print >> out, prefix + "n:", self.n
+    if out is None: out = sys.stdout
+    if show_n:
+      print(prefix + "n:", self.n, file=out)
     def f(v):
       return format_value(format=format, value=v)
-    print >> out, prefix + "min: ", f(self.min)
-    print >> out, prefix + "max: ", f(self.max)
-    print >> out, prefix + "mean:", f(self.mean)
+    print(prefix + "min: ", f(self.min), file=out)
+    print(prefix + "max: ", f(self.max), file=out)
+    print(prefix + "mean:", f(self.mean), file=out)
 
   def as_tuple(self):
     return (self.min, self.max, self.mean)
@@ -161,7 +160,7 @@ def _min_max_mean_double_init(self):
 
 def _standard_deviation_helper(data, m):
   den = data.size() - m
-  if (den <= 0): return None
+  if den <= 0: return None
   return (sum(pow2(data - mean(data))) / den)**0.5
 
 def _standard_deviation_of_the_sample(self):
@@ -271,9 +270,9 @@ class _(boost.python.injector, ext.linear_regression_core):
 
   def show_summary(self, f=None, prefix=""):
     if (f is None): f = sys.stdout
-    print >> f, prefix+"is_well_defined:", self.is_well_defined()
-    print >> f, prefix+"y_intercept:", self.y_intercept()
-    print >> f, prefix+"slope:", self.slope()
+    print(prefix+"is_well_defined:", self.is_well_defined(), file=f)
+    print(prefix+"y_intercept:", self.y_intercept(), file=f)
+    print(prefix+"slope:", self.slope(), file=f)
 
 class _(boost.python.injector, ext.double):
 
@@ -289,10 +288,10 @@ class _(boost.python.injector, ext.linear_correlation):
 
   def show_summary(self, f=None, prefix=""):
     if (f is None): f = sys.stdout
-    print >> f, prefix+"is_well_defined:", self.is_well_defined()
-    print >> f, prefix+"mean_x:", self.mean_x()
-    print >> f, prefix+"mean_y:", self.mean_y()
-    print >> f, prefix+"coefficient:", self.coefficient()
+    print(prefix+"is_well_defined:", self.is_well_defined(), file=f)
+    print(prefix+"mean_x:", self.mean_x(), file=f)
+    print(prefix+"mean_y:", self.mean_y(), file=f)
+    print(prefix+"coefficient:", self.coefficient(), file=f)
 
 class histogram_slot_info(object):
 
@@ -325,7 +324,7 @@ class _(boost.python.injector, ext.histogram):
     if (f is None): f = sys.stdout
     fmt = "%s" + format_cutoffs + " - " + format_cutoffs + ": %d"
     for info in self.slot_infos():
-      print >> f, fmt % (prefix, info.low_cutoff, info.high_cutoff, info.n)
+      print(fmt % (prefix, info.low_cutoff, info.high_cutoff, info.n), file=f)
 
 def show_count_stats(
       counts,
@@ -347,13 +346,13 @@ def show_count_stats(
     if (count >= threshold): continue
     assert count >= 0
     if (i > 0):
-      print >> out, fmt_val % (threshold, i, i/n)
+      print(fmt_val % (threshold, i, i/n), file=out)
     if (count == 0):
-      print >> out, fmt_zero % (n-i, 1-i/n)
+      print(fmt_zero % (n-i, 1-i/n), file=out)
       break
     threshold = max(1, threshold-group_size)
   else:
-    print >> out, fmt_val % (threshold, n, 1)
+    print(fmt_val % (threshold, n, 1), file=out)
 
 class weighted_histogram_slot_info(object):
 
@@ -386,7 +385,7 @@ class _(boost.python.injector, ext.weighted_histogram):
     if (f is None): f = sys.stdout
     fmt = "%s" + format_cutoffs + " - " + format_cutoffs + ": %d"
     for info in self.slot_infos():
-      print >> f, fmt % (prefix, info.low_cutoff, info.high_cutoff, info.n)
+      print(fmt % (prefix, info.low_cutoff, info.high_cutoff, info.n), file=f)
 
 def permutation_generator(size):
   result = size_t(xrange(size))
@@ -473,7 +472,7 @@ class smart_selection(object):
 
   def show_summary(self, out=None, prefix="", label="selected elements: "):
     if (out is None): out = sys.stdout
-    print >> out, prefix + label + self.format_summary()
+    print(prefix + label + self.format_summary(), file=out)
 
 
 def __show_sizes(f):
@@ -482,17 +481,14 @@ def __show_sizes(f):
   l = max([ len(typename) for typename, size in typename_n_size ])
   fmt = "%%%is : %%i" % l
   for typename, size in typename_n_size:
-    print fmt % (typename, size)
+    print(fmt % (typename, size))
 
 show_sizes_int = lambda: __show_sizes(empty_container_sizes_int)
 show_sizes_double = lambda: __show_sizes(empty_container_sizes_double)
 
 def exercise_triple(flex_triple, flex_order=None, as_double=False):
   from libtbx.test_utils import approx_equal
-  try:
-    import cPickle as pickle
-  except ImportError:
-    import pickle
+  from six.moves import cPickle as pickle
   a = flex_triple()
   assert a.size() == 0
   a = flex_triple(132)

--- a/scitbx/math/__init__.py
+++ b/scitbx/math/__init__.py
@@ -1,11 +1,13 @@
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division, print_function
+
+import math
+
 from scitbx.math.ext import *
 import scitbx.linalg.eigensystem
 import scitbx.math.gaussian # implicit import
 from scitbx import matrix
 from scitbx.array_family import flex
 from boost import rational # implicit import
-import math
 
 gaussian_fit_1d_analytical.__doc__ = """
 Fits a gaussian function to a list of points.
@@ -88,16 +90,14 @@ def r3_rotation_average_rotation_matrix_from_matrices(*matrices):
   """
 
   if not matrices:
-    raise TypeError, "Average of empty sequence"
+    raise TypeError("Average of empty sequence")
 
-  import operator
   import scitbx.matrix
 
-  average = reduce(
-    operator.add,
-    [ scitbx.matrix.col( r3_rotation_matrix_as_unit_quaternion( e ) )
-      for e in matrices ]
-    )
+  average = sum(
+      scitbx.matrix.col( r3_rotation_matrix_as_unit_quaternion( e ) )
+      for e in matrices
+  )
 
   return r3_rotation_unit_quaternion_as_matrix( average.normalize() )
 
@@ -111,13 +111,12 @@ def r3_rotation_average_rotation_via_lie_algebra(matrices, maxiter = 100, conver
   """
 
   if not matrices:
-    raise TypeError, "Average of empty sequence"
+    raise TypeError("Average of empty sequence")
 
   if maxiter < 0 or convergence <= 0:
-    raise ValueError, "Invalid iteration parameters"
+    raise ValueError("Invalid iteration parameters")
 
   from scitbx.math import so3_lie_algebra
-  import operator
 
   conv_sq = convergence * convergence
   norm = 1.0 / len( matrices )
@@ -125,10 +124,9 @@ def r3_rotation_average_rotation_via_lie_algebra(matrices, maxiter = 100, conver
 
   for i in range( maxiter ):
     inverse = current.inverse()
-    log_diff = norm * reduce(
-      operator.add,
-      [ so3_lie_algebra.element.from_rotation_matrix( matrix = inverse * m )
-        for m in matrices ]
+    log_diff = norm * sum(
+        so3_lie_algebra.element.from_rotation_matrix( matrix = inverse * m )
+        for m in matrices
       )
 
     if log_diff.norm_sq() < conv_sq:
@@ -136,7 +134,7 @@ def r3_rotation_average_rotation_via_lie_algebra(matrices, maxiter = 100, conver
 
     current *= log_diff.exponential()
 
-  raise RuntimeError, "Iteration limit exceeded"
+  raise RuntimeError("Iteration limit exceeded")
 
 def euler_angles_as_matrix(angles, deg=False):
   if (deg):
@@ -174,7 +172,7 @@ class erf_verification(object):
       if (self.max_delta < delta):
         self.max_delta = delta
         if (delta > self.tolerance):
-          print x, expected_result, result, delta
+          print(x, expected_result, result, delta)
 
 class minimum_covering_sphere_nd(object):
 

--- a/scitbx/matrix/__init__.py
+++ b/scitbx/matrix/__init__.py
@@ -9,7 +9,10 @@ used only if compactness is not affected. The scitbx/math module
 provides faster C++ alternatives to some algorithms included here.
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division, print_function
+
+import math
+import random
 
 _flex_imported = False
 def flex_proxy():
@@ -27,9 +30,6 @@ def numpy_proxy():
     except ImportError: _numpy_imported = None
     else: _numpy_imported = numpy
   return _numpy_imported
-
-import math
-import random
 
 class rec(object):
   """
@@ -181,7 +181,7 @@ class rec(object):
 
   def as_numpy_array(self):
     numpy = numpy_proxy()
-    assert numpy is not None
+    assert numpy
     return numpy.array(self.elems).reshape(self.n)
 
   def each_abs(self):
@@ -639,7 +639,7 @@ class rec(object):
       m.matrix_inversion_in_place()
       return rec(elems=m, n=n)
     numpy = numpy_proxy()
-    if (numpy is not None):
+    if numpy:
       m = numpy.asarray(self.elems)
       m.shape = n
       m = numpy.ravel(numpy.linalg.inv(m))
@@ -917,18 +917,19 @@ def mutable_zeros(n):
 def sum(iterable):
   """ The sum of the given sequence of matrices """
   sequence = iter(iterable)
-  result = sequence.next()
+  result = next(sequence)
   for m in sequence:
     result += m
   return result
 
-def cross_product_matrix((v0, v1, v2)):
+def cross_product_matrix(vector):
   """\
 Matrix associated with vector cross product:
   a.cross(b) is equivalent to cross_product_matrix(a) * b
 Useful for simplification of equations. Used frequently in
 robotics and classical mechanics literature.
 """
+  v0, v1, v2 = vector
   return sqr((
       0, -v2,  v1,
      v2,   0, -v0,
@@ -972,7 +973,7 @@ def _dihedral_angle(sites, deg):
 
 def dihedral_angle(sites, deg=False):
   flex = flex_proxy()
-  if (flex is None):
+  if not flex:
     return _dihedral_angle(sites=sites, deg=deg)
   from scitbx.math import dihedral_angle
   return dihedral_angle(sites=sites, deg=deg)
@@ -1170,7 +1171,7 @@ class rt(object):
           % (repr(self), repr(other)))
     if (n == 3):
       flex = flex_proxy()
-      if (flex is not None and isinstance(other, flex.vec3_double)):
+      if flex and isinstance(other, flex.vec3_double):
         return self.r.elems * other + self.t.elems
     raise TypeError("cannot multiply %s by %s" % (repr(self), repr(other)))
 
@@ -1301,630 +1302,7 @@ def determinant_via_lu(m):
     result = -result
   return result
 
-def exercise_1():
-  try:
-    from libtbx import test_utils
-  except ImportError:
-    print "INFO: libtbx not available: some tests disabled."
-    test_utils = None
-    def approx_equal(a, b): return True
-    Exception_expected = RuntimeError
-  else:
-    approx_equal = test_utils.approx_equal
-    Exception_expected = test_utils.Exception_expected
-  #
-  a = zeros(n=0)
-  assert a.n == (0,1)
-  assert a.elems == ()
-  a = zeros(n=1)
-  assert a.n == (1,1)
-  assert a.elems == (0,)
-  a = zeros(n=2)
-  assert a.n == (2,1)
-  assert a.elems == (0,0)
-  a = zeros(n=(0,0))
-  assert a.n == (0,0)
-  assert a.elems == ()
-  a = zeros(n=(1,0))
-  assert a.n == (1,0)
-  assert a.elems == ()
-  a = zeros(n=(2,3))
-  assert a.elems == (0,0,0,0,0,0)
-  #
-  a = mutable_col((0,0,0))
-  a[1] = 1
-  assert tuple(a) == (0,1,0)
-  #
-  for n in [(0,0), (1,0), (0,1)]:
-    a = rec((),n)
-    assert a.mathematica_form() == "{}"
-    assert a.matlab_form() == "[]"
-  a = rec(range(1,7), (3,2))
-  assert len(a) == 6
-  assert a[1] == 2
-  assert (a*3).mathematica_form() == "{{3, 6}, {9, 12}, {15, 18}}"
-  assert (-2*a).mathematica_form() == "{{-2, -4}, {-6, -8}, {-10, -12}}"
-  for seq in [(2,-3), [2,-3]]:
-    assert (a*seq).elems == (a*col((2,-3))).elems
-  b = rec(range(1,7), (2,3))
-  assert a.dot(b) == 91
-  assert col((3,4)).dot() == 25
-  c = a * b
-  d = rt((c, (1,2,3)))
-  assert (-a).mathematica_form() == "{{-1, -2}, {-3, -4}, {-5, -6}}"
-  assert d.r.mathematica_form() == "{{9, 12, 15}, {19, 26, 33}, {29, 40, 51}}"
-  assert d.t.mathematica_form() == "{{1}, {2}, {3}}"
-  e = d + col((3,5,6))
-  assert e.r.mathematica_form() == "{{9, 12, 15}, {19, 26, 33}, {29, 40, 51}}"
-  assert e.t.mathematica_form() == "{{4}, {7}, {9}}"
-  f = e - col((1,2,3))
-  assert f.r.mathematica_form() == "{{9, 12, 15}, {19, 26, 33}, {29, 40, 51}}"
-  assert f.t.mathematica_form() == "{{3}, {5}, {6}}"
-  e = e + f
-  assert e.r.mathematica_form() \
-      == "{{18, 24, 30}, {38, 52, 66}, {58, 80, 102}}"
-  assert e.t.mathematica_form() == "{{7}, {12}, {15}}"
-  f = f - e
-  assert f.r.mathematica_form() \
-      == "{{-9, -12, -15}, {-19, -26, -33}, {-29, -40, -51}}"
-  assert f.t.mathematica_form() == "{{-4}, {-7}, {-9}}"
-  e = f.as_float()
-  assert e.r.mathematica_form() \
-      == "{{-9.0, -12.0, -15.0}, {-19.0, -26.0, -33.0}, {-29.0, -40.0, -51.0}}"
-  assert e.t.mathematica_form() == "{{-4.0}, {-7.0}, {-9.0}}"
-  a = f.as_augmented_matrix()
-  assert a.mathematica_form() == "{{-9, -12, -15, -4}, {-19, -26, -33, -7}," \
-                               + " {-29, -40, -51, -9}, {0, 0, 0, 1}}"
-  assert a.extract_block(stop=(1,1)).mathematica_form() \
-      == "{{-9}}"
-  assert a.extract_block(stop=(2,2)).mathematica_form() \
-      == "{{-9, -12}, {-19, -26}}"
-  assert a.extract_block(stop=(3,3)).mathematica_form() \
-      == "{{-9, -12, -15}, {-19, -26, -33}, {-29, -40, -51}}"
-  assert a.extract_block(stop=(4,4)).mathematica_form() \
-      == a.mathematica_form()
-  assert a.extract_block(stop=(4,4),step=(2,2)).mathematica_form() \
-      == "{{-9, -15}, {-29, -51}}"
-  assert a.extract_block(start=(1,1),stop=(4,4),step=(2,2)).mathematica_form()\
-      == "{{-26, -7}, {0, 1}}"
-  assert a.extract_block(start=(1,0),stop=(4,3),step=(2,1)).mathematica_form()\
-      == "{{-19, -26, -33}, {0, 0, 0}}"
-  #
-  for ar in xrange(3):
-    for bc in xrange(3):
-      a = rec([], (ar,0))
-      b = rec([], (0,bc))
-      c = a * b
-      assert c.elems == tuple([0] * (ar*bc))
-      assert c.n == (ar,bc)
-  #
-  ar = range(1,10)
-  at = range(1,4)
-  br = range(11,20)
-  bt = range(4,7)
-  g = rt((ar,at)) * rt((br,bt))
-  assert g.r.mathematica_form() == \
-    "{{90, 96, 102}, {216, 231, 246}, {342, 366, 390}}"
-  assert g.t.mathematica_form() == "{{33}, {79}, {125}}"
-  grt = g.r.transpose()
-  assert grt.mathematica_form() == \
-    "{{90, 216, 342}, {96, 231, 366}, {102, 246, 390}}"
-  grtt = grt.transpose()
-  assert grtt.mathematica_form() == \
-    "{{90, 96, 102}, {216, 231, 246}, {342, 366, 390}}"
-  gtt = g.t.transpose()
-  assert gtt.mathematica_form() == "{{33, 79, 125}}"
-  gttt = gtt.transpose()
-  assert gttt.mathematica_form() == "{{33}, {79}, {125}}"
-  assert sqr([4]).determinant() == 4
-  assert sqr([3,2,-7,15]).determinant() == 59
-  m = rec(elems=(), n=(0,0))
-  mi = m.inverse()
-  assert mi.n == (0,0)
-  m = sqr([4])
-  mi = m.inverse()
-  assert mi.mathematica_form() == "{{0.25}}"
-  m = sqr((1,5,-3,9))
-  mi = m.inverse()
-  assert mi.n == (2,2)
-  assert approx_equal(mi, (3/8, -5/24, 1/8, 1/24))
-  m = sqr((7, 7, -4, 3, 1, -1, 15, 16, -9))
-  assert m.determinant() == 1
-  mi = m.inverse()
-  assert mi.mathematica_form() \
-      == "{{7.0, -1.0, -3.0}, {12.0, -3.0, -5.0}, {33.0, -7.0, -14.0}}"
-  assert (m*mi).mathematica_form() \
-      == "{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}"
-  assert (mi*m).mathematica_form() \
-      == "{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}"
-  s = rt((m, (1,-2,3)))
-  si = s.inverse()
-  assert si.r.mathematica_form() == mi.mathematica_form()
-  assert (s*si).r.mathematica_form() \
-      == "{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}"
-  assert (si*s).r.mathematica_form() \
-      == "{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}"
-  assert si.t.mathematica_form().replace("-0.0", "0.0") \
-      == "{{0.0}, {-3.0}, {-5.0}}"
-  assert (s*si).t.mathematica_form() == "{{0.0}, {0.0}, {0.0}}"
-  assert (si*s).t.mathematica_form() == "{{0.0}, {0.0}, {0.0}}"
-  #
-  m = rt((sqr([
-    0.1226004505424059, 0.69470636260753704, -0.70876808568064376,
-    0.20921402107901119, -0.71619825067837384, -0.66579993925291725,
-    -0.97015391712385002, -0.066656848694206489, -0.23314853980114805]),
-    col((0.34, -0.78, 0.43))))
-  assert approx_equal(m.r*m.r.transpose(), (1,0,0,0,1,0,0,0,1))
-  mi = m.inverse()
-  mio = m.inverse_assuming_orthogonal_r()
-  assert approx_equal(mio.r, mi.r)
-  assert approx_equal(mio.t, mi.t)
-  #
-  r = rec(elems=(8,-4,3,-2,7,9,-3,2,1), n=(3,3))
-  t = rec(elems=(7,-6,3), n=(3,1))
-  gr = g * r
-  assert gr.r == g.r * r
-  assert gr.t == g.t
-  gt = g * t
-  assert gt == g.r * t + g.t
-  gr = g * r.elems
-  assert gr.r == g.r * r
-  assert gr.t == g.t
-  gt = g * t.elems
-  assert gt == g.r * t + g.t
-  try: g * col([1])
-  except ValueError, e:
-    assert str(e).startswith("cannot multiply ")
-    assert str(e).endswith(": incompatible number of rows or columns")
-  else: raise Exception_expected
-  try: g * [1]
-  except ValueError, e:
-    assert str(e).startswith("cannot multiply ")
-    assert str(e).endswith(": incompatible number of elements")
-  else: raise Exception_expected
-  flex = flex_proxy()
-  if (flex is None):
-    print "INFO: scitbx.array_family.flex not available."
-  else:
-    gv = g * flex.vec3_double([(-1,2,3),(2,-3,4)])
-    assert isinstance(gv, flex.vec3_double)
-    assert approx_equal(gv, [(441, 1063, 1685), (333, 802, 1271)])
-  #
-  try: from boost import rational
-  except ImportError: pass
-  else:
-    assert approx_equal(col((rational.int(3,4),2,1.5)).as_float(),(0.75,2,1.5))
-  #
-  assert approx_equal(col((-2,3,-6)).normalize().elems, (-2/7.,3/7.,-6/7.))
-  assert col((-1,2,-3)).each_abs().elems == (1,2,3)
-  assert approx_equal(col((-1.7,2.8,3.4)).each_mod_short(), (0.3,-0.2,0.4))
-  assert col((5,3,4)).min() == 3
-  assert col((4,5,3)).max() == 5
-  assert col((5,3,4)).min_index() == 1
-  assert col((4,5,3)).max_index() == 1
-  assert col((4,5,3)).sum() == 12
-  assert col((2,3,4)).product() == 2*3*4
-  assert sqr((1,2,3,4,5,6,7,8,9)).trace() == 15
-  assert diag((1,2,3)).mathematica_form() == \
-    "{{1, 0, 0}, {0, 2, 0}, {0, 0, 3}}"
-  assert approx_equal(col((1,0,0)).cos_angle(col((1,1,0)))**2, 0.5)
-  assert approx_equal(col((1,0,0)).angle(col((1,1,0))), 0.785398163397)
-  assert approx_equal(col((1,0,0)).angle(col((1,1,0)), deg=True), 45)
-  assert approx_equal(col((-1,0,0)).angle(col((1,1,0)), deg=True), 45+90)
-  assert approx_equal(col((1,0,0)).accute_angle(col((1,1,0)), deg=True), 45)
-  assert approx_equal(col((-1,0,0)).accute_angle(col((1,1,0)), deg=True), 45)
-  m = sqr([4, 4, -1, 0, -3, -3, -3, -2, -3, 2, -1, 1, -4, 1, 3, 2])
-  md = m.determinant()
-  assert approx_equal(md, -75)
-  #
-  r = sqr([-0.9533, 0.2413, -0.1815,
-           0.2702, 0.414, -0.8692,
-           -0.1346, -0.8777, -0.4599])
-  assert r.mathematica_form(
-    label="rotation",
-    format="%.6g",
-    one_row_per_line=True,
-    prefix="  ") == """\
-  rotation={{-0.9533, 0.2413, -0.1815},
-            {0.2702, 0.414, -0.8692},
-            {-0.1346, -0.8777, -0.4599}}"""
-  r = sqr([])
-  assert r.mathematica_form() == "{}"
-  assert r.mathematica_form(one_row_per_line=True) == "{}"
-  r = sqr([1])
-  assert r.mathematica_form() == "{{1}}"
-  assert r.mathematica_form(one_row_per_line=True, prefix="&$") == """\
-&${{1}}"""
-  #
-  a = rec(range(1,6+1), (3,2))
-  b = rec(range(1,15+1), (3,5))
-  assert approx_equal(a.transpose_multiply(b), a.transpose() * b)
-  assert approx_equal(a.transpose_multiply(a), a.transpose() * a)
-  assert approx_equal(a.transpose_multiply(), a.transpose() * a)
-  assert approx_equal(b.transpose_multiply(b), b.transpose() * b)
-  assert approx_equal(b.transpose_multiply(), b.transpose() * b)
-  #
-  a = col([1,2,3])
-  b = row([10,20])
-  assert a.outer_product(b).as_list_of_lists() == [[10,20],[20,40],[30,60]]
-  assert a.outer_product().as_list_of_lists() == [[1,2,3],[2,4,6],[3,6,9]]
-  #
-  a = sym(sym_mat3=range(6))
-  assert a.as_list_of_lists() == [[0, 3, 4], [3, 1, 5], [4, 5, 2]]
-  assert approx_equal(a.as_sym_mat3(), range(6))
-  assert a.as_mat3() == (0,3,4,3,1,5,4,5,2)
-  if (flex is not None):
-    f = a.as_flex_double_matrix()
-    assert f.all() == a.n
-    assert approx_equal(f, a, eps=1.e-12)
-  #
-  for i in xrange(3):
-    x = rec([], n=(0,i))
-    assert repr(x) == "matrix.rec(elems=(), n=(0,%d))" % i
-    assert str(x) == "{}"
-    assert x.matlab_form() == "[]"
-    assert x.matlab_form(one_row_per_line=True) == "[]"
-    x = rec([], n=(i,0))
-    assert repr(x) == "matrix.rec(elems=(), n=(%d,0))" % i
-    assert str(x) == "{}"
-    assert x.matlab_form() == "[]"
-    assert x.matlab_form(one_row_per_line=True) == "[]"
-  x = rec([2], n=(1,1))
-  assert repr(x) == "matrix.rec(elems=(2,), n=(1,1))"
-  assert str(x) == "{{2}}"
-  assert x.matlab_form() == "[2]"
-  assert x.matlab_form(one_row_per_line=True) == "[2]"
-  x = col((1,2,3))
-  assert repr(x) == "matrix.rec(elems=(1, 2, 3), n=(3,1))"
-  assert str(x) == """\
-{{1},
- {2},
- {3}}"""
-  assert x.matlab_form() == "[1; 2; 3]"
-  assert x.matlab_form(one_row_per_line=True) == """\
-[1;
- 2;
- 3]"""
-  x = row((3,2,1))
-  assert repr(x) == "matrix.rec(elems=(3, 2, 1), n=(1,3))"
-  assert str(x) == "{{3, 2, 1}}"
-  assert x.matlab_form() == "[3, 2, 1]"
-  assert x.matlab_form(one_row_per_line=True) == "[3, 2, 1]"
-  x = rec((1,2,3,
-           4,5,6,
-           7,8,9,
-           -1,-2,-3), (4,3))
-  assert repr(x) == "matrix.rec(elems=(1, ..., -3), n=(4,3))"
-  assert str(x) == """\
-{{1, 2, 3},
- {4, 5, 6},
- {7, 8, 9},
- {-1, -2, -3}}"""
-  assert x.matlab_form() == "[1, 2, 3; 4, 5, 6; 7, 8, 9; -1, -2, -3]"
-  assert x.matlab_form(label="m", one_row_per_line=True, prefix="@") == """\
-@m=[1, 2, 3;
-@   4, 5, 6;
-@   7, 8, 9;
-@   -1, -2, -3]"""
-  #
-  t = (1,2,3,4,5,6)
-  g = (3,2)
-  a = rec(t, g)
-  b = rec(t, g)
-  assert a == b
-  if (flex is not None):
-    c = flex.double(t)
-    c.reshape(flex.grid(g))
-    assert a == c
-  #
-  a = identity(4)
-  for ir in xrange(4):
-    for ic in xrange(4):
-      assert (ir == ic and a(ir,ic) == 1) or (ir != ic and a(ir,ic) == 0)
-  a = inversion(4)
-  for ir in xrange(4):
-    for ic in xrange(4):
-      assert (ir == ic and a(ir,ic) == -1) or (ir != ic and a(ir,ic) == 0)
-  #
-  x = col((3/2+0.01, 5/4-0.02, 11/8+0.001))
-  assert (x*8).as_int()/8 == col((3/2, 5/4, 11/8))
-  #
-  for x in [(0, 0, 0), (1, -2, 5), (-2, 5, 1), (5, 1, -2) ]:
-    x = col(x)
-    assert approx_equal(x.dot(x.ortho()), 0)
-  #
-  x = col((1, -2, 3))
-  n = col((-2, 4, 5))
-  alpha = 2*math.pi/3
-  y = x.rotate_around_origin(n, alpha)
-  n = n.normalize()
-  x_perp = x - n.dot(x)*n
-  y_perp = y - n.dot(y)*n
-  assert approx_equal(x_perp.angle(y_perp), alpha)
-  x = col((0,1,0))
-  y = x.rotate_around_origin(axis=col((1,0,0)), angle=75, deg=True)
-  assert approx_equal(y, (0.0, 0.25881904510252074, 0.96592582628906831))
-  assert approx_equal(x.angle(y, deg=True), 75)
-  a = col((0.33985998937421624, 0.097042540321188753, -0.60916214763712317))
-  x = col((0.61837962293383231, -0.46724958233858915, -0.48367879178081852))
-  y = x.rotate_around_origin(axis=a, angle=37, deg=True)
-  assert approx_equal(abs(x), 0.913597670681)
-  assert approx_equal(abs(y), 0.913597670681)
-  assert approx_equal(x.angle(y, deg=True), 25.6685689758)
-  assert approx_equal(y, (0.2739222799, -0.5364841936, -0.6868857244))
-  uq = a.axis_and_angle_as_unit_quaternion(angle=37, deg=True)
-  assert approx_equal(uq, (0.94832366, 0.15312122, 0.04372175, -0.27445317))
-  r = uq.unit_quaternion_as_r3_rotation_matrix()
-  assert approx_equal(r*x, y)
-  assert approx_equal(
-    a.axis_and_angle_as_r3_rotation_matrix(angle=37, deg=True), r)
-  #
-  pivot = col((29.278,-48.061,72.641))
-  raa = pivot.rt_for_rotation_around_axis_through(
-    point=col((28.09,-48.047,71.684)),
-    angle=190.811940444, deg=True)
-  assert approx_equal(
-    raa * col((28.097,-47.559,70.248)),
-    (26.639170440424856,-48.299377845438173,72.046888429403481))
-  #
-  assert col((0,0,1)).vector_to_001_rotation().elems == (1,0,0,0,1,0,0,0,1)
-  assert col((0,0,-1)).vector_to_001_rotation().elems == (1,0,0,0,-1,0,0,0,-1)
-  assert approx_equal(
-    col((5,3,-7)).normalize().vector_to_001_rotation(),
-    (-0.3002572205351709, -0.78015433232110254, -0.54882129994845175,
-     -0.78015433232110254, 0.53190740060733865, -0.32929277996907103,
-     0.54882129994845175, 0.32929277996907103, -0.76834981992783236))
-  #
-  a = row((1,0,0))
-  b = row((0,1,0))
-  assert a.cross(b) == row((0,0,1))
-  #
-  a = col((1.43416642866471794, -2.47841960952275497, -0.7632916804502845))
-  b = col((0.34428681113080323, -1.85983494542314587, 0.37702845822372399))
-  assert approx_equal(a.cross(b), cross_product_matrix(a) * b)
-  #
-  f = linearly_dependent_pair_scaling_factor
-  assert approx_equal(f(vector_1=[1,2,3], vector_2=[3,6,9]), 3)
-  assert approx_equal(f(vector_1=[3,6,9], vector_2=[1,2,3]), 1/3)
-  assert f(vector_1=col([0,1,1]), vector_2=[1,1,1]) is None
-  assert f(vector_1=[1,1,1], vector_2=col([0,1,1])) is None
-  assert f(vector_1=col([0,0,0]), vector_2=col([0,0,0])) is 0
-  #
-  a = col_list(seq=[(1,2), (2,3)])
-  for e in a: assert isinstance(e, col)
-  assert approx_equal(a, [(1,2), (2,3)])
-  a = row_list(seq=[(1,2), (2,3)])
-  for e in a: assert isinstance(e, row)
-  assert approx_equal(a, [(1,2), (2,3)])
-  #
-  def f(a): return a.resolve_partitions().mathematica_form()
-  a = rec(elems=[], n=[0,0])
-  assert f(a) == "{}"
-  a = rec(elems=[], n=[0,1])
-  assert f(a) == "{}"
-  a = rec(elems=[], n=[1,0])
-  assert f(a) == "{}"
-  for e in [col([]), row([])]:
-    a = rec(elems=[e], n=[1,1])
-    assert f(a) == "{}"
-    a = rec(elems=[e, e], n=[1,2])
-    assert f(a) == "{}"
-    a = rec(elems=[e, e], n=[2,1])
-    assert f(a) == "{}"
-  for e in [col([1]), row([1])]:
-    a = rec(elems=[e], n=[1,1])
-    assert f(a) == "{{1}}"
-  a = rec(elems=[col([1,2]), col([3,4])], n=[1,2])
-  assert f(a) == "{{1, 3}, {2, 4}}"
-  a = rec(elems=[col([1,2]), col([3,4])], n=[2,1])
-  assert f(a) == "{{1}, {2}, {3}, {4}}"
-  a = rec(elems=[sqr([1,2,3,4]), sqr([5,6,7,8])], n=[1,2])
-  assert f(a) == "{{1, 2, 5, 6}, {3, 4, 7, 8}}"
-  a = rec(elems=[sqr([1,2,3,4]), sqr([5,6,7,8])], n=[2,1])
-  assert f(a) == "{{1, 2}, {3, 4}, {5, 6}, {7, 8}}"
-  a = rec(elems=[rec([1,2,3,4,5,6], n=(2,3)), rec([7,8], n=(2,1))], n=[1,2])
-  assert f(a) == "{{1, 2, 3, 7}, {4, 5, 6, 8}}"
-  a = rec(elems=[rec([1,2,3,4,5,6], n=(2,3)), rec([7,8,9], n=(1,3))], n=[2,1])
-  assert f(a) == "{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}"
-  a = rec(
-    elems=[
-      sqr([11,12,13,14,15,16,17,18,19]),
-      sqr([21,22,23,24,25,26,27,28,29]),
-      sqr([31,32,33,34,35,36,37,38,39]),
-      sqr([41,42,43,44,45,46,47,48,49])],
-    n=[2,2])
-  assert a.resolve_partitions().mathematica_form(one_row_per_line=True) == """\
-{{11, 12, 13, 21, 22, 23},
- {14, 15, 16, 24, 25, 26},
- {17, 18, 19, 27, 28, 29},
- {31, 32, 33, 41, 42, 43},
- {34, 35, 36, 44, 45, 46},
- {37, 38, 39, 47, 48, 49}}"""
-  a = rec(
-    elems=[
-      rec([1,2,3,4,5,6], n=(2,3)),
-      rec([7,8,9,10,11,12,13,14], n=(2,4)),
-      rec([15,16,17,18,19,20,21,22,23], n=(3,3)),
-      rec([24,25,26,27,28,29,30,31,32,33,34,35], n=(3,4)),
-      rec([36,37,38], n=(1,3)),
-      rec([39,40,41,42], n=(1,4))],
-    n=[3,2])
-  assert a.resolve_partitions().mathematica_form(one_row_per_line=True) == """\
-{{1, 2, 3, 7, 8, 9, 10},
- {4, 5, 6, 11, 12, 13, 14},
- {15, 16, 17, 24, 25, 26, 27},
- {18, 19, 20, 28, 29, 30, 31},
- {21, 22, 23, 32, 33, 34, 35},
- {36, 37, 38, 39, 40, 41, 42}}"""
-  #
-  def check(m, expected):
-    assert approx_equal(determinant_via_lu(m=m), expected)
-    assert approx_equal(m.determinant(), expected)
-    if (expected != 0):
-      mi = inverse_via_lu(m=m)
-      assert mi.n == m.n
-      assert approx_equal(mi*m, identity(n=m.n[0]))
-      assert approx_equal(m*mi, identity(n=m.n[0]))
-      mii = inverse_via_lu(m=mi)
-      assert approx_equal(mii, m)
-  check(sqr([]), 1)
-  check(sqr([0]), 0)
-  check(sqr([4]), 4)
-  check(sqr([0]*4), 0)
-  check(sqr([1,2,-3,4]), 10)
-  check(sqr([0]*9), 0)
-  check(sqr([
-    0.1226004505424059, 0.69470636260753704, -0.70876808568064376,
-    0.20921402107901119, -0.71619825067837384, -0.66579993925291725,
-    -0.97015391712385002, -0.066656848694206489, -0.23314853980114805]), 1)
-  check(sqr([0]*16), 0)
-  check(sqr([
-    -2/15,-17/75,4/75,-19/75,
-    7/15,22/75,-14/75,29/75,
-    1/3,4/15,-8/15,8/15,
-    -1,-1,1,-1]), -1/75)
-  #
-  r = identity(n=3)
-  assert r.is_r3_rotation_matrix()
-  uqr = r.r3_rotation_matrix_as_unit_quaternion()
-  assert approx_equal(uqr, (1,0,0,0))
-  # axis = (1/2**0.5, 1/2**0.5, 0)
-  # angle = 2 * math.asin((2/3.)**0.5)
-  uq = col((1/3**0.5,1/3**0.5,1/3**0.5,0))
-  r = sqr((
-     1/3.,2/3., 2/3.,
-     2/3.,1/3.,-2/3.,
-    -2/3.,2/3.,-1/3.))
-  assert approx_equal(uq.unit_quaternion_as_r3_rotation_matrix(), r)
-  uqr = r.r3_rotation_matrix_as_unit_quaternion()
-  assert approx_equal(uqr, uq)
-  #
-  for i_trial in xrange(10):
-    uq1 = col.random(n=4, a=-1, b=1).normalize()
-    uq2 = col.random(n=4, a=-1, b=1).normalize()
-    r1 = uq1.unit_quaternion_as_r3_rotation_matrix()
-    r2 = uq2.unit_quaternion_as_r3_rotation_matrix()
-    uqp12 = uq1.unit_quaternion_product(uq2)
-    rp12 = uqp12.unit_quaternion_as_r3_rotation_matrix()
-    assert approx_equal(rp12, r1*r2)
-    uqp21 = uq2.unit_quaternion_product(uq1)
-    rp21 = uqp21.unit_quaternion_as_r3_rotation_matrix()
-    assert approx_equal(rp21, r2*r1)
-    for uq,r in [(uq1,r1), (uq2,r2), (uqp12,rp12), (uqp21,rp21)]:
-      assert r.is_r3_rotation_matrix()
-      uqr = r.r3_rotation_matrix_as_unit_quaternion()
-      assert approx_equal(uqr.unit_quaternion_as_r3_rotation_matrix(), r)
-  #
-  r = sqr((
-    0.12, 0.69, -0.70,
-    0.20, -0.71, -0.66,
-    -0.97, -0.06, -0.23))
-  assert approx_equal(r.is_r3_rotation_matrix_rms(), 0.0291602469125)
-  assert not r.is_r3_rotation_matrix()
-  #
-  v = col((1.1, -2.2, 2.3))
-  assert approx_equal(v % 2, col((1.1, 1.8, 0.3)))
-  #
-  rational1 = sqr((2,1,1,0,1,0,0,0,1))
-  assert str(rational1.inverse().elems)==\
-    "(0.5, -0.5, -0.5, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)"
-  if (flex is not None):
-    assert str(rational1.as_boost_rational().inverse().elems)==\
-      "(1/2, -1/2, -1/2, 0, 1, 0, 0, 0, 1)"
-  #
-  assert _dihedral_angle(sites=col_list([(0,0,0)]*4), deg=False) is None
-  assert dihedral_angle(sites=col_list([(0,0,0)]*4)) is None
-  sites = col_list([
-    (-3.193, 1.904, 4.589),
-    (-1.955, 1.332, 3.895),
-    (-1.005, 2.228, 3.598),
-    ( 0.384, 1.888, 3.199)])
-  expected = 166.212120415
-  assert approx_equal(_dihedral_angle(sites=sites, deg=True), expected)
-  assert approx_equal(dihedral_angle(sites=sites, deg=True), expected)
-  # more dihedral tests in scitbx/math/boost_python/tst_math.py
-  #
-  if (test_utils is not None):
-    from libtbx import group_args
-    for deg in [False, True]:
-      args = group_args(
-        axis_point_1=sites[0],
-        axis_point_2=sites[1],
-        point=sites[2],
-        angle=13,
-        deg=True).__dict__
-      assert approx_equal(
-        rotate_point_around_axis(**args),
-        __rotate_point_around_axis(**args))
-    args = group_args(
-      axis_point_1=sites[0],
-      axis_point_2=sites[1],
-      point=sites[2]).__dict__
-    assert approx_equal(
-      project_point_on_axis(**args),
-      list(__project_point_on_axis(**args))[0])
-  # exercise plane_equation
-  point_1=col((1,2,3))
-  point_2=col((10,20,30))
-  point_3=col((7,53,18))
-  a,b,c,d = plane_equation(point_1=point_1, point_2=point_2, point_3=point_3)
-  point_in_plane = (point_3 - (point_2-point_1)/2)/2
-  assert approx_equal(
-    a*point_in_plane[0]+b*point_in_plane[1]+c*point_in_plane[2]+d,0)
-  xyz = (0,1,1)
-  assert approx_equal(2.828427,
-          distance_from_plane(xyz=(1,1,5), points=[(0,0,0), (1,1,1), (-1,1,1)]))
-  d = distance_from_plane(xyz=(0,0,1), points=[(0,0,0), (0,0,0), (0,1,0)])
-  assert d is None
-  d = distance_from_plane(xyz=(0,0,1), points=[(0,0,0), (1,0,0), (0,1,0)])
-  assert approx_equal(d, 1)
-  #
-  numpy = numpy_proxy()
-  if (numpy is None):
-    print "INFO: numpy not available."
-  else:
-    m = rec(elems=range(6), n=(2,3))
-    n = m.as_numpy_array()
-    assert n.tolist() == [[0, 1, 2], [3, 4, 5]]
-  #
-  print "OK"
-
-def exercise_2():
-  points = \
-    [[20.559, 2.613, 29.030],
-     [21.030, 3.817, 29.627],
-     [21.079, 3.972, 30.986],
-     [21.604, 5.302, 31.090],
-     [21.813, 5.803, 29.779],
-     [21.448, 4.862, 28.912],
-     [20.781, 3.239, 32.060],
-     [20.978, 3.765, 33.283],
-     [21.472, 5.018, 33.416],
-     [21.774, 5.761, 32.331],
-     [22.288, 7.066, 32.547],
-     [21.481, 4.924, 27.938],
-     [20.765, 3.241, 34.078],
-     [22.403, 7.376, 33.397],
-     [22.503, 7.595, 31.835]]
-  assert all_in_plane(points=points, tolerance=0.005)
-  points = \
-    [[20.559, 2.613, 29.030],
-     [21.030, 3.817, 29.627],
-     [21.079, 3.972, 30.986],
-     [21.604, 5.302, 31.090],
-     [21.813, 5.803, 29.779],
-     [21.448, 4.862, 28.912],
-     [20.781, 3.239, 32.060],
-     [20.978, 3.765, 33.283],
-     [21.472, 0.018, 33.416],
-     [21.774, 5.761, 32.331],
-     [22.288, 7.066, 32.547],
-     [21.481, 4.924, 27.938],
-     [20.765, 3.241, 34.078],
-     [22.403, 7.376, 33.397],
-     [22.503, 7.595, 31.835]]
-  assert not all_in_plane(points=points, tolerance=0.005)
-
-if (__name__ == "__main__"):
-  exercise_1()
-  exercise_2()
+if __name__ == "__main__":
+  import scitbx.matrix.tst_matrix
+  scitbx.matrix.tst_matrix.exercise_1()
+  scitbx.matrix.tst_matrix.exercise_2()

--- a/scitbx/matrix/tst_matrix.py
+++ b/scitbx/matrix/tst_matrix.py
@@ -1,0 +1,643 @@
+"""
+Note: this module can be used in isolation (without the rest of scitbx).
+All external dependencies (other than plain Python) are optional.
+
+The primary purpose of this module is to provide compact
+implementations of essential matrix/vector algorithms with minimal
+external dependencies. Optimizations for execution performance are
+used only if compactness is not affected. The scitbx/math module
+provides faster C++ alternatives to some algorithms included here.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import scitbx.matrix # to access internal variables
+from scitbx.matrix import *
+
+def exercise_1():
+  try:
+    from libtbx import test_utils
+  except ImportError:
+    print("INFO: libtbx not available: some tests disabled.")
+    test_utils = None
+    def approx_equal(a, b): return True
+    Exception_expected = RuntimeError
+  else:
+    approx_equal = test_utils.approx_equal
+    Exception_expected = test_utils.Exception_expected
+  #
+  a = zeros(n=0)
+  assert a.n == (0,1)
+  assert a.elems == ()
+  a = zeros(n=1)
+  assert a.n == (1,1)
+  assert a.elems == (0,)
+  a = zeros(n=2)
+  assert a.n == (2,1)
+  assert a.elems == (0,0)
+  a = zeros(n=(0,0))
+  assert a.n == (0,0)
+  assert a.elems == ()
+  a = zeros(n=(1,0))
+  assert a.n == (1,0)
+  assert a.elems == ()
+  a = zeros(n=(2,3))
+  assert a.elems == (0,0,0,0,0,0)
+  #
+  a = mutable_col((0,0,0))
+  a[1] = 1
+  assert tuple(a) == (0,1,0)
+  #
+  for n in [(0,0), (1,0), (0,1)]:
+    a = rec((),n)
+    assert a.mathematica_form() == "{}"
+    assert a.matlab_form() == "[]"
+  a = rec(range(1,7), (3,2))
+  assert len(a) == 6
+  assert a[1] == 2
+  assert (a*3).mathematica_form() == "{{3, 6}, {9, 12}, {15, 18}}"
+  assert (-2*a).mathematica_form() == "{{-2, -4}, {-6, -8}, {-10, -12}}"
+  for seq in [(2,-3), [2,-3]]:
+    assert (a*seq).elems == (a*col((2,-3))).elems
+  b = rec(range(1,7), (2,3))
+  assert a.dot(b) == 91
+  assert col((3,4)).dot() == 25
+  c = a * b
+  d = rt((c, (1,2,3)))
+  assert (-a).mathematica_form() == "{{-1, -2}, {-3, -4}, {-5, -6}}"
+  assert d.r.mathematica_form() == "{{9, 12, 15}, {19, 26, 33}, {29, 40, 51}}"
+  assert d.t.mathematica_form() == "{{1}, {2}, {3}}"
+  e = d + col((3,5,6))
+  assert e.r.mathematica_form() == "{{9, 12, 15}, {19, 26, 33}, {29, 40, 51}}"
+  assert e.t.mathematica_form() == "{{4}, {7}, {9}}"
+  f = e - col((1,2,3))
+  assert f.r.mathematica_form() == "{{9, 12, 15}, {19, 26, 33}, {29, 40, 51}}"
+  assert f.t.mathematica_form() == "{{3}, {5}, {6}}"
+  e = e + f
+  assert e.r.mathematica_form() \
+      == "{{18, 24, 30}, {38, 52, 66}, {58, 80, 102}}"
+  assert e.t.mathematica_form() == "{{7}, {12}, {15}}"
+  f = f - e
+  assert f.r.mathematica_form() \
+      == "{{-9, -12, -15}, {-19, -26, -33}, {-29, -40, -51}}"
+  assert f.t.mathematica_form() == "{{-4}, {-7}, {-9}}"
+  e = f.as_float()
+  assert e.r.mathematica_form() \
+      == "{{-9.0, -12.0, -15.0}, {-19.0, -26.0, -33.0}, {-29.0, -40.0, -51.0}}"
+  assert e.t.mathematica_form() == "{{-4.0}, {-7.0}, {-9.0}}"
+  a = f.as_augmented_matrix()
+  assert a.mathematica_form() == "{{-9, -12, -15, -4}, {-19, -26, -33, -7}," \
+                               + " {-29, -40, -51, -9}, {0, 0, 0, 1}}"
+  assert a.extract_block(stop=(1,1)).mathematica_form() \
+      == "{{-9}}"
+  assert a.extract_block(stop=(2,2)).mathematica_form() \
+      == "{{-9, -12}, {-19, -26}}"
+  assert a.extract_block(stop=(3,3)).mathematica_form() \
+      == "{{-9, -12, -15}, {-19, -26, -33}, {-29, -40, -51}}"
+  assert a.extract_block(stop=(4,4)).mathematica_form() \
+      == a.mathematica_form()
+  assert a.extract_block(stop=(4,4),step=(2,2)).mathematica_form() \
+      == "{{-9, -15}, {-29, -51}}"
+  assert a.extract_block(start=(1,1),stop=(4,4),step=(2,2)).mathematica_form()\
+      == "{{-26, -7}, {0, 1}}"
+  assert a.extract_block(start=(1,0),stop=(4,3),step=(2,1)).mathematica_form()\
+      == "{{-19, -26, -33}, {0, 0, 0}}"
+  #
+  for ar in xrange(3):
+    for bc in xrange(3):
+      a = rec([], (ar,0))
+      b = rec([], (0,bc))
+      c = a * b
+      assert c.elems == tuple([0] * (ar*bc))
+      assert c.n == (ar,bc)
+  #
+  ar = range(1,10)
+  at = range(1,4)
+  br = range(11,20)
+  bt = range(4,7)
+  g = rt((ar,at)) * rt((br,bt))
+  assert g.r.mathematica_form() == \
+    "{{90, 96, 102}, {216, 231, 246}, {342, 366, 390}}"
+  assert g.t.mathematica_form() == "{{33}, {79}, {125}}"
+  grt = g.r.transpose()
+  assert grt.mathematica_form() == \
+    "{{90, 216, 342}, {96, 231, 366}, {102, 246, 390}}"
+  grtt = grt.transpose()
+  assert grtt.mathematica_form() == \
+    "{{90, 96, 102}, {216, 231, 246}, {342, 366, 390}}"
+  gtt = g.t.transpose()
+  assert gtt.mathematica_form() == "{{33, 79, 125}}"
+  gttt = gtt.transpose()
+  assert gttt.mathematica_form() == "{{33}, {79}, {125}}"
+  assert sqr([4]).determinant() == 4
+  assert sqr([3,2,-7,15]).determinant() == 59
+  m = rec(elems=(), n=(0,0))
+  mi = m.inverse()
+  assert mi.n == (0,0)
+  m = sqr([4])
+  mi = m.inverse()
+  assert mi.mathematica_form() == "{{0.25}}"
+  m = sqr((1,5,-3,9))
+  mi = m.inverse()
+  assert mi.n == (2,2)
+  assert approx_equal(mi, (3/8, -5/24, 1/8, 1/24))
+  m = sqr((7, 7, -4, 3, 1, -1, 15, 16, -9))
+  assert m.determinant() == 1
+  mi = m.inverse()
+  assert mi.mathematica_form() \
+      == "{{7.0, -1.0, -3.0}, {12.0, -3.0, -5.0}, {33.0, -7.0, -14.0}}"
+  assert (m*mi).mathematica_form() \
+      == "{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}"
+  assert (mi*m).mathematica_form() \
+      == "{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}"
+  s = rt((m, (1,-2,3)))
+  si = s.inverse()
+  assert si.r.mathematica_form() == mi.mathematica_form()
+  assert (s*si).r.mathematica_form() \
+      == "{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}"
+  assert (si*s).r.mathematica_form() \
+      == "{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}"
+  assert si.t.mathematica_form().replace("-0.0", "0.0") \
+      == "{{0.0}, {-3.0}, {-5.0}}"
+  assert (s*si).t.mathematica_form() == "{{0.0}, {0.0}, {0.0}}"
+  assert (si*s).t.mathematica_form() == "{{0.0}, {0.0}, {0.0}}"
+  #
+  m = rt((sqr([
+    0.1226004505424059, 0.69470636260753704, -0.70876808568064376,
+    0.20921402107901119, -0.71619825067837384, -0.66579993925291725,
+    -0.97015391712385002, -0.066656848694206489, -0.23314853980114805]),
+    col((0.34, -0.78, 0.43))))
+  assert approx_equal(m.r*m.r.transpose(), (1,0,0,0,1,0,0,0,1))
+  mi = m.inverse()
+  mio = m.inverse_assuming_orthogonal_r()
+  assert approx_equal(mio.r, mi.r)
+  assert approx_equal(mio.t, mi.t)
+  #
+  r = rec(elems=(8,-4,3,-2,7,9,-3,2,1), n=(3,3))
+  t = rec(elems=(7,-6,3), n=(3,1))
+  gr = g * r
+  assert gr.r == g.r * r
+  assert gr.t == g.t
+  gt = g * t
+  assert gt == g.r * t + g.t
+  gr = g * r.elems
+  assert gr.r == g.r * r
+  assert gr.t == g.t
+  gt = g * t.elems
+  assert gt == g.r * t + g.t
+  try: g * col([1])
+  except ValueError as e:
+    assert str(e).startswith("cannot multiply ")
+    assert str(e).endswith(": incompatible number of rows or columns")
+  else: raise Exception_expected
+  try: g * [1]
+  except ValueError as e:
+    assert str(e).startswith("cannot multiply ")
+    assert str(e).endswith(": incompatible number of elements")
+  else: raise Exception_expected
+  flex = flex_proxy()
+  if flex:
+    gv = g * flex.vec3_double([(-1,2,3),(2,-3,4)])
+    assert isinstance(gv, flex.vec3_double)
+    assert approx_equal(gv, [(441, 1063, 1685), (333, 802, 1271)])
+  else:
+    print("INFO: scitbx.array_family.flex not available.")
+  #
+  try: from boost import rational
+  except ImportError: pass
+  else:
+    assert approx_equal(col((rational.int(3,4),2,1.5)).as_float(),(0.75,2,1.5))
+  #
+  assert approx_equal(col((-2,3,-6)).normalize().elems, (-2/7.,3/7.,-6/7.))
+  assert col((-1,2,-3)).each_abs().elems == (1,2,3)
+  assert approx_equal(col((-1.7,2.8,3.4)).each_mod_short(), (0.3,-0.2,0.4))
+  assert col((5,3,4)).min() == 3
+  assert col((4,5,3)).max() == 5
+  assert col((5,3,4)).min_index() == 1
+  assert col((4,5,3)).max_index() == 1
+  assert col((4,5,3)).sum() == 12
+  assert col((2,3,4)).product() == 2*3*4
+  assert sqr((1,2,3,4,5,6,7,8,9)).trace() == 15
+  assert diag((1,2,3)).mathematica_form() == \
+    "{{1, 0, 0}, {0, 2, 0}, {0, 0, 3}}"
+  assert approx_equal(col((1,0,0)).cos_angle(col((1,1,0)))**2, 0.5)
+  assert approx_equal(col((1,0,0)).angle(col((1,1,0))), 0.785398163397)
+  assert approx_equal(col((1,0,0)).angle(col((1,1,0)), deg=True), 45)
+  assert approx_equal(col((-1,0,0)).angle(col((1,1,0)), deg=True), 45+90)
+  assert approx_equal(col((1,0,0)).accute_angle(col((1,1,0)), deg=True), 45)
+  assert approx_equal(col((-1,0,0)).accute_angle(col((1,1,0)), deg=True), 45)
+  m = sqr([4, 4, -1, 0, -3, -3, -3, -2, -3, 2, -1, 1, -4, 1, 3, 2])
+  md = m.determinant()
+  assert approx_equal(md, -75)
+  #
+  r = sqr([-0.9533, 0.2413, -0.1815,
+           0.2702, 0.414, -0.8692,
+           -0.1346, -0.8777, -0.4599])
+  assert r.mathematica_form(
+    label="rotation",
+    format="%.6g",
+    one_row_per_line=True,
+    prefix="  ") == """\
+  rotation={{-0.9533, 0.2413, -0.1815},
+            {0.2702, 0.414, -0.8692},
+            {-0.1346, -0.8777, -0.4599}}"""
+  r = sqr([])
+  assert r.mathematica_form() == "{}"
+  assert r.mathematica_form(one_row_per_line=True) == "{}"
+  r = sqr([1])
+  assert r.mathematica_form() == "{{1}}"
+  assert r.mathematica_form(one_row_per_line=True, prefix="&$") == """\
+&${{1}}"""
+  #
+  a = rec(range(1,6+1), (3,2))
+  b = rec(range(1,15+1), (3,5))
+  assert approx_equal(a.transpose_multiply(b), a.transpose() * b)
+  assert approx_equal(a.transpose_multiply(a), a.transpose() * a)
+  assert approx_equal(a.transpose_multiply(), a.transpose() * a)
+  assert approx_equal(b.transpose_multiply(b), b.transpose() * b)
+  assert approx_equal(b.transpose_multiply(), b.transpose() * b)
+  #
+  a = col([1,2,3])
+  b = row([10,20])
+  assert a.outer_product(b).as_list_of_lists() == [[10,20],[20,40],[30,60]]
+  assert a.outer_product().as_list_of_lists() == [[1,2,3],[2,4,6],[3,6,9]]
+  #
+  a = sym(sym_mat3=range(6))
+  assert a.as_list_of_lists() == [[0, 3, 4], [3, 1, 5], [4, 5, 2]]
+  assert approx_equal(a.as_sym_mat3(), range(6))
+  assert a.as_mat3() == (0,3,4,3,1,5,4,5,2)
+  if flex:
+    f = a.as_flex_double_matrix()
+    assert f.all() == a.n
+    assert approx_equal(f, a, eps=1.e-12)
+  #
+  for i in xrange(3):
+    x = rec([], n=(0,i))
+    assert repr(x) == "matrix.rec(elems=(), n=(0,%d))" % i
+    assert str(x) == "{}"
+    assert x.matlab_form() == "[]"
+    assert x.matlab_form(one_row_per_line=True) == "[]"
+    x = rec([], n=(i,0))
+    assert repr(x) == "matrix.rec(elems=(), n=(%d,0))" % i
+    assert str(x) == "{}"
+    assert x.matlab_form() == "[]"
+    assert x.matlab_form(one_row_per_line=True) == "[]"
+  x = rec([2], n=(1,1))
+  assert repr(x) == "matrix.rec(elems=(2,), n=(1,1))"
+  assert str(x) == "{{2}}"
+  assert x.matlab_form() == "[2]"
+  assert x.matlab_form(one_row_per_line=True) == "[2]"
+  x = col((1,2,3))
+  assert repr(x) == "matrix.rec(elems=(1, 2, 3), n=(3,1))"
+  assert str(x) == """\
+{{1},
+ {2},
+ {3}}"""
+  assert x.matlab_form() == "[1; 2; 3]"
+  assert x.matlab_form(one_row_per_line=True) == """\
+[1;
+ 2;
+ 3]"""
+  x = row((3,2,1))
+  assert repr(x) == "matrix.rec(elems=(3, 2, 1), n=(1,3))"
+  assert str(x) == "{{3, 2, 1}}"
+  assert x.matlab_form() == "[3, 2, 1]"
+  assert x.matlab_form(one_row_per_line=True) == "[3, 2, 1]"
+  x = rec((1,2,3,
+           4,5,6,
+           7,8,9,
+           -1,-2,-3), (4,3))
+  assert repr(x) == "matrix.rec(elems=(1, ..., -3), n=(4,3))"
+  assert str(x) == """\
+{{1, 2, 3},
+ {4, 5, 6},
+ {7, 8, 9},
+ {-1, -2, -3}}"""
+  assert x.matlab_form() == "[1, 2, 3; 4, 5, 6; 7, 8, 9; -1, -2, -3]"
+  assert x.matlab_form(label="m", one_row_per_line=True, prefix="@") == """\
+@m=[1, 2, 3;
+@   4, 5, 6;
+@   7, 8, 9;
+@   -1, -2, -3]"""
+  #
+  t = (1,2,3,4,5,6)
+  g = (3,2)
+  a = rec(t, g)
+  b = rec(t, g)
+  assert a == b
+  if flex:
+    c = flex.double(t)
+    c.reshape(flex.grid(g))
+    assert a == c
+  #
+  a = identity(4)
+  for ir in xrange(4):
+    for ic in xrange(4):
+      assert (ir == ic and a(ir,ic) == 1) or (ir != ic and a(ir,ic) == 0)
+  a = inversion(4)
+  for ir in xrange(4):
+    for ic in xrange(4):
+      assert (ir == ic and a(ir,ic) == -1) or (ir != ic and a(ir,ic) == 0)
+  #
+  x = col((3/2+0.01, 5/4-0.02, 11/8+0.001))
+  assert (x*8).as_int()/8 == col((3/2, 5/4, 11/8))
+  #
+  for x in [(0, 0, 0), (1, -2, 5), (-2, 5, 1), (5, 1, -2) ]:
+    x = col(x)
+    assert approx_equal(x.dot(x.ortho()), 0)
+  #
+  x = col((1, -2, 3))
+  n = col((-2, 4, 5))
+  alpha = 2*math.pi/3
+  y = x.rotate_around_origin(n, alpha)
+  n = n.normalize()
+  x_perp = x - n.dot(x)*n
+  y_perp = y - n.dot(y)*n
+  assert approx_equal(x_perp.angle(y_perp), alpha)
+  x = col((0,1,0))
+  y = x.rotate_around_origin(axis=col((1,0,0)), angle=75, deg=True)
+  assert approx_equal(y, (0.0, 0.25881904510252074, 0.96592582628906831))
+  assert approx_equal(x.angle(y, deg=True), 75)
+  a = col((0.33985998937421624, 0.097042540321188753, -0.60916214763712317))
+  x = col((0.61837962293383231, -0.46724958233858915, -0.48367879178081852))
+  y = x.rotate_around_origin(axis=a, angle=37, deg=True)
+  assert approx_equal(abs(x), 0.913597670681)
+  assert approx_equal(abs(y), 0.913597670681)
+  assert approx_equal(x.angle(y, deg=True), 25.6685689758)
+  assert approx_equal(y, (0.2739222799, -0.5364841936, -0.6868857244))
+  uq = a.axis_and_angle_as_unit_quaternion(angle=37, deg=True)
+  assert approx_equal(uq, (0.94832366, 0.15312122, 0.04372175, -0.27445317))
+  r = uq.unit_quaternion_as_r3_rotation_matrix()
+  assert approx_equal(r*x, y)
+  assert approx_equal(
+    a.axis_and_angle_as_r3_rotation_matrix(angle=37, deg=True), r)
+  #
+  pivot = col((29.278,-48.061,72.641))
+  raa = pivot.rt_for_rotation_around_axis_through(
+    point=col((28.09,-48.047,71.684)),
+    angle=190.811940444, deg=True)
+  assert approx_equal(
+    raa * col((28.097,-47.559,70.248)),
+    (26.639170440424856,-48.299377845438173,72.046888429403481))
+  #
+  assert col((0,0,1)).vector_to_001_rotation().elems == (1,0,0,0,1,0,0,0,1)
+  assert col((0,0,-1)).vector_to_001_rotation().elems == (1,0,0,0,-1,0,0,0,-1)
+  assert approx_equal(
+    col((5,3,-7)).normalize().vector_to_001_rotation(),
+    (-0.3002572205351709, -0.78015433232110254, -0.54882129994845175,
+     -0.78015433232110254, 0.53190740060733865, -0.32929277996907103,
+     0.54882129994845175, 0.32929277996907103, -0.76834981992783236))
+  #
+  a = row((1,0,0))
+  b = row((0,1,0))
+  assert a.cross(b) == row((0,0,1))
+  #
+  a = col((1.43416642866471794, -2.47841960952275497, -0.7632916804502845))
+  b = col((0.34428681113080323, -1.85983494542314587, 0.37702845822372399))
+  assert approx_equal(a.cross(b), cross_product_matrix(a) * b)
+  #
+  f = linearly_dependent_pair_scaling_factor
+  assert approx_equal(f(vector_1=[1,2,3], vector_2=[3,6,9]), 3)
+  assert approx_equal(f(vector_1=[3,6,9], vector_2=[1,2,3]), 1/3)
+  assert f(vector_1=col([0,1,1]), vector_2=[1,1,1]) is None
+  assert f(vector_1=[1,1,1], vector_2=col([0,1,1])) is None
+  assert f(vector_1=col([0,0,0]), vector_2=col([0,0,0])) is 0
+  #
+  a = col_list(seq=[(1,2), (2,3)])
+  for e in a: assert isinstance(e, col)
+  assert approx_equal(a, [(1,2), (2,3)])
+  a = row_list(seq=[(1,2), (2,3)])
+  for e in a: assert isinstance(e, row)
+  assert approx_equal(a, [(1,2), (2,3)])
+  #
+  def f(a): return a.resolve_partitions().mathematica_form()
+  a = rec(elems=[], n=[0,0])
+  assert f(a) == "{}"
+  a = rec(elems=[], n=[0,1])
+  assert f(a) == "{}"
+  a = rec(elems=[], n=[1,0])
+  assert f(a) == "{}"
+  for e in [col([]), row([])]:
+    a = rec(elems=[e], n=[1,1])
+    assert f(a) == "{}"
+    a = rec(elems=[e, e], n=[1,2])
+    assert f(a) == "{}"
+    a = rec(elems=[e, e], n=[2,1])
+    assert f(a) == "{}"
+  for e in [col([1]), row([1])]:
+    a = rec(elems=[e], n=[1,1])
+    assert f(a) == "{{1}}"
+  a = rec(elems=[col([1,2]), col([3,4])], n=[1,2])
+  assert f(a) == "{{1, 3}, {2, 4}}"
+  a = rec(elems=[col([1,2]), col([3,4])], n=[2,1])
+  assert f(a) == "{{1}, {2}, {3}, {4}}"
+  a = rec(elems=[sqr([1,2,3,4]), sqr([5,6,7,8])], n=[1,2])
+  assert f(a) == "{{1, 2, 5, 6}, {3, 4, 7, 8}}"
+  a = rec(elems=[sqr([1,2,3,4]), sqr([5,6,7,8])], n=[2,1])
+  assert f(a) == "{{1, 2}, {3, 4}, {5, 6}, {7, 8}}"
+  a = rec(elems=[rec([1,2,3,4,5,6], n=(2,3)), rec([7,8], n=(2,1))], n=[1,2])
+  assert f(a) == "{{1, 2, 3, 7}, {4, 5, 6, 8}}"
+  a = rec(elems=[rec([1,2,3,4,5,6], n=(2,3)), rec([7,8,9], n=(1,3))], n=[2,1])
+  assert f(a) == "{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}"
+  a = rec(
+    elems=[
+      sqr([11,12,13,14,15,16,17,18,19]),
+      sqr([21,22,23,24,25,26,27,28,29]),
+      sqr([31,32,33,34,35,36,37,38,39]),
+      sqr([41,42,43,44,45,46,47,48,49])],
+    n=[2,2])
+  assert a.resolve_partitions().mathematica_form(one_row_per_line=True) == """\
+{{11, 12, 13, 21, 22, 23},
+ {14, 15, 16, 24, 25, 26},
+ {17, 18, 19, 27, 28, 29},
+ {31, 32, 33, 41, 42, 43},
+ {34, 35, 36, 44, 45, 46},
+ {37, 38, 39, 47, 48, 49}}"""
+  a = rec(
+    elems=[
+      rec([1,2,3,4,5,6], n=(2,3)),
+      rec([7,8,9,10,11,12,13,14], n=(2,4)),
+      rec([15,16,17,18,19,20,21,22,23], n=(3,3)),
+      rec([24,25,26,27,28,29,30,31,32,33,34,35], n=(3,4)),
+      rec([36,37,38], n=(1,3)),
+      rec([39,40,41,42], n=(1,4))],
+    n=[3,2])
+  assert a.resolve_partitions().mathematica_form(one_row_per_line=True) == """\
+{{1, 2, 3, 7, 8, 9, 10},
+ {4, 5, 6, 11, 12, 13, 14},
+ {15, 16, 17, 24, 25, 26, 27},
+ {18, 19, 20, 28, 29, 30, 31},
+ {21, 22, 23, 32, 33, 34, 35},
+ {36, 37, 38, 39, 40, 41, 42}}"""
+  #
+  def check(m, expected):
+    assert approx_equal(determinant_via_lu(m=m), expected)
+    assert approx_equal(m.determinant(), expected)
+    if (expected != 0):
+      mi = inverse_via_lu(m=m)
+      assert mi.n == m.n
+      assert approx_equal(mi*m, identity(n=m.n[0]))
+      assert approx_equal(m*mi, identity(n=m.n[0]))
+      mii = inverse_via_lu(m=mi)
+      assert approx_equal(mii, m)
+  check(sqr([]), 1)
+  check(sqr([0]), 0)
+  check(sqr([4]), 4)
+  check(sqr([0]*4), 0)
+  check(sqr([1,2,-3,4]), 10)
+  check(sqr([0]*9), 0)
+  check(sqr([
+    0.1226004505424059, 0.69470636260753704, -0.70876808568064376,
+    0.20921402107901119, -0.71619825067837384, -0.66579993925291725,
+    -0.97015391712385002, -0.066656848694206489, -0.23314853980114805]), 1)
+  check(sqr([0]*16), 0)
+  check(sqr([
+    -2/15,-17/75,4/75,-19/75,
+    7/15,22/75,-14/75,29/75,
+    1/3,4/15,-8/15,8/15,
+    -1,-1,1,-1]), -1/75)
+  #
+  r = identity(n=3)
+  assert r.is_r3_rotation_matrix()
+  uqr = r.r3_rotation_matrix_as_unit_quaternion()
+  assert approx_equal(uqr, (1,0,0,0))
+  # axis = (1/2**0.5, 1/2**0.5, 0)
+  # angle = 2 * math.asin((2/3.)**0.5)
+  uq = col((1/3**0.5,1/3**0.5,1/3**0.5,0))
+  r = sqr((
+     1/3.,2/3., 2/3.,
+     2/3.,1/3.,-2/3.,
+    -2/3.,2/3.,-1/3.))
+  assert approx_equal(uq.unit_quaternion_as_r3_rotation_matrix(), r)
+  uqr = r.r3_rotation_matrix_as_unit_quaternion()
+  assert approx_equal(uqr, uq)
+  #
+  for i_trial in xrange(10):
+    uq1 = col.random(n=4, a=-1, b=1).normalize()
+    uq2 = col.random(n=4, a=-1, b=1).normalize()
+    r1 = uq1.unit_quaternion_as_r3_rotation_matrix()
+    r2 = uq2.unit_quaternion_as_r3_rotation_matrix()
+    uqp12 = uq1.unit_quaternion_product(uq2)
+    rp12 = uqp12.unit_quaternion_as_r3_rotation_matrix()
+    assert approx_equal(rp12, r1*r2)
+    uqp21 = uq2.unit_quaternion_product(uq1)
+    rp21 = uqp21.unit_quaternion_as_r3_rotation_matrix()
+    assert approx_equal(rp21, r2*r1)
+    for uq,r in [(uq1,r1), (uq2,r2), (uqp12,rp12), (uqp21,rp21)]:
+      assert r.is_r3_rotation_matrix()
+      uqr = r.r3_rotation_matrix_as_unit_quaternion()
+      assert approx_equal(uqr.unit_quaternion_as_r3_rotation_matrix(), r)
+  #
+  r = sqr((
+    0.12, 0.69, -0.70,
+    0.20, -0.71, -0.66,
+    -0.97, -0.06, -0.23))
+  assert approx_equal(r.is_r3_rotation_matrix_rms(), 0.0291602469125)
+  assert not r.is_r3_rotation_matrix()
+  #
+  v = col((1.1, -2.2, 2.3))
+  assert approx_equal(v % 2, col((1.1, 1.8, 0.3)))
+  #
+  rational1 = sqr((2,1,1,0,1,0,0,0,1))
+  assert str(rational1.inverse().elems)==\
+    "(0.5, -0.5, -0.5, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)"
+  if flex:
+    assert str(rational1.as_boost_rational().inverse().elems)==\
+      "(1/2, -1/2, -1/2, 0, 1, 0, 0, 0, 1)"
+  #
+  assert scitbx.matrix._dihedral_angle(sites=col_list([(0,0,0)]*4), deg=False) is None
+  assert dihedral_angle(sites=col_list([(0,0,0)]*4)) is None
+  sites = col_list([
+    (-3.193, 1.904, 4.589),
+    (-1.955, 1.332, 3.895),
+    (-1.005, 2.228, 3.598),
+    ( 0.384, 1.888, 3.199)])
+  expected = 166.212120415
+  assert approx_equal(scitbx.matrix._dihedral_angle(sites=sites, deg=True), expected)
+  assert approx_equal(dihedral_angle(sites=sites, deg=True), expected)
+  # more dihedral tests in scitbx/math/boost_python/tst_math.py
+  #
+  if (test_utils is not None):
+    from libtbx import group_args
+    for deg in [False, True]:
+      args = group_args(
+        axis_point_1=sites[0],
+        axis_point_2=sites[1],
+        point=sites[2],
+        angle=13,
+        deg=True).__dict__
+      assert approx_equal(
+        rotate_point_around_axis(**args),
+        scitbx.matrix.__rotate_point_around_axis(**args))
+    args = group_args(
+      axis_point_1=sites[0],
+      axis_point_2=sites[1],
+      point=sites[2]).__dict__
+    assert approx_equal(
+      project_point_on_axis(**args),
+      list(scitbx.matrix.__project_point_on_axis(**args))[0])
+  # exercise plane_equation
+  point_1=col((1,2,3))
+  point_2=col((10,20,30))
+  point_3=col((7,53,18))
+  a,b,c,d = plane_equation(point_1=point_1, point_2=point_2, point_3=point_3)
+  point_in_plane = (point_3 - (point_2-point_1)/2)/2
+  assert approx_equal(
+    a*point_in_plane[0]+b*point_in_plane[1]+c*point_in_plane[2]+d,0)
+  xyz = (0,1,1)
+  assert approx_equal(2.828427,
+          distance_from_plane(xyz=(1,1,5), points=[(0,0,0), (1,1,1), (-1,1,1)]))
+  d = distance_from_plane(xyz=(0,0,1), points=[(0,0,0), (0,0,0), (0,1,0)])
+  assert d is None
+  d = distance_from_plane(xyz=(0,0,1), points=[(0,0,0), (1,0,0), (0,1,0)])
+  assert approx_equal(d, 1)
+  #
+  numpy = numpy_proxy()
+  if numpy:
+    m = rec(elems=range(6), n=(2,3))
+    n = m.as_numpy_array()
+    assert n.tolist() == [[0, 1, 2], [3, 4, 5]]
+  else:
+    print("INFO: numpy not available.")
+  #
+  print("OK")
+
+def exercise_2():
+  points = \
+    [[20.559, 2.613, 29.030],
+     [21.030, 3.817, 29.627],
+     [21.079, 3.972, 30.986],
+     [21.604, 5.302, 31.090],
+     [21.813, 5.803, 29.779],
+     [21.448, 4.862, 28.912],
+     [20.781, 3.239, 32.060],
+     [20.978, 3.765, 33.283],
+     [21.472, 5.018, 33.416],
+     [21.774, 5.761, 32.331],
+     [22.288, 7.066, 32.547],
+     [21.481, 4.924, 27.938],
+     [20.765, 3.241, 34.078],
+     [22.403, 7.376, 33.397],
+     [22.503, 7.595, 31.835]]
+  assert all_in_plane(points=points, tolerance=0.005)
+  points = \
+    [[20.559, 2.613, 29.030],
+     [21.030, 3.817, 29.627],
+     [21.079, 3.972, 30.986],
+     [21.604, 5.302, 31.090],
+     [21.813, 5.803, 29.779],
+     [21.448, 4.862, 28.912],
+     [20.781, 3.239, 32.060],
+     [20.978, 3.765, 33.283],
+     [21.472, 0.018, 33.416],
+     [21.774, 5.761, 32.331],
+     [22.288, 7.066, 32.547],
+     [21.481, 4.924, 27.938],
+     [20.765, 3.241, 34.078],
+     [22.403, 7.376, 33.397],
+     [22.503, 7.595, 31.835]]
+  assert not all_in_plane(points=points, tolerance=0.005)
+
+if __name__ == "__main__":
+  exercise_1()
+  exercise_2()

--- a/scitbx/random/__init__.py
+++ b/scitbx/random/__init__.py
@@ -1,22 +1,21 @@
-from __future__ import division
+from __future__ import absolute_import, division, print_function
+
 import os
 import time
+
 import boost.optional # import dependency
 import boost.python
 boost.python.import_ext("scitbx_random_ext")
 import scitbx_random_ext
 
-builtin_int = __builtins__["int"]
-builtin_long = __builtins__["long"]
-
 def get_random_seed():
   try:
-    result = builtin_long(os.getpid() * (2**16)) \
-           + builtin_long(time.time() * (2**8))
+    result = (os.getpid() * (2**16)) \
+           + (time.time() * (2**8))
   except KeyboardInterrupt: raise
   except Exception:
     result = time.time()
-  return builtin_int(result % (2**31-1))
+  return int(result % (2**31-1))
 
 def set_random_seed(value):
   mt19937.seed(value)
@@ -57,14 +56,14 @@ class variate_factory(object):
     for variate in self.variate_functions():
       try:
         return variate(engine, distribution)
-      except Exception, e:
+      except Exception as e:
         if str(e.__class__).find('Boost.Python.ArgumentError') >= 0:
           exceptions.append(e)
           continue
         else:
           raise
     else:
-      raise RuntimeError('\n'.join([ str(e) for e in exceptions ]))
+      raise RuntimeError('\n'.join(str(e) for e in exceptions))
 
 # Instantiate the one single variate factory doing it all
 variate = variate_factory()

--- a/scitbx/run_tests.py
+++ b/scitbx/run_tests.py
@@ -50,7 +50,7 @@ tst_list = (
   "$D/tests/tst_cubicle_neighbors.py",
   "$D/tests/tst_r3_utils.py",
   "$D/tests/tst_regular_grid_on_unit_sphere.py",
-  "$D/matrix/__init__.py",
+  "$D/matrix/tst_matrix.py",
   "$D/python_utils/tst_random_transform.py",
   "$D/python_utils/tst_graph.py",
   "$D/python_utils/tst_robust.py",


### PR DESCRIPTION
This pull requests consists of 4 commits. The first one (f070afa) is only trivial changes, print rewrites etc, which hopefully are generally uninteresting.

The second commit 8256c9c rewrites a bit in ```scitbx/random/__int__.py```. @rjgildea you wrote most of that file, could you please have a look at that?

The third commit f5d6afe replaces ```reduce(operator.add, <iterator>)``` with ```sum(<iterator>)``` in ```scitbx/math/__init__.py``` which should of course produce identical results, but does not rely on ```reduce```, which was removed from the python 3 global namespace. The file was last touched by @pafonine, @gbunkoczi, @luc-j-bourhis - could one of you please have a look at that?

The fourth commit f3633cbee does minor fixes in ```scitbx/matrix/__init__.py```, but I noticed that file contains a very large block that is only test code. I therefore moved the test into a separate file. You can still run the test by calling either file directly. This file was last touched by @pafonine, @olegsobolev, @phyy-nx - could one of you please have a look?

(This pull request is required but not sufficient for Python 3 building, #197 and #198 are also required)