### PR TITLE
Fix unicode issues in XDS parameter file readers

### DIFF
--- a/iotbx/xds/xparm.py
+++ b/iotbx/xds/xparm.py
@@ -129,7 +129,7 @@ class reader(object):
     self.beam_vector       = tuple(map(float, tokens[1][1:4]))
 
     # Detector stuff
-    self.num_segments      = None
+    self.num_segments      = 0
     self.detector_size     = tuple(map(int, tokens[2][0:2]))
     self.pixel_size        = tuple(map(float, tokens[2][2:4]))
     self.detector_distance = float(tokens[3][0])

--- a/iotbx/xds/xparm.py
+++ b/iotbx/xds/xparm.py
@@ -7,16 +7,16 @@
 #   Class to read all the data from a (G)XPARM.XDS file
 #
 from __future__ import absolute_import, division, print_function
+
+import io
 import sys
+
 from libtbx import adopt_init_args
 from six.moves import range
 from six.moves import map
 
 class reader(object):
   """A class to read the XPARM.XDS/GXPARM.XDS file used in XDS"""
-
-  def __init__(self):
-    pass
 
   @staticmethod
   def find_version(filename):
@@ -36,7 +36,7 @@ class reader(object):
     """
 
     # Check file contains 11 lines and 42 tokens
-    with open(filename, 'r') as file_handle:
+    with io.open(filename, 'r', encoding="ascii") as file_handle:
       tokens = []
       version = 1
       count = 0
@@ -81,7 +81,10 @@ class reader(object):
       True/False the file is a (G)XPARM.XDS file
 
     """
-    return reader.find_version(filename) != None
+    try:
+      return reader.find_version(filename) is not None
+    except UnicodeDecodeError:
+      return False
 
   def read_file(self, filename, check_filename = True):
     """Read the XPARM.XDS/GXPARAM.XDS file.
@@ -96,10 +99,11 @@ class reader(object):
 
     # Check version and read file
     version = reader.find_version(filename)
-    if version != None:
-      tokens = [l.split() for l in open(filename, 'r').readlines()]
-    else:
-      raise IOError("{0} is not a (G)XPARM.XDS file".format(filename))
+    if version is None:
+      raise IOError("{} is not a (G)XPARM.XDS file".format(filename))
+
+    with io.open(filename, 'r', encoding="ascii") as fh:
+      tokens = [l.split() for l in fh.readlines()]
 
     # Parse the tokens
     if version == 1:

--- a/rstbx/cftbx/coordinate_frame_helpers.py
+++ b/rstbx/cftbx/coordinate_frame_helpers.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, print_function
+
+import io
 import math
 import random
+
 from scitbx import matrix
 from cctbx import sgtbx
 from six.moves import range, zip
@@ -207,27 +210,22 @@ def is_xds_xparm(putative_xds_xparm_file):
 def is_xds_integrate_hkl(putative_integrate_hkl_file):
     '''See if this looks like an XDS INTEGRATE.HKL file.'''
 
-    first_record = open(putative_integrate_hkl_file).readline()
-
-    if '!OUTPUT_FILE=INTEGRATE.HKL' in first_record:
-        return True
-
-    return False
+    with io.open(putative_integrate_hkl_file, encoding="ascii") as fh:
+      try:
+        first_record = fh.readline()
+        return '!OUTPUT_FILE=INTEGRATE.HKL' in first_record
+      except UnicodeDecodeError:
+        return False
 
 def is_xds_ascii_hkl(putative_xds_ascii_hkl_file):
     '''See if this looks like an XDS INTEGRATE.HKL file.'''
 
-    lines = []
-    with open(putative_xds_ascii_hkl_file) as f:
-      lines.append(f.readline())
-      lines.append(f.readline())
-      if lines[1] == "":
-          return False
-
-      if '!OUTPUT_FILE=XDS_ASCII.HKL' in lines[1]:
-          return True
-
-    return False
+    with io.open(putative_xds_ascii_hkl_file, encoding="ascii") as f:
+      try:
+        f.readline()
+        return "!OUTPUT_FILE=XDS_ASCII.HKL" in f.readline()
+      except UnicodeDecodeError:
+        return False
 
 def is_recognized_file(filename):
     ''' Check if the file is recognized.'''
@@ -240,7 +238,7 @@ def is_recognized_file(filename):
     elif is_xds_inp(filename):
         return True
 
-    # Not recognices
+    # Not recognized
     return False
 
 def import_xds_integrate_hkl(integrate_hkl_file):

--- a/rstbx/cftbx/coordinate_frame_helpers.py
+++ b/rstbx/cftbx/coordinate_frame_helpers.py
@@ -185,7 +185,7 @@ def align_reference_frame(primary_axis, primary_target,
       axis_r = secondary_target.cross(Rprimary * secondary_axis)
       axis_s = primary_target
 
-      if (axis_r.angle(primary_target) > 0.5 * math.pi):
+      if (axis_r.angle(primary_target, value_if_undefined=0) > 0.5 * math.pi):
         angle_s = orthogonal_component(axis_s, secondary_target).angle(
           orthogonal_component(axis_s, Rprimary * secondary_axis))
       else:


### PR DESCRIPTION
this assumes XDS files are ASCII encoded, and that an encoding error means the format can not be understood.
Includes minor campsite improvements.
Tagging original authors for review.