### PR TITLE
Invert the BOOST FPE trap defaults.

### DIFF
--- a/boost/python.py
+++ b/boost/python.py
@@ -61,27 +61,18 @@ except AttributeError: pass # XXX backward compatibility 2009-11-24
 try: ostream = ext.ostream
 except AttributeError: pass
 
-if ("BOOST_ADAPTBX_SIGNALS_DEFAULT" not in os.environ):
+if os.getenv("BOOST_ADAPTBX_ENABLE_TRACE"):
   ext.enable_signals_backtrace_if_possible()
 
-
 class floating_point_exceptions_type(object):
-
   __shared_state = {'initialised': False}
 
-  def __init__(self, division_by_zero, invalid, overflow):
+  def __init__(self):
     self.__dict__ = self.__shared_state
     if not self.initialised:
-      if "BOOST_ADAPTBX_FPE_DEFAULT" in os.environ:
-        division_by_zero = self.division_by_zero_trapped
-        invalid = self.invalid_trapped
-        overflow = self.overflow_trapped
-      elif "BOOST_ADAPTBX_FE_DIVBYZERO_DEFAULT" in os.environ:
-        division_by_zero = self.division_by_zero_trapped
-      elif "BOOST_ADAPTBX_FE_INVALID_DEFAULT" in os.environ:
-        invalid = self.invalid_trapped
-      elif "BOOST_ADAPTBX_FE_OVERFLOW_DEFAULT" in os.environ:
-        overflow = self.overflow_trapped
+      division_by_zero = bool(os.getenv("BOOST_ADAPTBX_TRAP_FPE", self.division_by_zero_trapped))
+      invalid = bool(os.getenv("BOOST_ADAPTBX_TRAP_INVALID",self.invalid_trapped))
+      overflow = bool(os.getenv("BOOST_ADAPTBX_TRAP_OVERFLOW",self.overflow_trapped))
       ext.trap_exceptions(division_by_zero, invalid, overflow)
       self.initialised = True
 
@@ -118,15 +109,7 @@ class floating_point_exceptions_type(object):
     return locals()
   overflow_trapped = property(**overflow_trapped())
 
-def floating_point_exceptions():
-  import libtbx.load_env
-  if (libtbx.env.is_development_environment()):
-    flag = True
-  else:
-    flag = False
-  return floating_point_exceptions_type(
-    division_by_zero=flag, invalid=False, overflow=flag)
-floating_point_exceptions = floating_point_exceptions()
+floating_point_exceptions = floating_point_exceptions_type()
 
 
 class trapping(object):

--- a/boost_adaptbx/meta_ext.cpp
+++ b/boost_adaptbx/meta_ext.cpp
@@ -139,10 +139,14 @@ namespace {
 "                This crash may be due to a problem in any imported\n"
 "                Python module, including modules which are not part\n"
 "                of the cctbx project. To disable the traps leading\n"
-"                to this message, define these environment variables\n"
-"                (e.g. assign the value 1):\n"
-"                    BOOST_ADAPTBX_FPE_DEFAULT\n"
-"                    BOOST_ADAPTBX_SIGNALS_DEFAULT\n"
+"                to this message, undefine these environment variables\n"
+"                (or assign the value ""):\n"
+"                    BOOST_ADAPTBX_TRAP_FPE\n"
+"                    BOOST_ADAPTBX_TRAP_INVALID\n"
+"                    BOOST_ADAPTBX_TRAP_OVERFLOW\n"
+"                To disable the full trace but keep the exception you\n"
+"                can undefine:\n"
+"                    BOOST_ADAPTBX_ENABLE_TRACE\n"
 "                This will NOT solve the problem, just mask it, but\n"
 "                may allow you to proceed in case it is not critical.\n");
     fflush(stderr);


### PR DESCRIPTION
## Executive summary

FPE exceptions in Python inside development installations are no longer trapped by default, making the Python behaviour consistent with an environment from an installer. C++ exceptions continue to be trapped by default.

### How do I restore previous behaviour
To re-enable traces set the environment variable `BOOST_ADAPTBX_ENABLE_TRACE`,
to re-enable FPE crashes set `BOOST_ADAPTBX_TRAP_FPE`,
to re-enable python overflow crashes set `BOOST_ADAPTBX_TRAP_OVERFLOW`.

