### PR TITLE
Define python dependencies in libtbx_config

### DIFF
--- a/dxtbx/libtbx_config
+++ b/dxtbx/libtbx_config
@@ -1,3 +1,7 @@
 {
   "modules_required_for_use" : [ "iotbx", "cbflib_adaptbx" ],
+  "python_required": [
+    "mock>=2.0",
+    "pytest>=3.1"
+  ],
 }

--- a/dxtbx/libtbx_refresh.py
+++ b/dxtbx/libtbx_refresh.py
@@ -1,6 +1,1 @@
 from __future__ import absolute_import, division, print_function
-
-import libtbx.pkg_utils
-
-libtbx.pkg_utils.require("mock", ">=2.0")
-libtbx.pkg_utils.require("pytest", ">=3.1")

--- a/libtbx/command_line/show_python_dependencies.py
+++ b/libtbx/command_line/show_python_dependencies.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
             to_action.append(requirement)
 
     # Decide how to do output
-    if normal_output:
+    if normal_output and rows:
         _print_table(rows)
 
         if to_action:
@@ -227,6 +227,8 @@ if __name__ == "__main__":
                     + [_shell_quote_requirement(req) for req in to_action]
                 )
             )
+    elif normal_output and not rows:
+        print("No dependencies found.")
     elif args.all:
         print(" ".join(_shell_quote_requirement(x) for x in requirements))
     elif args.actions:

