### PR TITLE
Override pip requirements tracker directory

### DIFF
--- a/libtbx/auto_build/install_base_packages.py
+++ b/libtbx/auto_build/install_base_packages.py
@@ -658,6 +658,7 @@ Installation of Python packages may fail.
         pip_cmd.append('--no-cache-dir')
       else:
         pip_call = pip.main
+      os.environ['PIP_REQ_TRACKER'] = pkg_info['cachedir']
       print "  Running with pip:", pip_cmd
       assert pip_call(pip_cmd) == 0, 'pip download failed'
       return


### PR DESCRIPTION
Fixes #223 crash when using --download-only and pip 18 is installed.

Is not critical. Happy for this to wait until after phenix release.