### PR TITLE
Installer: Force use of provided script

### DIFF
--- a/libtbx/auto_build/create_installer.py
+++ b/libtbx/auto_build/create_installer.py
@@ -271,6 +271,9 @@ class SetupInstaller(object):
     """Generate shell scripts in the top-level installation directory."""
     if sys.platform == "win32":
       return
+    if self.install_script:
+      print("Not generating environment setup scripts as installer is provided")
+      return
     print("Generating %s environment setup scripts..."%self.installer.product_name)
     fmt = {'env_prefix':self.installer.product_name.upper(), 'version':self.version}
     # bash


### PR DESCRIPTION
When generating an installer we automatically generate two
   ```./xxxxx_env.sh``` and
   ```./xxxxx_env.csh```
scripts in the top level directory of the installer archive.
If the installer generation is run with ```--installer_script``` then the given script ends up as
   ```./install```
in the same place.

The user now has two options: They can run the install script or they can source one of the shell scripts.

While the result *may* be the same, we have now identified one case where this led to a runtime bug which was very difficult to track down.

I see two ways of resolving this. Either we add a command line switch to not generate the scripts, or we do not generate the scripts for the installer directory if an installer script is provided. The latter is more
likely to be the expected behaviour. Eg. the Phenix installer README asks the user to run the ```./install``` script and does not even mention the other scripts. Similarly for DIALS we did not expect the users to _not_ run our installer.
This patch changes the behaviour to not generate the additional shell scripts if an installer script is provided.

Opinions?
