### PR TITLE
Reading data with psana2

### DIFF
--- a/xfel/cftbx/detector/cspad_cbf_tbx.py
+++ b/xfel/cftbx/detector/cspad_cbf_tbx.py
@@ -303,12 +303,21 @@ def env_dxtbx_from_slac_metrology(run, address):
       @param env psana run object
       @param address address string for a detector
   """
+  try:
+      import psana
+      PSANA2_VERSION = psana.__version__
+  except AttributeError:
+      PSANA2_VERSION = 0
+    
+  if PSANA2_VERSION:
+    # FIXME: get metrology from a pickle file until det interface is ready
+    import cPickle as pickle
+    metro = pickle.load(open('/reg/d/psdm/cxi/cxid9114/scratch/mona/l2/psana-nersc/demo18/input/metro.pickle'))
+    cbf = get_cspad_cbf_handle(None, metro, 'cbf', None, "test", None, 100, verbose = True, header_only = True)
 
-  # FIXME: get metrology from a pickle file until det interface is ready
-  import cPickle as pickle
-  metro = pickle.load(open('/reg/d/psdm/cxi/cxid9114/scratch/mona/l2/demo18/input/metro.pickle'))
+    from dxtbx.format.FormatCBFCspad import FormatCBFCspadInMemory
+    return FormatCBFCspadInMemory(cbf)
   
-  """
   from psana import Detector
   try:
     # try to load the geometry from the detector interface
@@ -330,7 +339,6 @@ def env_dxtbx_from_slac_metrology(run, address):
     return None
 
   metro = read_slac_metrology(metro_path, geometry)
-  """
 
   cbf = get_cspad_cbf_handle(None, metro, 'cbf', None, "test", None, 100, verbose = True, header_only = True)
 

--- a/xfel/cftbx/detector/cspad_cbf_tbx.py
+++ b/xfel/cftbx/detector/cspad_cbf_tbx.py
@@ -297,25 +297,14 @@ def get_calib_file_path(env, address, run):
     return None
   return ''.join(map(chr, path_nda))
 
-def env_dxtbx_from_slac_metrology(run, address):
+def env_dxtbx_from_slac_metrology(run, address, metro=None):
   """ Loads a dxtbx cspad cbf header only object from the metrology path stored
       in a psana run object's calibration store
       @param env psana run object
       @param address address string for a detector
   """
-  try:
-      import psana
-      PSANA2_VERSION = psana.__version__
-  except AttributeError:
-      PSANA2_VERSION = 0
-
-  if PSANA2_VERSION:
+  if metro is not None:
     # FIXME: get metrology from a pickle file until det interface is ready
-    import cPickle as pickle
-    import os
-    PS_CALIB_DIR = os.environ.get('PS_CALIB_DIR')
-    assert PS_CALIB_DIR
-    metro = pickle.load(open(os.path.join(PS_CALIB_DIR,'metro.pickle'), 'r'))
     cbf = get_cspad_cbf_handle(None, metro, 'cbf', None, "test", None, 100, verbose = True, header_only = True)
 
     from dxtbx.format.FormatCBFCspad import FormatCBFCspadInMemory

--- a/xfel/cftbx/detector/cspad_cbf_tbx.py
+++ b/xfel/cftbx/detector/cspad_cbf_tbx.py
@@ -312,7 +312,10 @@ def env_dxtbx_from_slac_metrology(run, address):
   if PSANA2_VERSION:
     # FIXME: get metrology from a pickle file until det interface is ready
     import cPickle as pickle
-    metro = pickle.load(open('/reg/d/psdm/cxi/cxid9114/scratch/mona/l2/psana-nersc/demo18/input/metro.pickle'))
+    import os
+    PS_CALIB_DIR = os.environ.get('PS_CALIB_DIR')
+    assert PS_CALIB_DIR
+    metro = pickle.load(open(os.path.join(PS_CALIB_DIR,'metro.pickle'), 'r'))
     cbf = get_cspad_cbf_handle(None, metro, 'cbf', None, "test", None, 100, verbose = True, header_only = True)
 
     from dxtbx.format.FormatCBFCspad import FormatCBFCspadInMemory

--- a/xfel/cftbx/detector/cspad_cbf_tbx.py
+++ b/xfel/cftbx/detector/cspad_cbf_tbx.py
@@ -308,7 +308,7 @@ def env_dxtbx_from_slac_metrology(run, address):
       PSANA2_VERSION = psana.__version__
   except AttributeError:
       PSANA2_VERSION = 0
-    
+
   if PSANA2_VERSION:
     # FIXME: get metrology from a pickle file until det interface is ready
     import cPickle as pickle
@@ -320,7 +320,7 @@ def env_dxtbx_from_slac_metrology(run, address):
 
     from dxtbx.format.FormatCBFCspad import FormatCBFCspadInMemory
     return FormatCBFCspadInMemory(cbf)
-  
+
   from psana import Detector
   try:
     # try to load the geometry from the detector interface

--- a/xfel/cftbx/detector/cspad_cbf_tbx.py
+++ b/xfel/cftbx/detector/cspad_cbf_tbx.py
@@ -303,6 +303,12 @@ def env_dxtbx_from_slac_metrology(run, address):
       @param env psana run object
       @param address address string for a detector
   """
