### PR TITLE
Use OrderedDict to guarantee order of constraints (fixes #364)

### DIFF
--- a/iotbx/shelx/parsers.py
+++ b/iotbx/shelx/parsers.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 from six.moves import zip_longest
 from boost import rational
+from collections import OrderedDict
 
 from cctbx import uctbx
 from cctbx import sgtbx
@@ -328,7 +329,7 @@ class atom_parser(parser, variable_decoder):
     idx_assigned_by_builder_to_free_var_idx = {}
     builder = self.builder
     if self.builder_does_occupancy_pair_affine_constraint:
-      self.occupancies_depending_on_free_variable = {}
+      self.occupancies_depending_on_free_variable = OrderedDict()
     for command, line in self.command_stream:
       self.line = line
       cmd, args = command[0], command[-1]

--- a/smtbx/refinement/constraints/tests/test_occupancies.py
+++ b/smtbx/refinement/constraints/tests/test_occupancies.py
@@ -13,8 +13,8 @@ def test_simple_disorder():
 digraph dependencies {
 168 -> 0;
 169 -> 1;
-0 [label="independent_occupancy_parameter (C7A) #0"];
-1 [label="independent_occupancy_parameter (N3) #1"];
+0 [label="independent_occupancy_parameter (N3) #0"];
+1 [label="independent_occupancy_parameter (C7A) #1"];
 2 [label="independent_site_parameter (F1) #2"];
 5 [label="independent_u_star_parameter (F1) #5"];
 11 [label="independent_site_parameter (F2) #11"];
@@ -65,8 +65,8 @@ digraph dependencies {
 165 [label="independent_occupancy_parameter [cst] (C6) #165"];
 166 [label="independent_occupancy_parameter [cst] (N12) #166"];
 167 [label="independent_occupancy_parameter [cst] (C14) #167"];
-168 [label="affine_asu_occupancy_parameter (C7B) #168"];
-169 [label="affine_asu_occupancy_parameter (C3) #169"]
+168 [label="affine_asu_occupancy_parameter (C3) #168"];
+169 [label="affine_asu_occupancy_parameter (C7B) #169"]
 }
 """.strip()
   ls.build_up()


### PR DESCRIPTION
This pull requests fixes smtbx/refinement/constraints/tests/test_occupancies.py::test_simple_disorder on Python 3 (https://github.com/cctbx/cctbx_project/issues/364)