### PR TITLE
Implement Schrodinger hooks for refinement programs.

### DIFF
--- a/mmtbx/geometry_restraints/external.py
+++ b/mmtbx/geometry_restraints/external.py
@@ -69,17 +69,6 @@ if schrodinger_installed:
       .help = Parameters for using Schrodinger's force fields.
       .expert_level = 3
     {
-      use_schrodinger = False
-        .help = Use Schrodinger supported force field.
-        .type = bool
-      ligand_selection = None
-        .help = Use force field parameters only for selected ligands.
-        .type = atom_selection
-      forcefield = OPLS3e* None
-        .help = Force field to use during refinement.
-        .type = choice
-      maestro_file = None
-        .help = Schrodinger Maestro file containing structure.
-        .type = path
+      include scope mmtbx.geometry_restraints.schrodinger.master_phil_str
     }
 """

--- a/mmtbx/geometry_restraints/external.py
+++ b/mmtbx/geometry_restraints/external.py
@@ -59,16 +59,26 @@ if (afitt_installed) :
 
 # Schrodinger
 schrodinger_installed = False
-if os.environ.get("SCHRODINGER", None):
+if os.environ.get("SCHRODINGER", False):
   if os.path.exists(os.environ["SCHRODINGER"]):
     schrodinger_installed = True
 
 if schrodinger_installed:
-  external_energy_params_str += """
+  from glob import glob
+  paths = glob(os.path.join(
+      os.environ["SCHRODINGER"], 'psp-v*', 'data', 'phenix'))
+  if len(paths) == 1:
+    import sys
+    sys.path.append(paths[0])
+  try:
+    import phenix_schrodinger
+    external_energy_params_str += """
     schrodinger
       .help = Parameters for using Schrodinger's force fields.
       .expert_level = 3
     {
-      include scope mmtbx.geometry_restraints.schrodinger.master_phil_str
+      include scope phenix_schrodinger.master_phil_str
     }
 """
+  except ImportError:
+    schrodinger_installed = False

--- a/mmtbx/model/model.py
+++ b/mmtbx/model/model.py
@@ -1082,10 +1082,11 @@ class manager(object):
           selection=None,
           log=self.log)
 
