### PR TITLE
Add __str__, __repr__ to crystal.symmetry, uctbx.unit_cell

### DIFF
--- a/cctbx/crystal/__init__.py
+++ b/cctbx/crystal/__init__.py
@@ -140,14 +140,18 @@ class symmetry(object):
 
   def show_summary(self, f=None, prefix=""):
     if (f is None): f = sys.stdout
-    if (self.unit_cell() is None):
-      print(prefix + "Unit cell:", None, file=f)
-    else:
-      self.unit_cell().show_parameters(f=f, prefix=prefix+"Unit cell: ")
-    if (self.space_group_info() is None):
-      print(prefix + "Space group:", None, file=f)
-    else:
-      self.space_group_info().show_summary(f=f, prefix=prefix+"Space group: ")
+    print(self.as_str(prefix=prefix), file=f)
+
+  def as_str(self, prefix=""):
+    return (
+      prefix + "Unit cell: %s\n" % self.unit_cell() +
+      prefix + "Space group: %s" % (
+        self.space_group_info().symbol_and_number()
+        if self.space_group_info() is not None else None)
+    )
+
+  def __str__(self):
+    return self.as_str()
 
   def is_similar_symmetry(self,
                           other,

--- a/cctbx/crystal/__init__.py
+++ b/cctbx/crystal/__init__.py
@@ -134,14 +134,15 @@ class symmetry(object):
       'crystal.symmetry(\n'
       '%s  unit_cell=%s,\n'
       '%s  space_group_symbol=%s\n'
-      ')')
+      '%s)')
     return fmt % (
       indent,
       "(%s, %s, %s, %s, %s, %s)" % self.unit_cell().parameters()
       if self.unit_cell() is not None else None,
       indent,
       '"%s"' % self.space_group_info().type().lookup_symbol()
-      if self.space_group_info() is not None else None
+      if self.space_group_info() is not None else None,
+      indent
     )
 
   def show_summary(self, f=None, prefix=""):

--- a/cctbx/crystal/__init__.py
+++ b/cctbx/crystal/__init__.py
@@ -133,10 +133,16 @@ class symmetry(object):
     fmt = (
       'crystal.symmetry(\n'
       '%s  unit_cell=%s,\n'
-      '%s  space_group_symbol="%s")')
+      '%s  space_group_symbol=%s\n'
+      ')')
     return fmt % (
-      indent, str(self.unit_cell()),
-      indent, str(self.space_group_info()))
+      indent,
+      "(%s, %s, %s, %s, %s, %s)" % self.unit_cell().parameters()
+      if self.unit_cell() is not None else None,
+      indent,
+      '"%s"' % self.space_group_info().type().lookup_symbol()
+      if self.space_group_info() is not None else None
+    )
 
   def show_summary(self, f=None, prefix=""):
     if (f is None): f = sys.stdout
@@ -152,6 +158,9 @@ class symmetry(object):
 
   def __str__(self):
     return self.as_str()
+
+  def __repr__(self):
+    return self.as_py_code(indent="  ")
 
   def is_similar_symmetry(self,
                           other,

--- a/cctbx/crystal/tst_ext.py
+++ b/cctbx/crystal/tst_ext.py
@@ -23,11 +23,12 @@ def exercise_symmetry():
   cspc = cs.as_py_code(indent="*$")
   assert not show_diff(cspc, """\
 crystal.symmetry(
-*$  unit_cell=(12.548, 12.548, 20.789, 90, 90, 120),
-*$  space_group_symbol="P 63/m m c")""")
+*$  unit_cell=(12.548, 12.548, 20.789, 90.0, 90.0, 120.0),
+*$  space_group_symbol="P 63/m m c"
+)""")
   cspc = cs.as_py_code()
   cs2 = eval(cspc)
-  assert cs2.is_similar_symmetry(cs)
+  assert cs2.is_similar_symmetry(cs, 1e-8, 1e-8)
 
 def trial_structure(choice_of_coordinates=0):
   # zeolite framework type AFG

--- a/cctbx/crystal/tst_ext.py
+++ b/cctbx/crystal/tst_ext.py
@@ -25,7 +25,7 @@ def exercise_symmetry():
 crystal.symmetry(
 *$  unit_cell=(12.548, 12.548, 20.789, 90.0, 90.0, 120.0),
 *$  space_group_symbol="P 63/m m c"
-)""")
+*$)""")
   cspc = cs.as_py_code()
   cs2 = eval(cspc)
   assert cs2.is_similar_symmetry(cs, 1e-8, 1e-8)

--- a/cctbx/regression/tst_crystal.py
+++ b/cctbx/regression/tst_crystal.py
@@ -142,6 +142,7 @@ def exercise_correct_rhombohedral_setting_if_necessary():
 Unit cell: (20.3388, 20.3388, 20.3388, 98.9315, 98.9315, 98.9315)
 Space group: R 3 :R (No. 146)
 """)
