### PR TITLE
Lstbx add equations

### DIFF
--- a/scitbx/lstbx/boost_python/normal_equations.cpp
+++ b/scitbx/lstbx/boost_python/normal_equations.cpp
@@ -35,7 +35,8 @@ namespace boost_python {
         .def("add_equations",
              &wt::add_equations,
              (arg("right_hand_side"), arg("design_matrix"), arg("weights"),
-              arg("negate_right_hand_side")=false))
+              arg("negate_right_hand_side")=false,
+              arg("optimise_for_sparse")=true))
         .def("reset", &wt::reset)
         .def("solve", &wt::solve)
         .add_property("solved", &wt::solved)
@@ -66,11 +67,12 @@ namespace boost_python {
       void (wt::*add_dense_eqns)(af::const_ref<scalar_t> const &,
                                  af::const_ref<scalar_t, af::mat_grid> const &,
                                  af::const_ref<scalar_t> const &)
-        = &wt::add_equations;
+        = &wt::add_equations_dense;
       void (wt::*add_sparse_eqns)(af::const_ref<scalar_t> const &,
                                   sparse::matrix<scalar_t> const &,
-                                  af::const_ref<scalar_t> const &)
-        = &wt::add_equations;
+                                  af::const_ref<scalar_t> const &,
+                                  bool, bool)
+        = &wt::add_equations_sparse;
 
       class_<wt>(name, no_init)
         .def(init<int>(arg("n_parameters")))
@@ -99,7 +101,8 @@ namespace boost_python {
              (arg("residuals"), arg("jacobian"), arg("weights")))
         .def("add_equations",
              add_sparse_eqns,
-             (arg("residuals"), arg("jacobian"), arg("weights")))
+             (arg("residuals"), arg("jacobian"), arg("weights"),
+             arg("negate_right_hand_side")=true, arg("optimise_for_sparse")=true))
         .def("reset", &wt::reset)
         /* We use 'def' instead of add_property for those to stay consistent
            with the other wrappers in this module which can't use properties

--- a/scitbx/lstbx/boost_python/normal_equations.cpp
+++ b/scitbx/lstbx/boost_python/normal_equations.cpp
@@ -36,7 +36,7 @@ namespace boost_python {
              &wt::add_equations,
              (arg("right_hand_side"), arg("design_matrix"), arg("weights"),
               arg("negate_right_hand_side")=false,
-              arg("optimise_for_sparse")=true))
+              arg("optimise_for_tall_matrix")=true))
         .def("reset", &wt::reset)
         .def("solve", &wt::solve)
         .add_property("solved", &wt::solved)
@@ -102,7 +102,7 @@ namespace boost_python {
         .def("add_equations",
              add_sparse_eqns,
              (arg("residuals"), arg("jacobian"), arg("weights"),
-             arg("negate_right_hand_side")=true, arg("optimise_for_sparse")=true))
+             arg("negate_right_hand_side")=true, arg("optimise_for_tall_matrix")=true))
         .def("reset", &wt::reset)
         /* We use 'def' instead of add_property for those to stay consistent
            with the other wrappers in this module which can't use properties

--- a/scitbx/lstbx/boost_python/normal_equations.cpp
+++ b/scitbx/lstbx/boost_python/normal_equations.cpp
@@ -67,12 +67,12 @@ namespace boost_python {
       void (wt::*add_dense_eqns)(af::const_ref<scalar_t> const &,
                                  af::const_ref<scalar_t, af::mat_grid> const &,
                                  af::const_ref<scalar_t> const &)
-        = &wt::add_equations_dense;
+        = &wt::add_equations;
       void (wt::*add_sparse_eqns)(af::const_ref<scalar_t> const &,
                                   sparse::matrix<scalar_t> const &,
                                   af::const_ref<scalar_t> const &,
                                   bool, bool)
-        = &wt::add_equations_sparse;
+        = &wt::add_equations;
 
       class_<wt>(name, no_init)
         .def(init<int>(arg("n_parameters")))

--- a/scitbx/lstbx/normal_equations.h
+++ b/scitbx/lstbx/normal_equations.h
@@ -260,7 +260,7 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
     /// Add the linearisation of the equations \f$r(x) = 0\f$ all at once
     /** The Jacobian is that of \f$x \mapto r(x)\f$.
      */
