### PR TITLE
Fix further detector formats for Python 3

### DIFF
--- a/iotbx/detectors/edf.py
+++ b/iotbx/detectors/edf.py
@@ -20,14 +20,14 @@ class EDFImage:
    self.obj.seek(0)
 
    while True:
-       newchr = self.obj.read(1)
+       newchr = self.obj.read(1).decode("latin-1")
        assert ord(newchr)!=0
        if ptr==1:  assert ord(self.header[0])==0x7b
        self.header.append(newchr)
        if newchr == "}": break
        ptr += 1
 
-   assert self.obj.read(1) == "\n"
+   assert self.obj.read(1).decode("latin-1") == "\n"
    self.headersize = 1 + len(self.header)
    assert self.headersize%512==0
 

--- a/iotbx/detectors/eiger_minicbf.py
+++ b/iotbx/detectors/eiger_minicbf.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
-from six.moves import range
-import copy,re
+import copy
+import re
 from iotbx.detectors.detectorbase import DetectorImageBase
 from iotbx.detectors import ImageException
 
@@ -51,23 +51,21 @@ class EigerCBFImage(DetectorImageBase):
 
   def readHeader(self,maxlength=12288): # usually 1024 is OK; require 12288 for ID19
     if not self.parameters:
-      rawdata = open(self.filename,"rb").read(maxlength)
+      with open(self.filename,"rb") as fh:
+        rawdata = fh.read(maxlength)
 
       # The tag _array_data.header_convention "SLS_1.0" could be with/without quotes "..."
-      SLS_pattern = re.compile(r'''_array_data.header_convention[ "]*SLS''')
-      SLS_match = SLS_pattern.findall(rawdata)
-      PILATUS_pattern = re.compile(r'''_array_data.header_convention[ "]*PILATUS''')
-      PILATUS_match = PILATUS_pattern.findall(rawdata)
+      # SLS_match = re.findall(b'_array_data.header_convention[ "]*SLS', rawdata)
+      # PILATUS_match = re.findall(b'_array_data.header_convention[ "]*PILATUS', rawdata)
       #assert len(SLS_match) + len(PILATUS_match)>=1
 
       # read SLS header
-      headeropen = rawdata.index("_array_data.header_contents")
-      headerclose= rawdata.index("_array_data.data")
-      self.header = rawdata[headeropen+1:headerclose]
+      headeropen = rawdata.index(b"_array_data.header_contents")
+      headerclose = rawdata.index(b"_array_data.data")
+      self.header = rawdata[headeropen+1:headerclose].decode("latin-1")
       self.headerlines = [x.strip() for x in self.header.split("#")]
-      for idx in range(len(self.headerlines)):
-        for character in '\r\n,();':
-          self.headerlines[idx] = self.headerlines[idx].replace(character,'')
+      character_filter = re.compile(r"[\r\n,\(\);]")
+      self.headerlines = [character_filter.sub("", x) for x in self.headerlines]
 
       self.parameters={'CCD_IMAGE_SATURATION':65535}
       for tag,search,idx,datatype in [
@@ -111,7 +109,7 @@ class EigerCBFImage(DetectorImageBase):
       # read array size
       header_lines = []
       found_array_data_data = False
-      for record in rawdata.splitlines():
+      for record in rawdata.decode("latin-1").splitlines():
         if "_array_data.data" in record:
           found_array_data_data = True
         elif not found_array_data_data:
@@ -124,9 +122,7 @@ class EigerCBFImage(DetectorImageBase):
         header_lines.append(record)
       self.header = "\n".join(header_lines)
       self.headerlines = [x.strip() for x in self.header.split("\n")]
-      for idx in range(len(self.headerlines)):
-        for character in '\r\n,();':
-          self.headerlines[idx] = self.headerlines[idx].replace(character,'')
+      self.headerlines = [character_filter.sub("", x) for x in self.headerlines]
 
       for tag,search,idx,datatype in [
           ('SIZE1','X-Binary-Size-Second-Dimension',-1,int),

--- a/iotbx/detectors/noir.py
+++ b/iotbx/detectors/noir.py
@@ -14,16 +14,15 @@ class NoirImage(ADSCImage):
 
   def getTupleofType(self,inputstr,typefunc):
     parsed = inputstr.split(' ')
-    while '' in parsed:
-      parsed.remove('')
-    return [typefunc(I) for I in parsed]
+    return [typefunc(I) for I in parsed if I != '']
 
   def readHeader(self,maxlength=6144):
     if not self.parameters:
-      rawdata = open(self.filename,"rb").read(maxlength)
-      headeropen = rawdata.index("{")
-      headerclose= rawdata.index("}")
-      self.header = rawdata[headeropen+1:headerclose-headeropen]
+      with open(self.filename,"rb") as fh:
+        rawdata = fh.read(maxlength)
+      headeropen = rawdata.index(b"{")
+      headerclose= rawdata.index(b"}")
+      self.header = rawdata[headeropen+1:headerclose-headeropen].decode("latin-1")
 
       self.parameters={}
       for tag,search,datatype in [
@@ -58,8 +57,7 @@ class NoirImage(ADSCImage):
           #('DATE','DTREK_DATE_TIME',str),
           ('ROTATION',r'\nROTATION',FLOAT),
           ]:
-          pattern = re.compile(search+'='+r'(.*);')
-          matches = pattern.findall(self.header)
+          matches = re.findall(search+'='+r'(.*);', self.header)
           if len(matches)>0:
             if type(datatype) == type((0,1)):
               self.parameters[tag] = self.getTupleofType(
@@ -86,9 +84,9 @@ class NoirImage(ADSCImage):
 
   def read(self):
     from iotbx.detectors import ReadRAXIS
-    F = open(self.filename,'rb')
-    F.seek(self.dataoffset())
-    chardata = F.read(self.size1 * self.size2 * self.integerdepth() )
+    with open(self.filename,'rb') as fh:
+      fh.seek(self.dataoffset())
+      chardata = fh.read(self.size1 * self.size2 * self.integerdepth() )
     self.bin_safe_set_data( ReadRAXIS(chardata,self.dataoffset(),
          self.size1*self.bin,self.size2*self.bin,
          self.endian_swap_required())


### PR DESCRIPTION
these are, as far as I can tell, the remaining iotbx/detector classes that are touched/covered by dxtbx tests:
edf, eiger minicbf, noir, saturn.

* Usual necessary string/bytes modifications.
* Use context managers for file operations.
* Minor code cleanups.

Not surprisingly this is very similar to the other pull requests. dxtbx tests on python 2 still pass.

Mentioning @nksauter and @phyy-nx for awareness
