### PR TITLE
libtbx: Python 2/3 changes for python_code_parsing

### DIFF
--- a/libtbx/python_code_parsing.py
+++ b/libtbx/python_code_parsing.py
@@ -1,4 +1,7 @@
 from __future__ import division
+
+from builtins import object
+
 import sys
 assert sys.version_info[0:2] >= (2, 6)
 
@@ -29,7 +32,7 @@ class imported_name(object):
     return '.'.join(self.name)
 
 
-class unused_imports(ast.NodeVisitor):
+class unused_imports(ast.NodeVisitor, object):
   """ Unused import's in a module.
   This finds more of them than the algorithm in
   libtbx.find_unused_imports_crude
@@ -71,7 +74,7 @@ class unused_imports(ast.NodeVisitor):
   def __iter__(self):
     return iter(self._unused)
 
-  def __nonzero__(self):
+  def __bool__(self):
     return bool(self._unused)
 
   @property
@@ -182,7 +185,7 @@ class old_style_class(object):
     return '.'.join(self.name)
 
 
-class find_old_style_classes(ast.NodeVisitor):
+class find_old_style_classes(ast.NodeVisitor, object):
   """ Finds old-style classes (i.e. ones that don't inherit from object)
   """
 
@@ -213,7 +216,7 @@ class find_old_style_classes(ast.NodeVisitor):
   def __iter__(self):
     return iter(self._old_style_classes)
 
-  def __nonzero__(self):
+  def __bool__(self):
     return bool(self._old_style_classes)
 
   def visit_ClassDef(self, node):

--- a/libtbx/tst_python_code_parsing.py
+++ b/libtbx/tst_python_code_parsing.py
@@ -95,23 +95,23 @@ unused_imports_test_case_1_1 = """\
 
 unused_imports_test_case_1_2 = """\
 %s
-print foo.z
+type(foo.z)
 """ % unused_imports_test_case_1_header
 
 unused_imports_test_case_1_3 = """\
 %s
-print baz.x
+type(baz.x)
 """ % unused_imports_test_case_1_header
 
 unused_imports_test_case_1_4 = """\
 %s
-print foo.z
-print baz.x
+type(foo.z)
+type(baz.x)
 """ % unused_imports_test_case_1_header
 
 unused_imports_test_case_1_5 = """\
 %s
-print foo.baz
+type(foo.baz)
 """ % unused_imports_test_case_1_header
 
 
@@ -119,14 +119,14 @@ unused_imports_test_case_2 = """\
 import foo
 
 def f():
-  print foo.z
+  return type(foo.z)
 """
 
 unused_imports_test_case_3 = """\
 import foo
 
 def f():
-  print bar.foo.z
+  return type(bar.foo.z)
 """
 
 unused_imports_test_case_4 = """\
@@ -134,7 +134,7 @@ import bar
 
 def f():
   import foo
-  print bar.foo.z
+  return type(bar.foo.z)
 """
 
 unused_imports_test_case_5 = """\
@@ -143,7 +143,7 @@ import bar
 def f():
   import foo
   def g():
-    print bar.foo.z
+    return type(bar.foo.z)
   return g
 """
 
@@ -153,7 +153,7 @@ import bar
 def f():
   import foo
   def g():
-    print foo.z
+    return type(foo.z)
   return g
 """
 
@@ -162,7 +162,7 @@ import bar
 
 def f():
   def g():
-    print foo.z
+    return type(foo.z)
   import foo
   return g
 """
@@ -172,10 +172,10 @@ import bar
 
 def f():
   def g():
-    print foo.z
+    return type(foo.z)
   import foo
   def h():
-    print foo.y
+    return type(foo.y)
   return g, h
 """
 
@@ -221,32 +221,32 @@ def run():
 
 unused_imports_test_case_12 = """\
 import foo.bar
-print foo.bar.x
+type(foo.bar.x)
 """
 
 unused_imports_test_case_13 = """\
 import foo, bar
-print foo.moo.maz
+type(foo.moo.maz)
 """
 
 unused_imports_test_case_14 = """\
 import foo, bar
-print foo.moo().moz
+type(foo.moo().moz)
 """
 
 unused_imports_test_case_15 = """\
 import foo, bar
-print foo.moo[5].moz
+type(foo.moo[5].moz)
 """
 
 unused_imports_test_case_16 = """\
 from foo import bobar
-print bobar
+type(bobar)
 """
 
 unused_imports_test_case_17 = """\
 import foobar
-print '.'.join(foobar.z)
+text = '.'.join(foobar.z)
 """
 
 unused_imports_test_case_18 = """\
@@ -270,13 +270,13 @@ unused_imports_test_case_21 = """\
 from foo.bar import bakar
 import foo.bar.bakar.baaz
 
-print bakar.baaz
+type(bakar.baaz)
 """
 
 unused_imports_test_case_22 = """\
 from foo.bar import boz
 def f():
-  print g( boz(q) ).k
+  return g( boz(q) ).k
 """
 
 unused_imports_test_case_23 = """\


### PR DESCRIPTION
Hi Luc,

Here are some changes to libtbx/python_code_parsing.py for Python 3 compatibility. Basically, ```__nonzero__``` is replaced by ```__bool__``` in Python 3 and the test has a bunch of ```print``` statements.

The fixes are,
- use ```object``` from ```future.builtins``` that automatically maps ```__nonzero__``` to ```__bool___``` along with other Python 2/3 object mappings. Alternatively, we can just manually map the two if you do not plan on using any of the other standard object attributes.
- replace the ```print``` statements with ```type``` in the test

You can test this by configuring the ```libtbx``` module with Python 3 and running the test file. The test passes in both Python 2 and 3, so the fixes can be merged, but I wanted to double-check with you. Thanks!
