### PR TITLE
Fix split datablocks not being deserialized correctly (#203)

### DIFF
--- a/dxtbx/format/FormatMultiImage.py
+++ b/dxtbx/format/FormatMultiImage.py
@@ -190,6 +190,7 @@ class FormatMultiImage(object):
       format_instance = Class(filenames[0], **format_kwargs)
     else:
       format_instance = None
+      lazy = True
 
     # Read the vendor type
     if check_format is True:

--- a/dxtbx/imageset.py
+++ b/dxtbx/imageset.py
@@ -514,13 +514,17 @@ class ImageSetFactory(object):
     '''Create an image set'''
     from dxtbx.format.Registry import Registry
     from dxtbx.format.Format import Format
+    from dxtbx.format.FormatMultiImage import FormatMultiImage
 
     # Get the format object
     if format_class == None:
       if check_format:
         format_class = Registry.find(filenames[0])
       else:
-        format_class = Format
+        if single_file_indices is None or len(single_file_indices) == 0:
+          format_class = Format
+        else:
+          format_class = FormatMultiImage
     else:
       format_class = format_class
 

--- a/dxtbx/tests/test_split_singleimage_datablock.py
+++ b/dxtbx/tests/test_split_singleimage_datablock.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import, division, print_function
-import pytest, os
+import os
 from dxtbx.datablock import DataBlockFactory, DataBlockDumper
 
 """
-Test to show that deserializing a datablock that has single file indices while using check_format=False fails
+Test deserializing a datablock that has single file indices while using check_format = True or False
 """
 
 def get_indices(datablock):
   imageset = datablock.extract_imagesets()[0]
   return list(imageset.indices())
 
-@pytest.mark.xfail
 def test_split_single_image_datablock(dials_regression, tmpdir):
   tmpdir.chdir()
   sacla_file = os.path.join(dials_regression, "image_examples", "SACLA_MPCCD_Cheetah", "run266702-0-subset.h5")
@@ -32,4 +31,4 @@ def test_split_single_image_datablock(dials_regression, tmpdir):
 
   db = DataBlockFactory.from_json_file(dumped_filename, check_format = False)[0]
   assert db.num_images() == 1
-  assert get_indices(db) == [2] # fails. returns [0]
+  assert get_indices(db) == [2]


### PR DESCRIPTION
Three changes:
1) When constructing an imageset, if check_format=False and single_file_indices not None and not empty, use FormatMultiImage instead of Format to construct the imageset.
2) In FormatMultiImage.get_imageset, if check_format=False, return a Lazy imageset.
3) Mark test as expected to pass