### PR TITLE
change to template_regex to handle unrecognized filename templates

### DIFF
--- a/dxtbx/model/scan_helpers.py
+++ b/dxtbx/model/scan_helpers.py
@@ -43,9 +43,9 @@ def template_regex(filename):
     template = prefix + ''.join(['#' for d in digits]) + exten
     return template, int(digits)
 
-  # What is supposed to happen otherwise?
-  from libtbx.utils import Sorry
-  raise Sorry('Could not determine filename template')
+  # Non-standard template so assume the image does not come from a single
+  # dataset
+  return filename, 0
 
 def image2template(filename):
   return template_regex(filename)[0]

--- a/dxtbx/sweep_filenames.py
+++ b/dxtbx/sweep_filenames.py
@@ -51,6 +51,9 @@ def template_regex(filename):
     break
 
 # print "File name template:\n    %s\n -> %s (%d)" % (filename, template, int(digits))
+  if template is None:
+    template = filename
+
   return template, int(digits)
 
 

--- a/dxtbx/tests/test_sweep_filenames.py
+++ b/dxtbx/tests/test_sweep_filenames.py
@@ -10,7 +10,9 @@ def test_template_regex():
       'foo_bar_1.8A_001.img': 'foo_bar_1.8A_###.img',
       'foo_bar.001': 'foo_bar.###',
       'foo_bar_001.img1000': 'foo_bar_###.img1000',
-      'foo_bar_00001.img': 'foo_bar_#####.img'
+      'foo_bar_00001.img': 'foo_bar_#####.img',
+      'foo_1_bar.img': 'foo_1_bar.img',
+      'foo_1_bar_1.img': 'foo_1_bar_1.img'
   }
 
   for filename in questions_answers:

--- a/dxtbx/tests/test_sweep_filenames.py
+++ b/dxtbx/tests/test_sweep_filenames.py
@@ -12,7 +12,8 @@ def test_template_regex():
       'foo_bar_001.img1000': 'foo_bar_###.img1000',
       'foo_bar_00001.img': 'foo_bar_#####.img',
       'foo_1_bar.img': 'foo_1_bar.img',
-      'foo_1_bar_1.img': 'foo_1_bar_1.img'
+      'foo_1_bar_1.img': 'foo_1_bar_#.img',
+      'foo_1_bar_10.img': 'foo_1_bar_##.img'
   }
 
   for filename in questions_answers:


### PR DESCRIPTION
dxtbx returns a "Could not determine filename template" error when it encounters an image filename that a) ends on a word, b) ends on a number "1" without leading zeroes. This causes trouble with some SSRL / LCLS-MFX datasets. This is a workaround.

(also added a filename template test dataset to dials_regression)