### PR TITLE
dxtbx.scan: add a valid_image_ranges map to the scan object

### DIFF
--- a/dxtbx/model/boost_python/to_from_dict.h
+++ b/dxtbx/model/boost_python/to_from_dict.h
@@ -82,6 +82,16 @@ namespace dxtbx { namespace model { namespace boost_python {
   template <>
   CrystalBase* from_dict<CrystalBase>(boost::python::dict obj);
 
+  template <typename K, typename V>
+  boost::python::dict MaptoPythonDict(std::map<K, V> map) {
+    typename std::map<K, V>::iterator iter;
+      boost::python::dict dictionary;
+      for (iter = map.begin(); iter != map.end(); ++iter) {
+        dictionary[iter->first] = boost::python::list(iter->second);
+      }
+      return dictionary;
+  }
+
 }}} // namespace dxtbx::model::boost_python
 
 #endif /* DXTBX_MODEL_BOOST_PYTHON_TO_FROM_DICT_H */

--- a/dxtbx/model/boost_python/to_from_dict.h
+++ b/dxtbx/model/boost_python/to_from_dict.h
@@ -82,16 +82,6 @@ namespace dxtbx { namespace model { namespace boost_python {
   template <>
   CrystalBase* from_dict<CrystalBase>(boost::python::dict obj);
 
-  template <typename K, typename V>
-  boost::python::dict MaptoPythonDict(std::map<K, V> map) {
-    typename std::map<K, V>::iterator iter;
-      boost::python::dict dictionary;
-      for (iter = map.begin(); iter != map.end(); ++iter) {
-        dictionary[iter->first] = boost::python::list(iter->second);
-      }
-      return dictionary;
-  }
-
 }}} // namespace dxtbx::model::boost_python
 
 #endif /* DXTBX_MODEL_BOOST_PYTHON_TO_FROM_DICT_H */

--- a/dxtbx/model/scan.h
+++ b/dxtbx/model/scan.h
@@ -21,13 +21,13 @@
 #include <dxtbx/error.h>
 #include "scan_helpers.h"
 
