### PR TITLE
Upgrade bootstrap/installer minimum python requirement to 2.6

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -243,8 +243,11 @@ class Toolbox(object):
       url_request = urllib2.Request(url)
       if etag:
         url_request.add_header("If-None-Match", etag)
-      # Shorten timeout to 7 seconds if a copy of the file is already present
-      socket = urllib2.urlopen(url_request, None, 7)
+      if localcopy:
+        # Shorten timeout to 7 seconds if a copy of the file is already present
+        socket = urllib2.urlopen(url_request, None, 7)
+      else:
+        socket = urllib2.urlopen(url_request)
     except SSLError as e:
       # This could be a timeout
       if localcopy:

--- a/libtbx/auto_build/create_installer.py
+++ b/libtbx/auto_build/create_installer.py
@@ -40,8 +40,6 @@ if [ -z "$PYTHON_EXE" ]; then
     PYTHON_EXE='/usr/bin/python2.7'
   elif [ -f "/usr/bin/python2.6" ]; then
     PYTHON_EXE='/usr/bin/python2.6'
-  elif [ -f "/usr/bin/python2.5" ]; then
-    PYTHON_EXE='/usr/bin/python2.5'
   elif [ -f "/usr/bin/python2" ]; then
     PYTHON_EXE='/usr/bin/python2'
   fi

--- a/libtbx/auto_build/installer_utils.py
+++ b/libtbx/auto_build/installer_utils.py
@@ -13,8 +13,8 @@ import time
 # CCTBX itself requires Python 2.7, but this script is intended to bootstrap an
 # installation on older systems as well
 def check_python_version():
-  if sys.hexversion < 0x2050000:
-    sys.exit("Python version 2.5 or greater required to run this script")
+  if sys.hexversion < 0x2060000:
+    sys.exit("Python version 2.6 or greater required to run this script")
 
 def call(args, log=sys.stdout, shell=True, cwd=None, verbose=False, env=None):
   # shell=True requires string as args.
@@ -80,7 +80,6 @@ def untar(pkg_name, log=sys.stdout, verbose=False, change_ownership=False,
   else:
     # Note: This code breaks
     #   - extracting compressed files
-    #   - python <2.5 compatibility
     #   - logging
     #   - function parameters verbose and change_ownership
     #   - insufficient trapping of errors

--- a/libtbx/auto_build/package_defs.py
+++ b/libtbx/auto_build/package_defs.py
@@ -5,9 +5,9 @@ LABELIT, xia2, DIALS, and Phenix with GUI).  Not all of these can be downloaded
 via the web (yet).
 """
 
-from __future__ import absolute_import, division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
+import json
 import os
 import os.path as op
 import platform
@@ -28,9 +28,8 @@ def get_pypi_package_information(package, version=None, information_only=False):
   '''Retrieve information about a PyPi package.'''
   metadata = 'https://pypi.python.org/pypi/' + package + '/json'
   try:
-    import json
     pypidata = urllib2.urlopen(metadata).read()
-  except Exception: # Python <=2.5, TLS <1.2, ...
+  except Exception: # TLS <1.2, ...
     if information_only:
       return {'name': '', 'version': '', 'summary': ''}
     raise

--- a/libtbx/auto_build/setup_installer.py
+++ b/libtbx/auto_build/setup_installer.py
@@ -175,8 +175,6 @@ if [ -z "$PYTHON_EXE" ]; then
     PYTHON_EXE='/usr/bin/python2.7'
   elif [ -f "/usr/bin/python2.6" ]; then
     PYTHON_EXE='/usr/bin/python2.6'
-  elif [ -f "/usr/bin/python2.5" ]; then
-    PYTHON_EXE='/usr/bin/python2.5'
   elif [ -f "/usr/bin/python2" ]; then
     PYTHON_EXE='/usr/bin/python2'
   fi


### PR DESCRIPTION
A [recent change](https://github.com/cctbx/cctbx_project/commit/bb466f729ad1fb5bee9b89d5227b6d68421f51a5#r30946843) by @bkpoon added this requirement implicitly. This pull request will make that requirement explicit.

Any objections should be filed here.