### PR TITLE
Drop CentOS 5 support

### DIFF
--- a/boost_adaptbx/SConscript
+++ b/boost_adaptbx/SConscript
@@ -88,23 +88,6 @@ if (not env_etc.no_boost_python):
       env_etc.boost_include,
       env_etc.python_include])
 
-  # Argument-dependent lookup fails on GCC 4.1.2 (CentOS 5) and Boost >= 1.60
-  # The "get" function fails to resolve in boost/math/tools/roots.hpp
-  # Explicitly use "boost::fusion::get"
-  if ( (env_etc.gcc_version == 40102) and (env_etc.boost_version >= 106000) ):
-    directory = libtbx.env.module_dist_paths.get('boost','')
-    filename = os.path.join(abs(directory), 'boost/math/tools/roots.hpp')
-    old_filename = filename + '.original'
-    if (os.path.exists(filename)):
-      os.rename(filename, old_filename)
-      with open(old_filename,'r') as f_old, open(filename, 'w') as f_new:
-        lines = f_old.readlines()
-        for line in lines:
-          line = line.replace('= get<', '= boost::fusion::get<')
-          f_new.write(line)
-      copystat(old_filename, filename)
-      os.remove(old_filename)
-
   conf = env_pure_boost_python_ext.Clone().Configure()
   if (not conf.TryCompile("#include <iostream>", extension=".cpp")):
     sys.exit("""

--- a/libtbx/auto_build/install_base_packages.py
+++ b/libtbx/auto_build/install_base_packages.py
@@ -134,11 +134,6 @@ class installer (object) :
       self.cppflags_start += self.base_macos_flags
       self.ldflags_start += self.base_macos_flags
 
-    # Compilation flags for CentOS 5 (32-bit)
-    if ( (self.flag_is_linux) and (platform.architecture()[0] == '32bit') ):
-      old_cflags = os.environ.get('CFLAGS', '')
-      os.environ['CFLAGS'] = old_cflags + ' -march=i686'
-
     # Directory setup.
     self.tmp_dir = options.tmp_dir
     self.build_dir = options.build_dir
@@ -1256,11 +1251,6 @@ _replace_sysconfig_paths(build_time_vars)
     self.configure_and_build(config_args=gettext_conf_args, log=pkg_log)
 
   def build_glib(self):
-    # libffi dependency (for CentOS 5, especially)
-    self.build_compiled_package_simple(pkg_url=BASE_CCI_PKG_URL,
-                                       pkg_name=LIBFFI_PKG,
-                                       pkg_name_label='libffi')
-
     # glib
     pkg_log = self.start_building_package("glib")
     pkg = self.fetch_package(pkg_name=GLIB_PKG)
@@ -1352,12 +1342,6 @@ _replace_sysconfig_paths(build_time_vars)
       self.build_compiled_package_simple(pkg_name=pkg, pkg_name_label=name)
 
   def build_pixman(self):
-
-    # set CFLAGS for CentOS 5 (32-bit)
-    if ( (self.flag_is_linux) and (platform.architecture()[0] == '32bit') ):
-      old_cflags = os.environ.get('CFLAGS', '')
-      os.environ['CFLAGS'] = old_cflags + ' -g -O2'
-
     # pixman
     pkg_log = self.start_building_package("pixman")
     pkg = self.fetch_package(pkg_name=PIXMAN_PKG)
@@ -1367,18 +1351,8 @@ _replace_sysconfig_paths(build_time_vars)
       config_args=[self.prefix, "--disable-gtk", "--disable-static" ],
       log=pkg_log)
 
-    # reset CFLAGS for CentOS 5 32-bit
-    if ( (self.flag_is_linux) and (platform.architecture()[0] == '32bit') ):
-      os.environ['CFLAGS'] = old_cflags
-
   def build_cairo(self):
     #    self.include_dirs.append(op.join(self.base_dir, "include", "harfbuzz"))
-
-    # set CXXFLAGS for CentOS 5 (32-bit), needed for harfbuzz
-    if ( (self.flag_is_linux) and (platform.architecture()[0] == '32bit') ):
-      old_cflags = os.environ.get('CXXFLAGS', '')
-      os.environ['CXXFLAGS'] = old_cflags + ' -march=i686'
-
     for pkg, name in zip([CAIRO_PKG, HARFBUZZ_PKG],["cairo", "harfbuzz"]) :
       self.build_compiled_package_simple(pkg_name=pkg, pkg_name_label=name)
     self.build_compiled_package_simple(
@@ -1387,10 +1361,6 @@ _replace_sysconfig_paths(build_time_vars)
     self.build_compiled_package_simple(
       pkg_name=ATK_PKG, pkg_name_label="atk",
       extra_config_args=["--enable-introspection=no"])
-
-    # reset CXXFLAGS for CentOS 5 32-bit
-    if ( (self.flag_is_linux) and (platform.architecture()[0] == '32bit') ):
-      os.environ['CXXFLAGS'] = old_cflags
 
   def build_tiff(self):
     # tiff

--- a/libtbx/auto_build/package_defs.py
+++ b/libtbx/auto_build/package_defs.py
@@ -119,12 +119,6 @@ GTK_THEME_PKG = "gtk_themes.tar.gz"
 FONT_PKG = "fonts.tar.gz"
 
 MATPLOTLIB_PKG = "matplotlib-2.0.0.tar.gz"
-# CentOS 5 glibc too old to support matplotlib-2.0.0 dependency (subprocess32)
-# will be fixed in subprocess32 3.5+, https://github.com/google/python-subprocess32/blob/master/ChangeLog
-if (sys.platform.startswith("linux")):
-  distribution = platform.dist()
-  if ( (distribution[0] == 'redhat') and (distribution[1].startswith('5')) ):
-    MATPLOTLIB_PKG = "matplotlib-1.5.1.tar.gz"
 
 PYOPENGL_PKG = "PyOpenGL-3.1.0.tar.gz"
 # https://pypi.python.org/pypi/Send2Trash


### PR DESCRIPTION
Following on from #241: If CentOS 5 support really is dropped then we should consider removing the CentOS 5 specific code. These are the bits I could find.
(Patch is untested)