### PR TITLE
Chirality restraint for smtbx

### DIFF
--- a/cctbx/geometry_restraints/__init__.py
+++ b/cctbx/geometry_restraints/__init__.py
@@ -1330,11 +1330,17 @@ class _(boost.python.injector, chirality):
 
 class _(boost.python.injector, shared_chirality_proxy):
 
-  def deltas(self, sites_cart):
-    return chirality_deltas(sites_cart=sites_cart, proxies=self)
+  def deltas(self, sites_cart, unit_cell=None):
+    if unit_cell is None:
+      return chirality_deltas(sites_cart=sites_cart, proxies=self)
+    else:
+      return chirality_deltas(unit_cell=unit_cell, sites_cart=sites_cart, proxies=self)
 
-  def residuals(self, sites_cart):
-    return chirality_residuals(sites_cart=sites_cart, proxies=self)
+  def residuals(self, sites_cart, unit_cell=None):
+    if unit_cell is None:
+      return chirality_residuals(sites_cart=sites_cart, proxies=self)
+    else:
+      return chirality_residuals(unit_cell=unit_cell, sites_cart=sites_cart, proxies=self)
 
   def show_histogram_of_deltas(self,
         sites_cart,
@@ -1352,6 +1358,7 @@ class _(boost.python.injector, shared_chirality_proxy):
         by_value,
         sites_cart,
         site_labels=None,
+        unit_cell=None,
         proxy_label="Chirality",
         f=None,
         prefix="",
@@ -1360,7 +1367,7 @@ class _(boost.python.injector, shared_chirality_proxy):
         proxy_type=chirality,
         proxy_label=proxy_label,
         item_label="chirality",
-        by_value=by_value, unit_cell=None, sites_cart=sites_cart,
+        by_value=by_value, unit_cell=unit_cell, sites_cart=sites_cart,
         site_labels=site_labels, f=f, prefix=prefix, max_items=max_items)
 
   def get_sorted (self,

--- a/cctbx/geometry_restraints/chirality.h
+++ b/cctbx/geometry_restraints/chirality.h
@@ -277,11 +277,6 @@ namespace cctbx { namespace geometry_restraints {
         delta_sign = -1;
         if (both_signs && volume_model < 0) delta_sign = 1;
         delta = volume_ideal + delta_sign * volume_model;
-        std::cout << sites[0][0] << " " << sites[0][1] << " " << sites[0][2] << "\n";
-        std::cout << sites[1][0] << " " << sites[1][1] << " " << sites[1][2] << "\n";
-        std::cout << sites[2][0] << " " << sites[2][1] << " " << sites[2][2] << "\n";
-        std::cout << sites[3][0] << " " << sites[3][1] << " " << sites[3][2] << "\n";
-        std::cout << volume_ideal << " " << volume_model << " " << delta << "\n";
       }
   };
 

--- a/cctbx/geometry_restraints/chirality.h
+++ b/cctbx/geometry_restraints/chirality.h
@@ -190,9 +190,10 @@ namespace cctbx { namespace geometry_restraints {
       gradients() const
       {
         af::tiny<scitbx::vec3<double>, 4> result;
-        result[1] = d_02_cross_d_03;
-        result[2] = d_03.cross(d_01);
-        result[3] = d_01.cross(d_02);
+        double f = delta_sign * 2.0 * delta * weight;
+        result[1] = f * d_02_cross_d_03;
+        result[2] = f * d_03.cross(d_01);
+        result[3] = f * d_01.cross(d_02);
         result[0] = -result[1]-result[2]-result[3];
         return result;
       }
@@ -205,10 +206,9 @@ namespace cctbx { namespace geometry_restraints {
         af::ref<scitbx::vec3<double> > const& gradient_array,
         chirality_proxy::i_seqs_type const& i_seqs) const
       {
-        double f = delta_sign * 2.0 * delta * weight;
         af::tiny<scitbx::vec3<double>, 4> grads = gradients();
         for(int i=0;i<4;i++) {
-          gradient_array[i_seqs[i]] += f * grads[i];
+          gradient_array[i_seqs[i]] += grads[i];
         }
       }
 
@@ -222,6 +222,7 @@ namespace cctbx { namespace geometry_restraints {
         chirality_proxy::i_seqs_type const& i_seqs = proxy.i_seqs;
         af::tiny<scitbx::vec3<double>, 4> grads = gradients();
         std::size_t row_i = linearised_eqns.next_row();
+        double f = 1.0 /( 2.0 * delta * weight );
         for(int i=0;i<4;i++) {
           grads[i] = unit_cell.fractionalize_gradient(grads[i]);
           if ( sym_ops.get() != 0 && !sym_ops[i].is_unit_mx() ) {
@@ -233,7 +234,7 @@ namespace cctbx { namespace geometry_restraints {
             parameter_map[i_seqs[i]];
           if (ids_i.site == -1) continue;
           for (int j=0;j<3;j++) {
-            linearised_eqns.design_matrix(row_i, ids_i.site+j) += delta_sign * grads[i][j];
+            linearised_eqns.design_matrix(row_i, ids_i.site+j) += f * grads[i][j];
           }
 
           linearised_eqns.weights[row_i] = proxy.weight;

--- a/cctbx/geometry_restraints/chirality.h
+++ b/cctbx/geometry_restraints/chirality.h
@@ -226,10 +226,10 @@ namespace cctbx { namespace geometry_restraints {
             linearised_eqns.design_matrix(row_i, ids_i.site+j) += grads[i][j];
           }
 
-          //! The weight is given for V, scaling for L = 36V**2
+          //! The weight is given for 6V, scaling for L = (6V)**2
           //! Note: Var(X**2) = 2*Var(X)**2
-          linearised_eqns.weights[row_i] = proxy.weight*proxy.weight/(36.0*36.0*2.0);
-          linearised_eqns.deltas[row_i] = volume_model*volume_model - 36.0*volume_ideal*volume_ideal;
+          linearised_eqns.weights[row_i] = proxy.weight*proxy.weight/2.0;
+          linearised_eqns.deltas[row_i] = volume_model*volume_model - volume_ideal*volume_ideal;
         }
       }
 

--- a/cctbx/geometry_restraints/chirality_bpl.cpp
+++ b/cctbx/geometry_restraints/chirality_bpl.cpp
@@ -26,6 +26,7 @@ namespace {
       getinitargs(w_t const& self)
     {
       return boost::python::make_tuple(self.i_seqs,
+        self.sym_ops,
         self.volume_ideal,
         self.both_signs,
         self.weight,
@@ -39,6 +40,16 @@ namespace {
       using namespace boost::python;
       typedef return_value_policy<return_by_value> rbv;
       class_<w_t>("chirality_proxy", no_init)
+        .def(init<af::tiny<unsigned, 4> const&,
+          optional_container<af::shared<sgtbx::rt_mx> > const&,
+          double, bool, double,
+          unsigned char>((
+          arg("i_seqs"),
+          arg("sym_ops"),
+          arg("volume_ideal"),
+          arg("both_signs"),
+          arg("weight"),
+          arg("origin_id")=0)))
         .def(init<af::tiny<unsigned, 4> const&, double, bool, double,
           unsigned char>((
           arg("i_seqs"),
@@ -52,6 +63,7 @@ namespace {
         .def("scale_weight", &w_t::scale_weight, (arg("factor")))
         .def("sort_i_seqs", &w_t::sort_i_seqs)
         .add_property("i_seqs", make_getter(&w_t::i_seqs, rbv()))
+        .add_property("sym_ops", make_getter(&w_t::sym_ops, rbv()))
         .def_readonly("volume_ideal", &w_t::volume_ideal)
         .def_readonly("both_signs", &w_t::both_signs)
         .def_readwrite("weight", &w_t::weight)
@@ -119,10 +131,15 @@ namespace {
            arg("volume_ideal"),
            arg("both_signs"),
            arg("weight"))))
+        .def(init<uctbx::unit_cell const&,
+            af::const_ref<scitbx::vec3<double> > const&,
+            chirality_proxy const&>((
+            arg("unit_cell"), arg("sites_cart"), arg("proxy"))))
         .def(init<af::const_ref<scitbx::vec3<double> > const&,
                   chirality_proxy const&>(
           (arg("sites_cart"), arg("proxy"))))
         .add_property("sites", make_getter(&w_t::sites, rbv()))
+        .add_property("sym_ops", make_getter(&w_t::sym_ops, rbv()))
         .def_readonly("volume_ideal", &w_t::volume_ideal)
         .def_readonly("both_signs", &w_t::both_signs)
         .def_readonly("weight", &w_t::weight)
@@ -142,12 +159,47 @@ namespace {
     using namespace boost::python;
     chirality_proxy_wrappers::wrap();
     chirality_wrappers::wrap();
-    def("chirality_deltas", chirality_deltas,
+    def("chirality_deltas",
+      (af::shared<double>(*)(
+        af::const_ref<scitbx::vec3<double> > const&,
+        af::const_ref<chirality_proxy> const&))
+        chirality_deltas,
       (arg("sites_cart"), arg("proxies")));
-    def("chirality_residuals", chirality_residuals,
+    def("chirality_residuals",
+      (af::shared<double>(*)(
+        af::const_ref<scitbx::vec3<double> > const&,
+        af::const_ref<chirality_proxy> const&))
+        chirality_residuals,
       (arg("sites_cart"), arg("proxies")));
-    def("chirality_residual_sum", chirality_residual_sum,
+    def("chirality_residual_sum",
+      (double(*)(
+        af::const_ref<scitbx::vec3<double> > const&,
+        af::const_ref<chirality_proxy> const&,
+        af::ref<scitbx::vec3<double> > const&))
+        chirality_residual_sum,
       (arg("sites_cart"), arg("proxies"), arg("gradient_array")));
+    def("chirality_deltas",
+      (af::shared<double>(*)(
+        uctbx::unit_cell const&,
+        af::const_ref<scitbx::vec3<double> > const&,
+        af::const_ref<chirality_proxy> const&))
+        chirality_deltas,
+      (arg("unit_cell"), arg("sites_cart"), arg("proxies")));
+    def("chirality_residuals",
+      (af::shared<double>(*)(
+        uctbx::unit_cell const&,
+        af::const_ref<scitbx::vec3<double> > const&,
+        af::const_ref<chirality_proxy> const&))
+        chirality_residuals,
+      (arg("unit_cell"), arg("sites_cart"), arg("proxies")));
+    def("chirality_residual_sum",
+      (double(*)(
+        uctbx::unit_cell const&,
+        af::const_ref<scitbx::vec3<double> > const&,
+        af::const_ref<chirality_proxy> const&,
+        af::ref<scitbx::vec3<double> > const&))
+        chirality_residual_sum,
+      (arg("unit_cell"), arg("sites_cart"), arg("proxies"), arg("gradient_array")));
   }
 
 } // namespace <anonymous>

--- a/iotbx/cif/restraints.py
+++ b/iotbx/cif/restraints.py
@@ -12,6 +12,7 @@ def add_to_cif_block(cif_block, xray_structure,
                      bond_proxies=None,
                      angle_proxies=None,
                      dihedral_proxies=None,
+                     chirality_proxies=None,
                      bond_similarity_proxies=None,
                      rigid_bond_proxies=None,
                      adp_similarity_proxies=None,
@@ -25,6 +26,8 @@ def add_to_cif_block(cif_block, xray_structure,
     cif_block.add_loop(angles_as_cif_loop(xray_structure, angle_proxies))
   if dihedral_proxies is not None:
     cif_block.add_loop(dihedrals_as_cif_loop(xray_structure, dihedral_proxies))
+  if chirality_proxies is not None:
+    cif_block.add_loop(chirality_as_cif_loop(xray_structure, chirality_proxies))
   if bond_similarity_proxies is not None:
     loops = bond_similarity_as_cif_loops(xray_structure, bond_similarity_proxies)
     for loop in loops: cif_block.add_loop(loop)
@@ -152,6 +155,35 @@ def dihedrals_as_cif_loop(xray_structure, proxies):
                   space_group_info.cif_symmetry_code(sym_ops[2]),
                   space_group_info.cif_symmetry_code(sym_ops[3]),
                   fmt % restraint.angle_ideal,
+                  fmt % math.sqrt(1/restraint.weight),
+                  fmt % restraint.delta))
+  return loop
+  
+def chirality_as_cif_loop(xray_structure, proxies):
+  space_group_info = sgtbx.space_group_info(group=xray_structure.space_group())
+  unit_cell = xray_structure.unit_cell()
+  sites_cart = xray_structure.sites_cart()
+  site_labels = xray_structure.scatterers().extract_labels()
+  fmt = "%.4f"
+  loop = model.loop(header=(
+    "_restr_chirality_atom_site_label_1",
+    "_restr_chirality_atom_site_label_2",
+    "_restr_chirality_atom_site_label_3",
+    "_restr_chirality_atom_site_label_4",
+    "_restr_chirality_volume_target",
+    "_restr_chirality_weight_param",
+    "_restr_chirality_diff",
+  ))
+  for proxy in proxies:
+    restraint = geometry_restraints.chirality(
+      sites_cart=sites_cart,
+      proxy=proxy)
+    i_seqs = proxy.i_seqs
+    loop.add_row((site_labels[i_seqs[0]],
+                  site_labels[i_seqs[1]],
+                  site_labels[i_seqs[2]],
+                  site_labels[i_seqs[3]],
+                  fmt % restraint.volume_ideal,
                   fmt % math.sqrt(1/restraint.weight),
                   fmt % restraint.delta))
   return loop

--- a/iotbx/cif/restraints.py
+++ b/iotbx/cif/restraints.py
@@ -178,6 +178,7 @@ def chirality_as_cif_loop(xray_structure, proxies):
     "_restr_chirality_weight_param",
     "_restr_chirality_diff",
   ))
+  unit_mxs = [sgtbx.rt_mx()]*4
   for proxy in proxies:
     restraint = geometry_restraints.chirality(
       unit_cell=unit_cell,

--- a/iotbx/cif/restraints.py
+++ b/iotbx/cif/restraints.py
@@ -158,7 +158,7 @@ def dihedrals_as_cif_loop(xray_structure, proxies):
                   fmt % math.sqrt(1/restraint.weight),
                   fmt % restraint.delta))
   return loop
-  
+
 def chirality_as_cif_loop(xray_structure, proxies):
   space_group_info = sgtbx.space_group_info(group=xray_structure.space_group())
   unit_cell = xray_structure.unit_cell()
@@ -170,19 +170,30 @@ def chirality_as_cif_loop(xray_structure, proxies):
     "_restr_chirality_atom_site_label_2",
     "_restr_chirality_atom_site_label_3",
     "_restr_chirality_atom_site_label_4",
+    "_restr_chirality_site_symmetry_1",
+    "_restr_chirality_site_symmetry_2",
+    "_restr_chirality_site_symmetry_3",
+    "_restr_chirality_site_symmetry_4",
     "_restr_chirality_volume_target",
     "_restr_chirality_weight_param",
     "_restr_chirality_diff",
   ))
   for proxy in proxies:
     restraint = geometry_restraints.chirality(
+      unit_cell=unit_cell,
       sites_cart=sites_cart,
       proxy=proxy)
+    sym_ops = proxy.sym_ops
+    if sym_ops is None: sym_ops = unit_mxs
     i_seqs = proxy.i_seqs
     loop.add_row((site_labels[i_seqs[0]],
                   site_labels[i_seqs[1]],
                   site_labels[i_seqs[2]],
                   site_labels[i_seqs[3]],
+                  space_group_info.cif_symmetry_code(sym_ops[0]),
+                  space_group_info.cif_symmetry_code(sym_ops[1]),
+                  space_group_info.cif_symmetry_code(sym_ops[2]),
+                  space_group_info.cif_symmetry_code(sym_ops[3]),
                   fmt % restraint.volume_ideal,
                   fmt % math.sqrt(1/restraint.weight),
                   fmt % restraint.delta))
@@ -383,4 +394,3 @@ def adp_volume_similarity_as_cif_loops(xray_structure, proxies):
                     fmt % restraint.deltas()[i],
                     class_id))
   return class_loop, loop
-

--- a/iotbx/cif/tests/tst_restraints.py
+++ b/iotbx/cif/tests/tst_restraints.py
@@ -43,6 +43,26 @@ def exercise_geometry_restraints_as_cif():
       angle_ideal=90,
       weight=3),
   ))
+  chirality_proxies = geometry_restraints.shared_chirality_proxy((
+    geometry_restraints.chirality_proxy(
+      i_seqs = [1,0,1,0],
+      sym_ops = (sgtbx.rt_mx("1+y,1-x+y, z-1/3"),
+                 sgtbx.rt_mx(),
+                 sgtbx.rt_mx("x-y,x,z-2/3"),
+                 sgtbx.rt_mx("1-x,y-x,1/3-z")),
+      volume_ideal=1.2,
+      both_signs=False,
+      weight=2),
+    geometry_restraints.chirality_proxy(
+      i_seqs = [1,0,1,0],
+      sym_ops = (sgtbx.rt_mx("1+y,1-x+y, z-1/3"),
+                 sgtbx.rt_mx(),
+                 sgtbx.rt_mx("x-y,x,z-2/3"),
+                 sgtbx.rt_mx("1-x,y-x,1/3-z")),
+      volume_ideal=1.2,
+      both_signs=True,
+      weight=2),
+  ))
   angle_proxies = geometry_restraints.shared_angle_proxy((
     geometry_restraints.angle_proxy(
       i_seqs = [1,0,1],
@@ -80,6 +100,7 @@ def exercise_geometry_restraints_as_cif():
     bond_proxies=bond_proxies,
     angle_proxies=angle_proxies,
     dihedral_proxies=dihedral_proxies,
+    chirality_proxies=chirality_proxies,
     bond_similarity_proxies=bond_similarity_proxies)
   s = StringIO()
   cif_block.show(out=s)
@@ -122,6 +143,21 @@ loop_
   _restr_torsion_diff
   O  Si  O  Si  3_664  1  2_554  7_655  -30.0000  0.7071   6.9078
   O  Si  O  Si  3_664  1  4_554  2       90.0000  0.5774  11.7036
+
+loop_
+  _restr_chirality_atom_site_label_1
+  _restr_chirality_atom_site_label_2
+  _restr_chirality_atom_site_label_3
+  _restr_chirality_atom_site_label_4
+  _restr_chirality_site_symmetry_1
+  _restr_chirality_site_symmetry_2
+  _restr_chirality_site_symmetry_3
+  _restr_chirality_site_symmetry_4
+  _restr_chirality_volume_target
+  _restr_chirality_weight_param
+  _restr_chirality_diff
+  O  Si  O  Si  3_664  1  2_554  7_655  1.2000  0.7071   2.4415
+  O  Si  O  Si  3_664  1  2_554  7_655  1.2000  0.7071  -0.0415
 
 loop_
   _restr_equal_distance_class_class_id

--- a/smtbx/refinement/restraints/__init__.py
+++ b/smtbx/refinement/restraints/__init__.py
@@ -124,6 +124,7 @@ class manager(object):
       bond_proxies=self.bond_proxies,
       angle_proxies=self.angle_proxies,
       dihedral_proxies=self.dihedral_proxies,
+      chirality_proxies=self.chirality_proxies,
       bond_similarity_proxies=self.bond_similarity_proxies,
       rigid_bond_proxies=self.rigid_bond_proxies,
       adp_similarity_proxies=self.adp_similarity_proxies,

--- a/smtbx/refinement/restraints/__init__.py
+++ b/smtbx/refinement/restraints/__init__.py
@@ -66,7 +66,7 @@ class manager(object):
       self.chirality_proxies.show_sorted(
         by_value="residual",
         sites_cart=sites_cart, site_labels=site_labels,
-        f=f, prefix=prefix, max_items=max_items)
+        unit_cell=unit_cell, f=f, prefix=prefix, max_items=max_items)
       print(file=f)
     if (self.planarity_proxies is not None):
       self.planarity_proxies.show_sorted(

--- a/smtbx/refinement/restraints/__init__.py
+++ b/smtbx/refinement/restraints/__init__.py
@@ -145,6 +145,10 @@ class manager(object):
       for proxy in self.bond_similarity_proxies:
         n_restraints += proxy.i_seqs.size()
       geometry_proxies.append(self.bond_similarity_proxies)
+    if self.chirality_proxies is not None:
+      for proxy in self.chirality_proxies:
+        n_restraints += 1
+      geometry_proxies.append(self.chirality_proxies)
     adp_proxies = []
     if self.adp_similarity_proxies is not None:
       adp_proxies.append(self.adp_similarity_proxies)

--- a/smtbx/refinement/restraints/boost_python/restraints_ext.cpp
+++ b/smtbx/refinement/restraints/boost_python/restraints_ext.cpp
@@ -9,6 +9,7 @@
 #include <cctbx/geometry_restraints/bond.h>
 #include <cctbx/geometry_restraints/dihedral.h>
 #include <cctbx/geometry_restraints/bond_similarity.h>
+#include <cctbx/geometry_restraints/chirality.h>
 #include <cctbx/adp_restraints/adp_similarity.h>
 #include <cctbx/adp_restraints/rigid_bond.h>
 #include <cctbx/adp_restraints/isotropic_adp.h>
@@ -132,6 +133,9 @@ namespace boost_python {
 
     linearise_restraints_with_parameter_map_wrapper<
       double, geom_res::dihedral_proxy, geom_res::dihedral>::wrap();
+
+    linearise_restraints_with_parameter_map_wrapper<
+      double, geom_res::chirality_proxy, geom_res::chirality>::wrap();
 
     //linearise_restraints_with_parameter_map_wrapper<
     //  double, double, geom_res::planarity_proxy, geom_res::planarity>::wrap();

--- a/smtbx/refinement/restraints/tests/test_manager.py
+++ b/smtbx/refinement/restraints/tests/test_manager.py
@@ -56,6 +56,13 @@ def test_manager():
       i_seqs=((14,36),(12,38)),
       weights=(10,10),
       sym_ops=(sgtbx.rt_mx(),sgtbx.rt_mx())))
+  chirality_proxies=cctbx.geometry_restraints.shared_chirality_proxy()
+  chirality_proxies.append(
+    cctbx.geometry_restraints.chirality_proxy(
+      i_seqs=(14,36,12,38),
+      weight=10**4,
+      volume_ideal=1.2,
+      both_signs=False))
   # setup restraints manager
   manager = restraints.manager(
     bond_proxies=bond_proxies,
@@ -63,7 +70,8 @@ def test_manager():
     bond_similarity_proxies=bond_similarity_proxies,
     adp_similarity_proxies=adp_similarity_proxies,
     rigid_bond_proxies=rigid_bond_proxies,
-    isotropic_adp_proxies=isotropic_adp_proxies)
+    isotropic_adp_proxies=isotropic_adp_proxies,
+    chirality_proxies=chirality_proxies)
   sio = StringIO()
   manager.show_sorted(xray_structure, max_items=1, f=sio)
   if sys.platform.startswith("win") and sys.version_info[:2] < (2,6):
@@ -89,6 +97,15 @@ angle C3
     ideal   model   delta    sigma   weight residual
    110.00  108.00    2.00 7.07e-01 2.00e+00 8.03e+00
 ... (remaining 2 not shown)
+
+Chirality restraints: 1
+Sorted by residual:
+chirality O9
+          C9
+          O8
+          C10
+  both_signs  ideal   model   delta    sigma   weight residual
+    False      1.20    2.52   -1.32 1.00e-02 1.00e+04 1.75e+04
 
 Bond similarity restraints: 1
 Sorted by residual:


### PR DESCRIPTION
This is an addition for smtbx to the current chirality restraint. I also added sym_ops. 

These modifications are a bit more invasive than RIGU. I run the tests where the restraint was present and they are alright.