### PR TITLE
Register scitbx flex arrays as random-seedable

### DIFF
--- a/scitbx/libtbx_refresh.py
+++ b/scitbx/libtbx_refresh.py
@@ -20,3 +20,12 @@ if (self.env.is_ready_for_build()):
   from scitbx.source_generators import lbfgs_fem
   print("  Using fable to convert", op.join("scitbx", "lbfgs.f"))
   lbfgs_fem.run()
+
+  import libtbx.pkg_utils
+  libtbx.pkg_utils.define_entry_points(
+    {
+      "pytest_randomly.random_seeder": [
+        "scitbx_flex = scitbx.array_family.flex:set_random_seed"
+      ],
+    }
+  )


### PR DESCRIPTION
Declares the random seeder in scitbx so that it can be controlled for testing.
(Feature mentioned in dials/dials#890)

Am I doing this right, @ndevenish?