### PR TITLE
Rename output files

### DIFF
--- a/xfel/clustering/cluster.py
+++ b/xfel/clustering/cluster.py
@@ -144,9 +144,9 @@ class Cluster:
         for (dirpath, dirnames, filenames) in os.walk(arg):
           for filename in filenames:
             path = os.path.join(dirpath, filename)
-            if path.endswith("integrated.pickle"):
+            if path.endswith(("integrated.pickle", "integrated.refl")):
               dials_refls.append(path)
-            elif path.endswith("experiments.json"):
+            elif path.endswith(("experiments.json", "indexed.expt")):
               dials_expts.append(path)
 
     else:
@@ -157,8 +157,8 @@ class Cluster:
         for (dirpath, dirnames, filenames) in os.walk(arg):
           for filename in filenames:
             path = os.path.join(dirpath, filename)
-            if path.endswith(".pickle"):
-              print(path, "ends with .pickle")
+            if path.endswith((".pickle", ".refl")):
+              print(path, "ends with .pickle or .refl")
               pickles.append(path)
 
     return Cluster.from_files(pickle_list=pickles, dials_refls=dials_refls,
@@ -301,9 +301,9 @@ class Cluster:
       expts = []
       refls = []
       for path in raw:
-        if path.endswith(".pickle"):
+        if path.endswith((".pickle", ".refl")):
           refls.append(path)
-        elif path.endswith(".json"):
+        elif path.endswith((".json", ".expt")):
           expts.append(path)
       return (refls, expts)
 

--- a/xfel/command_line/cspad_detector_congruence.py
+++ b/xfel/command_line/cspad_detector_congruence.py
@@ -33,7 +33,7 @@ between two detectors.
 
 Example:
 
-  %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle
+  %s experiment1.expt experiment2.expt reflections1.refl reflections2.refl
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -229,7 +229,7 @@ class Script(object):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s experiment1.expt experiment2.expt reflections1.refl reflections2.refl" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,

--- a/xfel/command_line/cspad_detector_congruence2.py
+++ b/xfel/command_line/cspad_detector_congruence2.py
@@ -33,7 +33,7 @@ between two detectors.
 
 Example:
 
-  %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle
+  %s experiment1.expt experiment2.expt reflections1.refl reflections2.refl
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -180,7 +180,7 @@ class Script(object):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s experiment1.expt experiment2.expt reflections1.refl reflections2.refl" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,

--- a/xfel/command_line/cspad_detector_shifts.py
+++ b/xfel/command_line/cspad_detector_shifts.py
@@ -26,7 +26,7 @@ help_message = '''
 This program is used to show differences between a reference and a moving set of detectors
 Example:
 
-  %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle
+  %s experiment1.expt experiment2.expt reflections1.refl reflections2.refl
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -48,7 +48,7 @@ class Script(ParentScript):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s experiment1.json experiment2.json reflections1.pickle reflections2.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s experiment1.expt experiment2.expt reflections1.refl reflections2.refl" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,

--- a/xfel/command_line/cspad_detector_statistics.py
+++ b/xfel/command_line/cspad_detector_statistics.py
@@ -60,8 +60,8 @@ class Script(object):
     if params.tag is None:
       raise Usage(self.parser.usage)
 
-    level_json = "%s_%d_refined_experiments_level%d.json"
-    level_pickle = "%s_%d_refined_reflections_level%d.pickle"
+    level_json = "%s_%d_refined_level%d.expt"
+    level_pickle = "%s_%d_refined_level%d.refl"
 
     command = "cspad.detector_congruence %s %s %s %s hierarchy_level=%d show_plots=False"
 

--- a/xfel/command_line/cxi_index.py
+++ b/xfel/command_line/cxi_index.py
@@ -40,7 +40,7 @@ if (__name__ == "__main__"):
                           help="String to append to the front of output integration pickles")
                   .option(None, "--extension", "-e",
                           type="string",
-                          default=".pickle",
+                          default=".refl",
                           dest="extension",
                           help="File extension use to filter input files if a directory is given as input")
                   ).process(args=sys.argv[1:])

--- a/xfel/command_line/cxi_index.py
+++ b/xfel/command_line/cxi_index.py
@@ -40,7 +40,7 @@ if (__name__ == "__main__"):
                           help="String to append to the front of output integration pickles")
                   .option(None, "--extension", "-e",
                           type="string",
-                          default=".refl",
+                          default=".pickle",
                           dest="extension",
                           help="File extension use to filter input files if a directory is given as input")
                   ).process(args=sys.argv[1:])

--- a/xfel/command_line/cxi_merge.py
+++ b/xfel/command_line/cxi_merge.py
@@ -582,7 +582,7 @@ def load_result (file_name,
 
   else:
     #Check for pixel size (at this point we are assuming we have square pixels, all experiments described in one
-    #refined_experiments.json file use the same detector, and all panels on the detector have the same pixel size)
+    #refined.expt file use the same detector, and all panels on the detector have the same pixel size)
     if params.pixel_size is not None:
       pixel_size = params.pixel_size
     elif "pixel_size" in obj:

--- a/xfel/command_line/detector_residuals.py
+++ b/xfel/command_line/detector_residuals.py
@@ -36,7 +36,7 @@ between observed and predicted reflections
 
 Example:
 
-  dev.cctbx.xfel.detector_residuals experiment.json reflections.pickle
+  dev.cctbx.xfel.detector_residuals experiment.expt reflections.refl
 '''
 
 # Create the phil parameters

--- a/xfel/command_line/filter_experiments_by_rmsd.py
+++ b/xfel/command_line/filter_experiments_by_rmsd.py
@@ -30,7 +30,7 @@ interquartile range from the third quartile. When x=1.5, this is Tukey's rule.
 
 Example:
 
-  %s combined_experiments.json combined_reflections.pickle
+  %s combined.expt combined.refl
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -49,10 +49,10 @@ detector = None
   .type = int
   .help = If not None, only filter experiments matching this detector number
 output {
-  filtered_experiments = filtered_experiments.json
+  filtered_experiments = filtered.expt
     .type = str
     .help = Name of output filtered experiments file
-  filtered_reflections = filtered_reflections.pickle
+  filtered_reflections = filtered.refl
     .type = str
     .help = Name of output filtered reflections file
 }
@@ -71,7 +71,7 @@ class Script(object):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s combined_experiments.json combined_reflections.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s combined.expt combined.refl" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,

--- a/xfel/command_line/frame_extractor.py
+++ b/xfel/command_line/frame_extractor.py
@@ -20,10 +20,10 @@ phil_scope = iotbx.phil.parse("""
   input {
     experiments = None
       .type = path
-      .help = path to an experiments.json file
+      .help = path to an experiments.expt file
     reflections = None
       .type = path
-      .help = path to a reflection table (integrated.pickle) file
+      .help = path to a reflection table (integrated.refl) file
   }
   output {
     filename = None
@@ -222,10 +222,10 @@ class ConstructFrame(object):
 
 class ConstructFrameFromFiles(ConstructFrame):
   def __init__(self, refl_name, json_name, outname=None):
-    # load the integration.pickle file (reflection table) into memory and
-    # load the experiments.json file (json) into memory, piecewise.
-    # check_format=False because we don't wont to load any imagesets in the
-    # experiement list
+    # load the integration.refl file (reflection table) into memory and
+    # load the experiments.expt file (json) into memory, piecewise.
+    # check_format=False because we don't want to load any imagesets in the
+    # experiment list
     importer = Importer([refl_name, json_name], read_experiments=True, read_reflections=True, check_format=False)
     if importer.unhandled:
       print("unable to process:", importer.unhandled)

--- a/xfel/command_line/frame_unpickler.py
+++ b/xfel/command_line/frame_unpickler.py
@@ -191,7 +191,7 @@ class construct_reflection_table_and_experiment_list(object):
     else:
       loc = path_name
     name = os.path.basename(self.pickle).split(".pickle")[0]
-    expt_name = int_pickle_to_filename(name, "idx-", "_experiments.json")
+    expt_name = int_pickle_to_filename(name, "idx-", ".expt")
     experiments = os.path.join(loc, expt_name)
     dumper = experiment_list.ExperimentListDumper(self.experiment_list)
     dumper.as_json(experiments)
@@ -286,8 +286,8 @@ class construct_reflection_table_and_experiment_list(object):
       loc = os.path.dirname(self.pickle)
     else:
       loc = path_name
-    name = os.path.basename(self.pickle).split(".pickle")[0]
-    refl_name = int_pickle_to_filename(name, "idx-", "_integrated.pickle")
+    name = os.path.basename(self.pickle).split(".refl")[0]
+    refl_name = int_pickle_to_filename(name, "idx-", "_integrated.refl")
     reflections = os.path.join(loc, refl_name)
     self.reflections.as_pickle(reflections)
 
@@ -327,4 +327,4 @@ if __name__ == "__main__":
       result.reflections_to_pickle(params.refl_location)
     else:
       print("Skipping unreadable pickle file at", pickle_path)
-  print('Generated experiments.json and integrated.pickle files.')
+  print('Generated experiments.expt and integrated.refl files.')

--- a/xfel/command_line/recompute_mosaicity.py
+++ b/xfel/command_line/recompute_mosaicity.py
@@ -25,7 +25,7 @@ Recompute mosaic parameters for a set of experiments and apply outlier rejection
 
 Example:
 
-  %s refined_experiments.json refined_reflections.pickle
+  %s refined.expt refined.refl
 ''' % libtbx.env.dispatcher_name
 
 # Create the phil parameters
@@ -34,10 +34,10 @@ plot_changes = False
   .type = bool
   .help = If True, plot the change in the mosaic parameters
 output {
-  experiments = refined_experiments.json
+  experiments = refined.expt
     .type = str
     .help = Name of output  experiments file
-  reflections = refined_reflections.pickle
+  reflections = refined.refl
     .type = str
     .help = Name of output reflections file
 }
@@ -52,7 +52,7 @@ class Script(object):
     import libtbx.load_env
 
     # Create the option parser
-    usage = "usage: %s refined_experiments.json refined_reflections.pickle" % libtbx.env.dispatcher_name
+    usage = "usage: %s refined.expt refined.refl" % libtbx.env.dispatcher_name
     self.parser = OptionParser(
       usage=usage,
       sort_options=True,

--- a/xfel/command_line/stills_merge.py
+++ b/xfel/command_line/stills_merge.py
@@ -24,6 +24,8 @@ def eval_ending (file_name):
   ordered_endings_mapping = [
     ("refined_experiments.json", "integrated.pickle"),
     ("experiments.json", "integrated.pickle"),
+    ("refined.expt", "integrated.refl"),
+    ("indexed.expt", "integrated.refl"),
     ]
   dir_name = os.path.dirname(file_name)
   basename = os.path.basename(file_name)
@@ -62,7 +64,7 @@ def load_result (file_name,
                  params,
                  reindex_op,
                  out) :
-  # Pull relevant information from integrated.pickle and refined_experiments.json
+  # Pull relevant information from integrated.refl and refined.expt
   # files to construct the equivalent of a single integration pickle (frame).
   try:
     frame = frame_extractor.ConstructFrameFromFiles(eval_ending(file_name)[2], eval_ending(file_name)[1]).make_frame()
@@ -100,7 +102,7 @@ def load_result (file_name,
   print(unit_cell, file=out)
 
   #Check for pixel size (at this point we are assuming we have square pixels, all experiments described in one
-  #refined_experiments.json file use the same detector, and all panels on the detector have the same pixel size)
+  #refined.expt file use the same detector, and all panels on the detector have the same pixel size)
 
   if params.pixel_size is not None:
     pixel_size = params.pixel_size

--- a/xfel/command_line/striping.py
+++ b/xfel/command_line/striping.py
@@ -64,9 +64,9 @@ combine_experiments {
     }
   keep_integrated = False
     .type = bool
-    .help = "Combine refined_experiments.json and integrated.pickle files."
-    .help = "If False, ignore integrated.pickle files in favor of"
-    .help = "indexed.pickle files in preparation for reintegrating."
+    .help = "Combine refined.expt and integrated.refl files."
+    .help = "If False, ignore integrated.refl files in favor of"
+    .help = "indexed.refl files in preparation for reintegrating."
   include scope dials.command_line.combine_experiments.phil_scope
 }
 '''
@@ -74,8 +74,8 @@ combine_experiments {
 combining_override_str = '''
 combine_experiments {
   output {
-    experiments_filename = FILENAME_combined_experiments.json
-    reflections_filename = FILENAME_combined_reflections.pickle
+    experiments_filename = FILENAME_combined.expt
+    reflections_filename = FILENAME_combined.refl
     delete_shoeboxes = False
   }
   reference_from_experiment {
@@ -107,8 +107,8 @@ refinement {
 refinement_override_str = '''
 refinement {
   output {
-    experiments = FILENAME_refined_experiments_CLUSTER.json
-    reflections = FILENAME_refined_reflections_CLUSTER.pickle
+    experiments = FILENAME_refined_CLUSTER.expt
+    reflections = FILENAME_refined_CLUSTER.refl
     include_unused_reflections = False
     log = FILENAME_refine_CLUSTER.log
     debug_log = FILENAME_refine_CLUSTER.debug.log
@@ -135,8 +135,8 @@ refinement {
     }
   }
   input {
-    experiments = FILENAME_combined_experiments_CLUSTER.json
-    reflections = FILENAME_combined_reflections_CLUSTER.pickle
+    experiments = FILENAME_combined_CLUSTER.expt
+    reflections = FILENAME_combined_CLUSTER.refl
   }
 }
 '''
@@ -154,12 +154,12 @@ recompute_mosaicity {
 recompute_mosaicity_override_str = '''
 recompute_mosaicity {
   input {
-    experiments = FILENAME_refined_experiments_CLUSTER.json
-    reflections = FILENAME_refined_reflections_CLUSTER.pickle
+    experiments = FILENAME_refined_CLUSTER.expt
+    reflections = FILENAME_refined_CLUSTER.refl
   }
   output {
-    experiments = FILENAME_refined_experiments_CLUSTER.json
-    reflections = FILENAME_refined_reflections_CLUSTER.pickle
+    experiments = FILENAME_refined_CLUSTER.expt
+    reflections = FILENAME_refined_CLUSTER.refl
   }
 }
 '''
@@ -180,8 +180,8 @@ reintegration {
 reintegration_override_str = '''
 reintegration{
   output {
-    experiments = FILENAME_reintegrated_experiments_CLUSTER.json
-    reflections = FILENAME_reintegrated_reflections_CLUSTER.pickle
+    experiments = FILENAME_reintegrated_CLUSTER.expt
+    reflections = FILENAME_reintegrated_CLUSTER.refl
     log = FILENAME_reintegrate_CLUSTER.log
     debug_log = FILENAME_reintegrate_CLUSTER.debug.log
   }
@@ -210,8 +210,8 @@ reintegration{
     }
   }
   input {
-    experiments = FILENAME_refined_experiments_CLUSTER.json
-    reflections = FILENAME_refined_reflections_CLUSTER.pickle
+    experiments = FILENAME_refined_CLUSTER.expt
+    reflections = FILENAME_refined_CLUSTER.refl
   }
 }
 '''
@@ -227,11 +227,11 @@ postprocessing {
 postprocessing_override_str = """
 postprocessing {
   input {
-    experiments = FILENAME_reintegrated_experiments_CLUSTER.json
-    reflections = FILENAME_reintegrated_reflections_CLUSTER.pickle
+    experiments = FILENAME_reintegrated_CLUSTER.expt
+    reflections = FILENAME_reintegrated_CLUSTER.refl
   }
   output {
-    filename = FILENAME_CLUSTER_ITER_extracted.pickle
+    filename = FILENAME_CLUSTER_ITER_extracted.refl
     dirname = %s
   }
 }
@@ -266,7 +266,7 @@ def allocate_chunks(results_dir,
                     max_size=1000,
                     integrated=False):
   refl_ending = "_integrated" if integrated else "_indexed"
-  expt_ending = "_refined_experiments.json"
+  expt_ending = "_refined.expt"
   trial = "%03d" % trial_no
   print("processing trial %s" % trial)
   if rgs_selected:
@@ -318,7 +318,12 @@ def allocate_chunks(results_dir,
       expts = [c for c in contents if c.endswith(expt_ending)]
       n_img += len(expts)
       if extension is None:
-        extension = ".mpack" if any(c.endswith(".mpack") for c in contents) else ".pickle"
+        if any(c.endswith(".mpack") for c in contents):
+          extension = ".mpack"
+        elif any(c.endswith(".refl") for c in contents):
+          extension = ".refl"
+        else:
+         extension = ".pickle"
     if n_img == 0:
       print("no images found for %s" % batch)
       del batch_contents[batch]
@@ -380,8 +385,8 @@ def script_to_expand_over_clusters(clustered_json_name,
   """
   Write a bash script to find results of a clustering step and produce customized
   phils and commands to run with each of them. For example, run the command
-  dials.refine ...cluster8.json ...cluster8.pickle ...cluster8.phil followed by
-  dials.refine ...cluster9.json ...cluster9.pickle ...cluster9.phil.
+  dials.refine ...cluster8.expt ...cluster8.refl ...cluster8.phil followed by
+  dials.refine ...cluster9.expt ...cluster9.refl ...cluster9.phil.
   clustered_json_name, clustered_refl_name and phil_template_name must each
   contain an asterisk, and substitution in phil_template itself will occur at
   each instance of CLUSTER.

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -290,22 +290,22 @@ xtc_phil_str = '''
     logging_dir = None
       .type = str
       .help = Directory output log files will be placed
-    experiments_filename = %s_experiments.json
+    experiments_filename = %s.expt
       .type = str
       .help = The filename for output experiment list
-    strong_filename = %s_strong.pickle
+    strong_filename = %s_strong.refl
       .type = str
       .help = The filename for strong reflections from spot finder output.
-    indexed_filename = %s_indexed.pickle
+    indexed_filename = %s_indexed.refl
       .type = str
       .help = The filename for indexed reflections.
-    refined_experiments_filename = %s_refined_experiments.json
+    refined_experiments_filename = %s_refined.expt
       .type = str
       .help = The filename for saving refined experimental models
-    integrated_filename = %s_integrated.pickle
+    integrated_filename = %s_integrated.refl
       .type = str
       .help = The filename for final experimental modls
-    integrated_experiments_filename = %s_integrated_experiments.json
+    integrated_experiments_filename = %s_integrated.expt
       .type = str
       .help = The filename for final integrated reflections.
     profile_filename = None
@@ -314,7 +314,7 @@ xtc_phil_str = '''
     integration_pickle = int-%d-%s.pickle
       .type = str
       .help = Filename for cctbx.xfel-style integration pickle files
-    reindexedstrong_filename = %s_reindexedstrong.pickle
+    reindexedstrong_filename = %s_reindexedstrong.refl
       .type = str
       .help = The file name for re-indexed strong reflections
     tmp_output_dir = "(NONE)"
@@ -878,14 +878,14 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         experiment_jsons = []
         indexed_tables = []
         for filename in os.listdir(params.output.output_dir):
-          if not filename.endswith("_indexed.pickle"):
+          if not filename.endswith("_indexed.refl"):
             continue
-          experiment_jsons.append(os.path.join(params.output.output_dir, filename.split("_indexed.pickle")[0] + "_refined_experiments.json"))
+          experiment_jsons.append(os.path.join(params.output.output_dir, filename.split("_indexed.refl")[0] + "_refined.expt"))
           indexed_tables.append(os.path.join(params.output.output_dir, filename))
           if params.format.file_format == "cbf":
-            images.append(os.path.join(params.output.output_dir, filename.split("_indexed.pickle")[0] + ".cbf"))
+            images.append(os.path.join(params.output.output_dir, filename.split("_indexed.refl")[0] + ".cbf"))
           elif params.format.file_format == "pickle":
-            images.append(os.path.join(params.output.output_dir, filename.split("_indexed.pickle")[0] + ".pickle"))
+            images.append(os.path.join(params.output.output_dir, filename.split("_indexed.refl")[0] + ".pickle"))
 
         if len(images) < params.joint_reintegration.minimum_results:
           pass # print and return
@@ -900,8 +900,8 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
           f.write("}\n")
         f.close()
 
-        combined_experiments_file = os.path.join(reint_dir, "combined_experiments.json")
-        combined_reflections_file = os.path.join(reint_dir, "combined_reflections.pickle")
+        combined_experiments_file = os.path.join(reint_dir, "combined.expt")
+        combined_reflections_file = os.path.join(reint_dir, "combined.refl")
         command = "dials.combine_experiments reference_from_experiment.average_detector=True %s output.reflections=%s output.experiments=%s"% \
           (combo_input, combined_reflections_file, combined_experiments_file)
         print(command)
@@ -925,20 +925,20 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         from dxtbx.model.experiment_list import ExperimentListDumper
         from dxtbx.model import ExperimentList
         dump = ExperimentListDumper(experiments)
-        dump.as_json(os.path.join(reint_dir, "refined_experiments.json"))
-        reflections.as_pickle(os.path.join(reint_dir, "refined_reflections.pickle"))
+        dump.as_json(os.path.join(reint_dir, "refined.expt"))
+        reflections.as_pickle(os.path.join(reint_dir, "refined.refl"))
 
         for expt_id, (expt, img_file) in enumerate(zip(experiments, images)):
           try:
             refls = reflections.select(reflections['id'] == expt_id)
             refls['id'] = flex.int(len(refls), 0)
             base_name = os.path.splitext(os.path.basename(img_file))[0]
-            self.params.output.integrated_filename = os.path.join(reint_dir, base_name + "_integrated.pickle")
+            self.params.output.integrated_filename = os.path.join(reint_dir, base_name + "_integrated.refl")
 
             expts = ExperimentList([expt])
             self.integrate(expts, refls)
             dump = ExperimentListDumper(expts)
-            dump.as_json(os.path.join(reint_dir, base_name + "_refined_experiments.json"))
+            dump.as_json(os.path.join(reint_dir, base_name + "_refined.expt"))
           except Exception as e:
             print("Couldn't reintegrate", img_file, str(e))
     print("Rank %d signing off"%rank)

--- a/xfel/cxi/util.py
+++ b/xfel/cxi/util.py
@@ -5,7 +5,9 @@ import os
 #for integration pickles:
 allowable_basename_endings = ["_00000.pickle",
                               ".pickle",
+                              ".refl",
                               "_refined_experiments.json",
+                              "_refined.expt",
                               "_experiments.json"
                              ]
 def is_odd_numbered(file_name, use_hash = False):

--- a/xfel/merging/application/input/file_loader.py
+++ b/xfel/merging/application/input/file_loader.py
@@ -38,8 +38,11 @@ def create_experiment_identifier(experiment, experiment_file_path, experiment_id
 #for integration pickles:
 allowable_basename_endings = ["_00000.pickle",
                               ".pickle",
+                              ".refl",
                               "_refined_experiments.json",
-                              "_experiments.json"
+                              "_refined.expt",
+                              "_experiments.json",
+                              "_indexed.expt"
                              ]
 def is_odd_numbered(file_name, use_hash = False):
   if use_hash:

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -19,12 +19,12 @@ input {
     .multiple = True
     .help = paths are validated as a glob, directory or file.
     .help = however, validation is delayed until data are assigned to parallel ranks.
-    .help = integrated_experiments (.json) and reflection tables (.pickle) must both be
+    .help = integrated experiments (.expt) and reflection tables (.refl) must both be
     .help = present as matching files.  Only one need be explicitly specified.
-  reflections_suffix = _integrated.pickle
+  reflections_suffix = _integrated.refl
     .type = str
     .help = Find file names with this suffix for reflections
-  experiments_suffix = _integrated_experiments.json
+  experiments_suffix = _integrated.expt
     .type = str
     .help = Find file names with this suffix for experiments
   parallel_file_load {

--- a/xfel/merging/application/worker.py
+++ b/xfel/merging/application/worker.py
@@ -65,4 +65,4 @@ def exercise_worker(worker_class):
 
   prefix = worker_class.__name__
   reflections.as_msgpack_file(prefix + ".mpack")
-  ExperimentListDumper(experiments).as_file(prefix + ".json")
+  ExperimentListDumper(experiments).as_file(prefix + ".expt")

--- a/xfel/merging/command_line/merge.py
+++ b/xfel/merging/command_line/merge.py
@@ -153,9 +153,9 @@ class Script(object):
           id_.set_selected(sel, expt_number)
         reflections['id'] = id_
 
-      reflections.as_pickle(os.path.join(self.params.output.output_dir, self.params.output.prefix + "_%06d.pickle"%self.mpi_helper.rank))
+      reflections.as_pickle(os.path.join(self.params.output.output_dir, self.params.output.prefix + "_%06d.refl"%self.mpi_helper.rank))
       dump = ExperimentListDumper(experiments)
-      dump.as_file(os.path.join(self.params.output.output_dir, self.params.output.prefix + "_%06d.json"%self.mpi_helper.rank))
+      dump.as_file(os.path.join(self.params.output.output_dir, self.params.output.prefix + "_%06d.expt"%self.mpi_helper.rank))
 
     self.mpi_logger.log_step_time("TOTAL", True)
 

--- a/xfel/sacla/mpccd_geom2json.py
+++ b/xfel/sacla/mpccd_geom2json.py
@@ -89,7 +89,7 @@ def run(args):
   experiment = Experiment(detector = detector, beam = beam)
   experiments.append(experiment)
   dump = ExperimentListDumper(experiments)
-  dump.as_json("geometry.json")
+  dump.as_json("geometry.expt")
 
 if __name__ == "__main__":
   run(sys.argv[1:])

--- a/xfel/small_cell/small_cell.py
+++ b/xfel/small_cell/small_cell.py
@@ -347,7 +347,7 @@ def small_cell_index(path, horiz_phil):
     sel.append(test.count(True) == 0)
   reflections = reflections.select(sel)
 
-  reflections_dump(reflections, "spotfinder.pickle")
+  reflections_dump(reflections, "spotfinder.refl")
   print("saved %d"%len(reflections))
 
   max_clique_len, experiments, refls = small_cell_index_detail(experiments, reflections, horiz_phil)
@@ -1084,7 +1084,7 @@ def small_cell_index_detail(experiments, reflections, horiz_phil, write_output =
         experiments = ExperimentListFactory.from_imageset_and_crystal(imageset, crystal)
         if write_output:
           dump = ExperimentListDumper(experiments)
-          dump.as_json(os.path.splitext(os.path.basename(path).strip())[0]+"_integrated_experiments.json")
+          dump.as_json(os.path.splitext(os.path.basename(path).strip())[0]+"_integrated.expt")
 
         refls = flex.reflection_table()
         refls['id'] = flex.int(len(indexed_hkls), 0)
@@ -1104,7 +1104,7 @@ def small_cell_index_detail(experiments, reflections, horiz_phil, write_output =
 
         refls.set_flags(flex.bool(len(refls), True), refls.flags.indexed)
         if write_output:
-          refls.as_pickle(os.path.splitext(os.path.basename(path).strip())[0]+"_integrated.pickle")
+          refls.as_pickle(os.path.splitext(os.path.basename(path).strip())[0]+"_integrated.refl")
 
         print("cctbx.small_cell: integrated %d spots."%len(results), end=' ')
         integrated_count = len(results)

--- a/xfel/ui/command_line/plot_reflection_stats.py
+++ b/xfel/ui/command_line/plot_reflection_stats.py
@@ -21,7 +21,7 @@ For each plot, the median value per two theta bin is plotted.  The shaded area c
 N reflections per two theta bin is also plotted.
 
 Example:
-cctbx.xfel.plot_reflection_stats integrated1.json integrated1.pickle integrated2.json integrated2.pickle
+cctbx.xfel.plot_reflection_stats integrated1.expt integrated1.refl integrated2.expt integrated2.refl
 """
 
 phil_str = """

--- a/xfel/ui/command_line/plot_run_stats_from_experiments.py
+++ b/xfel/ui/command_line/plot_run_stats_from_experiments.py
@@ -105,7 +105,7 @@ def run(args):
       filename = os.path.basename(path)
       extension = os.path.splitext(filename)[1]
       split_fn = filename.split('_')
-      if extension not in ['.pickle', '.mpack'] or len(split_fn) <= 0 or not split_fn[-1].startswith('strong'):
+      if extension not in ['.refl', '.pickle', '.mpack'] or len(split_fn) <= 0 or not split_fn[-1].startswith('strong'):
         continue
       base = os.path.join(root, "_".join(split_fn[:-1]))
       print(filename)
@@ -124,7 +124,11 @@ def run(args):
       two_theta_high.append(0)
 
       # Read indexing results if possible
-      experiments_name = base + "_integrated_experiments.json"
+      experiments_name = base + "_integrated"
+      if extension == ".refl":
+        experiments_name += ".expt"
+      else:
+        experiments_name += "_experiments.json"
       indexed_name = base + "_integrated%s"%extension
       if not os.path.exists(experiments_name) or not os.path.exists(indexed_name):
         print("Frame didn't index")

--- a/xfel/ui/command_line/plot_uc_cloud_from_experiments.py
+++ b/xfel/ui/command_line/plot_uc_cloud_from_experiments.py
@@ -7,11 +7,11 @@ from six.moves import range
 from libtbx.phil import parse
 
 help_message = """
-Plot a cloud of unit cell dimensions from stills. Provide either a combined_experiments.json
-file or a specify individual .json files on the command line. To generate an overlay of
+Plot a cloud of unit cell dimensions from stills. Provide either a combined.expt
+file or a specify individual .expt files on the command line. To generate an overlay of
 multiple plots (similar to grouping by run tag in the XFEL GUI), provide multiple
-combined_experiments.json files named as ${tag}_combined_experiments*.json and set
-extract_tags to True in the phil scope.
+combined.expt files named as ${tag}_combined_*.expt and set extract_tags to True in
+the phil scope.
 """
 
 phil_str = """
@@ -23,7 +23,7 @@ phil_str = """
     .help = Lower and upper bounds for the ranges to display for each of the a, b and c axes
   extract_tags = False
     .type = bool
-    .help = Extract tags from the names of multiple combined_experiments.json filenames and use
+    .help = Extract tags from the names of multiple combined.expt filenames and use
     .help = these tags to label multiple groups of experiments.
   combine_all_input = False
     .type = bool

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -2291,7 +2291,7 @@ class RunStatsTab(SpotfinderTab):
       params, ts_list = self.strong_indexed_image_timestamps[idx]
       ext = '.' + params['format']
       image_paths = self.strong_indexed_image_paths[idx][:self.n_dump]
-      indexed_paths = [path.split(ext)[0]+'_indexed.pickle' for path in image_paths]
+      indexed_paths = [path.split(ext)[0]+'_indexed.refl' for path in image_paths]
       if all([os.path.exists(p) for p in (image_paths + indexed_paths)]):
         command = str('dials.image_viewer ' + ' '.join(image_paths) + \
           ' ' + ' '.join(indexed_paths))

--- a/xfel/util/dials_pickle_reader.py
+++ b/xfel/util/dials_pickle_reader.py
@@ -10,7 +10,7 @@ from xfel.command_line.frame_extractor import ConstructFrame
 
 def find_json(pickle, pickle_ext=None, json_ext=None):
   """find the matching json file for a given dials-format non-image pickle file"""
-  name = os.path.basename(pickle).split(".pickle")[0]
+  name = os.path.basename(pickle).split(".refl")[0]
   dirname = os.path.dirname(pickle)
   if pickle_ext is not None:
     if pickle_ext == "":
@@ -24,11 +24,11 @@ def find_json(pickle, pickle_ext=None, json_ext=None):
   else:
     base = name
   if json_ext is not None:
-    json = os.path.join(dirname, base + json_ext + ".json")
-  elif os.path.exists(os.path.join(dirname, base + "_refined_experiments.json")):
-    json = os.path.join(dirname, base + "_refined_experiments.json")
-  elif os.path.exists(os.path.join(dirname, base + "_experiments.json")):
-    json = os.path.join(dirname, base + "_experiments.json")
+    json = os.path.join(dirname, base + json_ext + ".expt")
+  elif os.path.exists(os.path.join(dirname, base + "_refined.expt")):
+    json = os.path.join(dirname, base + "_refined.expt")
+  elif os.path.exists(os.path.join(dirname, base + "_indexed.expt")):
+    json = os.path.join(dirname, base + "_indexed.expt")
   else:
     json = None
   return json


### PR DESCRIPTION
This branch contains changes imposed by output file renaming in https://github.com/dials/dials/pull/822.

I'm not sure if these changes are complete, or if some errors have been introduced. I'm not very familiar with the cctbx.xfel code. So it wasn't always obvious to me when a pickle file is a dxtbx pickle or when it is a cctbx style integration pickle, or one of the other auxiliary pickles used by cctbx.xfel. There may be places where I have missed changes, or places where I have introduced unwanted changes.

Nevertheless, the tests in `libtbx.run_tests_parallel module=xfel_regression run_in_tmp_dir=true` pass, and do so on this branch whether or not DIALS is on https://github.com/dials/dials/pull/822, so at least under the coverage implied by these tests, backwards compatibility appears to be retained.

One file I didn't touch at all is [spotfinder_scraper.py](https://github.com/cctbx/cctbx_project/blob/master/xfel/ui/components/spotfinder_scraper.py). This still looks for `datablock.json`, so I figured this one is not being updated in step with DIALS master anyway.

There are other questions that I have inserted into the commit messages.

I understand that this branch made need more changes, but it would be really helpful if this can be accepted soon. We are already getting merge errors in https://github.com/dials/dials/pull/822 and other PRs backed up as https://github.com/dials/dials/pull/822 should be merged ahead of them.