### PR TITLE
Fix deprecation warnings

### DIFF
--- a/xfel/command_line/cspad_cbf_metrology.py
+++ b/xfel/command_line/cspad_cbf_metrology.py
@@ -495,7 +495,7 @@ def refine_expanding(params, merged_scope, combine_phil):
       # panels will have been left behind.  Read back the new metrology, compute the shift applied to the panels refined
       # in this step,and apply that shift to the unrefined panels in this step
       if params.flat_refinement and params.flat_refinement_with_distance and i > 0:
-        from dxtbx.model.experiment_list import ExperimentListFactory, ExperimentListDumper
+        from dxtbx.model.experiment_list import ExperimentListFactory
         from xfel.command_line.cspad_detector_congruence import iterate_detector_at_level, iterate_panels
         from scitbx.array_family import flex
         from scitbx.matrix import col
@@ -550,8 +550,7 @@ def refine_expanding(params, merged_scope, combine_phil):
         for k in range(1, len(displacements)):
           assert approx_equal(displacements[0], displacements[k])
 
-        dump = ExperimentListDumper(experiments)
-        dump.as_json(output_experiments)
+        experiments.as_file(output_experiments)
 
       previous_step_and_level = j,i
 

--- a/xfel/command_line/cspad_detector_congruence.py
+++ b/xfel/command_line/cspad_detector_congruence.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import, division, print_function
 from six.moves import range
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 from scitbx.matrix import col
 from matplotlib import pyplot as plt
 from matplotlib.patches import Polygon
@@ -812,9 +813,6 @@ class Script(object):
       plt.show()
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/cspad_detector_congruence2.py
+++ b/xfel/command_line/cspad_detector_congruence2.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import, division, print_function
 from six.moves import range
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 from scitbx.matrix import col, sqr
 from matplotlib import pyplot as plt
 from matplotlib.patches import Polygon
@@ -888,9 +889,6 @@ class Script(object):
       plt.show()
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/cspad_detector_shifts.py
+++ b/xfel/command_line/cspad_detector_shifts.py
@@ -13,6 +13,7 @@
 #
 from __future__ import absolute_import, division, print_function
 from six.moves import range
+from dials.util import show_mail_on_error
 from scitbx.array_family import flex
 from scitbx.matrix import col
 from libtbx.phil import parse
