### PR TITLE
check which entries in a flex.vec3_double array are equal to a vec3_double

### DIFF
--- a/scitbx/array_family/boost_python/flex_vec3_double.cpp
+++ b/scitbx/array_family/boost_python/flex_vec3_double.cpp
@@ -184,6 +184,18 @@ namespace {
     return result;
   }
 
+  // Checks which elements in flex vec3_double is equal
+  // to a vec3_double and returns a flex.bool
+  af::shared<bool> is_equal_to_vec3_double(
+      af::const_ref < vec3 <double> > const& self,
+      vec3 <double> other) {
+    af::shared<bool> result(self.size());
+    for (std::size_t i = 0; i < self.size(); ++i) {
+      bool a = self[i] == other;
+      result[i] = a;
+    }
+    return result;
+  }
 
   flex_double
   as_double(flex<vec3<double> >::type const& a)
@@ -600,6 +612,11 @@ namespace boost_python {
           bool)) &angle, (
             arg("other"),
             arg("deg") = false))
+      .def("is_equal_to_vec3_double",
+        (af::shared<bool>(*)(
+          af::const_ref< vec3<double> > const&,
+          vec3<double>)) &is_equal_to_vec3_double, (
+            arg("other")))
       .def("as_double", as_double)
       .def("add_selected",
         (object(*)(

--- a/scitbx/array_family/boost_python/flex_vec3_double.cpp
+++ b/scitbx/array_family/boost_python/flex_vec3_double.cpp
@@ -197,18 +197,18 @@ namespace {
     return result;
   }
 
-  // Checks if all elements of a flex.vec3_double are equal 
-  // to all elements of another flex.vec3_double. Returns a bool
-  bool equal_all_all(
+  // Element-wise comparison between two flex.vec3_double of same size
+  // to assess which elements are equal. Returns a flex.bool
+  af::shared<bool> equal_all_all(
       af::const_ref < vec3 <double> > const& self,
       af::const_ref < vec3 <double> > const& other) {
     SCITBX_ASSERT(self.size() == other.size());
+    af::shared<bool> result(self.size());
     for (std::size_t i = 0; i < self.size(); ++i) {
-      if (self[i] != other[i]){
-        return false;
-        }
+      bool a = self[i] == other[i];
+      result[i] = a;
     }
-    return true;
+    return result;
   }
 
   // Checks which elements in flex vec3_double is not equal
@@ -224,19 +224,18 @@ namespace {
     return result;
   }
 
-  // Checks if all elements of a flex.vec3_double are equal 
-  // to all elements of another flex.vec3_double. Returns a bool
-  // Basically even with a single inequality, false is returned
-  bool not_equal_all_all(
+  // Element-wise comparison between two flex.vec3_double of same size
+  // to assess which elements are not equal. Returns a flex.bool
+  af::shared<bool> not_equal_all_all(
       af::const_ref < vec3 <double> > const& self,
       af::const_ref < vec3 <double> > const& other) {
     SCITBX_ASSERT(self.size() == other.size());
+    af::shared<bool> result(self.size());
     for (std::size_t i = 0; i < self.size(); ++i) {
-      if (self[i] != other[i]){
-        return true;
-        }
+      bool a = self[i] != other[i];
+      result[i] = a;
     }
-    return false;
+    return result;
   }
 
   flex_double
@@ -687,13 +686,21 @@ namespace boost_python {
           af::const_ref< vec3<double> > const&,
           vec3<double>)) &equal_all_single, (
             arg("other")))
-      .def("__eq__",&equal_all_all)
+      .def("__eq__",
+        (af::shared<bool>(*)(
+          af::const_ref< vec3<double> > const&,
+          af::const_ref< vec3<double> > const& )) &equal_all_all, (
+            arg("other")))
       .def("__ne__",
         (af::shared<bool>(*)(
           af::const_ref< vec3<double> > const&,
           vec3<double>)) &not_equal_all_single, (
             arg("other")))
-      .def("__ne__",&not_equal_all_all)
+      .def("__ne__",
+        (af::shared<bool>(*)(
+          af::const_ref< vec3<double> > const&,
+          af::const_ref< vec3<double> > const& )) &not_equal_all_all, (
+            arg("other")))
       .def("round", round)
       .def("iround", iround)
       .def("dot", dot_a_s)

--- a/scitbx/array_family/boost_python/flex_vec3_double.cpp
+++ b/scitbx/array_family/boost_python/flex_vec3_double.cpp
@@ -186,7 +186,7 @@ namespace {
 
   // Checks which elements in flex vec3_double is equal
   // to a vec3_double and returns a flex.bool
-  af::shared<bool> is_equal_to_vec3_double(
+  af::shared<bool> equal_all_single(
       af::const_ref < vec3 <double> > const& self,
       vec3 <double> other) {
     af::shared<bool> result(self.size());
@@ -195,6 +195,48 @@ namespace {
       result[i] = a;
     }
     return result;
+  }
+
+  // Checks if all elements of a flex.vec3_double are equal 
+  // to all elements of another flex.vec3_double. Returns a bool
+  bool equal_all_all(
+      af::const_ref < vec3 <double> > const& self,
+      af::const_ref < vec3 <double> > const& other) {
+    SCITBX_ASSERT(self.size() == other.size());
+    for (std::size_t i = 0; i < self.size(); ++i) {
+      if (self[i] != other[i]){
+        return false;
+        }
+    }
+    return true;
+  }
+
+  // Checks which elements in flex vec3_double is not equal
+  // to a vec3_double and returns a flex.bool
+  af::shared<bool> not_equal_all_single(
+      af::const_ref < vec3 <double> > const& self,
+      vec3 <double> other) {
+    af::shared<bool> result(self.size());
+    for (std::size_t i = 0; i < self.size(); ++i) {
+      bool a = self[i] != other;
+      result[i] = a;
+    }
+    return result;
+  }
+
+  // Checks if all elements of a flex.vec3_double are equal 
+  // to all elements of another flex.vec3_double. Returns a bool
+  // Basically even with a single inequality, false is returned
+  bool not_equal_all_all(
+      af::const_ref < vec3 <double> > const& self,
+      af::const_ref < vec3 <double> > const& other) {
+    SCITBX_ASSERT(self.size() == other.size());
+    for (std::size_t i = 0; i < self.size(); ++i) {
+      if (self[i] != other[i]){
+        return true;
+        }
+    }
+    return false;
   }
 
   flex_double
@@ -612,11 +654,6 @@ namespace boost_python {
           bool)) &angle, (
             arg("other"),
             arg("deg") = false))
-      .def("is_equal_to_vec3_double",
-        (af::shared<bool>(*)(
-          af::const_ref< vec3<double> > const&,
-          vec3<double>)) &is_equal_to_vec3_double, (
-            arg("other")))
       .def("as_double", as_double)
       .def("add_selected",
         (object(*)(
@@ -645,6 +682,18 @@ namespace boost_python {
       .def("__truediv__", div_a_as)
       .def("__mul__", mul_a_mat3)
       .def("__rmul__", rmul_a_mat3)
+      .def("__eq__",
+        (af::shared<bool>(*)(
+          af::const_ref< vec3<double> > const&,
+          vec3<double>)) &equal_all_single, (
+            arg("other")))
+      .def("__eq__",&equal_all_all)
+      .def("__ne__",
+        (af::shared<bool>(*)(
+          af::const_ref< vec3<double> > const&,
+          vec3<double>)) &not_equal_all_single, (
+            arg("other")))
+      .def("__ne__",&not_equal_all_all)
       .def("round", round)
       .def("iround", iround)
       .def("dot", dot_a_s)

--- a/scitbx/array_family/boost_python/tst_flex.py
+++ b/scitbx/array_family/boost_python/tst_flex.py
@@ -1848,6 +1848,17 @@ def exercise_flex_vec3_double():
   for aa, tt1 in zip(a, t1):
     tt2 = matrix.col(aa).angle(b)
     assert(abs(tt1-tt2) < eps)
+  # checks for __eq__ and __ne__ for flex.vec3_double to (a) vec3_double and (b) flex.vec3_double
+  a = flex.vec3_double([(1,2,5), (-2,3,4), (3,4,3)])
+  b = flex.vec3_double([(1,2,5), (-2,3,4), (3,4,3)])
+  c = flex.vec3_double([(1,2,6), (-2,3,5), (3,4,1)])
+  d = (-2.0, 3.0, 4.0)
+  assert list(a==d).count(True)==1
+  assert a==b
+  assert (a==c)==False
+  assert list(a!=d).count(True)==2
+  assert a!=c
+  assert (a!=b)==False
 
 
 

--- a/scitbx/array_family/boost_python/tst_flex.py
+++ b/scitbx/array_family/boost_python/tst_flex.py
@@ -1851,14 +1851,14 @@ def exercise_flex_vec3_double():
   # checks for __eq__ and __ne__ for flex.vec3_double to (a) vec3_double and (b) flex.vec3_double
   a = flex.vec3_double([(1,2,5), (-2,3,4), (3,4,3)])
   b = flex.vec3_double([(1,2,5), (-2,3,4), (3,4,3)])
-  c = flex.vec3_double([(1,2,6), (-2,3,5), (3,4,1)])
+  c = flex.vec3_double([(1,2,6), (-2,3,5), (3,4,3)])
   d = (-2.0, 3.0, 4.0)
   assert list(a==d).count(True)==1
-  assert a==b
-  assert (a==c)==False
+  assert list(a==b).count(True)==3
+  assert list(a==c).count(False)==2
   assert list(a!=d).count(True)==2
-  assert a!=c
-  assert (a!=b)==False
+  assert list(a!=c).count(True)==2
+  assert list(a!=b).count(False)==3
 
 
 


### PR DESCRIPTION
The comparison is done on an element by element basis in C++ and returns a flex bool array. Currently the == operator for flex.vec3_double returns a single bool value which is why this new function was implemented. 