### PR TITLE
Add --use-conda flag to bootstrap.py

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -1414,7 +1414,15 @@ class Builder(object):
     Helper function for determining the location of the conda environment
     """
     if __name__ == '__main__' and __package__ is None:
-      sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+      root_path = os.path.dirname(os.path.abspath(__file__))
+      paths = [root_path,
+               os.path.join(root_path, 'modules', 'cctbx_project', 'libtbx',
+                            'auto_build')]
+      for path in paths:
+        if os.path.isfile(os.path.join(path, 'install_conda.py')):
+          if path not in sys.path:
+            sys.path.append(path)
+            break
       from install_conda import conda_manager
     else:
       from .install_conda import conda_manager

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -1476,12 +1476,12 @@ class Builder(object):
       # (case 1)
       if self.use_conda == '' and conda_env is None:
         conda_python = os.path.join(os.path.join('..', 'conda_base'),
-                                    m_get_conda_python(()))
+                                    m_get_conda_python(self))
       # (case 2)
       # conda environment is active, overrides any path provided to --use-conda
       elif conda_env is not None:
         if os.path.isdir(conda_env):
-          conda_python = os.path.join(conda_env, m_get_conda_python())
+          conda_python = os.path.join(conda_env, m_get_conda_python(self))
         else:
           raise RuntimeError("""
 The path specified by the CONDA_PREFIX environment variable does not
@@ -1491,14 +1491,14 @@ exist. Please make sure you have a valid conda environment in
       else:
         self.use_conda = os.path.abspath(self.use_conda)
         if os.path.isdir(self.use_conda):
-          conda_python = os.path.join(self.use_conda, m_get_conda_python())
+          conda_python = os.path.join(self.use_conda, m_get_conda_python(self))
         else:
           raise RuntimeError("""
 The path specified by the --use-conda flag does not exist. Please make
 sure you have a valid conda environment in
 {conda_env}""".format(conda_env=self.use_conda))
 
-      if conda_python is None or not os.path.isfile(conda_python):
+      if conda_python is None:
         raise RuntimeError('A conda version of python could not be found.')
 
     return conda_python

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -1599,7 +1599,7 @@ base conda installation.
             raise RuntimeError("""
 The path specified by the CONDA_PREFIX environment variable does not have
 python installed. Please make sure you have a valid conda environment in
-{conda_env}""").format(conda_env=conda_env)
+{conda_env}""".format(conda_env=conda_env))
       # use path provided to --use-conda
       else:
         self.use_conda = os.path.abspath(self.use_conda)
@@ -1609,12 +1609,12 @@ python installed. Please make sure you have a valid conda environment in
             raise RuntimeError("""
 The path specified by the --use-conda flag does not have python installed.
 Please make sure you have a valid conda environment in
-{conda_env}""").format(conda_env=conda_env)
+{conda_env}""".format(conda_env=conda_env))
         else:
           raise RuntimeError("""
 The path specified by the --use-conda flag does not exist. Please make
 sure you have a valid conda environment in
-{conda_env}""").format(conda_env=conda_env)
+{conda_env}""".format(conda_env=conda_env))
 
     if len(command) > 0:
       print("Installing base packages using:\n  " + " ".join(command))


### PR DESCRIPTION
- The optparse module is updated to argparse to more easily handle an optional argument for `--use-conda`
- The base step will optionally install miniconda3 and create an environment
- Or a path to a conda environment can be used
- Or the currently active conda environment can be used

This pull request is more for testing the move from optparse to argparse since `--use-conda` is an optional flag. A consequence of moving to argparse is that the actions and flags should be grouped together and the --use-conda flag should not be before an action since it can have an optional argument. So

`python bootstrap.py hot --builder=cctbx base --nproc=4 --use-conda`

would not work. But,

`python bootstrap.py --builder=cctbx --use-conda --nproc=4 hot update base`
`python bootstrap.py hot update base --builder=cctbx --use-conda --nproc=4`

will work because the actions and flags are grouped separately.

To build CCTBX programs using `conda`, use

1) `python bootstrap.py --builder=<builder> --use-conda --nproc=<nproc>`
This will install `miniconda3` at the `root` directory, which is where the `modules` and `build` directories reside. The conda environment for the builder will be created in the `conda_base` directory at the root directory. The conda environment is called `conda_base` because `base` is reserved for the base conda installation.

2) Alternatively, if a conda environment is active, the above command from will skip the installation of `miniconda3` and the creation of `conda_base`. The active environment is used for dependencies and only basic checks on accessibility are done. To create a suitable conda environment, use the dependency manifests in `libtbx/auto_build/conda_envs`. Currently, there is one monolithic environment, but the goal is to separate the dependencies and place similar dependency manifests in the repository of each program. To use the `cctbx` manifest on linux, the command is
`conda create -n <env_name> --file <modules>/libtbx/auto_build/conda_envs/cctbx_py27_linux-64.txt`
There are files for macOS and Windows as well.

3) Another alternative is to provide the path to conda environment as an argument to `--use-conda`. If the `miniconda3` installation is in the home directory, the `bootstrap.py` command would look like
`python bootstrap.py --builder=<builder> --use-conda=${HOME}/miniconda3/envs/<env_name> --nproc=<nproc>`

The last 2 options are aimed at developers that want more control and are using `conda` natively.
The first option and last option makes `conda` invisible since an active conda environment is not necessary for running CCTBX programs.

On Windows, the automatic installation of miniconda3 is still being tested. Administrative rights may be required. The environments are functional, though, and can be used for building.

Multi-user conda installations are supported, but really only through options 2 or 3. Option 1 will work, but a new miniconda3 installation is created.

If problems are encountered with these changes, please provide,
1) the operating system and version
2) the command used to generate to issue