--- a/libtbx/command_line/show_python_dependencies.py
+++ b/libtbx/command_line/show_python_dependencies.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python
+
+"""
+Lists the module python dependencies and the state of install.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import argparse
+import copy
+import re
+import sys
+
+import libtbx.load_env
+import libtbx.pkg_utils
+from libtbx.pkg_utils import pkg_resources
+from libtbx.pkg_utils import packaging
+
+
+BOLD = "\033[1m"
+RED = "\033[1;31m"
+MAGENTA = "\033[1;35m"
+GREEN = "\033[32m"
+GRAY = "\033[37m"
+NC = "\033[0m"
+
+# A regex to check for requirement characters that are not shell-safe
+reSafe = re.compile(r"[^a-zA-Z0-9,._+:@%/\[\]-]")
+
+
+def _get_requirement_status(requirement):
+    # type: (packaging.requirements.Requirement) -> Tuple[Any, str]
+    """Get the requirement status of a package.
+
+    Args:
+        requirement (packaging.requirements.Requirement):
+            The requirement object to check
+
+    Returns:
+        Tuple[str, str]:
+            The status value, and - if it exists - the current version.
+            The status value can currently be one of:
+                - "SKIPPED": The package is excluded by env markers
+                - "VALID":   Already installed with correct version
+                - "UNKNOWNEXTRA": Installed, but missing extras
+                - "MISSING": The package is not installed
+                - "MISMATCH": An incompatible version is installed
+    """
+    requirement = copy.deepcopy(requirement)
+    if requirement.marker and not requirement.marker.evaluate():
+        # Try to get a version without the marker
+        requirement.marker = None
+        # Look to see if we have an installed version anyway
+        try:
+            version = pkg_resources.require(str(requirement))[0].version
+            return ("SKIPPED", version)
+        except pkg_resources.ResolutionError:
+            return ("SKIPPED", None)
+
+    # Try to find this package
+    try:
+        pkg = pkg_resources.require(str(requirement))[0]
+        return ("VALID", pkg.version)
+    except pkg_resources.UnknownExtra:
+        # Package exists, but extra is missing. Get the base description.
+        requirement.extras = set()
+        version = pkg_resources.require(str(requirement))[0].version
+        return ("UNKNOWNEXTRA", version)
+    except pkg_resources.VersionConflict:
+        requirement.specifier = packaging.specifiers.SpecifierSet()
+        version = pkg_resources.require(str(requirement))[0].version
+        return ("MISMATCH", version)
+    except pkg_resources.DistributionNotFound:
+        # Package not installed
+        return ("MISSING", None)
+
+
+def _shell_quote_requirement(req):
+    # type: (Union[packaging.requirements.Requirement, str]) -> str
+    """Returns a shell-quoted requirement string.
+
+    Since we know the form of the requirement, it is safe to single-quote
+    anything and convert internal single-quotes to double (we know no
+    recursive quoting). But if it's not necessary to do this, it won't.
+
+    Args:
+        req (Requirement or str):
+            The requirement, as an object or PEP508 string.
+
+    Returns:
+        str:
+            A shell-safe, potentially escaped version of the string.
+    """
+    out = str(req)
+    if reSafe.search(out):
+        # Something needs to be quoted. Quote it, but we know the
+        # general form and know we don't have recursively nested quotes
+        out = "'" + out.replace("'", '"') + "'"
+    return out
+
+
+def _print_table(rows):
+    # type: (List[List[str]]) -> None
+    """Prints a pretty formatted table of dependencies.
+
+    Args:
+        rows (List[List[str]]):
+            The row data, containing six columns in the order of
+            Status, Name, Specifier, Available, Marker, From
+    """
+
+    titles = ["Status", "Name", "Specifier", "Available", "Marker", "From"]
+    justification = ["l", "l", "l", "r", "l", "l"]
+
+    # Remove marker row if no markers
+    if not any(x[4] for x in rows):
+        for row in rows + [titles] + [justification]:
+            row.pop(4)
+
+    column_widths = [
+        max(len(str(row[i])) for row in rows + [titles]) for i in range(len(rows[0]))
+    ]
+
+    colors = {
+        "VALID": GREEN,
+        "MISSING": RED,
+        "UNKNOWNEXTRA": MAGENTA,
+        "MISMATCH": MAGENTA,
+        "SKIPPED": GRAY,
+        "Status": "",
+    }
+    # Print a formatted table
+    for row in [titles] + rows:
+        color = colors[row[0]]
+        out_cols = []
+        for col, just, width in zip(row[1:], justification[1:], column_widths[1:]):
+            col_txt = col.ljust(width)
+            if just == "r":
+                col_txt = col.rjust(width)
+            elif just == "c":
+                col_txt = col.center(width)
+            out_cols.append(col_txt)
+        print(color + " ".join(out_cols) + (NC if color else ""))
+
+
+if __name__ == "__main__":
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(description="Show python package requirements")
+    parser.add_argument(
+        "--norefresh", action="store_true", help="Don't re-read module config"
+    )
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument(
+        "--all", action="store_true", help="Just show a list of all dependencies"
+    )
+    modes.add_argument(
+        "--actions", action="store_true", help="Show packages to install/upgrade"
+    )
+    args = parser.parse_args()
+
+    # Should we do the normal actions if nothing special has been asked for?
+    normal_output = not args.all and not args.actions
+
+    # Check for packaging
+    if not libtbx.pkg_utils.pkg_resources:
+        print(
+            "\n".join(
+                [
+                    "  WARNING: Can not verify python package requirements - pip/setuptools out of date",
+                    "  Please update pip and setuptools by running:",
+                    "",
+                    "    libtbx.python -m pip install pip setuptools --upgrade",
+                    "",
+                    "  or following the instructions at https://pip.pypa.io/en/stable/installing/",
+                ]
+            )
+        )
+        sys.exit(1)
+
+    # Re-read all config files, without a refresh. Not entirely sure that
+    # this is the proper thing to do as makes a slight race condition with
+    # refresh, and cannot get a stage where module is listed but not refreshed?
+    if not args.norefresh:
+        for module in libtbx.env.module_list:
+            module.process_libtbx_config()
+
+    # Gather the requirements
+    requirements = sorted(
+        libtbx.pkg_utils.collate_python_requirements(libtbx.env.module_list),
+        key=lambda x: x.name.lower(),
+    )
+
+    rows = []
+    to_action = []
+
+    for requirement in requirements:
+        # Check the status of this requirement
+        status, cur_ver = _get_requirement_status(requirement)
+        name = requirement.name
+        if requirement.extras:
+            name = name + "[" + ",".join(requirement.extras) + "]"
+        # Build a row object for table display
+        rows.append(
+            [
+                status,
+                name,
+                str(requirement.specifier),
+                str(cur_ver) if cur_ver is not None else "",
+                str(requirement.marker) if requirement.marker else "",
+                ", ".join(sorted(requirement.modules)),
+            ]
+        )
+        if status in {"MISSING", "UNKNOWNEXTRA", "MISMATCH"}:
+            to_action.append(requirement)
+
+    # Decide how to do output
+    if normal_output:
+        _print_table(rows)
+
+        if to_action:
+            print(
+                "\nThere are packaging actions required. pip command to resolve\npackaging differences:\n"
+            )
+            print(
+                " ".join(
+                    ["    libtbx.pip", "install"]
+                    + [_shell_quote_requirement(req) for req in to_action]
+                )
+            )
+    elif args.all:
+        print(" ".join(_shell_quote_requirement(x) for x in requirements))
+    elif args.actions:
+        print(" ".join(_shell_quote_requirement(x) for x in to_action))

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -17,6 +17,9 @@ import re
 import site
 import sys
 import sysconfig
+
+import libtbx.pkg_utils
+
 op = os.path
 
 if os.environ.get('LIBTBX_WINGIDE_DEBUG'):
@@ -1826,6 +1829,10 @@ selfx:
         source_is_python_exe=True)
     for module in self.module_list:
       module.process_command_line_directories()
+      # Reload the libtbx_config in case dependencies have changed
+      module.process_libtbx_config()
+    # Resolve python dependencies in advance of potential use in refresh scripts
+    libtbx.pkg_utils.resolve_module_python_dependencies(self.module_list)
     for path in self.pythonpath:
       sys.path.insert(0, abs(path))
     for module in self.module_list:
@@ -1859,7 +1866,11 @@ selfx:
     return result
 
 class module:
-
+  """
+  Attributes:
+    python_required (List[str]):
+      List of python package requirement specifiers. Should match PEP508-style.
+  """
   def __init__(self, env, name, dist_path=None, mate_suffix="adaptbx"):
     self.env = env
     self.mate_suffix = mate_suffix
@@ -1874,6 +1885,7 @@ class module:
       self.names = [name, name + mate_suffix]
       if (dist_path is not None):
         self.dist_paths = [dist_path, None]
+    self.python_required = []
 
   def names_active(self):
     for name,path in zip(self.names, self.dist_paths):
@@ -1908,6 +1920,7 @@ class module:
     self.exclude_from_binary_bundle = []
     dist_paths = []
     self.extra_command_line_locations = []
+    self.python_required = []
     for dist_path in self.dist_paths:
       if (dist_path is not None):
         while True:
@@ -1948,6 +1961,7 @@ class module:
             "modules_required_for_build", []))
           self.required_for_use.extend(config.get(
             "modules_required_for_use", []))
+          self.python_required.extend(config.get("python_required", []))
           self.optional.extend(config.get(
             "optional_modules", []))
           self.optional.extend(

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -17,9 +17,6 @@ import re
 import site
 import sys
 import sysconfig
-
-import libtbx.pkg_utils
-
 op = os.path
 
 if os.environ.get('LIBTBX_WINGIDE_DEBUG'):
@@ -1831,8 +1828,12 @@ selfx:
       module.process_command_line_directories()
       # Reload the libtbx_config in case dependencies have changed
       module.process_libtbx_config()
+
     # Resolve python dependencies in advance of potential use in refresh scripts
-    libtbx.pkg_utils.resolve_module_python_dependencies(self.module_list)
+    # Lazy-load the import here as we might not have an environment before this
+    from . import pkg_utils
+    pkg_utils.resolve_module_python_dependencies(self.module_list)
+
     for path in self.pythonpath:
       sys.path.insert(0, abs(path))
     for module in self.module_list:

--- a/libtbx/pkg_utils.py
+++ b/libtbx/pkg_utils.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 import contextlib
+import itertools
 import os
 import sys
 
@@ -31,6 +32,20 @@ try:
 except ImportError:
   pip = None
   pkg_resources = None
+
+# Try to find packaging. This is normally(?) installed by setuptools but
+# otherwise pip keeps a copy.
+try:
+  import packaging
+  from packaging.requirements import Requirement
+except ImportError:
+  try:
+    import pip._vendor.packaging as packaging
+    from pip._vendor.packaging.requirements import Requirement
+  except ImportError:
+    # If all else fails then we need the symbol to check
+    Requirement = None
+    packaging = None
 
 try:
   import setuptools
@@ -69,11 +84,20 @@ def require(pkgname, version=None):
   if not version:
     version = ''
 
-  # package name without feature specification
-  basepkgname = pkgname.split('[')[0]
+  requirement = Requirement(pkgname+version)
 
-  requirestring = pkgname + version
-  baserequirestring = basepkgname + version
+  # Check if we have an environment marker in the request
+  if requirement.marker and not requirement.marker.evaluate():
+    # We skip dependencies that don't match our current environment
+    return True
+  # Erase the marker from any further output
+  requirement.marker = None
+
+  # package name without feature specification
+  basepkgname = requirement.name
+
+  requirestring = str(requirement)
+  baserequirestring = requirement.name + str(requirement.specifier)
   try:
     try:
       print("requires %s, has %s" % (requirestring, pkg_resources.require(requirestring)[0].version))
@@ -205,3 +229,81 @@ def define_entry_points(epdict, **kwargs):
       sys.argv = argv_orig
   finally:
     os.chdir(curdir)
+
+def _merge_requirements(requirements, new_req):
+  # type: (List[packaging.requirements.Requirement], packaging.requirements.Requirement) -> None
+  """Merge a new requirement with a list.
+
+  If it exists in an identical form (name, marker) then the
+  specifiers and extras will be merged, otherwise it will be added.
+
+  If the environment markers are different it will assume that they
+  are mutually exclusive - entries will only be merged if identical, which
+  could cause problems with duplicate requirement entries if not filtered
+  by pass status later.
+
+  URL field is also not handled, as unsure how to merge these if they differ.
+
+  Args:
+    requirements (List[packaging.requirements.Requirement]): Existing.
+    new_req (packaging.requirements.Requirement): New requirement
+  """
+  assert new_req.url is None, "URL requirement fields not handled/tested"
+  matches = [
+    x
+    for x in requirements
+    if x.name == new_req.name
+    and x.marker == new_req.marker
+  ]
+  if len(matches) > 0:
+    if len(matches) > 1:
+      print("Warning: More than one match for requirement", new_req, ": ", matches)
+    match = matches[0]
+  else:
+    match = None
+
+  if match:
+    match.specifier = match.specifier & new_req.specifier
+    match.modules = match.modules | new_req.modules
+    match.extras = match.extras | new_req.extras
+  else:
+    requirements.append(new_req)
+
+def collate_python_requirements(modules):
+  # type: (List[libtbx.env_config.module]) -> List[packaging.requirements.Requirement]
+  """Combine python requirements from a module list.
+
+  An attempt will be made to merge any joint requirements. The requirement
+  objects will have an added property 'modules', which is a set of module
+  names that formed the requirement.
+
+  Attr:
+      modules (Iterable[libtbx.env_config.module]): The module list
+
+  Returns:
+      List[packaging.requirements.Requirement]: The merged requirements
+  """
+  requirements = []
+  for module, spec in itertools.chain(*[[(x.name, y) for y in x.python_required] for x in modules if hasattr(x, "python_required")]):
+    requirement = Requirement(spec)
+    # Track where dependencies came from
+    requirement.modules = {module}
+    # Attempt to merge this with any other requirements to avoid double-specifying
+    _merge_requirements(requirements, requirement)
+  return requirements
+
+def resolve_module_python_dependencies(modules):
+  # type: (List[libtbx.env_config.module]) -> None
+  """Resolve all python dependencies from the list of modules"""
+  # Check we can do anything here
+  if Requirement is None:
+    _notice("  WARNING: Can not find package requirements tools - pip/setuptools out of date?",
+            "  Please update pip and setuptools by running:", "",
+            "    libtbx.python -m pip install pip setuptools --upgrade", "",
+            "  or following the instructions at https://pip.pypa.io/en/stable/installing/")
+    return
+  requirements = collate_python_requirements(modules)
+  # Now we should have an unduplicated set of requirements
+  for requirement in requirements:
+    # Pass everything as the requirement string rather than trying to reconstruct
+    result = require(str(requirement), "")


### PR DESCRIPTION
At the moment python dependency resolution is done and installed at the `libtbx.refresh` stage, via each packages `libtbx_refresh.py`. This can cause problems if packages cannot be installed e.g. on an offline node, or if the global site-packages folder is read-only. 

Having the configuration inside the `libtbx_refresh.py` file means that the only way to tell what's required is by manual inspection or parsing the output of refresh. And, since each package only knows about it's own requirements, leaves the potential of conflicting requirements going unnoticed.

This patch moves the listing of requirements to the libtbx_config configuration file, where the other module dependencies are specified, which means that it can be easily read before running libtbx.refresh - dependencies can be worked out before you have a fully running and configured distribution, and merged before installation.

This would help some of the issues discussed in #151.

Also, added a utility, `libtbx.show_python_dependencies`, to list/inspect python dependencies in an existing environment. Here's what the standard output looks like where I've converted the `dxtbx`, `dials` (sample commit https://github.com/ndevenish/dials-fork/commit/6e9f736c0d90bcd2f637f28f97398e87b8f4df21) and `xia2` refresh scripts:

![image](https://user-images.githubusercontent.com/529963/52868316-d69d2d80-313a-11e9-8b43-a569d4ac06c8.png)

By passing the `--all` flag you can get a list of all requirements suitable for e.g. building an offline list:
```
$ libtbx.show_python_dependencies --all
blosc Jinja2 'mock>=2.0' msgpack orderedset 'procrunner>=0.6' 'pytest>=3.1,>=3.6' scikit_learn[alldeps] scipy tabulate 'tqdm==4.23.4'
```