+
+  # FIXME: get metrology from a pickle file until det interface is ready
+  import cPickle as pickle
+  metro = pickle.load(open('/reg/d/psdm/cxi/cxid9114/scratch/mona/l2/demo18/input/metro.pickle'))
+  
+  """
   from psana import Detector
   try:
     # try to load the geometry from the detector interface
@@ -324,6 +330,8 @@ def env_dxtbx_from_slac_metrology(run, address):
     return None
 
   metro = read_slac_metrology(metro_path, geometry)
+  """
+
   cbf = get_cspad_cbf_handle(None, metro, 'cbf', None, "test", None, 100, verbose = True, header_only = True)
 
   from dxtbx.format.FormatCBFCspad import FormatCBFCspadInMemory

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -363,11 +363,11 @@ def run_psana2(ims, params):
     """" Begins psana2
     This setup a DataSource psana2 style. The parallelization is determined within
     the generation of the DataSource.
-    
+
     ims: InMemScript (cctbx driver class)
     params: input parameters"""
-    
-    ds = psana.DataSource("exp=cxid9114:run=95:dir=%s"%params.input.xtc_dir, 
+
+    ds = psana.DataSource("exp=cxid9114:run=95:dir=%s"%params.input.xtc_dir,
             filter=filter, max_events=params.dispatch.max_events)
     det = None
     if ds.nodetype == "bd":
@@ -628,7 +628,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         write_newline = os.path.exists(self.mpi_log_file_path)
         if write_newline: # needed if the there was a crash
           self.mpi_log_write("\n")
-   
+
     # FIXME MONA: psana 2 has pedestals and geometry hardcoded for cxid9114.
     # We can remove after return code when all interfaces are ready.
     if PSANA2_VERSION:
@@ -670,7 +670,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
 
     if params.format.file_format == "cbf":
       self.psana_det = psana.Detector(params.input.address, ds.env())
-    
+
     # set this to sys.maxint to analyze all events
     if params.dispatch.max_events is None:
       max_events = sys.maxint
@@ -945,7 +945,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
           return
 
     self.debug_start(ts)
-    
+
     # FIXME MONA: below will be replaced with filter() callback
     if not PSANA2_VERSION:
       if evt.get("skip_event") or "skip_event" in [key.key() for key in evt.keys()]:
@@ -1057,8 +1057,8 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
       from dials.command_line.estimate_gain import estimate_gain
       estimate_gain(imgset)
       return
-    
-    # FIXME MONA: radial avg. is currently disabled 
+
+    # FIXME MONA: radial avg. is currently disabled
     if not PSANA2_VERSION:
       # Two values from a radial average can be stored by mod_radial_average. If present, retrieve them here
       key_low = 'cctbx.xfel.radial_average.two_theta_low'

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -964,9 +964,12 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
           # FIXME MONA: relace this with above when all detector interfaces are ready
           raw = det.raw(evt)
           pedestals = det.pedestals(run)
+          data = None
           import cPickle as pickle
-          gain_mask = pickle.load(open('/reg/d/psdm/cxi/cxid9114/scratch/mona/l2/psana-nersc/demo18/input/gain_mask.pickle', 'r'))
-          data = gain_mask * (raw - pedestals)
+          PS_CALIB_DIR = os.environ.get('PS_CALIB_DIR')
+          if PS_CALIB_DIR:
+            gain_mask = pickle.load(open(os.path.join(PS_CALIB_DIR,'gain_mask.pickle'), 'r'))
+            data = gain_mask * (raw - pedestals)
         else:
           data = cspad_cbf_tbx.get_psana_corrected_data(self.psana_det, evt, use_default=False, dark=True,
                                                       common_mode=self.common_mode,


### PR DESCRIPTION
With these changes, the indexing and integration modules can now use psana2 interface to read out detector data (xtc2 format) and calibration files. The selection between the old psana and psana2 is done automatically through version checking. 