@@ -295,9 +296,6 @@ Rot Z: rotation around detector normal in lab space
 """)
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/cspad_detector_statistics.py
+++ b/xfel/command_line/cspad_detector_statistics.py
@@ -14,6 +14,7 @@
 #
 from __future__ import absolute_import, division, print_function
 from six.moves import range
+from dials.util import show_mail_on_error
 from libtbx.phil import parse
 import libtbx.load_env
 from libtbx.utils import Usage
@@ -87,9 +88,6 @@ class Script(object):
 
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/detector_residuals.py
+++ b/xfel/command_line/detector_residuals.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import, division, print_function
 from six.moves import range
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 from scitbx.matrix import col
 from matplotlib import pyplot as plt
 from matplotlib.patches import Polygon
@@ -1366,9 +1367,6 @@ class ResidualsPlotter(object):
       plt.show()
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/experiment_json_to_cbf_def.py
+++ b/xfel/command_line/experiment_json_to_cbf_def.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 # Script to convert the output from a joint refinement using dials.refine to a CSPAD
 # cbf header file. Note hardcoded distance of 100 isn't relevant for just a cbf header
 
+from dials.util import show_mail_on_error
 from dials.util.options import OptionParser
 from dials.util.options import flatten_experiments
 from xfel.cftbx.detector.cspad_cbf_tbx import write_cspad_cbf, map_detector_to_basis_dict
@@ -36,10 +37,7 @@ class Script(object):
     print("Done")
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)
 

--- a/xfel/command_line/filter_experiments_by_rmsd.py
+++ b/xfel/command_line/filter_experiments_by_rmsd.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import, division, print_function
 from six.moves import range
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 from scitbx.matrix import col
 from matplotlib import pyplot as plt
 from libtbx.phil import parse
@@ -196,16 +197,11 @@ class Script(object):
 
     print("Final experiment count", len(filtered_experiments))
 
-    from dxtbx.model.experiment_list import ExperimentListDumper
-    dump = ExperimentListDumper(filtered_experiments)
-    dump.as_json(params.output.filtered_experiments)
+    filtered_experiments.as_file(params.output.filtered_experiments)
 
     filtered_reflections.as_pickle(params.output.filtered_reflections)
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/find_highres_shots.py
+++ b/xfel/command_line/find_highres_shots.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 #
 import os, glob
 import libtbx.load_env
+from dials.util import show_mail_on_error
 from dials.util.options import OptionParser
 from libtbx.phil import parse
 from libtbx import easy_pickle
@@ -160,9 +161,6 @@ class Script(object):
     print(cmd.rstrip())
 
 if __name__ == "__main__":
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/frame_unpickler.py
+++ b/xfel/command_line/frame_unpickler.py
@@ -193,8 +193,7 @@ class construct_reflection_table_and_experiment_list(object):
     name = os.path.basename(self.pickle).split(".pickle")[0]
     expt_name = int_pickle_to_filename(name, "idx-", ".expt")
     experiments = os.path.join(loc, expt_name)
-    dumper = experiment_list.ExperimentListDumper(self.experiment_list)
-    dumper.as_json(experiments)
+    self.experiment_list.as_file(experiments)
 
   # construct the reflection table
   def refl_table_maker(self):

--- a/xfel/command_line/recompute_mosaicity.py
+++ b/xfel/command_line/recompute_mosaicity.py
@@ -14,9 +14,9 @@ from six.moves import range
 #
 # LIBTBX_SET_DISPATCHER_NAME cctbx.xfel.recompute_mosaicity
 #
-from dxtbx.model.experiment_list import ExperimentListDumper
 from dials.algorithms.indexing.nave_parameters import NaveParameters
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 import libtbx.load_env
 from libtbx.phil import parse
 
@@ -99,8 +99,7 @@ class Script(object):
       filtered_reflections.extend(refls)
 
     print("Saving new experiments as %s"%params.output.experiments)
-    dump = ExperimentListDumper(experiments)
-    dump.as_json(params.output.experiments)
+    experiments.as_file(params.output.experiments)
 
     print("Removed %d out of %d reflections as outliers"%(len(reflections) - len(filtered_reflections), len(reflections)))
     print("Saving filtered reflections as %s"%params.output.experiments)
@@ -117,9 +116,6 @@ class Script(object):
       plt.show()
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/striping.py
+++ b/xfel/command_line/striping.py
@@ -8,6 +8,7 @@ from six.moves import range
 # run group and then distrbute each run group's results into subgroups and run
 # dials.combine_experiments (optionally with clustering and selecting clusters).
 #
+from dials.util import show_mail_on_error
 from libtbx.phil import parse
 from libtbx.utils import Sorry
 from libtbx import easy_run
@@ -568,7 +569,7 @@ class Script(object):
     return all_commands
 
 if __name__ == "__main__":
-  from dials.util import halraiser
+  import sys
   if "-h" in sys.argv[1:] or "--help" in sys.argv[1:]:
     print(helpstring)
     exit()
@@ -579,8 +580,6 @@ if __name__ == "__main__":
     with open("striping_defaults.phil", "wb") as defaults:
       defaults.write(phil_scope.as_str())
     exit()
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/xfel_process.py
+++ b/xfel/command_line/xfel_process.py
@@ -10,6 +10,7 @@ See dials.stills_process. This version adds mysql database logging for each even
 
 '''
 
+from dials.util import show_mail_on_error
 from libtbx.phil import parse
 control_phil_str = '''
   input {
@@ -88,9 +89,6 @@ if __name__ == '__main__':
   import dials.command_line.stills_process
   dials.command_line.stills_process.Processor = DialsProcessorWithLogging
 
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -14,11 +14,13 @@ except ImportError:
 except AttributeError:
   pass
 
+import errno
 from xfel.cftbx.detector import cspad_cbf_tbx
 from xfel.cxi.cspad_ana import cspad_tbx, rayonix_tbx
 import pycbf, os, sys, copy, socket
 import libtbx.load_env
 from libtbx.utils import Sorry, Usage
+from dials.util import show_mail_on_error
 from dials.util.options import OptionParser
 from libtbx.phil import parse
 from dxtbx.model.experiment_list import ExperimentListFactory
@@ -350,9 +352,6 @@ xtc_phil_str = '''
 from dials.command_line.stills_process import dials_phil_str, program_defaults_phil_str
 
 extra_dials_phil_str = '''
-  verbosity = 1
-   .type = int(value_min=0)
-   .help = The verbosity level
   border_mask {
     include scope dials.util.masking.phil_scope
   }
@@ -545,12 +544,13 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         else:
           tmp_dir = os.path.join(params.output.tmp_output_dir, '.tmp')
         if not os.path.exists(tmp_dir):
-          try:
-            os.makedirs(tmp_dir)
-          except Exception as e:
-            # Can fail if running multiprocessed, which is ok if the tmp folder was created
-            if not os.path.exists(tmp_dir):
-              halraiser(e)
+          with show_mail_on_error():
+            try:
+              os.makedirs(tmp_dir)
+              # Can fail if running multiprocessed - that's OK if the folder was created
+            except OSError as e:  # In Python 2, a FileExistsError is just an OSError
+              if e.errno != errno.EEXIST:  # If this OSError is not a FileExistsError
+                raise
       os.environ['CBF_TMP_DIR'] = tmp_dir
 
     for abs_params in params.integration.absorption_correction:
@@ -633,7 +633,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
       debug_path = os.path.join(params.output.logging_dir, "debug_rank%04d.out"%rank)
 
     from dials.util import log
-    log.config(params.verbosity, info=info_path, debug=debug_path)
+    log.config(options.verbose, info=info_path, debug=debug_path)
 
     debug_dir = os.path.join(params.output.output_dir, "debug")
     if not os.path.exists(debug_dir):
@@ -929,10 +929,8 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
         experiments = refiner.get_experiments()
         reflections = combined_reflections.select(refiner.selection_used_for_refinement())
 
-        from dxtbx.model.experiment_list import ExperimentListDumper
         from dxtbx.model import ExperimentList
-        dump = ExperimentListDumper(experiments)
-        dump.as_json(os.path.join(reint_dir, "refined.expt"))
+        experiments.as_file(os.path.join(reint_dir, "refined.expt"))
         reflections.as_pickle(os.path.join(reint_dir, "refined.refl"))
 
         for expt_id, (expt, img_file) in enumerate(zip(experiments, images)):
@@ -944,8 +942,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
 
             expts = ExperimentList([expt])
             self.integrate(expts, refls)
-            dump = ExperimentListDumper(expts)
-            dump.as_json(os.path.join(reint_dir, base_name + "_refined.expt"))
+            expts.as_file(os.path.join(reint_dir, base_name + "_refined.expt"))
           except Exception as e:
             print("Couldn't reintegrate", img_file, str(e))
     print("Rank %d signing off"%rank)
@@ -1356,9 +1353,6 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
     super(InMemScript, self).finalize()
 
 if __name__ == "__main__":
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = InMemScript()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/merging/application/worker.py
+++ b/xfel/merging/application/worker.py
@@ -43,7 +43,6 @@ def exercise_worker(worker_class):
   """ Boilerplate code for testing a worker class """
   from xfel.merging.application.phil.phil import phil_scope
   from dials.util.options import OptionParser
-  from dxtbx.model.experiment_list import ExperimentListDumper
   # Create the parser
   parser = OptionParser(phil=phil_scope)
 
@@ -65,4 +64,4 @@ def exercise_worker(worker_class):
 
   prefix = worker_class.__name__
   reflections.as_msgpack_file(prefix + ".mpack")
-  ExperimentListDumper(experiments).as_file(prefix + ".expt")
+  experiments.as_file(prefix + ".expt")

--- a/xfel/sacla/mpccd_geom2json.py
+++ b/xfel/sacla/mpccd_geom2json.py
@@ -84,12 +84,10 @@ def run(args):
   beam = BeamFactory.simple(wavelength)
 
   from dxtbx.model import Experiment, ExperimentList
-  from dxtbx.model.experiment_list import ExperimentListDumper
   experiments = ExperimentList()
   experiment = Experiment(detector = detector, beam = beam)
   experiments.append(experiment)
-  dump = ExperimentListDumper(experiments)
-  dump.as_json("geometry.expt")
+  experiments.as_file("geometry.expt")
 
 if __name__ == "__main__":
   run(sys.argv[1:])

--- a/xfel/small_cell/command_line/small_cell_process.py
+++ b/xfel/small_cell/command_line/small_cell_process.py
@@ -5,6 +5,9 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
+
+from dials.util import show_mail_on_error
+
 logger = logging.getLogger('cctbx.small_cell_process')
 
 help_message = '''
@@ -51,9 +54,6 @@ if __name__ == '__main__':
   stills_process.Processor = Processor
   stills_process.phil_scope = phil_scope
 
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = stills_process.Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/small_cell/command_line/xfel_small_cell_process.py
+++ b/xfel/small_cell/command_line/xfel_small_cell_process.py
@@ -21,6 +21,7 @@ from xfel.small_cell.command_line.small_cell_process import Processor as SmallCe
 class SmallCellProcessorWithLogging(DialsProcessorWithLogging, SmallCellProcessor):
   pass
 
+from dials.util import show_mail_on_error
 from dials.command_line.stills_process import dials_phil_str, program_defaults_phil_str, Script as DialsScript, control_phil_str as dials_control_phil_str
 from xfel.ui import db_phil_str
 from xfel.small_cell.command_line.small_cell_process import program_defaults_phil_str as small_cell_program_defaults_phil_str
@@ -53,9 +54,6 @@ if __name__ == '__main__':
   import dials.command_line.stills_process
   dials.command_line.stills_process.Processor = SmallCellProcessorWithLogging
 
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/small_cell/small_cell.py
+++ b/xfel/small_cell/small_cell.py
@@ -22,7 +22,7 @@ import cctbx.miller
 from cctbx.uctbx import unit_cell
 from cctbx import sgtbx
 import operator
-from dxtbx.model.experiment_list import ExperimentListFactory, ExperimentListDumper
+from dxtbx.model.experiment_list import ExperimentListFactory
 
 from dials.algorithms.shoebox import MaskCode
 mask_peak = MaskCode.Valid|MaskCode.Foreground
@@ -1083,8 +1083,9 @@ def small_cell_index_detail(experiments, reflections, horiz_phil, write_output =
         crystal = ori_to_crystal(ori, horiz_phil.small_cell.spacegroup)
         experiments = ExperimentListFactory.from_imageset_and_crystal(imageset, crystal)
         if write_output:
-          dump = ExperimentListDumper(experiments)
-          dump.as_json(os.path.splitext(os.path.basename(path).strip())[0]+"_integrated.expt")
+          experiments.as_file(
+            os.path.splitext(os.path.basename(path).strip())[0] + "_integrated.expt"
+          )
 
         refls = flex.reflection_table()
         refls['id'] = flex.int(len(indexed_hkls), 0)

--- a/xfel/ui/command_line/plot_reflection_stats.py
+++ b/xfel/ui/command_line/plot_reflection_stats.py
@@ -6,6 +6,7 @@ from six.moves import range
 from matplotlib import pyplot as plt
 from xfel.command_line.detector_residuals import setup_stats
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 import math
 from libtbx.phil import parse
 from scitbx.math import five_number_summary
@@ -182,9 +183,6 @@ class Script(object):
       plt.show()
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)

--- a/xfel/ui/command_line/plot_uc_cloud_from_experiments.py
+++ b/xfel/ui/command_line/plot_uc_cloud_from_experiments.py
@@ -4,6 +4,7 @@ from six.moves import range
 # LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
 # LIBTBX_PRE_DISPATCHER_INCLUDE_SH export BOOST_ADAPTBX_FPE_DEFAULT=1
 
+from dials.util import show_mail_on_error
 from libtbx.phil import parse
 
 help_message = """
