### PR TITLE
Modified references to reflection pickle files from dials to use msgpack

### DIFF
--- a/xfel/command_line/cspad_cbf_metrology.py
+++ b/xfel/command_line/cspad_cbf_metrology.py
@@ -67,7 +67,7 @@ phil_scope = parse("""
     .type = choice
     .help = Algorithm to be used for choosing the n_subset images/experiments for \
             refinement.  n_refl chooses the set with the largest numbers of reflections \
-            listed in the pickle files, thus giving maximal coverage of the detector tiles \
+            listed in the mpack files, thus giving maximal coverage of the detector tiles \
             with the fewest refineable parameters. Significance_filter chooses the subset of \
             images with maximum reflections above an I/sigI cutoff
   n_refl_panel_list = None
@@ -244,9 +244,9 @@ def find_files(path, reflections):
   all_ref = []
   for filename in os.listdir(path):
     if reflections in filename:
-      exp_path = os.path.join(path, filename.rstrip("_%s.pickle"%reflections) + "_refined_experiments.json")
+      exp_path = os.path.join(path, filename.rstrip("_%s.mpack"%reflections) + "_refined_experiments.json")
       if not os.path.exists(exp_path):
-        exp_path = os.path.join(path, filename.rstrip("_%s.pickle"%reflections) + "_experiments.json")
+        exp_path = os.path.join(path, filename.rstrip("_%s.mpack"%reflections) + "_experiments.json")
         if not os.path.exists(exp_path): continue
       all_exp.append(exp_path)
       all_ref.append(os.path.join(path, filename))
@@ -266,7 +266,7 @@ def write_combine_phil(params, all_exp, all_ref):
 
 def refine(params, merged_scope, combine_phil):
   print "Combining experiments..."
-  command = "dials.combine_experiments reference_from_experiment.average_detector=True reference_from_experiment.average_hierarchy_level=0 output.experiments_filename=%s_combined_experiments.json output.reflections_filename=%s_combined_reflections.pickle %s"%(params.tag, params.tag, combine_phil)
+  command = "dials.combine_experiments reference_from_experiment.average_detector=True reference_from_experiment.average_hierarchy_level=0 output.experiments_filename=%s_combined_experiments.json output.reflections_filename=%s_combined_reflections.mpack %s"%(params.tag, params.tag, combine_phil)
   if params.n_subset is not None:
     command += " n_subset=%d n_subset_method=%s"%(params.n_subset, params.n_subset_method)
     if params.n_refl_panel_list is not None:
@@ -287,7 +287,7 @@ def refine_hierarchical(params, merged_scope, combine_phil):
   if params.panel_filter is not None:
     from libtbx import easy_pickle
     print "Filtering out all reflections except those on panels %s"%(", ".join(["%d"%p for p in params.panel_filter]))
-    combined_path = "%s_combined_reflections.pickle"%params.tag
+    combined_path = "%s_combined_reflections.mpack"%params.tag
     data = easy_pickle.load(combined_path)
     sel = None
     for panel_id in params.panel_filter:
@@ -310,11 +310,11 @@ def refine_hierarchical(params, merged_scope, combine_phil):
     if params.rmsd_filter.enable:
       command = "cctbx.xfel.filter_experiments_by_rmsd %s %s output.filtered_experiments=%s output.filtered_reflections=%s"
       if i == params.start_at_hierarchy_level:
-        command = command%("%s_combined_experiments.json"%params.tag, "%s_combined_reflections.pickle"%params.tag,
-                           "%s_filtered_experiments.json"%params.tag, "%s_filtered_reflections.pickle"%params.tag)
+        command = command%("%s_combined_experiments.json"%params.tag, "%s_combined_reflections.mpack"%params.tag,
+                           "%s_filtered_experiments.json"%params.tag, "%s_filtered_reflections.mpack"%params.tag)
       else:
-        command = command%("%s_refined_experiments_level%d.json"%(params.tag, i-1), "%s_refined_reflections_level%d.pickle"%(params.tag, i-1),
-                           "%s_filtered_experiments_level%d.json"%(params.tag, i-1), "%s_filtered_reflections_level%d.pickle"%(params.tag, i-1))
+        command = command%("%s_refined_experiments_level%d.json"%(params.tag, i-1), "%s_refined_reflections_level%d.mpack"%(params.tag, i-1),
+                           "%s_filtered_experiments_level%d.json"%(params.tag, i-1), "%s_filtered_reflections_level%d.mpack"%(params.tag, i-1))
       command += " iqr_multiplier=%f"%params.rmsd_filter.iqr_multiplier
       print command
       result = easy_run.fully_buffered(command=command).raise_if_errors()
@@ -343,13 +343,13 @@ def refine_hierarchical(params, merged_scope, combine_phil):
         diff_phil = "refinement.parameterisation.detector.fix_list=Group1Tau1\n" # refine almost everything
 
     if i == params.start_at_hierarchy_level:
-      command = "dials.refine %s %s_%s_experiments.json %s_%s_reflections.pickle"%(refine_phil_file, params.tag, input_name, params.tag, input_name)
+      command = "dials.refine %s %s_%s_experiments.json %s_%s_reflections.mpack"%(refine_phil_file, params.tag, input_name, params.tag, input_name)
     else:
-      command = "dials.refine %s %s_%s_experiments_level%d.json %s_%s_reflections_level%d.pickle"%(refine_phil_file, params.tag, input_name, i-1, params.tag, input_name, i-1)
+      command = "dials.refine %s %s_%s_experiments_level%d.json %s_%s_reflections_level%d.mpack"%(refine_phil_file, params.tag, input_name, i-1, params.tag, input_name, i-1)
 
     diff_phil += "refinement.parameterisation.detector.hierarchy_level=%d\n"%i
 
-    command += " output.experiments=%s_refined_experiments_level%d.json output.reflections=%s_refined_reflections_level%d.pickle"%( \
+    command += " output.experiments=%s_refined_experiments_level%d.json output.reflections=%s_refined_reflections_level%d.mpack"%( \
       params.tag, i, params.tag, i)
 
     scope = merged_scope.fetch(parse(diff_phil))
@@ -368,8 +368,8 @@ def refine_expanding(params, merged_scope, combine_phil):
   if params.rmsd_filter.enable:
     input_name = "filtered"
     command = "cctbx.xfel.filter_experiments_by_rmsd %s %s output.filtered_experiments=%s output.filtered_reflections=%s"
-    command = command%("%s_combined_experiments.json"%params.tag, "%s_combined_reflections.pickle"%params.tag,
-                       "%s_filtered_experiments.json"%params.tag, "%s_filtered_reflections.pickle"%params.tag)
+    command = command%("%s_combined_experiments.json"%params.tag, "%s_combined_reflections.mpack"%params.tag,
+                       "%s_filtered_experiments.json"%params.tag, "%s_filtered_reflections.mpack"%params.tag)
     command += " iqr_multiplier=%f"%params.rmsd_filter.iqr_multiplier
     print command
     result = easy_run.fully_buffered(command=command).raise_if_errors()
@@ -380,7 +380,7 @@ def refine_expanding(params, merged_scope, combine_phil):
   if params.panel_filter is not None:
     from libtbx import easy_pickle
     print "Filtering out all reflections except those on panels %s"%(", ".join(["%d"%p for p in params.panel_filter]))
-    combined_path = "%s_combined_reflections.pickle"%params.tag
+    combined_path = "%s_combined_reflections.mpack"%params.tag
     data = easy_pickle.load(combined_path)
     sel = None
     for panel_id in params.panel_filter:
@@ -418,8 +418,8 @@ def refine_expanding(params, merged_scope, combine_phil):
   for j in range(8):
     from libtbx import easy_pickle
     print "Filtering out all reflections except those on panels %s"%(", ".join(["%d"%p for p in steps[j]]))
-    combined_path = "%s_%s_reflections.pickle"%(params.tag, input_name)
-    output_path = "%s_reflections_step%d.pickle"%(params.tag, j)
+    combined_path = "%s_%s_reflections.mpack"%(params.tag, input_name)
+    output_path = "%s_reflections_step%d.mpack"%(params.tag, j)
     data = easy_pickle.load(combined_path)
     sel = None
     for panel_id in steps[j]:
@@ -454,22 +454,22 @@ def refine_expanding(params, merged_scope, combine_phil):
           diff_phil = "refinement.parameterisation.detector.fix_list=Group1Tau1\n" # refine almost everything
 
       if previous_step_and_level is None:
-        command = "dials.refine %s %s_%s_experiments.json %s_reflections_step%d.pickle"%( \
+        command = "dials.refine %s %s_%s_experiments.json %s_reflections_step%d.mpack"%( \
           refine_phil_file, params.tag, input_name, params.tag, j)
       else:
         p_step, p_level = previous_step_and_level
         if p_step == j:
-          command = "dials.refine %s %s_refined_experiments_step%d_level%d.json %s_refined_reflections_step%d_level%d.pickle"%( \
+          command = "dials.refine %s %s_refined_experiments_step%d_level%d.json %s_refined_reflections_step%d_level%d.mpack"%( \
             refine_phil_file, params.tag, p_step, p_level, params.tag, p_step, p_level)
         else:
-          command = "dials.refine %s %s_refined_experiments_step%d_level%d.json %s_reflections_step%d.pickle"%( \
+          command = "dials.refine %s %s_refined_experiments_step%d_level%d.json %s_reflections_step%d.mpack"%( \
             refine_phil_file, params.tag, p_step, p_level, params.tag, j)
 
 
       diff_phil += "refinement.parameterisation.detector.hierarchy_level=%d\n"%i
 
       output_experiments = "%s_refined_experiments_step%d_level%d.json"%(params.tag, j, i)
-      command += " output.experiments=%s output.reflections=%s_refined_reflections_step%d_level%d.pickle"%( \
+      command += " output.experiments=%s output.reflections=%s_refined_reflections_step%d_level%d.mpack"%( \
         output_experiments, params.tag, j, i)
 
       scope = merged_scope.fetch(parse(diff_phil))

--- a/xfel/command_line/cspad_cbf_metrology.py
+++ b/xfel/command_line/cspad_cbf_metrology.py
@@ -67,7 +67,7 @@ phil_scope = parse("""
     .type = choice
     .help = Algorithm to be used for choosing the n_subset images/experiments for \
             refinement.  n_refl chooses the set with the largest numbers of reflections \
-            listed in the mpack files, thus giving maximal coverage of the detector tiles \
+            listed in the reflection table files, thus giving maximal coverage of the detector tiles \
             with the fewest refineable parameters. Significance_filter chooses the subset of \
             images with maximum reflections above an I/sigI cutoff
   n_refl_panel_list = None

--- a/xfel/command_line/cspad_cbf_metrology.py
+++ b/xfel/command_line/cspad_cbf_metrology.py
@@ -285,10 +285,10 @@ def refine(params, merged_scope, combine_phil):
 
 def refine_hierarchical(params, merged_scope, combine_phil):
   if params.panel_filter is not None:
-    from libtbx import easy_pickle
+    from dials.array_family import flex
     print "Filtering out all reflections except those on panels %s"%(", ".join(["%d"%p for p in params.panel_filter]))
     combined_path = "%s_combined_reflections.mpack"%params.tag
-    data = easy_pickle.load(combined_path)
+    data = flex.reflection_table.from_file(combined_path)
     sel = None
     for panel_id in params.panel_filter:
       if sel is None:
@@ -296,7 +296,7 @@ def refine_hierarchical(params, merged_scope, combine_phil):
       else:
         sel |= data['panel'] == panel_id
     print "Retaining", len(data.select(sel)), "out of", len(data), "reflections"
-    easy_pickle.dump(combined_path, data.select(sel))
+    data.select(sel).as_msgpack_file(combined_path)
 
   for i in range(params.start_at_hierarchy_level, params.refine_to_hierarchy_level+1):
     if params.rmsd_filter.enable:
@@ -378,10 +378,10 @@ def refine_expanding(params, merged_scope, combine_phil):
     input_name = "combined"
   # --------------------------
   if params.panel_filter is not None:
-    from libtbx import easy_pickle
+    from dials.array_family import flex
     print "Filtering out all reflections except those on panels %s"%(", ".join(["%d"%p for p in params.panel_filter]))
     combined_path = "%s_combined_reflections.mpack"%params.tag
-    data = easy_pickle.load(combined_path)
+    data = flex.reflection_table.from_file(combined_path)
     sel = None
     for panel_id in params.panel_filter:
       if sel is None:
@@ -389,7 +389,7 @@ def refine_expanding(params, merged_scope, combine_phil):
       else:
         sel |= data['panel'] == panel_id
     print "Retaining", len(data.select(sel)), "out of", len(data), "reflections"
-    easy_pickle.dump(combined_path, data.select(sel))
+    data.select(sel).as_msgpack_file(combined_path)
   # ----------------------------------
   # this is the order to refine the CSPAD in
   steps = {}
@@ -416,11 +416,11 @@ def refine_expanding(params, merged_scope, combine_phil):
 
   previous_step_and_level = None
   for j in range(8):
-    from libtbx import easy_pickle
+    from dials.array_family import flex
     print "Filtering out all reflections except those on panels %s"%(", ".join(["%d"%p for p in steps[j]]))
     combined_path = "%s_%s_reflections.mpack"%(params.tag, input_name)
     output_path = "%s_reflections_step%d.mpack"%(params.tag, j)
-    data = easy_pickle.load(combined_path)
+    data = flex.reflection_table.from_file(combined_path)
     sel = None
     for panel_id in steps[j]:
       if sel is None:
@@ -428,7 +428,7 @@ def refine_expanding(params, merged_scope, combine_phil):
       else:
         sel |= data['panel'] == panel_id
     print "Retaining", len(data.select(sel)), "out of", len(data), "reflections"
-    easy_pickle.dump(output_path, data.select(sel))
+    data.select(sel).as_msgpack_file(output_path)
 
     for i in levels[j]:
       print "Step", j , "refining at hierarchy level", i

--- a/xfel/command_line/cspad_cbf_metrology.py
+++ b/xfel/command_line/cspad_cbf_metrology.py
@@ -244,9 +244,11 @@ def find_files(path, reflections):
   all_ref = []
   for filename in os.listdir(path):
     if reflections in filename:
-      exp_path = os.path.join(path, filename.rstrip("_%s.mpack"%reflections) + "_refined_experiments.json")
+      extension = os.path.splitext(filename)[1]
+      if extension not in ['.pickle', '.mpack']: continue
+      exp_path = os.path.join(path, filename.rstrip("_%s%s"%(reflections, extension)) + "_refined_experiments.json")
       if not os.path.exists(exp_path):
-        exp_path = os.path.join(path, filename.rstrip("_%s.mpack"%reflections) + "_experiments.json")
+        exp_path = os.path.join(path, filename.rstrip("_%s%s"%(reflections, extension)) + "_experiments.json")
         if not os.path.exists(exp_path): continue
       all_exp.append(exp_path)
       all_ref.append(os.path.join(path, filename))

--- a/xfel/command_line/cspad_detector_congruence.py
+++ b/xfel/command_line/cspad_detector_congruence.py
@@ -32,7 +32,7 @@ between two detectors.
 
 Example:
 
-  %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle
+  %s experiment1.json experiment2.json reflections1.mpack reflections2.mpack
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -228,7 +228,7 @@ class Script(object):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s experiment1.json experiment2.json reflections1.mpack reflections2.mpack" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,

--- a/xfel/command_line/cspad_detector_congruence2.py
+++ b/xfel/command_line/cspad_detector_congruence2.py
@@ -32,7 +32,7 @@ between two detectors.
 
 Example:
 
-  %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle
+  %s experiment1.json experiment2.json reflections1.mpack reflections2.mpack
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -179,7 +179,7 @@ class Script(object):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s experiment1.json experiment2.json reflections1.mpack reflections2.mpack" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,

--- a/xfel/command_line/cspad_detector_shifts.py
+++ b/xfel/command_line/cspad_detector_shifts.py
@@ -25,7 +25,7 @@ help_message = '''
 This program is used to show differences between a reference and a moving set of detectors
 Example:
 
-  %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle
+  %s experiment1.json experiment2.json reflections1.mpack reflections2.mpack
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -47,7 +47,7 @@ class Script(ParentScript):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s experiment1.json experiment2.json reflections1.mpack reflections2.mpack" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,

--- a/xfel/command_line/cspad_detector_statistics.py
+++ b/xfel/command_line/cspad_detector_statistics.py
@@ -61,7 +61,7 @@ class Script(object):
       raise Usage(self.parser.usage)
 
     level_json = "%s_%d_refined_experiments_level%d.json"
-    level_pickle = "%s_%d_refined_reflections_level%d.pickle"
+    level_pickle = "%s_%d_refined_reflections_level%d.mpack"
 
     command = "cspad.detector_congruence %s %s %s %s hierarchy_level=%d show_plots=False"
 

--- a/xfel/command_line/detector_residuals.py
+++ b/xfel/command_line/detector_residuals.py
@@ -35,7 +35,7 @@ between observed and predicted reflections
 
 Example:
 
-  dev.cctbx.xfel.detector_residuals experiment.json reflections.pickle
+  dev.cctbx.xfel.detector_residuals experiment.json reflections.mpack
 '''
 
 # Create the phil parameters

--- a/xfel/command_line/filter_experiments_by_rmsd.py
+++ b/xfel/command_line/filter_experiments_by_rmsd.py
@@ -30,7 +30,7 @@ interquartile range from the third quartile. When x=1.5, this is Tukey's rule.
 
 Example:
 
-  %s combined_experiments.json combined_reflections.pickle
+  %s combined_experiments.json combined_reflections.mpack
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -52,7 +52,7 @@ output {
   filtered_experiments = filtered_experiments.json
     .type = str
     .help = Name of output filtered experiments file
-  filtered_reflections = filtered_reflections.pickle
+  filtered_reflections = filtered_reflections.mpack
     .type = str
     .help = Name of output filtered reflections file
 }
@@ -71,7 +71,7 @@ class Script(object):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s combined_experiments.json combined_reflections.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s combined_experiments.json combined_reflections.mpack" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,
@@ -200,7 +200,7 @@ class Script(object):
     dump = ExperimentListDumper(filtered_experiments)
     dump.as_json(params.output.filtered_experiments)
 
-    filtered_reflections.as_pickle(params.output.filtered_reflections)
+    filtered_reflections.as_msgpack_file(params.output.filtered_reflections)
 
 if __name__ == '__main__':
   from dials.util import halraiser

--- a/xfel/command_line/frame_extractor.py
+++ b/xfel/command_line/frame_extractor.py
@@ -22,7 +22,7 @@ phil_scope = iotbx.phil.parse("""
       .help = path to an experiments.json file
     reflections = None
       .type = path
-      .help = path to a reflection table (integrated.pickle) file
+      .help = path to a reflection table (integrated.mpack) file
   }
   output {
     filename = None

--- a/xfel/command_line/frame_unpickler.py
+++ b/xfel/command_line/frame_unpickler.py
@@ -281,15 +281,15 @@ class construct_reflection_table_and_experiment_list(object):
     self.refl_kapton_correction_maker()
     self.refl_s1_maker() # depends on successful completion of refl_xyz_obs_maker
 
-  def reflections_to_pickle(self, path_name=None):
+  def reflections_to_msgpack_file(self, path_name=None):
     if path_name is None:
       loc = os.path.dirname(self.pickle)
     else:
       loc = path_name
     name = os.path.basename(self.pickle).split(".pickle")[0]
-    refl_name = int_pickle_to_filename(name, "idx-", "_integrated.pickle")
+    refl_name = int_pickle_to_filename(name, "idx-", "_integrated.mpack")
     reflections = os.path.join(loc, refl_name)
-    self.reflections.as_pickle(reflections)
+    self.reflections.as_msgpack_file(reflections)
 
 if __name__ == "__main__":
   master_phil_scope = iotbx.phil.parse("""
@@ -324,7 +324,7 @@ if __name__ == "__main__":
       result.assemble_experiments()
       result.assemble_reflections()
       result.experiments_to_json(params.json_location)
-      result.reflections_to_pickle(params.refl_location)
+      result.reflections_to_msgpack_file(params.refl_location)
     else:
       print "Skipping unreadable pickle file at", pickle_path
-  print 'Generated experiments.json and integrated.pickle files.'
+  print 'Generated experiments.json and integrated.mpack files.'

--- a/xfel/command_line/recompute_mosaicity.py
+++ b/xfel/command_line/recompute_mosaicity.py
@@ -25,7 +25,7 @@ Recompute mosaic parameters for a set of experiments and apply outlier rejection
 
 Example:
 
-  %s refined_experiments.json refined_reflections.pickle
+  %s refined_experiments.json refined_reflections.mpack
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -37,7 +37,7 @@ output {
   experiments = refined_experiments.json
     .type = str
     .help = Name of output  experiments file
-  reflections = refined_reflections.pickle
+  reflections = refined_reflections.mpack
     .type = str
     .help = Name of output reflections file
 }
@@ -52,7 +52,7 @@ class Script(object):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s refined_experiments.json refined_reflections.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s refined_experiments.json refined_reflections.mpack" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,
@@ -96,7 +96,7 @@ class Script(object):
 
     print "Removed %d out of %d reflections as outliers"%(len(reflections) - len(filtered_reflections), len(reflections))
     print "Saving filtered reflections as %s"%params.output.experiments
-    filtered_reflections.as_pickle(params.output.reflections)
+    filtered_reflections.as_msgpack_file(params.output.reflections)
 
     if params.plot_changes:
       from matplotlib import pyplot as plt

--- a/xfel/command_line/stills_merge.py
+++ b/xfel/command_line/stills_merge.py
@@ -22,8 +22,8 @@ op = os.path
 
 def eval_ending (file_name):
   ordered_endings_mapping = [
-    ("refined_experiments.json", "integrated.pickle"),
-    ("experiments.json", "integrated.pickle"),
+    ("refined_experiments.json", "integrated.mpack"),
+    ("experiments.json", "integrated.mpack"),
     ]
   dir_name = os.path.dirname(file_name)
   basename = os.path.basename(file_name)
@@ -62,7 +62,7 @@ def load_result (file_name,
                  params,
                  reindex_op,
                  out) :
-  # Pull relevant information from integrated.pickle and refined_experiments.json
+  # Pull relevant information from integrated.mpack and refined_experiments.json
   # files to construct the equivalent of a single integration pickle (frame).
   try:
     frame = frame_extractor.ConstructFrameFromFiles(eval_ending(file_name)[2], eval_ending(file_name)[1]).make_frame()

--- a/xfel/command_line/striping.py
+++ b/xfel/command_line/striping.py
@@ -63,9 +63,9 @@ combine_experiments {
     }
   keep_integrated = False
     .type = bool
-    .help = "Combine refined_experiments.json and integrated.pickle files."
-    .help = "If False, ignore integrated.pickle files in favor of"
-    .help = "indexed.pickle files in preparation for reintegrating."
+    .help = "Combine refined_experiments.json and integrated.mpack files."
+    .help = "If False, ignore integrated.mpack files in favor of"
+    .help = "indexed.mpack files in preparation for reintegrating."
   include scope dials.command_line.combine_experiments.phil_scope
 }
 '''
@@ -74,7 +74,7 @@ combining_override_str = '''
 combine_experiments {
   output {
     experiments_filename = FILENAME_combined_experiments.json
-    reflections_filename = FILENAME_combined_reflections.pickle
+    reflections_filename = FILENAME_combined_reflections.mpack
     delete_shoeboxes = False
   }
   reference_from_experiment {
@@ -107,7 +107,7 @@ refinement_override_str = '''
 refinement {
   output {
     experiments = FILENAME_refined_experiments_CLUSTER.json
-    reflections = FILENAME_refined_reflections_CLUSTER.pickle
+    reflections = FILENAME_refined_reflections_CLUSTER.mpack
     include_unused_reflections = False
     log = FILENAME_refine_CLUSTER.log
     debug_log = FILENAME_refine_CLUSTER.debug.log
@@ -135,7 +135,7 @@ refinement {
   }
   input {
     experiments = FILENAME_combined_experiments_CLUSTER.json
-    reflections = FILENAME_combined_reflections_CLUSTER.pickle
+    reflections = FILENAME_combined_reflections_CLUSTER.mpack
   }
 }
 '''
@@ -154,11 +154,11 @@ recompute_mosaicity_override_str = '''
 recompute_mosaicity {
   input {
     experiments = FILENAME_refined_experiments_CLUSTER.json
-    reflections = FILENAME_refined_reflections_CLUSTER.pickle
+    reflections = FILENAME_refined_reflections_CLUSTER.mpack
   }
   output {
     experiments = FILENAME_refined_experiments_CLUSTER.json
-    reflections = FILENAME_refined_reflections_CLUSTER.pickle
+    reflections = FILENAME_refined_reflections_CLUSTER.mpack
   }
 }
 '''
@@ -180,7 +180,7 @@ reintegration_override_str = '''
 reintegration{
   output {
     experiments = FILENAME_reintegrated_experiments_CLUSTER.json
-    reflections = FILENAME_reintegrated_reflections_CLUSTER.pickle
+    reflections = FILENAME_reintegrated_reflections_CLUSTER.mpack
     log = FILENAME_reintegrate_CLUSTER.log
     debug_log = FILENAME_reintegrate_CLUSTER.debug.log
   }
@@ -210,7 +210,7 @@ reintegration{
   }
   input {
     experiments = FILENAME_refined_experiments_CLUSTER.json
-    reflections = FILENAME_refined_reflections_CLUSTER.pickle
+    reflections = FILENAME_refined_reflections_CLUSTER.mpack
   }
 }
 '''
@@ -227,10 +227,10 @@ postprocessing_override_str = """
 postprocessing {
   input {
     experiments = FILENAME_reintegrated_experiments_CLUSTER.json
-    reflections = FILENAME_reintegrated_reflections_CLUSTER.pickle
+    reflections = FILENAME_reintegrated_reflections_CLUSTER.mpack
   }
   output {
-    filename = FILENAME_CLUSTER_ITER_extracted.pickle
+    filename = FILENAME_CLUSTER_ITER_extracted.mpack
     dirname = %s
   }
 }
@@ -264,7 +264,7 @@ def allocate_chunks(results_dir,
                     stripe=False,
                     max_size=1000,
                     integrated=False):
-  refl_ending = "_integrated.pickle" if integrated else "_indexed.pickle"
+  refl_ending = "_integrated.mpack" if integrated else "_indexed.mpack"
   expt_ending = "_refined_experiments.json"
   trial = "%03d" % trial_no
   print "processing trial %s" % trial
@@ -375,8 +375,8 @@ def script_to_expand_over_clusters(clustered_json_name,
   """
   Write a bash script to find results of a clustering step and produce customized
   phils and commands to run with each of them. For example, run the command
-  dials.refine ...cluster8.json ...cluster8.pickle ...cluster8.phil followed by
-  dials.refine ...cluster9.json ...cluster9.pickle ...cluster9.phil.
+  dials.refine ...cluster8.json ...cluster8.mpack ...cluster8.phil followed by
+  dials.refine ...cluster9.json ...cluster9.mpack ...cluster9.phil.
   clustered_json_name, clustered_refl_name and phil_template_name must each
   contain an asterisk, and substitution in phil_template itself will occur at
   each instance of CLUSTER.

--- a/xfel/command_line/striping.py
+++ b/xfel/command_line/striping.py
@@ -264,7 +264,7 @@ def allocate_chunks(results_dir,
                     stripe=False,
                     max_size=1000,
                     integrated=False):
-  refl_ending = "_integrated.mpack" if integrated else "_indexed.mpack"
+  refl_ending = "_integrated" if integrated else "_indexed"
   expt_ending = "_refined_experiments.json"
   trial = "%03d" % trial_no
   print "processing trial %s" % trial
@@ -296,6 +296,7 @@ def allocate_chunks(results_dir,
     batchable = {"all":rgs}
   # for either grouping, iterate over the top level keys in batchable and
   # distribute the events within those "batches" in stripes or chunks
+  extension = None
   for batch, rungroups in batchable.iteritems():
     rg_by_run = {}
     for rungroup, runs in rungroups.iteritems():
@@ -315,6 +316,8 @@ def allocate_chunks(results_dir,
       batch_contents[batch].extend(abs_contents)
       expts = [c for c in contents if c.endswith(expt_ending)]
       n_img += len(expts)
+      if extension is None:
+        extension = ".mpack" if any(c.endswith(".mpack") for c in contents) else ".pickle"
     if n_img == 0:
       print "no images found for %s" % batch
       del batch_contents[batch]
@@ -324,6 +327,7 @@ def allocate_chunks(results_dir,
     batch_chunk_nums_sizes[batch] = (n_chunks, chunk_size)
   if len(batch_contents) == 0:
     raise Sorry("no DIALS integration results found.")
+  refl_ending += extension
   batch_chunks = {}
   for batch, num_size_tuple in batch_chunk_nums_sizes.iteritems():
     num, size = num_size_tuple

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -907,7 +907,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         from dxtbx.model.experiment_list import ExperimentListFactory
 
         combined_experiments = ExperimentListFactory.from_json_file(combined_experiments_file, check_format=False)
-        combined_reflections = flex.reflection_table.from_msgpack_file(combined_reflections_file)
+        combined_reflections = flex.reflection_table.from_file(combined_reflections_file)
 
         from dials.algorithms.refinement import RefinerFactory
 

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -289,16 +289,16 @@ xtc_phil_str = '''
     experiments_filename = %s_experiments.json
       .type = str
       .help = The filename for output experiment list
-    strong_filename = %s_strong.pickle
+    strong_filename = %s_strong.mpack
       .type = str
       .help = The filename for strong reflections from spot finder output.
-    indexed_filename = %s_indexed.pickle
+    indexed_filename = %s_indexed.mpack
       .type = str
       .help = The filename for indexed reflections.
     refined_experiments_filename = %s_refined_experiments.json
       .type = str
       .help = The filename for saving refined experimental models
-    integrated_filename = %s_integrated.pickle
+    integrated_filename = %s_integrated.mpack
       .type = str
       .help = The filename for final experimental modls
     integrated_experiments_filename = %s_integrated_experiments.json
@@ -874,14 +874,14 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         experiment_jsons = []
         indexed_tables = []
         for filename in os.listdir(params.output.output_dir):
-          if not filename.endswith("_indexed.pickle"):
+          if not filename.endswith("_indexed.mpack"):
             continue
-          experiment_jsons.append(os.path.join(params.output.output_dir, filename.split("_indexed.pickle")[0] + "_refined_experiments.json"))
+          experiment_jsons.append(os.path.join(params.output.output_dir, filename.split("_indexed.mpack")[0] + "_refined_experiments.json"))
           indexed_tables.append(os.path.join(params.output.output_dir, filename))
           if params.format.file_format == "cbf":
-            images.append(os.path.join(params.output.output_dir, filename.split("_indexed.pickle")[0] + ".cbf"))
+            images.append(os.path.join(params.output.output_dir, filename.split("_indexed.mpack")[0] + ".cbf"))
           elif params.format.file_format == "pickle":
-            images.append(os.path.join(params.output.output_dir, filename.split("_indexed.pickle")[0] + ".pickle"))
+            images.append(os.path.join(params.output.output_dir, filename.split("_indexed.mpack")[0] + ".pickle"))
 
         if len(images) < params.joint_reintegration.minimum_results:
           pass # print and return
@@ -897,7 +897,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         f.close()
 
         combined_experiments_file = os.path.join(reint_dir, "combined_experiments.json")
-        combined_reflections_file = os.path.join(reint_dir, "combined_reflections.pickle")
+        combined_reflections_file = os.path.join(reint_dir, "combined_reflections.mpack")
         command = "dials.combine_experiments reference_from_experiment.average_detector=True %s output.reflections=%s output.experiments=%s"% \
           (combo_input, combined_reflections_file, combined_experiments_file)
         print command
@@ -907,7 +907,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         from dxtbx.model.experiment_list import ExperimentListFactory
 
         combined_experiments = ExperimentListFactory.from_json_file(combined_experiments_file, check_format=False)
-        combined_reflections = easy_pickle.load(combined_reflections_file)
+        combined_reflections = flex.reflection_table.from_msgpack_file(combined_reflections_file)
 
         from dials.algorithms.refinement import RefinerFactory
 
@@ -922,14 +922,14 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         from dxtbx.model import ExperimentList
         dump = ExperimentListDumper(experiments)
         dump.as_json(os.path.join(reint_dir, "refined_experiments.json"))
-        reflections.as_pickle(os.path.join(reint_dir, "refined_reflections.pickle"))
+        reflections.as_msgpack_file(os.path.join(reint_dir, "refined_reflections.mpack"))
 
         for expt_id, (expt, img_file) in enumerate(zip(experiments, images)):
           try:
             refls = reflections.select(reflections['id'] == expt_id)
             refls['id'] = flex.int(len(refls), 0)
             base_name = os.path.splitext(os.path.basename(img_file))[0]
-            self.params.output.integrated_filename = os.path.join(reint_dir, base_name + "_integrated.pickle")
+            self.params.output.integrated_filename = os.path.join(reint_dir, base_name + "_integrated.mpack")
 
             expts = ExperimentList([expt])
             self.integrate(expts, refls)
@@ -1186,7 +1186,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         from dials.util.command_line import Command
         Command.start('Saving {0} reflections to {1}'.format(
             len(observed), os.path.basename(strong_filename)))
-        observed.as_pickle(strong_filename)
+        observed.as_msgpack_file(strong_filename)
         Command.end('Saved {0} observed to {1}'.format(
             len(observed), os.path.basename(strong_filename)))
 

--- a/xfel/small_cell/small_cell.py
+++ b/xfel/small_cell/small_cell.py
@@ -1100,7 +1100,7 @@ def small_cell_index_detail(experiments, reflections, horiz_phil, write_output =
 
         refls.set_flags(flex.bool(len(refls), True), refls.flags.indexed)
         if write_output:
-          refls.as_pickle(os.path.splitext(os.path.basename(path).strip())[0]+"_integrated.pickle")
+          refls.as_msgpack_file(os.path.splitext(os.path.basename(path).strip())[0]+"_integrated.mpack")
 
         print "cctbx.small_cell: integrated %d spots."%len(results),
         integrated_count = len(results)


### PR DESCRIPTION
This pull request is related to the changes made in dials to use msgpack rather than pickle to serialize reflection data. https://github.com/dials/dials/pull/743

I have made some changes here to make sure that reflection files are serialized in the same way. Old reflection files in the pickle format can still be read using dials programs and if you used the dials.util.option.OptionParser class then pickle and msgpack files will be read transparently anyway. 