-    if (getattr(self._pdb_interpretation_params, "schrodinger", None) and
-        self._pdb_interpretation_params.schrodinger.use_schrodinger):
-      # so schrodinger would have fully constructed geometry to play with
-      geometry = None # schrodinger_geometry(geometry)
+    # Use Schrodinger force field if requested
+    params = self._pdb_interpretation_params
+    if hasattr(params, "schrodinger") and params.schrodinger.use_schrodinger:
+      from mmtbx.geometry_restraints.schrodinger import schrodinger_manager
+      geometry = schrodinger_manager(self._pdb_hierarchy, params, cleanup=True, grm=geometry)
 
     restraints_manager = mmtbx.restraints.manager(
       geometry      = geometry,

--- a/mmtbx/model/model.py
+++ b/mmtbx/model/model.py
@@ -1085,7 +1085,7 @@ class manager(object):
     # Use Schrodinger force field if requested
     params = self._pdb_interpretation_params
     if hasattr(params, "schrodinger") and params.schrodinger.use_schrodinger:
-      from mmtbx.geometry_restraints.schrodinger import schrodinger_manager
+      from phenix_schrodinger import schrodinger_manager
       geometry = schrodinger_manager(self._pdb_hierarchy, params, cleanup=True, grm=geometry)
 
     restraints_manager = mmtbx.restraints.manager(

--- a/mmtbx/refinement/ensemble_refinement/__init__.py
+++ b/mmtbx/refinement/ensemble_refinement/__init__.py
@@ -1698,7 +1698,7 @@ def run(args, command_name = "phenix.ensemble_refinement", out=None,
   # Process PDB file
   cif_objects = inputs.cif_objects
   pdb_file = inputs.pdb_file_names[0]
-  pdb_ip = mmtbx.model.manager.get_default_pdb_interpretation_params()
+  pdb_ip = mmtbx.model.manager.get_default_pdb_interpretation_params(er_params)
   pdb_ip.pdb_interpretation.clash_guard.nonbonded_distance_threshold = -1.0
   pdb_ip.pdb_interpretation.clash_guard.max_number_of_distances_below_threshold = 100000000
   pdb_ip.pdb_interpretation.clash_guard.max_fraction_of_distances_below_threshold = 1.0

--- a/mmtbx/refinement/ensemble_refinement/__init__.py
+++ b/mmtbx/refinement/ensemble_refinement/__init__.py
@@ -1698,7 +1698,7 @@ def run(args, command_name = "phenix.ensemble_refinement", out=None,
   # Process PDB file
   cif_objects = inputs.cif_objects
   pdb_file = inputs.pdb_file_names[0]
-  pdb_ip = mmtbx.model.manager.get_default_pdb_interpretation_params(er_params)
+  pdb_ip = mmtbx.model.manager.get_default_pdb_interpretation_params()
   pdb_ip.pdb_interpretation.clash_guard.nonbonded_distance_threshold = -1.0
   pdb_ip.pdb_interpretation.clash_guard.max_number_of_distances_below_threshold = 100000000
   pdb_ip.pdb_interpretation.clash_guard.max_fraction_of_distances_below_threshold = 1.0

--- a/mmtbx/refinement/real_space/individual_sites.py
+++ b/mmtbx/refinement/real_space/individual_sites.py
@@ -347,6 +347,12 @@ class box_refinement_manager(object):
       geo_box.remove_reference_coordinate_restraints_in_place() # disaster happens otherwise
       map_box = box.map_box
       sites_cart_box = box.xray_structure_box.sites_cart()
+
+      # When using the Schrodinger force field, move the whole structure as the
+      # selected atoms are environment aware.
+      if hasattr(geo_box, 'schrodinger') and geo_box.schrodinger.use_schrodinger:
+        geo_box.shift_cart(box.shift_cart)
+
       rsr_simple_refiner = simple(
         target_map                  = map_box,
         selection                   = sel,
@@ -371,6 +377,8 @@ class box_refinement_manager(object):
         iselection, sites_cart_refined)
       self.xray_structure.set_sites_cart(sites_cart_moving)
       self.sites_cart = self.xray_structure.sites_cart()
+      if hasattr(geo_box, 'schrodinger') and geo_box.schrodinger.use_schrodinger:
+        geo_box.shift_cart(shift_back)
     else: # NCS constraints are present
       # select on xrs, grm, ncs_groups
       grm = self.geometry_restraints_manager.select(selection)

--- a/mmtbx/refinement/real_space/individual_sites.py
+++ b/mmtbx/refinement/real_space/individual_sites.py
@@ -350,7 +350,7 @@ class box_refinement_manager(object):
 
       # When using the Schrodinger force field, move the whole structure as the
       # selected atoms are environment aware.
-      if geobox.get_source() == 'SCHRODINGER':
+      if geo_box.get_source() == 'SCHRODINGER':
         geo_box.shift_cart(box.shift_cart)
 
       rsr_simple_refiner = simple(
@@ -377,7 +377,7 @@ class box_refinement_manager(object):
         iselection, sites_cart_refined)
       self.xray_structure.set_sites_cart(sites_cart_moving)
       self.sites_cart = self.xray_structure.sites_cart()
-      if geobox.get_source() == 'SCHRODINGER':
+      if geo_box.get_source() == 'SCHRODINGER':
         geo_box.shift_cart(shift_back)
     else: # NCS constraints are present
       # select on xrs, grm, ncs_groups

--- a/mmtbx/refinement/real_space/individual_sites.py
+++ b/mmtbx/refinement/real_space/individual_sites.py
@@ -350,7 +350,7 @@ class box_refinement_manager(object):
 
       # When using the Schrodinger force field, move the whole structure as the
       # selected atoms are environment aware.
-      if hasattr(geo_box, 'schrodinger') and geo_box.schrodinger.use_schrodinger:
+      if geobox.get_source() == 'SCHRODINGER':
         geo_box.shift_cart(box.shift_cart)
 
       rsr_simple_refiner = simple(
@@ -377,7 +377,7 @@ class box_refinement_manager(object):
         iselection, sites_cart_refined)
       self.xray_structure.set_sites_cart(sites_cart_moving)
       self.sites_cart = self.xray_structure.sites_cart()
-      if hasattr(geo_box, 'schrodinger') and geo_box.schrodinger.use_schrodinger:
+      if geobox.get_source() == 'SCHRODINGER':
         geo_box.shift_cart(shift_back)
     else: # NCS constraints are present
       # select on xrs, grm, ncs_groups


### PR DESCRIPTION
I left out the `schrodinger.py` and `tst_schrodinger.py` files. 

I updated the ensemble refinement parameter reading, cause, to my understanding, only the default values would be created, and by passing the er_params the schrodinger commandline options would be transferred to the pdb_ip instance.

Also 2 extra lines were added to the individual_sites.py file to shift the structure back to its original position.