-    void add_equations_dense(af::const_ref<scalar_t> const &r,
+    void add_equations(af::const_ref<scalar_t> const &r,
                        af::const_ref<scalar_t, af::mat_grid> const &jacobian,
                        af::const_ref<scalar_t> const &w)
     {
@@ -274,7 +274,7 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
       }
     }
 
-    void add_equations_sparse(af::const_ref<scalar_t> const &r,
+    void add_equations(af::const_ref<scalar_t> const &r,
                        sparse::matrix<scalar_t> const &jacobian,
                        af::const_ref<scalar_t> const &w,
                        bool negate_right_hand_side=true,

--- a/scitbx/lstbx/normal_equations.h
+++ b/scitbx/lstbx/normal_equations.h
@@ -104,16 +104,16 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
                        sparse::matrix<scalar_t> const &a,
                        af::const_ref<scalar_t> const &w,
                        bool negate_right_hand_side=false,
-                       bool optimise_for_sparse=true)
+                       bool optimise_for_tall_matrix=true)
     {
       SCITBX_ASSERT(   a.n_rows() == b.size()
                     && b.size()   == w.size())(a.n_rows())(b.size())(w.size());
       SCITBX_ASSERT(a.n_cols() == n_parameters());
       sparse::matrix<scalar_t> at_w_a;
-      if (optimise_for_sparse) {
-        at_w_a = a.transpose().this_times_diagonal_times_this_transpose(w);
-      } else {
+      if (optimise_for_tall_matrix) {
         at_w_a = a.this_transpose_times_diagonal_times_this(w);
+      } else {
+        at_w_a = a.transpose().this_times_diagonal_times_this_transpose(w);
       }
       vector_t a_t_w_b = a.transpose_times((w * b).const_ref());
       update_matrix(at_w_a, a_t_w_b, negate_right_hand_side);
@@ -285,7 +285,7 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
                        sparse::matrix<scalar_t> const &jacobian,
                        af::const_ref<scalar_t> const &w,
                        bool negate_right_hand_side=true,
-                       bool optimise_for_sparse=true)
+                       bool optimise_for_tall_matrix=true)
     {
       SCITBX_ASSERT(   r.size() == jacobian.n_rows()
                     && (!w.size() || r.size() == w.size()))
@@ -293,7 +293,7 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
       SCITBX_ASSERT(jacobian.n_cols() == n_parameters())
                    (jacobian.n_cols())(n_parameters());
       add_residuals(r, w);
-      linearised.add_equations(r, jacobian, w, negate_right_hand_side, optimise_for_sparse);
+      linearised.add_equations(r, jacobian, w, negate_right_hand_side, optimise_for_tall_matrix);
     }
 
     /// Objective value \f$L(x)\f$ for the current value of the unknowns

