### PR TITLE
cxi.xmerge include_negatives fix

### DIFF
--- a/xfel/command_line/cxi_merge.py
+++ b/xfel/command_line/cxi_merge.py
@@ -305,6 +305,9 @@ postrefinement {
 include_negatives = False
   .type = bool
   .help = Whether to include negative intensities during scaling and merging
+include_negatives_fix_27May2018 = True
+  .type = bool
+  .help = Bugfix for include negatives. Affects cxi.xmerge.
 plot_single_index_histograms = False
   .type = bool
 data_subsubsets {
@@ -1541,6 +1544,11 @@ class scaling_manager (intensity_data) :
     sel_observations = flex.intersection(
       size=observations.data().size(),
       iselections=[indices])
+
+    if self.params.include_negatives_fix_27May2018:
+      # Super-rare exception. If saved sigmas instead of I/sigmas in the ISIGI dict, this wouldn't be needed.
+      sel_observations &= observations.data() != 0
+
     set_original_hkl = observations_original_index_indices.select(
       flex.intersection(
         size=observations_original_index_indices.size(),

--- a/xfel/command_line/cxi_xmerge.py
+++ b/xfel/command_line/cxi_xmerge.py
@@ -149,6 +149,8 @@ def run(args):
       "set_average_unit_cell=True.")
   if work_params.raw_data.sdfac_auto and work_params.raw_data.sdfac_refine:
     raise Usage("Cannot specify both sdfac_auto and sdfac_refine")
+  if not work_params.include_negatives_fix_27May2018:
+    work_params.include_negatives = False # use old behavior
 
   log = open("%s_%s.log" % (work_params.output.prefix,work_params.scaling.algorithm), "w")
   out = multi_out()
@@ -300,7 +302,8 @@ def run(args):
 
     from xfel import scaling_results, get_scaling_results, get_isigi_dict
     results = scaling_results(scaler._observations, scaler._frames,
-              scaler.millers["merged_asu_hkl"],scaler.frames["data_subset"])
+              scaler.millers["merged_asu_hkl"],scaler.frames["data_subset"],
+              work_params.include_negatives)
     results.__getattribute__(
       work_params.scaling.algorithm)(
       scaler.params.min_corr, scaler.params.target_unit_cell)

--- a/xfel/ext.cpp
+++ b/xfel/ext.cpp
@@ -363,10 +363,11 @@ public:
   shared_int completeness, summed_N, hkl_ids;
   shared_vec3 i_isig_list;
   int Nhkl;
+  bool include_negatives_;
 
   scaling_results (column_parser &observations, column_parser &frames,
-                   shared_miller& hkls, shared_bool& data_subset):
-    observations(observations),frames(frames),merged_asu_hkl(hkls),
+                   shared_miller& hkls, shared_bool& data_subset, bool include_negatives):
+    observations(observations),frames(frames),merged_asu_hkl(hkls),include_negatives_(include_negatives),
     selected_frames(data_subset){}
   void mark0 (double const& params_min_corr,
               cctbx::uctbx::unit_cell const& params_unit_cell) {
@@ -397,7 +398,7 @@ public:
       double this_i = intensity[iobs];
       double this_sig = sigi[iobs];
       n_obs[this_frame_id] += 1;
-      if (this_i <=0.){
+      if (!include_negatives_ && this_i <=0.){
         n_rejected[this_frame_id] += 1;
         continue;
       }
@@ -474,7 +475,7 @@ public:
       double this_i = intensity[iobs];
       double this_sig = sigi[iobs];
       n_obs[this_frame_id] += 1;
-      if (this_i <=0.){
+      if (!include_negatives_ && this_i <=0.){
         n_rejected[this_frame_id] += 1;
         continue;
       }
@@ -795,7 +796,7 @@ namespace boost_python { namespace {
 
     class_<scaling_results>("scaling_results",no_init)
       .def(init<column_parser&, column_parser&, scaling_results::shared_miller&,
-                scaling_results::shared_bool&>())
+                scaling_results::shared_bool&, bool>())
       .def("count_frames",&scaling_results::count_frames)
       .def("mark0",&scaling_results::mark0)
       .def("mark1",&scaling_results::mark1)


### PR DESCRIPTION
Adds correct include negatives fix to cxi.xmerge and includes a fix to cxi.merge to not write out reflections with 0 intensity to the .db files.

Disable this commit with include_negatives_fix_27May2018=False.

Co-authored-by: Aaron Brewster <asbrewster@lbl.gov>
Co-authored-by: Iris Young <idyoung@lbl.gov>