### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/cctbx/web/iotbx_cif_validate.html
+++ b/cctbx/web/iotbx_cif_validate.html
@@ -66,7 +66,7 @@ If you use iotbx.cif in your work please cite:
 R. J. Gildea, L. J. Bourhis, O. V. Dolomanov, R. W. Grosse-Kunstleve,
 H. Puschmann, P. D. Adams and J. A. K. Howard:
 <em>iotbx.cif: a comprehensive CIF toolbox</em>.
-<a class="reference" href="http://dx.doi.org/10.1107/S0021889811041161">J. Appl. Cryst. (2011). 44, 1259-1263</a>.</blockquote>
+<a class="reference" href="https://doi.org/10.1107/S0021889811041161">J. Appl. Cryst. (2011). 44, 1259-1263</a>.</blockquote>
 
 <hr>
 [<a href="index.html">Index of services</a>]

--- a/fable/doc/index.txt
+++ b/fable/doc/index.txt
@@ -25,7 +25,7 @@
 
     Grosse-Kunstleve RW, Terwilliger TC, Sauter NK, Adams PD:
     *Automatic Fortran to C++ conversion with FABLE*.
-    `Source Code for Biology and Medicine 2012, 7:5 <http://dx.doi.org/10.1186/1751-0473-7-5>`_.
+    `Source Code for Biology and Medicine 2012, 7:5 <https://doi.org/10.1186/1751-0473-7-5>`_.
 
 - fable and fem development was supported by supplemental funding from
   the American Recovery and Reinvestment Act (ARRA) to NIH/NIGMS grant

--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -4,7 +4,7 @@ H. Puschmann, P. D. Adams and J. A. K. Howard:
 iotbx.cif: a comprehensive CIF toolbox.
 J. Appl. Cryst. (2011). 44, 1259-1263.
 
-http://dx.doi.org/10.1107/S0021889811041161
+https://doi.org/10.1107/S0021889811041161
 
 http://cctbx.sourceforge.net/iotbx_cif
 

--- a/iotbx/examples/iotbx_cif.txt
+++ b/iotbx/examples/iotbx_cif.txt
@@ -9,7 +9,7 @@ If you use ``iotbx.cif`` in your work please cite:
   R. J. Gildea, L. J. Bourhis, O. V. Dolomanov, R. W. Grosse-Kunstleve,
   H. Puschmann, P. D. Adams and J. A. K. Howard:
   *iotbx.cif: a comprehensive CIF toolbox*.
-  `J. Appl. Cryst. (2011). 44, 1259-1263 <http://dx.doi.org/10.1107/S0021889811041161>`_.
+  `J. Appl. Cryst. (2011). 44, 1259-1263 <https://doi.org/10.1107/S0021889811041161>`_.
 
 ==================
 Reading a CIF file

--- a/libtbx/citations.py
+++ b/libtbx/citations.py
@@ -278,7 +278,7 @@ def format_citation_html (article) :
   if (article.url is not None) :
     output += """<a href="%s">%s</a>.""" % (article.url, journal_ref)
   elif (article.doi_id is not None) :
