### PR TITLE
Speed up DIALS .mtz export

### DIFF
--- a/iotbx/mtz/object.cpp
+++ b/iotbx/mtz/object.cpp
@@ -272,15 +272,12 @@ namespace iotbx { namespace mtz {
 
     CMtz::MTZBAT* p = ptr()->batch;
     CMtz::MTZBAT* p_tail = p;
-    int max_batch_number = 0;
-    int i_batch = 0;
-    int n_batches = image_range[1] - image_range[0] + 1;
-    for(;;i_batch++) {
-      if (p == 0) break;
-      max_batch_number = std::max(max_batch_number, p->num);
+    while(p != 0) {
       p_tail = p;
       p = p->next;
     }
+    int i_batch;
+    int n_batches = image_range[1] - image_range[0] + 1;
     for(i_batch = 0; i_batch < n_batches; i_batch++) {
       int batch_num = i_batch + batch_offset + 1;
 

--- a/iotbx/mtz/object.cpp
+++ b/iotbx/mtz/object.cpp
@@ -1,3 +1,4 @@
+#include <cstdio>
 #include <cvecmat.h>
 #include <ccp4_spg.h>
 #include <csymlib.h>
@@ -244,6 +245,166 @@ namespace iotbx { namespace mtz {
       result.push_back(batch(*this, i_batch));
     }
     return result;
+  }
+
+  void
+  object::add_dials_batches(int dataset_id,
+                            af::tiny<int, 2> image_range,
+                            int batch_offset,
+                            float wavelength,
+                            float mosaic,
+                            af::shared<float> phi_start,
+                            af::shared<float> phi_range,
+                            af::const_ref<float, af::c_grid<2>  > cell_array,
+                            af::const_ref<float, af::c_grid<2>  > umat_array,
+                            af::tiny<int, 2> panel_size,
+                            float panel_distance,
+                            af::shared<float> axis,
+                            af::shared<float> s0n)
+  {
+    // static assertions at the start
+
+#if defined(__DECCXX_VER)
+    BOOST_STATIC_ASSERT(sizeof(float) == sizeof(int));
+#else
+    IOTBX_ASSERT(sizeof(float) == sizeof(int));
+#endif
+
+    CMtz::MTZBAT* p = ptr()->batch;
+    CMtz::MTZBAT* p_tail = p;
+    int max_batch_number = 0;
+    int i_batch = 0;
+    int n_batches = image_range[1] - image_range[0] + 1;
+    for(;;i_batch++) {
+      if (p == 0) break;
+      max_batch_number = std::max(max_batch_number, p->num);
+      p_tail = p;
+      p = p->next;
+    }
+    for(i_batch = 0; i_batch < n_batches; i_batch++) {
+      int batch_num = i_batch + batch_offset + 1;
+
+      // original code from add_batch below - probably excessive in this
+      // case but seems harmless at this point - moved sizeof() assert out
+
+      boost::scoped_array<float> buf(new float[NBATCHINTEGERS+NBATCHREALS]);
+      std::fill_n(buf.get(), NBATCHINTEGERS+NBATCHREALS, static_cast<float>(0));
+      IOTBX_ASSERT(CMtz::ccp4_lwbat(
+        ptr(), 0, batch_num, buf.get(), "") == 1);
+      p = (p_tail == 0 ? ptr()->batch : p_tail->next);
+      IOTBX_ASSERT(p != 0);
+      IOTBX_ASSERT(p->next == 0);
+      IOTBX_ASSERT(p->num == batch_num);
+
+      // now we need to write in all the numbers - just use direct data
+      // access in the data structure...
+
+      p->nbsetid = dataset_id;
+      p->ncryst = 1;
+      p->time1 = 0.0;
+      p->time2 = 0.0;
+      sprintf((char *) &(p->title), "Batch %d", batch_num);
+      p->ndet = 1;
+      p->theta[0] = 0.0;
+      p->theta[1] = 0.0;
+      p->lbmflg = 0;
+      p->alambd = wavelength;
+      p->delamb = 0.0;
+      p->delcor = 0.0;
+      p->divhd = 0.0;
+      p->divvd = 0.0;
+
+      for (int j = 0; j < 3; j++) {
+        p->so[j] = s0n[j];
+      }
+
+      p->source[0] = 0;
+      p->source[1] = 0;
+      p->source[2] = -1;
+
+      p->bbfac = 0.0;
+      p->bscale = 1.0;
+      p->sdbfac = 0.0;
+      p->sdbscale = 0.0;
+      p->nbscal = 0;
+
+      // cell constants and flags to indicate what was refined - these should
+      // probably be != -1 :-/
+      for (int j = 0; j < 6; j++) {
+        p->cell[j] = cell_array(i_batch, j);
+        p->lbcell[j] = -1;
+      }
+
+      for (int j = 0; j < 9; j++) {
+        p->umat[j] = umat_array(i_batch, j);
+      }
+
+      p->crydat[0] = mosaic;
+
+      for (int j = 1; j <= 11; j++) {
+        p->crydat[j] = 0.0;
+      }
+
+      p->lcrflg = 0;
+      p->datum[0] = 0.0;
+      p->datum[1] = 0.0;
+      p->datum[2] = 0.0;
+
+      // detector limits
+      p->detlm[0][0][0] = 0;
+      p->detlm[0][0][1] = panel_size[0];
+      p->detlm[0][1][0] = 0;
+      p->detlm[0][1][1] = panel_size[1];
+      p->detlm[1][0][0] = 0;
+      p->detlm[1][0][1] = 0;
+      p->detlm[1][1][0] = 0;
+      p->detlm[1][1][1] = 0;
+
+      p->dx[0] = panel_distance;
+      p->dx[1] = 0;
+
+      // goniometer axes and names, and scan axis number, and num axes, missets
+      // should we be using this to unroll the setting matrix etc? at this time
+      // assume single-axis goniometer
+
+      p->e1[0] = axis[0];
+      p->e1[1] = axis[1];
+      p->e1[2] = axis[2];
+
+      p->e2[0] = 0.0;
+      p->e2[1] = 0.0;
+      p->e2[2] = 0.0;
+      p->e3[0] = 0.0;
+      p->e3[1] = 0.0;
+      p->e3[2] = 0.0;
+
+      strcpy((char *) &(p->gonlab[0]), "AXIS");
+      strcpy((char *) &(p->gonlab[1]), "");
+      strcpy((char *) &(p->gonlab[2]), "");
+
+      p->jsaxs = 1;
+      p->ngonax = 1;
+
+      // missets all 0 - encoded in U matrix
+      for (int j=0; j < 3; j++) {
+        p->phixyz[0][j] = 0.0;
+        p->phixyz[1][j] = 0.0;
+      }
+
+      p->phistt = phi_start[i_batch];
+      p->phirange = phi_range[i_batch];
+      p->phiend = phi_start[i_batch] + phi_range[i_batch];
+
+      for (int j=0; j<3; j++) {
+        p->scanax[j] = axis[j];
+      }
+
+      p->misflg = 0;
+      p->jumpax = 0;
+      p->ldtype = 2;
+
+      p_tail = p;
+    }
   }
 
   batch

--- a/iotbx/mtz/object.h
+++ b/iotbx/mtz/object.h
@@ -316,6 +316,21 @@ namespace mtz {
       batch
       add_batch();
 
+      void
+      add_dials_batches(int dataset_id,
+                        af::tiny<int, 2> image_range,
+                        int batch_offset,
+                        float wavelength,
+                        float mosaic,
+                        af::shared<float> phi_start,
+                        af::shared<float> phi_range,
+                        af::const_ref<float, af::c_grid<2>  > cell_array,
+                        af::const_ref<float, af::c_grid<2>  > umat_array,
+                        af::tiny<int, 2> panel_size,
+                        float panel_distance,
+                        af::shared<float> axis,
+                        af::shared<float> s0n);
+
       //! Wrapper for CMtz::sort_batches() .
       void
       sort_batches()

--- a/iotbx/mtz/object_bpl.cpp
+++ b/iotbx/mtz/object_bpl.cpp
@@ -114,6 +114,7 @@ namespace {
         .def("n_batches", &w_t::n_batches)
         .def("batches", &w_t::batches)
         .def("add_batch", &w_t::add_batch)
+        .def("add_dials_batches", &w_t::add_dials_batches)
         .def("sort_batches", &w_t::sort_batches)
         .def("n_reflections", &w_t::n_reflections)
         .def("max_min_resolution", &w_t::max_min_resolution)


### PR DESCRIPTION
Instead of running O(n) calls to _add_batch(), which runs an O(n) check
and then runs another C library function running another O(n) check for
a total complexity of O(2n²)...

...run one custom function that inserts all batch information at the
same time for O(n) cost in time.

Relevant ticket: https://github.com/dials/dials/issues/924