### PR TITLE
Write the libtbx eggs to the build directory

### DIFF
--- a/libtbx/pkg_utils.py
+++ b/libtbx/pkg_utils.py
@@ -235,6 +235,28 @@ def define_entry_points(epdict, **kwargs):
   finally:
     os.chdir(curdir)
 
+  # With the entry points installed into build/lib check for any legacy entry
+  # point definitions in both build/ and base/ and remove them where possible.
+  # Code block can be removed April 2020
+  try:
+    legacy_path = abs(libtbx.env.build_path / 'libtbx.{}.egg-info'.format(caller))
+    if os.path.exists(legacy_path):
+      print("Removing legacy entry points from", legacy_path)
+      import shutil
+      shutil.rmtree(legacy_path)
+  except Exception as e:
+    print("Could not remove legacy entry points:", str(e))
+  try:
+    import site
+    for spp in site.getsitepackages():
+      legacy_path = os.path.join(spp, 'libtbx.{}.egg-link'.format(caller))
+      if os.path.exists(legacy_path):
+        print("Removing legacy entry points from", legacy_path)
+        os.remove(legacy_path)
+  except Exception as e:
+    print("Could not remove legacy entry points:", str(e))
+
+
 def _merge_requirements(requirements, new_req):
   # type: (List[packaging.requirements.Requirement], packaging.requirements.Requirement) -> None
   """Merge a new requirement with a list.

--- a/libtbx/pkg_utils.py
+++ b/libtbx/pkg_utils.py
@@ -212,17 +212,16 @@ def define_entry_points(epdict, **kwargs):
   for ep in epdict:
     print("  {n} entries for entry point {ep}".format(ep=ep, n=len(epdict[ep])))
 
-  # Temporarily change to build/ directory. This is where a directory
-  # named libtbx.{caller}.egg-info will be created containing the
-  # entry point info. Create libtbx.{caller}.egg-link in
-  # {libtbx.env.build_path}/lib, which must be in sys.path.
+  # Temporarily change to {libtbx.env.build_path}/lib directory. This
+  # is where a directory named libtbx.{caller}.egg-info will be
+  # created containing the entry point info.
   try:
     curdir = os.getcwd()
-    os.chdir(abs(libtbx.env.build_path))
+    os.chdir(os.path.join(abs(libtbx.env.build_path), 'lib'))
     # Now trick setuptools into thinking it is in control here.
     try:
       argv_orig = sys.argv
-      sys.argv = ['setup.py', 'develop', '--install-dir=%s' % os.path.join(abs(libtbx.env.build_path), 'lib')]
+      sys.argv = ['setup.py', 'egg_info']
       # And make it run quietly
       with _silence():
         setuptools.setup(

--- a/libtbx/pkg_utils.py
+++ b/libtbx/pkg_utils.py
@@ -212,23 +212,29 @@ def define_entry_points(epdict, **kwargs):
   for ep in epdict:
     print("  {n} entries for entry point {ep}".format(ep=ep, n=len(epdict[ep])))
 
-  # Now trick setuptools into thinking it is in control here.  Create
-  # libtbx.{caller}.egg-info with the entry point information in
-  # {libtbx.env.build_path} and libtbx.{caller}.egg-link in
-  # {libtbx.env.build_path}/lib, which must be in PYTHONPATH.
+  # Temporarily change to build/ directory. This is where a directory
+  # named libtbx.{caller}.egg-info will be created containing the
+  # entry point info. Create libtbx.{caller}.egg-link in
+  # {libtbx.env.build_path}/lib, which must be in sys.path.
   try:
-    argv_orig = sys.argv
-    sys.argv = ['setup.py', 'develop', '--install-dir=%s' % os.path.join(abs(libtbx.env.build_path), 'lib'), '--script-dir=%s' % abs(libtbx.env.build_path)]
-    # And make it run quietly
-    with _silence():
-      setuptools.setup(
-        name='libtbx.{}'.format(caller),
-        description='libtbx entry point manager for {}'.format(caller),
-        entry_points=epdict,
-        **kwargs
-      )
+    curdir = os.getcwd()
+    os.chdir(abs(libtbx.env.build_path))
+    # Now trick setuptools into thinking it is in control here.
+    try:
+      argv_orig = sys.argv
+      sys.argv = ['setup.py', 'develop', '--install-dir=%s' % os.path.join(abs(libtbx.env.build_path), 'lib')]
+      # And make it run quietly
+      with _silence():
+        setuptools.setup(
+          name='libtbx.{}'.format(caller),
+          description='libtbx entry point manager for {}'.format(caller),
+          entry_points=epdict,
+          **kwargs
+        )
+    finally:
+      sys.argv = argv_orig
   finally:
-    sys.argv = argv_orig
+    os.chdir(curdir)
 
 def _merge_requirements(requirements, new_req):
   # type: (List[packaging.requirements.Requirement], packaging.requirements.Requirement) -> None


### PR DESCRIPTION
Tell setuptools to put the libtbx eggs in the build directory and eliminate the chdir around the setup() invocation.  This allows libtbx.refresh to run on a custom Python where write-access to site-packages directory is restricted.