### PR TITLE
Update DIALSBuilder to run DIALS and dxtbx tests

### DIFF
--- a/cctbx/command_line/cctbx_test_nightly.py
+++ b/cctbx/command_line/cctbx_test_nightly.py
@@ -15,8 +15,6 @@ if (__name__ == "__main__"):
     "module=smtbx",
     "nproc=Auto",
   ]
-  if 'dxtbx' in libtbx.env.module_dict:
-    args.append("module=dxtbx")
 
   if (libtbx.env.find_in_repositories("chem_data") is not None and
       os.path.exists(libtbx.env.find_in_repositories("chem_data"))):

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -2023,8 +2023,14 @@ class DIALSBuilder(CCIBuilder):
   LIBTBX_EXTRA = ['dials', 'xia2', 'prime', 'iota', '--skip_phenix_dispatchers']
   HOT_EXTRA = ['msgpack']
   def add_tests(self):
-    self.add_test_command('cctbx_regression.test_nightly')
-    self.add_test_parallel('dials', flunkOnFailure=False, warnOnFailure=True)
+    self.add_test_command('libtbx.pytest',
+                          args=['--regression', '-n', 'auto'],
+                          workdir=['modules', 'dxtbx'],
+                          haltOnFailure=True)
+    self.add_test_command('libtbx.pytest',
+                          args=['--regression', '-n', 'auto'],
+                          workdir=['modules', 'dials'],
+                          haltOnFailure=True)
 
   def add_base(self, extra_opts=[]):
     super(DIALSBuilder, self).add_base(


### PR DESCRIPTION
When running tests via bootstrap or buildbot then run the dxtbx and DIALS tests using pytest.

Please refer to the discussion in dials/dials#890 for background information.

For those actually running tests whis way:
What you may want to consider is whether you want to run the tests that depend on external data. My patch includes the `--regression` flag, so that data will be downloaded and the tests will be run. If you don't want to download the test data and/or run the extended tests then you can remove this flag. We DLS-folks won't mind either way as we do not use the bootstrap testing feature at all.

If you want to run the full test suite: I don't know how your buildbot setup is laid out, but if you do throw away the build directories between builds then you can save yourself time and bandwith by pointing the `DIALS_DATA` environment variable to a shared location outside of the build path. That way you won't keep downloading the same files over and over again. More information on this is available at https://dials-data.readthedocs.io/en/latest/installation.html#where-are-the-regression-datasets-stored
