### PR TITLE
move dxtbx to separate repository

### DIFF
--- a/dxtbx/README.md
+++ b/dxtbx/README.md
@@ -1,18 +1,15 @@
 ## Diffraction Experiment Toolbox
 
-![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
+This code has now moved into a separate repository.
+If you set up your build environment after April 2019 it should already include
+the necessary changes.
 
-A [cctbx](https://cctbx.github.io/)-style toolbox to describe single-crystal diffraction experiments, where
-a monochromatic beam is used to illuminate a sample which is rotated during
-the exposure and diffraction recorded on a flat area detector.
+Otherwise you can pick up dxtbx from its new location by running the command
+```bash
+libtbx.install dxtbx
+```
+which will install dxtbx in the modules/ directory.
 
-This toolbox will include code for:
-
- * reading image headers
- * transforming contents of image header to standard (i.e. imgCIF) frame
- * python models of experiment
- * reading a sweep into memory using existing cctbx image reading tools in [iotbx](https://cctbx.github.io/iotbx/index.html)
-
-Initially implemented to support [xia2](https://github.com/xia2/xia2) development, dxtbx is designed to be extensible, to support other applications and to make it easy to work with other detectors, with a generic approach to reading the data files.
-
-A paper describing how to use dxtbx, as well as documenting its development and some of its applications, was published as [J. Appl. Cryst. (2014) **47**, 1459-1465](https://doi.org/10.1107/S1600576714011996).
+If you have any cctbx\_project development branches that touch the dxtbx
+directory and need help in transferring commits over please open an issue on
+Github and we are happy to help.

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -919,6 +919,13 @@ class dials_module(SourceModule):
                'https://github.com/dials/dials.git',
                'https://github.com/dials/dials/archive/master.zip']
 
+class dxtbx_module(SourceModule):
+  module = 'dxtbx'
+  anonymous = ['git',
+               'git@github.com:cctbx/dxtbx.git',
+               'https://github.com/cctbx/dxtbx.git',
+               'https://github.com/cctbx/dxtbx/archive/master.zip']
+
 class dials_regression_module(SourceModule):
   module = 'dials_regression'
   authenticated = ['svn',
@@ -2024,8 +2031,8 @@ class CCTBXBuilder(CCIBuilder):
     pass
 
 class DIALSBuilder(CCIBuilder):
-  CODEBASES_EXTRA = ['dials', 'xia2']
-  LIBTBX_EXTRA = ['dials', 'xia2', 'prime', 'iota', '--skip_phenix_dispatchers']
+  CODEBASES_EXTRA = ['dials', 'dxtbx', 'xia2']
+  LIBTBX_EXTRA = ['dials', 'dxtbx', 'xia2', 'prime', 'iota', '--skip_phenix_dispatchers']
   HOT_EXTRA = ['msgpack']
   def add_tests(self):
     self.add_test_command('cctbx_regression.test_nightly')

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -1812,6 +1812,7 @@ class CCIBuilder(Builder):
     'boost',
     'cbflib',
     'cctbx_project',
+    'dxtbx',
     'gui_resources',
     'ccp4io_adaptbx',
     'annlib_adaptbx',
@@ -1832,12 +1833,12 @@ class CCIBuilder(Builder):
   LIBTBX = [
     'cctbx',
     'cbflib',
+    'dxtbx',
     'scitbx',
     'libtbx',
     'iotbx',
     'mmtbx',
     'smtbx',
-    'dxtbx',
     'gltbx',
     'wxtbx',
   ]
@@ -2031,8 +2032,8 @@ class CCTBXBuilder(CCIBuilder):
     pass
 
 class DIALSBuilder(CCIBuilder):
-  CODEBASES_EXTRA = ['dials', 'dxtbx', 'xia2']
-  LIBTBX_EXTRA = ['dials', 'dxtbx', 'xia2', 'prime', 'iota', '--skip_phenix_dispatchers']
+  CODEBASES_EXTRA = ['dials', 'xia2']
+  LIBTBX_EXTRA = ['dials', 'xia2', 'prime', 'iota', '--skip_phenix_dispatchers']
   HOT_EXTRA = ['msgpack']
   def add_tests(self):
     self.add_test_command('cctbx_regression.test_nightly')
@@ -2069,13 +2070,11 @@ class LABELITBuilder(CCIBuilder):
 class XFELBuilder(CCIBuilder):
   CODEBASES_EXTRA = [
     'dials',
-    'dxtbx',
     'labelit',
     'cxi_xdr_xes'
   ]
   LIBTBX_EXTRA = [
     'dials',
-    'dxtbx',
     'labelit',
     'xfel',
     'cxi_xdr_xes',
@@ -2100,7 +2099,6 @@ class XFELBuilder(CCIBuilder):
 class PhenixBuilder(CCIBuilder):
   CODEBASES_EXTRA = [
     'chem_data',
-    'dxtbx',
     'phenix',
     'phenix_regression',
     'phenix_html',
@@ -2129,7 +2127,6 @@ class PhenixBuilder(CCIBuilder):
   HOT_EXTRA = ['msgpack']
   LIBTBX_EXTRA = [
     'chem_data',
-    'dxtbx',
     'phenix',
     'phenix_regression',
     'phenix_examples',

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -2069,11 +2069,13 @@ class LABELITBuilder(CCIBuilder):
 class XFELBuilder(CCIBuilder):
   CODEBASES_EXTRA = [
     'dials',
+    'dxtbx',
     'labelit',
     'cxi_xdr_xes'
   ]
   LIBTBX_EXTRA = [
     'dials',
+    'dxtbx',
     'labelit',
     'xfel',
     'cxi_xdr_xes',
@@ -2098,6 +2100,7 @@ class XFELBuilder(CCIBuilder):
 class PhenixBuilder(CCIBuilder):
   CODEBASES_EXTRA = [
     'chem_data',
+    'dxtbx',
     'phenix',
     'phenix_regression',
     'phenix_html',
@@ -2126,6 +2129,7 @@ class PhenixBuilder(CCIBuilder):
   HOT_EXTRA = ['msgpack']
   LIBTBX_EXTRA = [
     'chem_data',
+    'dxtbx',
     'phenix',
     'phenix_regression',
     'phenix_examples',

--- a/libtbx/command_line/install.py
+++ b/libtbx/command_line/install.py
@@ -8,7 +8,15 @@ import shutil
 import sys
 from optparse import SUPPRESS_HELP, OptionParser
 
-import procrunner
+try:
+  import procrunner
+except ImportError:
+  try:
+    import libtbx.pkg_utils
+    libtbx.pkg_utils.require("procrunner")
+    import procrunner
+  except Exception:
+    sys.exit("libtbx.install requires procrunner. Please run: libtbx.python -m pip install procrunner")
 
 import libtbx.load_env
 from libtbx.auto_build.bootstrap import Toolbox

--- a/libtbx/command_line/install.py
+++ b/libtbx/command_line/install.py
@@ -205,6 +205,11 @@ warehouse = {
   'dlstbx': {
     'git-auth': 'dascgitolite@dasc-git.diamond.ac.uk:/dials/dlstbx.git',
   },
+  'dxtbx': {
+    'git-auth': 'git@github.com:cctbx/dxtbx',
+    'git-anon': 'https://github.com/cctbx/dxtbx.git',
+    'http-zip': { 'url': 'https://github.com/cctbx/dxtbx/archive/master.zip', 'trim': 1 },
+  },
   'fast_dp': {
     'pip-auth': 'git@github.com:/DiamondLightSource/fast_dp',
     'pip-anon': 'https://github.com/DiamondLightSource/fast_dp.git',

--- a/rstbx/SConscript
+++ b/rstbx/SConscript
@@ -17,6 +17,7 @@ env_etc.rstbx_common_includes = [
   env_etc.annlib_include[1],
   env_etc.annlib_adaptbx_include[0],
   env_etc.annlib_adaptbx_include[1],
+  env_etc.dxtbx_include,
 ]
 
 env = env_base.Clone(SHLINKFLAGS=env_etc.shlinkflags)

--- a/rstbx/libtbx_config
+++ b/rstbx/libtbx_config
@@ -1,5 +1,5 @@
 {
   "modules_required_for_use": ["iotbx"],
-  "modules_required_for_build": ["annlib","spotfinder"],
+  "modules_required_for_build": ["annlib","dxtbx","spotfinder"],
   "optional_modules": ["annlib"]
 }

--- a/simtbx/SConscript
+++ b/simtbx/SConscript
@@ -1,6 +1,5 @@
 import libtbx.load_env
 import os
-op = os.path
 Import("env_base", "env_etc")
 
 env_etc.simtbx_dist = libtbx.env.dist_path("simtbx")
@@ -11,14 +10,15 @@ env_etc.simtbx_common_includes = [
   env_etc.simtbx_include,
   env_etc.boost_adaptbx_include,
   env_etc.boost_include,
-  op.dirname(libtbx.env.find_in_repositories(
-    relative_path="tbxx", optional=False))
+  os.path.dirname(libtbx.env.find_in_repositories(
+    relative_path="tbxx", optional=False)),
+  env_etc.dxtbx_include,
 ]
 
-if (not env_etc.no_boost_python):
+if not env_etc.no_boost_python:
   Import("env_no_includes_boost_python_ext")
   env_simtbx = env_no_includes_boost_python_ext.Clone()
-  
+
   env_etc.include_registry.append(
     env=env_simtbx,
     paths=env_etc.simtbx_common_includes + [env_etc.python_include])

--- a/spotfinder/SConscript
+++ b/spotfinder/SConscript
@@ -19,6 +19,7 @@ env_etc.spotfinder_common_includes = [
   env_etc.annlib_include[1],
   env_etc.annlib_adaptbx_include[0],
   env_etc.annlib_adaptbx_include[1],
+  env_etc.dxtbx_include,
 ]
 
 env = env_base.Clone(

--- a/spotfinder/libtbx_config
+++ b/spotfinder/libtbx_config
@@ -1,4 +1,4 @@
 {
   "modules_required_for_use": ["iotbx","annlib"],
-  "modules_required_for_build": [],
+  "modules_required_for_build": ["dxtbx"],
 }


### PR DESCRIPTION
Following the decision to move dxtbx to a separate repository and based on the discussion with @bkpoon and @phyy-nx here are the proposed changes and the next steps.

## Pull request

This pull request contains the necessary bits to
* modify bootstrap to check out `dxtbx` from https://github.com/cctbx/dxtbx directly into the modules/ directory
* modify `SConscript` build files of `cctbx_project` modules to include `dxtbx` where required
* modify the [`cctbx_project/dxtbx/README.md` to contain instructions for migrating existing developer setups](https://github.com/cctbx/cctbx_project/blob/4d3948b55ec0785799ecae9578e7da1db1563f87/dxtbx/README.md) using `libtbx.install`, and
* add a corresponding installation routine to `libtbx.install`.

This pull request does not yet remove any files from the `cctbx_project/dxtbx` directory.

## Next steps

The next steps are as follows:
* We will wait a number of days for developers wanting to merge any development branches touching `cctbx_project/dxtbx`. We are aware that there are some long-running branches that will not be mergeable in this timeframe and a migration path will be offered.
* Once ready, the pull request is merged.
* We ensure that the `dxtbx` repository corresponds to the final version of the `cctbx_project/dxtbx` directory.
* We then remove everything but the README file from the `cctbx_project/dxtbx` directory.
* Developers then have to run the migration command ```libtbx.install dxtbx``` to obtain dxtbx from its new location.

## In future

Following the merge
* The entire `dxtbx` history (beyond its lifetime in `cctbx_project`) will be contained in the new `dxtbx` repository.
* The `cctbx_project/dxtbx` history will remain in the `cctbx_project` repository.
* The `cctbx_project/dxtbx` directory containing the README file will remain for a limited time (6 months?) and will be eventually removed to avoid confusion.
* Any `cctbx_project` developer branches that touch the `cctbx_project/dxtbx` directory will no longer merge cleanly. We will offer support to help anyone with the process of transferring the `cctbx_project/dxtbx` portions to the new repository. The same offer stands for long-running branches that are not ready for merging yet.