Traps can be enabled for specific code sections using the context handler:
```python
import boost.python

with boost.python.trapping(overflow=True):
  inf_value = 1e300
  while inf_value != inf_value*inf_value:
    inf_value *= inf_value   # crash
```

### Details
Right now the following two commands behave differently on any development installation:
```libtbx.python -c "import math; print math.ldexp(1.0,1023)*2"```
```libtbx.python -c "import boost.python;import math; print math.ldexp(1.0,1023)*2"```
The first command prints out `inf`, while the second command crashes the python interpreter with an uncatchable FPE exception. When run on a installation from an installer _both_ commands will print `inf`.

Importing the `boost.python` package changes the behaviour of Python (the language) for development installations. This does not necessarily pose a problem within cctbx, as we can work around these cases. However this may cause 3rd party libraries to crash in unexpected ways, including widely used libraries such as pyyaml and pytables. Our work-around usually involves setting the environment variables `BOOST_ADAPTBX_FPE_DEFAULT`and `BOOST_ADAPTBX_SIGNALS_DEFAULT` in dispatchers. This is currently the case for 53 dispatchers in cctbx_project, 18 in dials, and 4 in xia2. This results in code paths within cctbx_project and dials that are not supposed to be executed by dispatchers that do not carry this flag. The code paths are of course not marked as such, and therefore we continue to encounter these FPE issues on a regular basis.

### Current behaviour
To investigate the actual effects of the FPE trap logic I ran the following three commands:
**A**) ```libtbx.python -c "import boost.python; import math; print math.ldexp(1.0,1023)*2"```
**B**) ```libtbx.python -c "import boost.python; print boost.python.ext.divide_doubles(1, 0)"```
**C**) ```libtbx.python -c "import scitbx.array_family.flex as f; print f.int([1,2,3])/0"```

under the following conditions: 
**1** = Developer environment
**2** = Deployment environment
**F** = `BOOST_ADAPTBX_FPE_DEFAULT` set
**S** = `BOOST_ADAPTBX_SIGNALS_DEFAULT` set

with the following results: 

**i** = prints "inf"
**E** = crashes with "Floating point exception"
**T** = crashes with stack trace

. | A | B | C
--- | --- | --- | ---
1  | T | T | T
1F  | i|  i|  T
1S   |E  |E  |E
1FS  |i  |i  |E
2    |i  |i  |T
2F   |i  |i  |T
2S   |i  |i  |E
2FS  |i  |i  |E

#### Observations:
* The crashes only happen on development builds. In fact there is currently no way to enable trace messages on non-development builds. This is counterintuitive, as on a development build we do not necessarily need trace messages as we could attach a debugger, whereas on a non-development build we can not attach a debugger, so this would be where traces are more useful.
* C++ code in flex arrays always crashes, no matter what flags are set.
* Python code that should simply return infinity does so everywhere but on development builds.

### Proposal
My proposal is therefore to invert the trap defaults. Replace the existing `BOOST_ADAPTBX_*` environment variables with 
* `BOOST_ADAPTBX_ENABLE_TRACE` to enable traces
* `BOOST_ADAPTBX_TRAP_FPE` to enable FPE crashes
* `BOOST_ADAPTBX_TRAP_OVERFLOW` to enable python overflow crashes

And with those conditions
**X** = `BOOST_ADAPTBX_ENABLE_TRACE` set
**Y** = `BOOST_ADAPTBX_TRAP_FPE` set
**Z** = `BOOST_ADAPTBX_TRAP_OVERFLOW` set
and
**3** = any environment (development or deployment)

I get the following results:

. | A | B | C
--- | --- | --- | ---
3   | i |  i  | E
3Y  | i | E  | E
3Z  | E |  i  | E
3YZ  | E | E | E
3X   | i | i  | T
3XY  | i | T |  T
3XZ  | T |  i | T
3XYZ | T | T | T

#### In other words:
* C++ code in flex arrays continues to crash (as this is independent of flags)
* Python code works consistently on development and deployment
* all code works out of the box on all occasions, and this includes 3rd party python modules that are not under our control
* With this it becomes possible for the first time to enable the traps on a deployment build (right now this is not possible, setting `*_FPE_DEFAULT` to "" or 0 is treated the same as 1, ie. it disables the flags)
* and to enable those flags separately.

To get the same behaviour as before all people have to do is to set the three flags in their environment, or use the context manager as outlined above to enable the flags selectively as and when needed.