### PR TITLE
Import experiments

### DIFF
--- a/rstbx/command_line/slip_viewer.py
+++ b/rstbx/command_line/slip_viewer.py
@@ -95,12 +95,10 @@ def run(argv=None):
 
     # from dxtbx.imageset import ImageSetFactory
     # sets = ImageSetFactory.new(paths)
-    from dxtbx.datablock import DataBlockFactory
+    from dxtbx.model.experiment_list import ExperimentListFactory
     from rstbx.slip_viewer.frame import chooser_wrapper
-    db = DataBlockFactory.from_filenames(paths)
-    sets = []
-    for d in db:
-      sets.extend(d.extract_imagesets())
+    experiments = ExperimentListFactory.from_filenames(paths)
+    sets = experiments.imagesets()
 
     for imgset in sets:
       for idx in imgset.indices():

--- a/spotfinder/servers/apache_dials.py
+++ b/spotfinder/servers/apache_dials.py
@@ -12,7 +12,7 @@ def run(args, verbose=False):
   import os
   from spotfinder.servers import LoggingFramework
   from dials.array_family import flex
-  from dxtbx.datablock import DataBlockFactory
+  from dxtbx.model.experiment_list import ExperimentListFactory
   phil_scope = parse("""
   file_name = None
     .type = str
@@ -45,17 +45,17 @@ def run(args, verbose=False):
   print "Image: %s\n"%params.file_name
 
   try:
-    datablock = DataBlockFactory.from_filenames([params.file_name])[0]
-    imageset = datablock.extract_imagesets()[0]
-    if datablock.num_images() > 0 and params.frame_number is not None:
+    experiments = ExperimentListFactory.from_filenames([params.file_name])
+    assert len(experiments) == 1
+    if len(experiments[0].imageset) > 0 and params.frame_number is not None:
       print "Frame number", params.frame_number
-      imageset = imageset[params.frame_number:params.frame_number+1]
-      datablock = DataBlockFactory.from_imageset(imageset)[0]
-    reflections = flex.reflection_table.from_observations(datablock, params)
+      experiments[0].imageset = experiments[0].imageset[params.frame_number:params.frame_number+1]
+      experiments[0].scan = experiments[0].imageset.get_scan()
+    reflections = flex.reflection_table.from_observations(experiments, params)
 
     if params.stats:
       from dials.algorithms.spot_finding.per_image_analysis import  stats_single_image
-      print stats_single_image(imageset, reflections, i=None, resolution_analysis=True, plot=False)
+      print stats_single_image(experiments[0].imageset, reflections, i=None, resolution_analysis=True, plot=False)
 
   except Exception:
     import traceback

--- a/xfel/command_line/cspad_detector_congruence.py
+++ b/xfel/command_line/cspad_detector_congruence.py
@@ -252,7 +252,7 @@ class Script(object):
 
     # Verify inputs
     if len(detectors) != 2:
-      print "Please provide two experiments and or datablocks for comparison"
+      print "Please provide two experiments for comparison"
       return
 
     # These lines exercise the iterate_detector_at_level and iterate_panels functions

--- a/xfel/command_line/cspad_detector_congruence.py
+++ b/xfel/command_line/cspad_detector_congruence.py
@@ -234,27 +234,21 @@ class Script(object):
       sort_options=True,
       phil=phil_scope,
       read_experiments=True,
-      read_datablocks=True,
       read_reflections=True,
       epilog=help_message)
 
   def run(self):
     ''' Parse the options. '''
-    from dials.util.options import flatten_experiments, flatten_datablocks, flatten_reflections
+    from dials.util.options import flatten_experiments, flatten_reflections
     # Parse the command line arguments
     params, options = self.parser.parse_args(show_diff_phil=True)
     self.params = params
     experiments = flatten_experiments(params.input.experiments)
-    datablocks = flatten_datablocks(params.input.datablock)
     reflections = flatten_reflections(params.input.reflections)
 
     # Find all detector objects
     detectors = []
     detectors.extend(experiments.detectors())
-    dbs = []
-    for datablock in datablocks:
-      dbs.extend(datablock.unique_detectors())
-    detectors.extend(dbs)
 
     # Verify inputs
     if len(detectors) != 2:

--- a/xfel/command_line/cspad_detector_congruence2.py
+++ b/xfel/command_line/cspad_detector_congruence2.py
@@ -204,7 +204,7 @@ class Script(object):
 
     # Verify inputs
     if len(detectors) != 2:
-      print "Please provide two experiments and or datablocks for comparison"
+      print "Please provide two experiments for comparison"
       return
 
     # These lines exercise the iterate_detector_at_level and iterate_panels functions

--- a/xfel/command_line/cspad_detector_congruence2.py
+++ b/xfel/command_line/cspad_detector_congruence2.py
@@ -185,28 +185,22 @@ class Script(object):
       sort_options=True,
       phil=phil_scope,
       read_experiments=True,
-      read_datablocks=True,
       read_reflections=True,
       check_format=False,
       epilog=help_message)
 
   def run(self):
     ''' Parse the options. '''
-    from dials.util.options import flatten_experiments, flatten_datablocks, flatten_reflections
+    from dials.util.options import flatten_experiments, flatten_reflections
     # Parse the command line arguments
     params, options = self.parser.parse_args(show_diff_phil=True)
     self.params = params
     experiments = flatten_experiments(params.input.experiments)
-    datablocks = flatten_datablocks(params.input.datablock)
     reflections = flatten_reflections(params.input.reflections)
 
     # Find all detector objects
     detectors = []
     detectors.extend(experiments.detectors())
-    dbs = []
-    for datablock in datablocks:
-      dbs.extend(datablock.unique_detectors())
-    detectors.extend(dbs)
 
     # Verify inputs
     if len(detectors) != 2:

--- a/xfel/command_line/cspad_detector_shifts.py
+++ b/xfel/command_line/cspad_detector_shifts.py
@@ -72,7 +72,7 @@ class Script(ParentScript):
 
     # Verify inputs
     if len(detectors) != 2:
-      raise Sorry("Please provide a reference and a moving set of experiments and or datablocks")
+      raise Sorry("Please provide a reference and a moving set of experiments")
 
     reflections = reflections[1]
     detector = detectors[1]

--- a/xfel/command_line/cspad_detector_shifts.py
+++ b/xfel/command_line/cspad_detector_shifts.py
@@ -53,28 +53,22 @@ class Script(ParentScript):
       sort_options=True,
       phil=phil_scope,
       read_experiments=True,
-      read_datablocks=True,
       read_reflections=True,
       check_format=False,
       epilog=help_message)
 
   def run(self):
     ''' Parse the options. '''
-    from dials.util.options import flatten_experiments, flatten_datablocks, flatten_reflections
+    from dials.util.options import flatten_experiments, flatten_reflections
     # Parse the command line arguments
     params, options = self.parser.parse_args(show_diff_phil=True)
     self.params = params
     experiments = flatten_experiments(params.input.experiments)
-    datablocks = flatten_datablocks(params.input.datablock)
     reflections = flatten_reflections(params.input.reflections)
 
     # Find all detector objects
     detectors = []
     detectors.extend(experiments.detectors())
-    dbs = []
-    for datablock in datablocks:
-      dbs.extend(datablock.unique_detectors())
-    detectors.extend(dbs)
 
     # Verify inputs
     if len(detectors) != 2:

--- a/xfel/command_line/detector_residuals.py
+++ b/xfel/command_line/detector_residuals.py
@@ -351,7 +351,6 @@ class Script(DCScript):
       sort_options=True,
       phil=phil_scope,
       read_experiments=True,
-      read_datablocks=True,
       read_reflections=True,
       check_format=False,
       epilog=help_message)

--- a/xfel/command_line/experiment_json_to_cbf_def.py
+++ b/xfel/command_line/experiment_json_to_cbf_def.py
@@ -5,7 +5,7 @@ from __future__ import division
 # cbf header file. Note hardcoded distance of 100 isn't relevant for just a cbf header
 
 from dials.util.options import OptionParser
-from dials.util.options import flatten_datablocks, flatten_experiments
+from dials.util.options import flatten_experiments
 from xfel.cftbx.detector.cspad_cbf_tbx import write_cspad_cbf, map_detector_to_basis_dict
 from libtbx import phil
 
@@ -21,19 +21,14 @@ class Script(object):
     # Create the parser
     self.parser = OptionParser(
       phil = phil_scope,
-      read_datablocks = True,
       read_experiments = True,
       check_format = False)
 
   def run(self):
     params, options = self.parser.parse_args(show_diff_phil=True)
-    datablocks = flatten_datablocks(params.input.datablock)
     experiments = flatten_experiments(params.input.experiments)
 
-    if len(datablocks) > 0:
-      detector = datablocks[0].unique_detectors()[0]
-    else:
-      detector = experiments[0].detector
+    detector = experiments[0].detector
 
     metro = map_detector_to_basis_dict(detector)
     write_cspad_cbf(None, metro, 'cbf', None, params.output_def_file, None, detector.hierarchy().get_distance(), header_only=True)

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -20,7 +20,7 @@ import libtbx.load_env
 from libtbx.utils import Sorry, Usage
 from dials.util.options import OptionParser
 from libtbx.phil import parse
-from dxtbx.datablock import DataBlockFactory
+from dxtbx.model.experiment_list import ExperimentListFactory
 from scitbx.array_family import flex
 import numpy as np
 from libtbx import easy_pickle
@@ -286,9 +286,9 @@ xtc_phil_str = '''
     logging_dir = None
       .type = str
       .help = Directory output log files will be placed
-    datablock_filename = %s_datablock.json
+    experiments_filename = %s_experiments.json
       .type = str
-      .help = The filename for output datablock
+      .help = The filename for output experiment list
     strong_filename = %s_strong.pickle
       .type = str
       .help = The filename for strong reflections from spot finder output.
@@ -1205,8 +1205,8 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
 
     if self.params.dispatch.dump_indexed:
       img_path = self.save_image(dxtbx_img, self.params, os.path.join(self.params.output.output_dir, "idx-" + s))
-      datablock = DataBlockFactory.from_filenames([img_path])[0]
-      imgset = datablock.extract_imagesets()[0]
+      experiments = ExperimentListFactory.from_filenames([img_path])
+      imgset = experiments.imagesets()[0]
       assert len(experiments.detectors()) == 1;   imgset.set_detector(experiments[0].detector)
       assert len(experiments.beams()) == 1;       imgset.set_beam(experiments[0].beam)
       assert len(experiments.scans()) <= 1;       imgset.set_scan(experiments[0].scan)

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -1099,7 +1099,8 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
       if tt_low is not None or tt_high is not None:
         print "Warning, mod_radial_average is being used while also using xtc_process radial averaging. mod_radial_averaging results will not be logged to the database."
 
-    experiments = ExperimentListFactory.from_imageset_and_crystal(imgset, None)[0]
+    from dxtbx.model.experiment_list import ExperimentListFactory
+    experiments = ExperimentListFactory.from_imageset_and_crystal(imgset, None)
 
     try:
       self.pre_process(experiments)
@@ -1205,8 +1206,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
 
     if self.params.dispatch.dump_indexed:
       img_path = self.save_image(dxtbx_img, self.params, os.path.join(self.params.output.output_dir, "idx-" + s))
-      experiments = ExperimentListFactory.from_filenames([img_path])
-      imgset = experiments.imagesets()[0]
+      imgset = ExperimentListFactory.from_filenames([img_path]).imagesets()[0]
       assert len(experiments.detectors()) == 1;   imgset.set_detector(experiments[0].detector)
       assert len(experiments.beams()) == 1;       imgset.set_beam(experiments[0].beam)
       assert len(experiments.scans()) <= 1;       imgset.set_scan(experiments[0].scan)

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -1099,10 +1099,10 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
       if tt_low is not None or tt_high is not None:
         print "Warning, mod_radial_average is being used while also using xtc_process radial averaging. mod_radial_averaging results will not be logged to the database."
 
-    datablock = DataBlockFactory.from_imageset(imgset)[0]
+    experiments = ExperimentListFactory.from_imageset_and_crystal(imgset, None)[0]
 
     try:
-      self.pre_process(datablock)
+      self.pre_process(experiments)
     except Exception as e:
       self.debug_write("preprocess_exception", "fail")
       return
@@ -1148,7 +1148,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
 
     self.debug_write("spotfind_start")
     try:
-      observed = self.find_spots(datablock)
+      observed = self.find_spots(experiments)
     except Exception as e:
       import traceback; traceback.print_exc()
       print str(e), "event", timestamp
@@ -1196,7 +1196,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
     # index and refine
     self.debug_write("index_start")
     try:
-      experiments, indexed = self.index(datablock, observed)
+      experiments, indexed = self.index(experiments, observed)
     except Exception as e:
       import traceback; traceback.print_exc()
       print str(e), "event", timestamp

--- a/xfel/small_cell/command_line/small_cell_process.py
+++ b/xfel/small_cell/command_line/small_cell_process.py
@@ -17,7 +17,7 @@ from iotbx.phil import parse
 phil_scope.adopt_scope(parse(small_cell_phil_str))
 
 class Processor(BaseProcessor):
-  def index(self, datablock, reflections):
+  def index(self, experiments, reflections):
     from time import time
     import copy
     from xfel.small_cell.small_cell import small_cell_index_detail
@@ -30,7 +30,7 @@ class Processor(BaseProcessor):
 
     params = copy.deepcopy(self.params)
 
-    max_clique_len, experiments, indexed = small_cell_index_detail(datablock, reflections, params, write_output=False)
+    max_clique_len, experiments, indexed = small_cell_index_detail(experiments, reflections, params, write_output=False)
 
     logger.info('')
     logger.info('Time Taken = %f seconds' % (time() - st))

--- a/xfel/small_cell/small_cell.py
+++ b/xfel/small_cell/small_cell.py
@@ -308,7 +308,7 @@ def small_cell_index(path, horiz_phil):
   with unknown basis vectors """
 
   # Load the dials and small cell parameters
-  from dxtbx.datablock import DataBlockFactory
+  from dxtbx.model.experiment_list import ExperimentListFactory
   from dials.algorithms.spot_finding.factory import SpotFinderFactory
   from dials.model.serialize.dump import reflections as reflections_dump
 
@@ -325,8 +325,8 @@ def small_cell_index(path, horiz_phil):
   find_spots = SpotFinderFactory.from_parameters(horiz_phil)
 
   # spotfind
-  datablock = DataBlockFactory.from_imageset(imageset)[0]
-  reflections = find_spots(datablock)
+  experiments = ExperimentListFactory.from_imageset_and_crystal(imageset, None)[0]
+  reflections = find_spots(experiments)
 
   # filter the reflections for those near asic boundries
   print "Filtering %s reflections by proximity to asic boundries..."%len(reflections),
@@ -347,15 +347,15 @@ def small_cell_index(path, horiz_phil):
   reflections_dump(reflections, "spotfinder.pickle")
   print "saved %d"%len(reflections)
 
-  max_clique_len, experiments, refls = small_cell_index_detail(datablock, reflections, horiz_phil)
+  max_clique_len, experiments, refls = small_cell_index_detail(experiments, reflections, horiz_phil)
   return max_clique_len
 
-def small_cell_index_detail(datablock, reflections, horiz_phil, write_output = True):
+def small_cell_index_detail(experiments, reflections, horiz_phil, write_output = True):
   """ Index an image with a few spots and a known, small unit cell,
   with unknown basis vectors """
   import os,math
 
-  imagesets = datablock.extract_imagesets()
+  imagesets = experiments.imagesets()
   assert len(imagesets) == 1
   imageset = imagesets[0]
   path = imageset.paths()[0]

--- a/xfel/util/reflection_length.py
+++ b/xfel/util/reflection_length.py
@@ -80,8 +80,8 @@ class ReflectionsRadialLengths(object):
 
 class ReflectionsRadialLengthsFromFiles(ReflectionsRadialLengths):
   def __init__(self, files):
-    from dials.util.options import Importer, flatten_reflections, flatten_experiments, flatten_datablocks
-    importer = Importer(files, read_experiments=True, read_datablocks=True,
+    from dials.util.options import Importer, flatten_reflections, flatten_experiments
+    importer = Importer(files, read_experiments=True,
       read_reflections=True, check_format=False)
     if importer.unhandled:
       print "Unable to handle one or more files:", importer.unhandled
@@ -94,10 +94,6 @@ class ReflectionsRadialLengthsFromFiles(ReflectionsRadialLengths):
       experiments = flatten_experiments(importer.experiments)
       assert len(experiments) == 1, "Implemented only for one experiment at a time presently"
       experiment = experiments[0]
-    if importer.datablocks:
-      datablocks  = flatten_datablocks(importer.datablocks)
-      assert len(datablocks) == 1, "Implemented only for one datablock at a time presently"
-      datablock = datablocks[0]
     super(ReflectionsRadialLengthsFromFiles, self).__init__(
       reflections[0], datablock=datablock, experiment=experiment)
 

--- a/xfel/util/reflection_length.py
+++ b/xfel/util/reflection_length.py
@@ -10,19 +10,14 @@ from dials.algorithms.shoebox import MaskCode
 class ReflectionsRadialLengths(object):
   """Compute the length of each spotfinder spot in the radial direction."""
   valid_code = MaskCode.Valid | MaskCode.Foreground
-  def __init__(self, strong_spots, experiment=None, datablock=None):
+  def __init__(self, strong_spots, experiment=None):
     self.strong = strong_spots
     assert 'bbox' in self.strong and 'shoebox' in self.strong, \
       "Spotfinder shoeboxes are required for spot length calculations."
-    assert experiment or datablock, \
-      "Supply one experiment or datablock object."
-    if datablock:
-      imgset = datablock._imagesets[0]
-      self.det = imgset.get_detector()
-      self.beam = imgset.get_beam()
-    else:
-      self.det = experiment.detector
-      self.beam = experiment.beam
+    assert experiment, \
+      "Supply one experiment object."
+    self.det = experiment.detector
+    self.beam = experiment.beam
     self.s0 = matrix.col(self.beam.get_unit_s0())
     self.panel_s0_intersections = flex.vec2_double(
       [self.det[i].get_ray_intersection_px(self.s0) for i in range(len(self.det))])
@@ -88,14 +83,13 @@ class ReflectionsRadialLengthsFromFiles(ReflectionsRadialLengths):
       return
     reflections = flatten_reflections(importer.reflections)
     assert len(reflections) == 1, "Implemented only for one reflection table at a time presently"
-    datablock = None
     experiment = None
     if importer.experiments:
       experiments = flatten_experiments(importer.experiments)
       assert len(experiments) == 1, "Implemented only for one experiment at a time presently"
       experiment = experiments[0]
     super(ReflectionsRadialLengthsFromFiles, self).__init__(
-      reflections[0], datablock=datablock, experiment=experiment)
+      reflections[0], experiment=experiment)
 
 if __name__ == "__main__":
   import sys


### PR DESCRIPTION
This is related to the import_experiments branch in dials (https://github.com/dials/dials/pull/613).

I have been trying to remove references to data block in dials in favour of using experiment lists for everything. However, some things in cctbx/xfel and cctbx/iota also rely on dials functions which have now had a change of interface. I thought it would be helpful if I made these changes myself; I tried my best to update things but I don't know what tests to run to ensure my changes are correct. 

@phyy-nx and @alyubimov could you check for me that xfel and iota work using the changes on this branch, or alternatively could you tell me which tests I can run to make sure things are ok? Thanks!