### PR TITLE
Use stable sort by default

### DIFF
--- a/scitbx/array_family/flex.py
+++ b/scitbx/array_family/flex.py
@@ -49,7 +49,7 @@ class _(boost.python.injector, grid):
     print("all:", self.all(), file=f)
     return self
 
-def sorted(data, reverse=False, stable=False):
+def sorted(data, reverse=False, stable=True):
   return data.select(
     sort_permutation(data=data, reverse=reverse, stable=stable))
 

--- a/scitbx/array_family/sort.h
+++ b/scitbx/array_family/sort.h
@@ -59,7 +59,7 @@ namespace scitbx { namespace af {
   sort_permutation(
     const_ref<DataType> const& data,
     bool reverse=false,
-    bool stable=false
+    bool stable=true
     )
   {
     if (stable) {


### PR DESCRIPTION
following #288.

Performance impact appears to be, if there is any at all, on the positive side.