+  assert not show_diff(sio.getvalue().rstrip(), str(cs))
   cs = crystal.symmetry(
     unit_cell="31 31 31 85 85 86",
     space_group_symbol="R3:H",
@@ -153,6 +154,7 @@ Space group: R 3 :R (No. 146)
 Unit cell: (36.4146, 36.4146, 31, 90, 90, 120)
 Space group: R 3 :H (No. 146)
 """)
+  assert not show_diff(sio.getvalue().rstrip(), str(cs))
 
 def exercise_select_crystal_symmetry():
   xs1 = crystal.symmetry(unit_cell   = "23,30,40,90,90,90",

--- a/cctbx/regression/tst_crystal.py
+++ b/cctbx/regression/tst_crystal.py
@@ -344,6 +344,28 @@ def exercise_subtract_continuous_allowed_origin_shifts(
     xray_structure=structure_transl, algorithm="direct").f_calc())
   assert approx_equal(f_transl.data(), f_obs.data())
 
+
+def exercise_str():
+  uc = uctbx.unit_cell((10, 11, 12, 89, 90, 91))
+  sg = sgtbx.space_group_info("P1").group()
+  cs = crystal.symmetry(unit_cell=None, space_group=None)
+  assert not show_diff(str(cs), """\
+Unit cell: None
+Space group: None""")
+  cs = crystal.symmetry(unit_cell=uc, space_group=None)
+  assert not show_diff(str(cs), """\
+Unit cell: (10, 11, 12, 89, 90, 91)
+Space group: None""")
+  cs = crystal.symmetry(unit_cell=None, space_group=sg)
+  assert not show_diff(str(cs), """\
+Unit cell: None
+Space group: P 1 (No. 1)""")
+  cs = crystal.symmetry(unit_cell=uc, space_group=sg)
+  assert not show_diff(str(cs), """\
+Unit cell: (10, 11, 12, 89, 90, 91)
+Space group: P 1 (No. 1)""")
+
+
 def run_call_back(flags, space_group_info):
   exercise_site_symmetry(space_group_info)
   for use_niggli_cell in [False, True]:
@@ -352,6 +374,7 @@ def run_call_back(flags, space_group_info):
       use_niggli_cell=use_niggli_cell)
 
 def run():
+  exercise_str()
   exercise_symmetry()
   exercise_correct_rhombohedral_setting_if_necessary()
   exercise_non_crystallographic_symmetry()

--- a/cctbx/regression/tst_crystal.py
+++ b/cctbx/regression/tst_crystal.py
@@ -345,24 +345,28 @@ def exercise_subtract_continuous_allowed_origin_shifts(
   assert approx_equal(f_transl.data(), f_obs.data())
 
 
-def exercise_str():
-  uc = uctbx.unit_cell((10, 11, 12, 89, 90, 91))
-  sg = sgtbx.space_group_info("P1").group()
+def exercise_str_repr():
+  sgi = sgtbx.space_group_info('P1')
+  uc = sgi.any_compatible_unit_cell(volume=1000)
   cs = crystal.symmetry(unit_cell=None, space_group=None)
+  assert eval(repr(cs)).is_similar_symmetry(cs)
   assert not show_diff(str(cs), """\
 Unit cell: None
 Space group: None""")
   cs = crystal.symmetry(unit_cell=uc, space_group=None)
+  assert eval(repr(cs)).is_similar_symmetry(cs, 1e-8, 1e-3)
   assert not show_diff(str(cs), """\
-Unit cell: (10, 11, 12, 89, 90, 91)
+Unit cell: (8.52593, 11.0837, 14.4941, 83, 109, 129)
 Space group: None""")
-  cs = crystal.symmetry(unit_cell=None, space_group=sg)
+  cs = crystal.symmetry(unit_cell=None, space_group=sgi.group())
+  assert eval(repr(cs)).is_similar_symmetry(cs, 1e-8, 1e-3)
   assert not show_diff(str(cs), """\
 Unit cell: None
 Space group: P 1 (No. 1)""")
-  cs = crystal.symmetry(unit_cell=uc, space_group=sg)
+  cs = crystal.symmetry(unit_cell=uc, space_group=sgi.group())
+  assert eval(repr(cs)).is_similar_symmetry(cs, 1e-8, 1e-3)
   assert not show_diff(str(cs), """\
-Unit cell: (10, 11, 12, 89, 90, 91)
+Unit cell: (8.52593, 11.0837, 14.4941, 83, 109, 129)
 Space group: P 1 (No. 1)""")
 
 
@@ -374,7 +378,7 @@ def run_call_back(flags, space_group_info):
       use_niggli_cell=use_niggli_cell)
 
 def run():
-  exercise_str()
+  exercise_str_repr()
   exercise_symmetry()
   exercise_correct_rhombohedral_setting_if_necessary()
   exercise_non_crystallographic_symmetry()

--- a/cctbx/regression/tst_xray.py
+++ b/cctbx/regression/tst_xray.py
@@ -1315,8 +1315,9 @@ def exercise_xray_structure_as_py_code():
   assert not show_diff(pc, """\
 Vxray.structure(
 V  crystal_symmetry=crystal.symmetry(
-V    unit_cell=(2, 2, 3, 90, 90, 80),
-V    space_group_symbol="P 1 1 2"),
+V    unit_cell=(2.0, 2.0, 3.0, 90.0, 90.0, 80.0),
+V    space_group_symbol="P 1 1 2"
+V  ),
 V  scatterers=flex.xray_scatterer([
 V    xray.scatterer( #0
 V      label="C1",

--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -122,6 +122,9 @@ class _():
   def __str__(self):
     return format(self, "({:.6g}, {:.6g}, {:.6g}, {:.6g}, {:.6g}, {:.6g})")
 
+  def __repr__(self):
+    return format(self, "uctbx.unit_cell(({}, {}, {}, {}, {}, {}))")
+
   def __format__(self, format_spec="({:.6g}, {:.6g}, {:.6g}, {:.6g}, {:.6g}, {:.6g})"):
     return format_spec.format(*self.parameters())
 

--- a/cctbx/uctbx/boost_python/tst_uctbx.py
+++ b/cctbx/uctbx/boost_python/tst_uctbx.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
   import pickle
 from cctbx.array_family import flex
-from cctbx import uctbx
+from cctbx import sgtbx, uctbx
 from scitbx import matrix
 from libtbx.test_utils import approx_equal, not_approx_equal, show_diff
 import random
@@ -237,7 +237,6 @@ def exercise_frac_orth():
     assert approx_equal(om*matrix.col(fi), ci)
     assert approx_equal(fm*matrix.col(ci), fi)
   #
-  from cctbx import sgtbx
   s = sgtbx.rt_mx("-x,-x+y,-x+z", r_den=12)
   assert approx_equal(u.matrix_cart(rot_mx=s.r()), [
     -0.3622586, -0.1191822, -0.5137527,
@@ -292,7 +291,6 @@ def exercise_change_basis():
     u.change_basis((0,1,0, 0,0,1, 1,0,0)).parameters(),
     (5,2,3,90,90,90))
   #
-  from cctbx import sgtbx
   cb_op = sgtbx.change_of_basis_op("y,z,x").inverse()
   assert approx_equal(
     u.change_basis(cb_op=cb_op).parameters(),
@@ -733,7 +731,6 @@ def exercise_d_metrical_matrix_d_params():
     grads = flex.double(grads)
     grads.resize(flex.grid((6,6)))
     return grads.matrix_transpose()
-  from cctbx import sgtbx
   p1 = sgtbx.space_group_info('P1')
   uc = p1.any_compatible_unit_cell(27)
   grads = uc.d_metrical_matrix_d_params()
@@ -758,7 +755,6 @@ def exercise_downstream_methods():
       assert ms.indices().size() == 26
 
 def exercise_unit_cell_format():
-  from cctbx import sgtbx
   sgi = sgtbx.space_group_info('P1')
   uc = sgi.any_compatible_unit_cell(volume=1000)
   s = str(uc)
@@ -766,7 +762,14 @@ def exercise_unit_cell_format():
   s = format(uc, '{:.2f} {:.2f} {:.2f} {:.2f} {:.2f} {:.2f}')
   assert s == '8.53 11.08 14.49 83.00 109.00 129.00', s
 
+def exercise_unit_cell_repr():
+  sgi = sgtbx.space_group_info('P1')
+  uc = sgi.any_compatible_unit_cell(volume=1000)
+  assert eval(repr(uc)).is_similar_to(uc, 1e-8, 1e-3)
+
+
 def run():
+  exercise_unit_cell_repr()
   exercise_unit_cell_format()
   exercise_d_metrical_matrix_d_params()
   exercise_tensor_rank_2_orth_and_frac_linear_maps()


### PR DESCRIPTION
Add a more useful `__str__` output to crystal.symmetry:
```
>>> from cctbx import sgtbx
>>> cs = sgtbx.space_group_info("P1").any_compatible_crystal_symmetry(volume=1000)
>>> print(cs)
Unit cell: (8.52593, 11.0837, 14.4941, 83, 109, 129)
Space group: P 1 (No. 1)
```