### PR TITLE
wxPython 3/4 compatibility

### DIFF
--- a/wxtbx/metallicbutton.py
+++ b/wxtbx/metallicbutton.py
@@ -18,10 +18,11 @@ __all__ = ["MetallicButton", "AdjustAlpha", "AdjustColour",
            "MB_STYLE_DEFAULT", "GB_STYLE_BOLD_LABEL", "GB_STYLE_DROPARROW"]
 
 
-import wx
 import wx.lib.wordwrap
 import wx.lib.imageutils
 from wx.lib.colourutils import *
+
+from wxtbx import wx4_compatibility as wx4c
 
 # Used on OSX to get access to carbon api constants
 CAPTION_SIZE = 9
@@ -40,8 +41,9 @@ MB_STYLE_DEFAULT = 1
 MB_STYLE_BOLD_LABEL = 2
 MB_STYLE_DROPARROW = 4
 
-class MetallicButton(wx.PyControl):
-  def __init__(self,
+WxCtrl = wx4c.get_wx_mod(wx, wx.Control)
+class MetallicButton(WxCtrl):
+  def __init__ (self,
                 parent,
                 id_=wx.ID_ANY,
                 label='',
@@ -59,9 +61,10 @@ class MetallicButton(wx.PyControl):
                 button_margin=2,
                 disable_after_click=0,
                 bmp2=None):
-    wx.PyControl.__init__(self, parent, id_, pos, size,
-      wx.NO_BORDER, name=name)
+
+    WxCtrl.__init__(self, parent, id_, pos, size, wx.NO_BORDER, name=name)
     self.InheritAttributes()
+
     self._bmp = dict(enable=bmp)
     self._margin = button_margin
     if bmp is not None :
@@ -78,11 +81,15 @@ class MetallicButton(wx.PyControl):
     # XXX this crashes on wxOSX_Cocoa!
     if (not 'wxOSX-cocoa' in wx.PlatformInfo):
       self._label2_font.SetStyle(wx.FONTSTYLE_ITALIC)
+      # with wx4c.set_font_style(wx.FONTSTYLE_ITALIC) as fs:
+      #   self._label2_font.SetStyle(fs)
     font_size = label_size
     self._label_font = self.GetFont()
     self._label_font.SetPointSize(label_size)
     if style & MB_STYLE_BOLD_LABEL :
-      self._label_font.SetWeight(wx.FONTWEIGHT_BOLD)
+      self._label2_font.SetWeight(wx.FONTWEIGHT_BOLD)
+      # with wx4c.set_font_weight(wx.FONTWEIGHT_BOLD) as fw:
+      #   self._label2_font.SetWeight(fw)
     self.SetFont(self._label_font)
     #self._label2_font = wx.Font(caption_size, wx.SWISS, wx.ITALIC, wx.NORMAL)
 
@@ -263,7 +270,8 @@ class MetallicButton(wx.PyControl):
       if wx.Platform == '__WXMAC__':
         brush = wx.Brush((100,100,100))
         brush.MacSetTheme(Carbon.Appearance.kThemeBrushFocusHighlight)
-        pen = wx.Pen(brush.GetColour(), 1, wx.SOLID)
+        with wx4c.set_brush_style(wx.BRUSHSTYLE_SOLID) as bstyle:
+          pen = wx.Pen(brush.GetColour(), 1, bstyle)
       else:
         pen = wx.Pen(AdjustColour(self._color['press_start'], -80, 220), 1)
       #gc.SetPen(pen)
@@ -343,7 +351,7 @@ class MetallicButton(wx.PyControl):
 
   def Disable(self):
     """Disable the control"""
-    wx.PyControl.Disable(self)
+    WxCtrl.Disable(self)
     self.Refresh()
 
   def DoGetBestSize(self):
@@ -371,11 +379,14 @@ class MetallicButton(wx.PyControl):
 
     if self._label2 != '' :
       if wx.Platform == '__WXMAC__' :
-        dc = wx.GraphicsContext.CreateMeasuringContext()
+        with wx4c.create_measuring_context() as context:
+          dc = context
+          gfont = dc.CreateFont(self._label2_font, self.GetForegroundColour())
       else :
         dc = wx.ClientDC(self)
+        gfont = self._label2_font
         #dc = wx.MemoryDC()
-      dc.SetFont(self._label2_font)
+      dc.SetFont(gfont)
       min_w, min_h = self.GetSize() #self._size
       if min_w == -1 :
         min_w = 120
@@ -412,7 +423,7 @@ class MetallicButton(wx.PyControl):
 
   def Enable(self, enable=True):
     """Enable/Disable the control"""
-    wx.PyControl.Enable(self, enable)
+    WxCtrl.Enable(self, enable)
     self.Refresh()
 
   def GetBackgroundBrush(self, dc):
@@ -425,14 +436,16 @@ class MetallicButton(wx.PyControl):
       return wx.TRANSPARENT_BRUSH
 
     bkgrd = self.GetBackgroundColour()
-    brush = wx.Brush(bkgrd, wx.SOLID)
+    with wx4c.set_brush_style(wx.BRUSHSTYLE_SOLID) as bstyle:
+        brush = wx.Brush(bkgrd, bstyle)
     my_attr = self.GetDefaultAttributes()
     p_attr = self.GetParent().GetDefaultAttributes()
     my_def = bkgrd == my_attr.colBg
     p_def = self.GetParent().GetBackgroundColour() == p_attr.colBg
     if my_def and not p_def:
       bkgrd = self.GetParent().GetBackgroundColour()
-      brush = wx.Brush(bkgrd, wx.SOLID)
+      with wx4c.set_brush_style(wx.BRUSHSTYLE_SOLID) as bstyle:
+        brush = wx.Brush(bkgrd, bstyle)
     return brush
 
   def GetBitmapDisabled(self):
@@ -454,7 +467,7 @@ class MetallicButton(wx.PyControl):
   GetBitmapHover = GetBitmapLabel
 
   # Alias for GetLabel
-  GetLabelText = wx.PyControl.GetLabel
+  GetLabelText = WxCtrl.GetLabel
 
   def GetMenu(self):
     """Return the menu associated with this button or None if no
@@ -611,11 +624,11 @@ class MetallicButton(wx.PyControl):
     """Set this control to have the focus"""
     if self._state['cur'] != GRADIENT_PRESSED:
       self.SetState(GRADIENT_HIGHLIGHT)
-    wx.PyControl.SetFocus(self)
+    WxCtrl.SetFocus(self)
 
   def SetFont(self, font):
     """Adjust size of control when font changes"""
-    wx.PyControl.SetFont(self, font)
+    WxCtrl.SetFont(self, font)
     self.InvalidateBestSize()
 
   def SetLabel(self, label):
@@ -623,7 +636,7 @@ class MetallicButton(wx.PyControl):
     @param label: lable string
 
     """
-    wx.PyControl.SetLabel(self, label)
+    WxCtrl.SetLabel(self, label)
     self.InvalidateBestSize()
 
   def SetLabelColor(self, normal, hlight=wx.NullColour):
@@ -707,7 +720,11 @@ class MetallicButton(wx.PyControl):
 
   def SetWindowVariant(self, variant):
     """Set the variant/font size of this control"""
+<<<<<<< HEAD
     wx.PyControl.SetWindowVariant(self, variant)
+=======
+    WxCtrl.SetWindowVariant(self, variant)
+>>>>>>> wxPython 3/4 compatibility
     self.InvalidateBestSize()
 
   def ShouldInheritColours(self):
@@ -819,7 +836,8 @@ if __name__ == "__main__" :
   panel_sizer.Add(btn3, 0, wx.ALL|wx.EXPAND, 10)
   btn4 = MetallicButton(
     parent=panel,
-    label="Button with bitmap and caption",
+    style=MB_STYLE_BOLD_LABEL,
+    label="Button with bitmap and BOLD caption",
     label2="This is the button caption that I can't figure out how to wrap "+
       "properly on any platform (but especially Linux!).",
     bmp=folder_home.GetBitmap(),

--- a/wxtbx/metallicbutton.py
+++ b/wxtbx/metallicbutton.py
@@ -270,8 +270,8 @@ class MetallicButton(WxCtrl):
       if wx.Platform == '__WXMAC__':
         brush = wx.Brush((100,100,100))
         brush.MacSetTheme(Carbon.Appearance.kThemeBrushFocusHighlight)
-        with wx4c.set_brush_style(wx.BRUSHSTYLE_SOLID) as bstyle:
-          pen = wx.Pen(brush.GetColour(), 1, bstyle)
+        with wx4c.set_pen_style(wx.PENSTYLE_SOLID) as pstyle:
+          pen = wx.Pen(brush.GetColour(), 1, pstyle)
       else:
         pen = wx.Pen(AdjustColour(self._color['press_start'], -80, 220), 1)
       #gc.SetPen(pen)

--- a/wxtbx/metallicbutton.py
+++ b/wxtbx/metallicbutton.py
@@ -87,7 +87,7 @@ class MetallicButton(WxCtrl):
     self._label_font = self.GetFont()
     self._label_font.SetPointSize(label_size)
     if style & MB_STYLE_BOLD_LABEL :
-      self._label2_font.SetWeight(wx.FONTWEIGHT_BOLD)
+      self._label_font.SetWeight(wx.FONTWEIGHT_BOLD)
       # with wx4c.set_font_weight(wx.FONTWEIGHT_BOLD) as fw:
       #   self._label2_font.SetWeight(fw)
     self.SetFont(self._label_font)

--- a/wxtbx/wx4_compatibility.py
+++ b/wxtbx/wx4_compatibility.py
@@ -1,0 +1,212 @@
+from __future__ import division, print_function
+
+'''
+Author      : Lyubimov, A.Y.
+Created     : 04/14/2014
+Last Changed: 11/05/2018
+Description : wxPython 3-4 compatibility tools
+
+The context managers, classes, and other tools below can be used to make the 
+GUI code compatible with wxPython 3 and 4. Mostly, the tools convert the 
+functions, enumerations, and classes which have been renamed in wxPython 4; 
+the name mismatches result in exceptions.
+
+Use case 1: subclassing wx.PyControl or wx.Control:
+
+from wxtbx import wx4_compatibility as wx4c
+WxCtrl = wx4c.get_wx_mod(wx, wx.Control)
+class MyCustomControl(WxCtrl): ...
+
+
+Use case 2: brush style (NOTE: you can do that with fonts as well, but it 
+doesn't seem to be necessary):
+
+from wxtbx import wx4_compatibility as wx4c
+bkgrd = self.GetBackgroundColour()
+with wx4c.set_brush_style(wx.BRUSHSTYLE_SOLID) as bstyle:
+    brush = wx.Brush(bkgrd, bstyle)
+
+
+Use case 3: Toolbars
+
+from wxtbx import wx4_compatibility as wx4c, bitmaps
+class MyFrame(wx.Frame):
+  def __init__(self, parent, id, title, *args, **kwargs):
+    wx.Frame.__init__(self, parent, id, title, *args, **kwargs)
+  
+    self.toolbar = wx4c.ToolBar(self, style=wx.TB_3DBUTTONS | wx.TB_TEXT)
+    self.quit_button = self.toolbar.AddTool(toolId=wx.ID_ANY,
+                                             label='Quit',
+                                             kind=wx.ITEM_NORMAL,
+                                             bitmap=bitmaps.fetch_icon_bitmap('actions', 'exit')
+                                             shortHelp='Exit program')
+    ...
+    self.SetToolBar(self.toolbar)
+    self.toolbar.Realize()
+
+
+'''
+
+import wx
+from contextlib import contextmanager
+import importlib
+
+wx4 = wx.__version__[0] == '4'
+
+modnames = [
+  ('PyControl', 'Control'),
+  ('PyDataObjectSimple', 'DataObjectSimple'),
+  ('PyDropTarget', 'DropTarget'),
+  ('PyEvtHandler', 'EvtHandler'),
+  ('PyImageHandler', 'ImageHandler'),
+  ('PyLocale', 'Locale'),
+  ('PyLog', 'Log'),
+  ('PyPanel', 'Panel'),
+  ('PyPickerBase', 'PickerBase'),
+  ('PyPreviewControlBar', 'PreviewControlBar'),
+  ('PyPreviewFrame', 'PreviewFrame'),
+  ('PyPrintPreview', 'PrintPreview'),
+  ('PyScrolledWindow', 'ScrolledWindow'),
+  ('PySimpleApp', 'App'),
+  ('PyTextDataObject', 'TextDataObject'),
+  ('PyTimer', 'Timer'),
+  ('PyTipProvider', 'adv.TipProvider'),
+  ('PyValidator', 'Validator'),
+  ('PyWindow'', Window')
+]
+
+font_families = [
+  (wx.DEFAULT, wx.FONTFAMILY_DEFAULT),
+  (wx.DECORATIVE, wx.FONTFAMILY_DECORATIVE),
+  (wx.ROMAN, wx.FONTFAMILY_ROMAN),
+  (wx.SCRIPT, wx.FONTFAMILY_SCRIPT),
+  (wx.SWISS, wx.FONTFAMILY_SWISS),
+  (wx.MODERN, wx.FONTFAMILY_MODERN),
+  (wx.TELETYPE, wx.FONTFAMILY_TELETYPE)
+]
+
+font_weights = [
+  (wx.NORMAL, wx.FONTWEIGHT_NORMAL),
+  (wx.LIGHT, wx.FONTWEIGHT_LIGHT),
+  (wx.BOLD, wx.FONTWEIGHT_BOLD)
+]
+
+font_styles = [
+  (wx.NORMAL, wx.FONTSTYLE_NORMAL),
+  (wx.ITALIC, wx.FONTSTYLE_ITALIC),
+  (wx.SLANT, wx.FONTSTYLE_SLANT)
+]
+
+pen_styles = [
+  (wx.SOLID, wx.PENSTYLE_SOLID),
+  (wx.DOT, wx.PENSTYLE_DOT),
+  (wx.LONG_DASH, wx.PENSTYLE_LONG_DASH),
+  (wx.SHORT_DASH, wx.PENSTYLE_SHORT_DASH),
+  (wx.DOT_DASH, wx.PENSTYLE_DOT_DASH),
+  (wx.USER_DASH, wx.PENSTYLE_USER_DASH),
+  (wx.TRANSPARENT, wx.PENSTYLE_TRANSPARENT)
+]
+
+brush_styles = [
+  (wx.SOLID, wx.BRUSHSTYLE_SOLID),
+  (wx.TRANSPARENT, wx.BRUSHSTYLE_TRANSPARENT),
+  (wx.STIPPLE_MASK_OPAQUE, wx.BRUSHSTYLE_STIPPLE_MASK_OPAQUE),
+  (wx.STIPPLE_MASK, wx.BRUSHSTYLE_STIPPLE_MASK),
+  (wx.STIPPLE, wx.BRUSHSTYLE_STIPPLE),
+  (wx.BDIAGONAL_HATCH, wx.BRUSHSTYLE_BDIAGONAL_HATCH),
+  (wx.CROSSDIAG_HATCH, wx.BRUSHSTYLE_CROSSDIAG_HATCH),
+  (wx.FDIAGONAL_HATCH, wx.BRUSHSTYLE_FDIAGONAL_HATCH),
+  (wx.CROSS_HATCH, wx.BRUSHSTYLE_CROSS_HATCH),
+  (wx.HORIZONTAL_HATCH, wx.BRUSHSTYLE_HORIZONTAL_HATCH),
+  (wx.VERTICAL_HATCH, wx.BRUSHSTYLE_VERTICAL_HATCH),
+]
+
+def find_module(module):
+  for m in modnames:
+    if module.__name__ in m:
+      return m
+
+def find_enum(enums, item):
+  for en in enums:
+    if item in en:
+      value = en[1] if wx4 else en[0]
+      return value
+
+def get_wx_mod(base, module):
+  mname = find_module(module)[1] if wx4 else find_module(module)[0]
+  bname = base.__name__
+  if '.' in mname:
+    spl = [i for i in mname.split('.') if i != bname]
+    modname = '.'.join(spl[:-1])
+    mod = importlib.import_module('{}.{}'.format(bname, modname))
+    return getattr(mod, spl[-1])
+  else:
+    return getattr(base, mname)
+
+@contextmanager
+def wx_mod(base, module):
+  ''' Identify and import the appropriate wxPython module '''
+  yield get_wx_mod(base, module)
+
+@contextmanager
+def set_font_style(style):
+  yield find_enum(font_styles, style)
+
+@contextmanager
+def set_font_weight(weight):
+  yield find_enum(font_weights, weight)
+
+@contextmanager
+def set_font_family(family):
+  yield find_enum(font_families, family)
+
+@contextmanager
+def set_pen_style(style):
+  yield find_enum(pen_styles, style)
+
+@contextmanager
+def set_brush_style(style):
+  yield find_enum(brush_styles, style)
+
+@contextmanager
+def create_measuring_context():
+  dc = wx.GraphicsContext.Create() if wx4 else \
+    wx.GraphicsContext.CreateMeasuringContext()
+  yield dc
+
+class Wx3ToolBar(wx.ToolBar):
+  ''' Special toolbar class that accepts wxPython 4-style AddTool command and
+  converts it to a wxPython 3-style AddLabelTool command '''
+  def __init__(self, parent, id=wx.ID_ANY, pos=wx.DefaultPosition,
+               size=wx.DefaultSize, style=wx.TB_HORIZONTAL, name='toolbar'):
+    wx.ToolBar.__init__(self, parent, id, pos, size, style, name)
+
+  def AddTool(self, toolId, label, bitmap, bmpDisabled=wx.NullBitmap,
+              kind=wx.ITEM_NORMAL, shortHelp='', longHelp='',
+              clientData=None):
+    ''' Override to make this a very thin wrapper for AddLabelTool, which in
+    wxPython 3 is the same as AddTool in wxPython 4 '''
+    return self.AddLabelTool(id=toolId, label=label, bitmap=bitmap,
+                             bmpDisabled=bmpDisabled, kind=kind,
+                             shortHelp=shortHelp, longHelp=longHelp,
+                             clientData=clientData)
+
+class Wx4ToolBar(wx.ToolBar):
+  ''' Special toolbar class that accepts wxPython 3-style AddLabelTool command
+  and converts it to a wxPython 4-style AddTool command '''
+  def __init__(self, parent, id=wx.ID_ANY, pos=wx.DefaultPosition,
+               size=wx.DefaultSize, style=wx.TB_HORIZONTAL, name='toolbar'):
+    wx.ToolBar.__init__(self, parent, id, pos, size, style, name)
+
+  def AddLabelTool(self, id, label, bitmap, bmpDisabled=wx.NullBitmap,
+              kind=wx.ITEM_NORMAL, shortHelp='', longHelp='',
+              clientData=None):
+    ''' Override to make this a very thin wrapper for AddTool, which in
+    wxPython 4 is the same as AddLabelTool in wxPython 3 '''
+    return self.AddTool(toolId=id, label=label, bitmap=bitmap,
+                        bmpDisabled=bmpDisabled, kind=kind,
+                        shortHelp=shortHelp, longHelp=longHelp,
+                        clientData=clientData)
+
+# Use this ToolBar class to create toolbars in frames
+ToolBar = Wx4ToolBar if wx4 else Wx3ToolBar


### PR DESCRIPTION
Per Nick's request:
- wx4_compatibility has a set of tools to make sure that various controls work with both versions
- metallicbutton has been modified to work with both versions
- so far tested with wxPython 4 on MacOS 10.13 and wxPython4 on RHEL6