-    output += """<a href="http://dx.doi.org/%s">%s</a>.""" % (article.doi_id,
+    output += """<a href="https://doi.org/%s">%s</a>.""" % (article.doi_id,
       journal_ref)
   elif (article.pmid is not None) :
     output += """<a href="http://www.ncbi.nlm.nih.gov/pubmed/%s">%s</a>.""" % \

--- a/libtbx/sphinx/pubmed.py
+++ b/libtbx/sphinx/pubmed.py
@@ -43,7 +43,7 @@ class PubMedDirective(docutils.parsers.rst.Directive):
       if len(possible_doi) > 0:
         text.append('| |%s|' %possible_doi[0])
         raw_directives.append(raw_html_link_new_tab(
-          possible_doi[0], get_title, "http://dx.doi.org/%s" %possible_doi[0]))
+          possible_doi[0], get_title, "https://doi.org/%s" %possible_doi[0]))
 
       # Author list
       authors = [ " ".join([elem["LastName"],elem["Initials"]])

--- a/libtbx/tst_citations.py
+++ b/libtbx/tst_citations.py
@@ -30,7 +30,7 @@ def test_format():
   actual = citations.format_citation_iucr(citation)
   assert not show_diff(actual, expected)
 
-  expected = """<b>Iterative-build OMIT maps: map improvement by iterative model building and refinement without model bias.</b> T.C. Terwilliger, R.W. Grosse-Kunstleve, P.V. Afonine, N.W. Moriarty, P.D. Adams, R.J. Read, P.H. Zwart, and L.-W. Hung. <a href="http://dx.doi.org/doi:10.1107/S0907444908004319"><i>Acta Cryst.</i> D<b>64</b>, 515-524 (2008)</a>."""
+  expected = """<b>Iterative-build OMIT maps: map improvement by iterative model building and refinement without model bias.</b> T.C. Terwilliger, R.W. Grosse-Kunstleve, P.V. Afonine, N.W. Moriarty, P.D. Adams, R.J. Read, P.H. Zwart, and L.-W. Hung. <a href="https://doi.org/doi:10.1107/S0907444908004319"><i>Acta Cryst.</i> D<b>64</b>, 515-524 (2008)</a>."""
   citation = citations.citations_db['autobuild_omit']
   actual = citations.format_citation_html(citation)
   assert not show_diff(actual, expected)

--- a/prime/postrefine/mod_input.py
+++ b/prime/postrefine/mod_input.py
@@ -371,7 +371,7 @@ Prime: post-refinement and merging.
 
 For more detail and citation, see Enabling X-ray free electron laser crystallography
 for challenging biological systems from a limited number of crystals
-"DOI: http://dx.doi.org/10.7554/eLife.05421".
+"DOI: https://doi.org/10.7554/eLife.05421".
 
 Usage: prime.postrefine parameter.phil
 

--- a/sphinx/iotbx/iotbx.cif.rst
+++ b/sphinx/iotbx/iotbx.cif.rst
@@ -21,7 +21,7 @@ If you use :py:mod:`iotbx.cif` in your work please cite:
   R. J. Gildea, L. J. Bourhis, O. V. Dolomanov, R. W. Grosse-Kunstleve,
   H. Puschmann, P. D. Adams and J. A. K. Howard:
   *iotbx.cif: a comprehensive CIF toolbox*.
-  `J. Appl. Cryst. (2011). 44, 1259-1263 <http://dx.doi.org/10.1107/S0021889811041161>`_.
+  `J. Appl. Cryst. (2011). 44, 1259-1263 <https://doi.org/10.1107/S0021889811041161>`_.
 
 See also http://www.iucr.org/resources/cif.
 

--- a/ucif/examples/ucif_example.txt
+++ b/ucif/examples/ucif_example.txt
@@ -9,7 +9,7 @@ If you use ``ucif`` in your work please cite:
   R. J. Gildea, L. J. Bourhis, O. V. Dolomanov, R. W. Grosse-Kunstleve,
   H. Puschmann, P. D. Adams and J. A. K. Howard:
   *iotbx.cif: a comprehensive CIF toolbox*.
-  `J. Appl. Cryst. (2011). 44, 1259-1263 <http://dx.doi.org/10.1107/S0021889811041161>`_.
+  `J. Appl. Cryst. (2011). 44, 1259-1263 <https://doi.org/10.1107/S0021889811041161>`_.
 
 =============================
 Creating a minimal cif parser

--- a/xfel/command_line/smooth_spectrum.py
+++ b/xfel/command_line/smooth_spectrum.py
@@ -165,7 +165,7 @@ def estimate_signal_to_noise(x, y_noisy, y_smoothed, plot=False):
      See:
        The extraction of signal to noise values in x-ray absorption spectroscopy
        A. J. Dent, P. C. Stephenson, and G. N. Greaves
-       Rev. Sci. Instrum. 63, 856 (1992); http://dx.doi.org/10.1063/1.1142627
+       Rev. Sci. Instrum. 63, 856 (1992); https://doi.org/10.1063/1.1142627
   """
   noise = y_noisy - y_smoothed
   noise_sq = flex.pow2(noise)


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!