### PR TITLE
Lazy experiment list

### DIFF
--- a/dxtbx/format/FormatHDF5SaclaMPCCD.py
+++ b/dxtbx/format/FormatHDF5SaclaMPCCD.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 from dxtbx.format.FormatHDF5 import FormatHDF5
 from dxtbx.format.FormatStill import FormatStill
+from dxtbx.format.FormatMultiImageLazy import FormatMultiImageLazy
 
 # 151028: deepcopying this class causes crash in h5py
 #         temporary fix by closing the file in every methods(!)
@@ -12,7 +13,7 @@ from dxtbx.format.FormatStill import FormatStill
 # 180724: update 'understand' to exclude Rayonix data
 
 
-class FormatHDF5SaclaMPCCD(FormatHDF5, FormatStill):
+class FormatHDF5SaclaMPCCD(FormatMultiImageLazy, FormatHDF5, FormatStill):
     """
     Class to handle multi-event HDF5 files from MPCCD
     preprocessed by Cheetah SFX pipeline at SACLA.

--- a/dxtbx/model/boost_python/experiment.cc
+++ b/dxtbx/model/boost_python/experiment.cc
@@ -23,7 +23,7 @@ namespace dxtbx { namespace model { namespace boost_python {
 
   struct ExperimentPickleSuite : boost::python::pickle_suite {
     static
-    boost::python::tuple getinitargs(const Experiment &obj) {
+    boost::python::tuple getinitargs(Experiment &obj) {
       return boost::python::make_tuple(
         obj.get_beam(),
         obj.get_detector(),
@@ -87,7 +87,8 @@ namespace dxtbx { namespace model { namespace boost_python {
           boost::python::object,
           boost::python::object,
           boost::python::object,
-          std::string>((
+          std::string,
+          bool>((
               arg("beam") = boost::shared_ptr<BeamBase>(),
               arg("detector") = boost::shared_ptr<Detector>(),
               arg("goniometer") = boost::shared_ptr<Goniometer>(),
@@ -96,7 +97,8 @@ namespace dxtbx { namespace model { namespace boost_python {
               arg("profile") = boost::python::object(),
               arg("imageset") = boost::python::object(),
               arg("scaling_model") = boost::python::object(),
-              arg("identifier") = "")))
+              arg("identifier") = "",
+              arg("lazy") = false)))
       .add_property(
           "beam",
           &Experiment::get_beam,

--- a/dxtbx/model/boost_python/experiment_list.cc
+++ b/dxtbx/model/boost_python/experiment_list.cc
@@ -142,17 +142,17 @@ namespace dxtbx { namespace model { namespace boost_python {
   struct experiment_list_indices_pointers {
 
     typedef scitbx::af::shared<std::size_t> (ExperimentList::*beam_type)(
-        const boost::shared_ptr<BeamBase>&)const;
+        const boost::shared_ptr<BeamBase>&);
     typedef scitbx::af::shared<std::size_t> (ExperimentList::*detector_type)(
-        const boost::shared_ptr<Detector>&)const;
+        const boost::shared_ptr<Detector>&);
     typedef scitbx::af::shared<std::size_t> (ExperimentList::*goniometer_type)(
-        const boost::shared_ptr<Goniometer>&)const;
+        const boost::shared_ptr<Goniometer>&);
     typedef scitbx::af::shared<std::size_t> (ExperimentList::*scan_type)(
-        const boost::shared_ptr<Scan>&)const;
+        const boost::shared_ptr<Scan>&);
     typedef scitbx::af::shared<std::size_t> (ExperimentList::*crystal_type)(
         const boost::shared_ptr<CrystalBase>&)const;
     typedef scitbx::af::shared<std::size_t> (ExperimentList::*object_type)(
-        boost::python::object)const;
+        boost::python::object);
 
     static beam_type beam() {
       return &ExperimentList::indices;

--- a/dxtbx/model/experiment_list.h
+++ b/dxtbx/model/experiment_list.h
@@ -396,7 +396,7 @@ namespace dxtbx { namespace model {
     /**
      * Get indices which have this model
      */
-    scitbx::af::shared<std::size_t> indices(const boost::shared_ptr<BeamBase> &obj) const {
+    scitbx::af::shared<std::size_t> indices(const boost::shared_ptr<BeamBase> &obj) {
       scitbx::af::shared<std::size_t> result;
       for (std::size_t i = 0; i < size(); ++i) {
          if (data_[i].get_beam() == obj) {
@@ -409,7 +409,7 @@ namespace dxtbx { namespace model {
     /**
      * Get indices which have this model
      */
-    scitbx::af::shared<std::size_t> indices(const boost::shared_ptr<Detector> &obj) const {
+    scitbx::af::shared<std::size_t> indices(const boost::shared_ptr<Detector> &obj) {
       scitbx::af::shared<std::size_t> result;
       for (std::size_t i = 0; i < size(); ++i) {
          if (data_[i].get_detector() == obj) {
@@ -422,7 +422,7 @@ namespace dxtbx { namespace model {
     /**
      * Get indices which have this model
      */
-    scitbx::af::shared<std::size_t> indices(const boost::shared_ptr<Goniometer> &obj) const {
+    scitbx::af::shared<std::size_t> indices(const boost::shared_ptr<Goniometer> &obj) {
       scitbx::af::shared<std::size_t> result;
       for (std::size_t i = 0; i < size(); ++i) {
          if (data_[i].get_goniometer() == obj) {
@@ -435,7 +435,7 @@ namespace dxtbx { namespace model {
     /**
      * Get indices which have this model
      */
-    scitbx::af::shared<std::size_t> indices(const boost::shared_ptr<Scan> &obj) const {
+    scitbx::af::shared<std::size_t> indices(const boost::shared_ptr<Scan> &obj) {
       scitbx::af::shared<std::size_t> result;
       for (std::size_t i = 0; i < size(); ++i) {
          if (data_[i].get_scan() == obj) {
@@ -461,7 +461,7 @@ namespace dxtbx { namespace model {
     /**
      * Get indices which have this model
      */
-    scitbx::af::shared<std::size_t> indices(boost::python::object obj) const {
+    scitbx::af::shared<std::size_t> indices(boost::python::object obj) {
       boost::python::extract< boost::shared_ptr<BeamBase> > get_beam(obj);
       boost::python::extract< boost::shared_ptr<Detector> > get_detector(obj);
       boost::python::extract< boost::shared_ptr<Goniometer> > get_goniometer(obj);
@@ -500,7 +500,7 @@ namespace dxtbx { namespace model {
         boost::shared_ptr<CrystalBase> crystal,
         boost::python::object profile,
         boost::python::object imageset,
-        boost::python::object scaling_model) const {
+        boost::python::object scaling_model) {
       scitbx::af::shared<std::size_t> result;
       for (std::size_t i = 0; i < size(); ++i) {
         if (beam && data_[i].get_beam() != beam) {

--- a/dxtbx/model/experiment_list.py
+++ b/dxtbx/model/experiment_list.py
@@ -727,18 +727,28 @@ class ExperimentListFactory(object):
     @staticmethod
     def from_stills_and_crystal(imageset, crystal):
         """ Create an experiment list from stills and crystal. """
+        from dxtbx.imageset import ImageSetLazy
         experiments = ExperimentList()
-        for i in range(len(imageset)):
-            experiments.append(
-                Experiment(
-                    imageset=imageset[i : i + 1],
-                    beam=imageset.get_beam(i),
-                    detector=imageset.get_detector(i),
-                    goniometer=imageset.get_goniometer(i),
-                    scan=imageset.get_scan(i),
-                    crystal=crystal,
+        if isinstance(imageset, ImageSetLazy):
+            for i in range(len(imageset)):
+                experiments.append(Experiment(
+                        imageset=imageset[i : i + 1],
+                        crystal=crystal,
+                        lazy=True,
+                    )
                 )
-            )
+        else:
+            for i in range(len(imageset)):
+                experiments.append(
+                    Experiment(
+                        imageset=imageset[i : i + 1],
+                        beam=imageset.get_beam(i),
+                        detector=imageset.get_detector(i),
+                        goniometer=imageset.get_goniometer(i),
+                        scan=imageset.get_scan(i),
+                        crystal=crystal,
+                    )
+                )
         return experiments
 
     @staticmethod


### PR DESCRIPTION
This pull request adds lazy loading of experiments.  With this change, the loop in from_stills_and_crystal is greatly sped up as the individual models are not loaded for each experiment.  With this change, the time to load a big dataset greatly improves. This is vital for multiprocessing, since each process cannot be expected to read all the models when it will only handle a small subset of them.

Timing example snippet:

```
from dxtbx.model.experiment_list import ExperimentListFactory
import sys

experiments = ExperimentListFactory.from_filenames([sys.argv[1]])
print len(experiments)
```

With this snippet and an EuXFEL NeXus file with 32960 frames, the time to load the dataset using from_filenames improves from ~34.4s to ~7.7s.

Fixes #307.

Details:
- Add the attribute lazy = false to the Experiment constructor.  If true, the first time the detector, beam, goniometer, or scan are accessed, the function load_models is called. This function uses the experiment's imageset to go load the models.
- Change function from_stills_and_crystal to test if the imageset is an ImageSetLazy. If so, don't read the models up front and instead create the Experiments with lazy=True.

Notes:
- Because functions like Experiment.get_beam can now modify the beam (from None to a loaded beam), get_beam can't be const.  This caused lots of functions to lose the const keyword.
- load_models needs to use the python imageset methods which in this case will be ImageSetLazy methods.  That class uses the python format object load the models and cache them so for that reason load_models calls up and out of the C++ code into the python code.