@@ -121,9 +122,6 @@ class Script(object):
     plotter.plt.show()
 
 if __name__ == '__main__':
-  from dials.util import halraiser
-  try:
+  with show_mail_on_error():
     script = Script()
     script.run()
-  except Exception as e:
-    halraiser(e)


### PR DESCRIPTION
Follows dials/dials#885 & dials/dials#860.  Fixes #385.
  - Replace `dials.util.halraiser` with `dials.util.show_mail_on_error` context manager;
  - Replace `dxtbx.model.experiment_list.ExperimentListDumper` and `dxtbx.serialize.dump` with `as_file` method of experiment list;
  - Fix "DeprecationWarning: Setting verbosity for a Refiner is deprecated."

This conversion was largely automatic, performed at the same time as dials/dials#885.  There are only really three places where I used any judgement.  Once while applying the change necessary to match dials/dials#860 and twice while replacing `halraiser` calls.  The latter case, in particular, requires careful review since both instances are in sections of code for catching a race condition.  I haven't tested any of this, so you probably want to check I haven't introduced a regression in the handling of this race condition.  I've commented on the relevant parts of the commit, so they're easier to find.

Also, I'm not sure whether a slightly different `show_mail_on_error` context manager would be appropriate (with a different email address).  @phyy-nx, I leave this with you.  I hope it saves you a bit of tedious legwork.