-typedef std::map<std::string, scitbx::af::shared<int> > ExpImgRangeMap;
-
 namespace dxtbx { namespace model {
 
   using scitbx::vec2;
   using scitbx::rad_as_deg;
   using scitbx::constants::pi;
+
+  typedef std::map<std::string, scitbx::af::shared<vec2<int> > > ExpImgRangeMap;
 
   /** A scan base class */
   class ScanBase {};
@@ -126,14 +126,14 @@ namespace dxtbx { namespace model {
     }
 
     /** Get the map, not exported to python **/
-    ExpImgRangeMap get_valid_image_ranges() const {
+    ExpImgRangeMap get_valid_image_ranges_map() const {
       return valid_image_ranges_;
     }
 
     /** Get the element for a given key if it exists, else return empty array**/
-    scitbx::af::shared<int> get_valid_image_ranges_key(std::string i) const {
+    scitbx::af::shared<vec2<int> > get_valid_image_ranges_key(std::string i) const {
       if (valid_image_ranges_.find(i) == valid_image_ranges_.end()) {
-        scitbx::af::shared<int> empty;
+        scitbx::af::shared<vec2<int> > empty;
         return empty;
       }
       else {
@@ -141,12 +141,14 @@ namespace dxtbx { namespace model {
       }
     }
 
-    void set_valid_image_ranges(std::string i, scitbx::af::shared<int> values){
-      /** Set a list of valid image ranges for experiment identifier 'i'**/
-      DXTBX_ASSERT(values.size() % 2 == 0);
+    void set_valid_image_ranges_array(std::string i, scitbx::af::shared<vec2<int> > values){
+      /** Set a list of valid image range tuples for experiment identifier 'i'**/
       for (std::size_t i = 0; i < values.size(); ++i) {
-        DXTBX_ASSERT(values[i] >= image_range_[0]);
-        DXTBX_ASSERT(values[i] <= image_range_[1]);
+        vec2<int> pair = values[i];
+        DXTBX_ASSERT(pair[0] >= image_range_[0]);
+        DXTBX_ASSERT(pair[0] <= image_range_[1]);
+        DXTBX_ASSERT(pair[1] >= image_range_[0]);
+        DXTBX_ASSERT(pair[1] <= image_range_[1]);
       }
       valid_image_ranges_[i] = values;
     }

--- a/dxtbx/model/scan.py
+++ b/dxtbx/model/scan.py
@@ -122,7 +122,8 @@ class ScanFactory:
       d['exposure_time'] = [d['exposure_time']]
 
     d.setdefault('batch_offset', 0) # backwards compatibility 20180205
-
+    if 'valid_image_ranges' not in d:
+      d['valid_image_ranges'] = {} # backwards compatibility 20181113
     # Create the model from the dictionary
     return Scan.from_dict(d)
 

--- a/dxtbx/tests/model/test_scan_data.py
+++ b/dxtbx/tests/model/test_scan_data.py
@@ -100,6 +100,16 @@ def test_swap():
   assert(scan2.get_oscillation() == (0.0, 1.0))
   assert(scan1.get_oscillation() == (10.0, 2.0))
 
+def test_valid_image_ranges():
+  scan = Scan((1, 100), (0.0, 1.0))
+  scan.set_valid_image_ranges("0", (1,80))
+  scan.set_valid_image_ranges("1", (1,50))
+  assert list(scan.get_valid_image_ranges("0")) == [1, 80]
+  assert list(scan.get_valid_image_ranges("1")) == [1, 50]
+  scan.set_valid_image_ranges("0", (1,50, 80, 100))
+  assert list(scan.get_valid_image_ranges("0")) == [1, 50, 80, 100]
+  assert list(scan.get_valid_image_ranges("2")) == []
+
 def test_from_phil():
   from dxtbx.model.scan import ScanFactory, scan_phil_scope
   from libtbx.phil import parse

--- a/dxtbx/tests/model/test_scan_data.py
+++ b/dxtbx/tests/model/test_scan_data.py
@@ -102,12 +102,12 @@ def test_swap():
 
 def test_valid_image_ranges():
   scan = Scan((1, 100), (0.0, 1.0))
-  scan.set_valid_image_ranges("0", (1,80))
-  scan.set_valid_image_ranges("1", (1,50))
-  assert list(scan.get_valid_image_ranges("0")) == [1, 80]
-  assert list(scan.get_valid_image_ranges("1")) == [1, 50]
-  scan.set_valid_image_ranges("0", (1,50, 80, 100))
-  assert list(scan.get_valid_image_ranges("0")) == [1, 50, 80, 100]
+  scan.set_valid_image_ranges("0", [(1,80)])
+  scan.set_valid_image_ranges("1", [(1,50)])
+  assert list(scan.get_valid_image_ranges("0")) == [(1, 80)]
+  assert list(scan.get_valid_image_ranges("1")) == [(1, 50)]
+  scan.set_valid_image_ranges("0", [(1,50), (80, 100)])
+  assert list(scan.get_valid_image_ranges("0")) == [(1, 50), (80, 100)]
   assert list(scan.get_valid_image_ranges("2")) == []
 
 def test_from_phil():

--- a/dxtbx/tests/model/test_to_from_dict.py
+++ b/dxtbx/tests/model/test_to_from_dict.py
@@ -40,6 +40,7 @@ def test_scan():
     oscillation=(5.0, 0.1),
     exposure_times=flex.double(range(20)),
     epochs=flex.double(range(20,40)))
+  s1.set_valid_image_ranges("0", (1, 20))
 
   d = s1.to_dict()
   s2 = Scan.from_dict(d)

--- a/dxtbx/tests/model/test_to_from_dict.py
+++ b/dxtbx/tests/model/test_to_from_dict.py
@@ -40,7 +40,7 @@ def test_scan():
     oscillation=(5.0, 0.1),
     exposure_times=flex.double(range(20)),
     epochs=flex.double(range(20,40)))
-  s1.set_valid_image_ranges("0", (1, 20))
+  s1.set_valid_image_ranges("0", [(1, 20)])
 
   d = s1.to_dict()
   s2 = Scan.from_dict(d)


### PR DESCRIPTION
The purpose of this addition is to allow different images ranges to be indicated for a sweep containing multiple lattices. This allows separated treatment of experiments which share a scan. It is intended that the map key can be the experiment identifier and the values are scitbx-int-arrays of
image ranges valid for each experiment (in the form [start1, end1, start2, end2, ...] for nonconsecutive ranges). The map is initialised as empty for all constructors.

For example, for a multi-lattice sweep with two lattices (with image range (1,100)), this map could be initially set to {"0", [1, 100], "1", [1, 100] }, then to indicate an excluded range (61 - 80) for experiment "0", it would be updated to {"0" : [1, 60, 81, 100], "1" : [1, 100] }. This can be set/managed by a few helper functions that will be added to DIALS.

Although this doesn't change a lot of code, I would welcome a quick review of my code to see if there are any obvious issues as I have less experience with c++.