### PR TITLE
Refactor python3 syntax check to match libtbx programming patterns

### DIFF
--- a/libtbx/run_tests.py
+++ b/libtbx/run_tests.py
@@ -38,7 +38,7 @@ tst_list = (
   "$D/tst_representation.py",
   "$D/tst_runtime_utils.py",
 # "$D/tst_xmlrpc_utils.py", # This test is failing
-  "$D/test_python3_regression.py",
+  "$D/tst_python3_regression.py",
   )
 
 def run():

--- a/libtbx/tst_python3_regression.py
+++ b/libtbx/tst_python3_regression.py
@@ -1,22 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
-class pytest():
-  @classmethod
-  def skip(cls, arg):
-    print("SKIP: %s" % arg)
-  @classmethod
-  def fail(cls, arg):
-    import sys
-    sys.exit("FAIL: %s" % arg)
-
 def test_find_python3_violations():
   import libtbx
   import libtbx.test_utils.python3_regression as py3test
   result = py3test.find_new_python3_incompatible_code(libtbx)
   if result is None:
-    pytest.skip('No python3 interpreter available')
+    print("SKIP: No python3 interpreter available")
   elif result:
-    pytest.fail(result)
+    import sys
+    sys.exit("FAIL: %s" % result)
 
 if __name__ == '__main__':
   test_find_python3_violations()


### PR DESCRIPTION
Thanks @Anthchirp for the python3 syntax check.  I've refactored it to match the libtbx programming model, dropping references to pytest, naming the test like the other tests in the folder, and using libtbx.easy_run.  The last bit is because libtbx shouldn't have a procrunner dependency.

I've tested this to work on:
- Python 2 (conda), no python3.  Test is skipped.
- Python 3 (conda), no python 2.  Test passes and can be caused to fail if a new bad file is introduced.
- Python 2 (conda), with python 3 available.  Test passes and can be caused to fail if a new bad file is introduced.