--- a/scitbx/lstbx/normal_equations.h
+++ b/scitbx/lstbx/normal_equations.h
@@ -93,17 +93,28 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
     /// Add the equations A x = b with the given weights
     /** w[i] weights the i-th equation, i.e. the row \f$ A_{i.} \f$.
         If negate_right_hand_side, then the equation is A x + b = 0 instead
+        Optimise_for_sparse can be used to control the method used to calculate
+        A^T W A, which may vary significantly in performance depending on the
+        shape and sparsity of the problem. Simple testing suggests that this
+        variable should be set to true for a highly sparse case, but it is
+        recommended that a developer assesses the best option for their problem.
+        See github pull request #295 for further discussion on this topic.
      */
     void add_equations(af::const_ref<scalar_t> const &b,
                        sparse::matrix<scalar_t> const &a,
                        af::const_ref<scalar_t> const &w,
-                       bool negate_right_hand_side=false)
+                       bool negate_right_hand_side=false,
+                       bool optimise_for_sparse=true)
     {
       SCITBX_ASSERT(   a.n_rows() == b.size()
                     && b.size()   == w.size())(a.n_rows())(b.size())(w.size());
       SCITBX_ASSERT(a.n_cols() == n_parameters());
-      sparse::matrix<scalar_t>
-      at_w_a = a.transpose().this_times_diagonal_times_this_transpose(w);
+      sparse::matrix<scalar_t> at_w_a;
+      if (optimise_for_sparse) {
+        at_w_a = a.transpose().this_times_diagonal_times_this_transpose(w);
+      } else {
+        at_w_a = a.this_transpose_times_diagonal_times_this(w);
+      }
       vector_t a_t_w_b = a.transpose_times((w * b).const_ref());
       normal_matrix_ += sparse::upper_diagonal_of(at_w_a);
       if (negate_right_hand_side) right_hand_side_ -= a_t_w_b.const_ref();
@@ -249,7 +260,7 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
     /// Add the linearisation of the equations \f$r(x) = 0\f$ all at once
     /** The Jacobian is that of \f$x \mapto r(x)\f$.
      */
-    void add_equations(af::const_ref<scalar_t> const &r,
+    void add_equations_dense(af::const_ref<scalar_t> const &r,
                        af::const_ref<scalar_t, af::mat_grid> const &jacobian,
                        af::const_ref<scalar_t> const &w)
     {
@@ -263,9 +274,11 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
       }
     }
 
-    void add_equations(af::const_ref<scalar_t> const &r,
+    void add_equations_sparse(af::const_ref<scalar_t> const &r,
                        sparse::matrix<scalar_t> const &jacobian,
-                       af::const_ref<scalar_t> const &w)
+                       af::const_ref<scalar_t> const &w,
+                       bool negate_right_hand_side=true,
+                       bool optimise_for_sparse=true)
     {
       SCITBX_ASSERT(   r.size() == jacobian.n_rows()
                     && (!w.size() || r.size() == w.size()))
@@ -273,7 +286,7 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
       SCITBX_ASSERT(jacobian.n_cols() == n_parameters())
                    (jacobian.n_cols())(n_parameters());
       add_residuals(r, w);
-      linearised.add_equations(r, jacobian, w, /*negate_right_hand_side=*/true);
+      linearised.add_equations(r, jacobian, w, negate_right_hand_side, optimise_for_sparse);
     }
 
     /// Objective value \f$L(x)\f$ for the current value of the unknowns

--- a/scitbx/lstbx/normal_equations.h
+++ b/scitbx/lstbx/normal_equations.h
@@ -116,6 +116,13 @@ namespace scitbx { namespace lstbx { namespace normal_equations {
         at_w_a = a.this_transpose_times_diagonal_times_this(w);
       }
       vector_t a_t_w_b = a.transpose_times((w * b).const_ref());
+      update_matrix(at_w_a, a_t_w_b, negate_right_hand_side);
+    }
+
+    // Add directly to the normal matrix equation
+    void update_matrix(sparse::matrix<scalar_t> const &at_w_a,
+                       vector_t const &a_t_w_b,
+                       bool negate_right_hand_side){
       normal_matrix_ += sparse::upper_diagonal_of(at_w_a);
       if (negate_right_hand_side) right_hand_side_ -= a_t_w_b.const_ref();
       else                        right_hand_side_ += a_t_w_b.const_ref();

--- a/smtbx/refinement/least_squares.py
+++ b/smtbx/refinement/least_squares.py
@@ -135,7 +135,8 @@ def crystallographic_ls_class(non_linear_ls_with_separable_scale_factor=None):
         self.reduced_problem().add_equations(
           linearised_eqns.deltas,
           linearised_eqns.design_matrix * jacobian,
-          linearised_eqns.weights * self.restraints_normalisation_factor)
+          linearised_eqns.weights * self.restraints_normalisation_factor,
+          optimise_for_tall_matrix=False)
         self.n_restraints = linearised_eqns.n_restraints()
         self.chi_sq_data_and_restraints = self.chi_sq()
       if not objective_only:


### PR DESCRIPTION
These changes add an option to choose the method for calculating the A^T W A matrix during add_equation, to enable switching depending on the shape and sparsity of the problem. The default is set to the new behaviour after pull request #295. Setting optimise_for_sparse=False enables one to recover the previous behaviour.

I have verified that I can switch between the old and new behaviour for my use case.
@luc-j-bourhis I would appreciate it if you are able to have a quick check over this and maybe test that everything still works the same for smtbx refinement.

Thanks,
James