### PR TITLE
Optionally avoid auto_anomalous check in iotbx.mtz.object.as_miller_arrays()

### DIFF
--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -113,7 +113,8 @@ class reader(object):
                        crystal_symmetry=None,
                        force_symmetry=False,
                        merge_equivalents=True,
-                       base_array_info=None):
+                       base_array_info=None,
+                       anomalous=None):
     if base_array_info is None:
       base_array_info = miller.array_info(
         source=self.file_path, source_type="cif")
@@ -134,6 +135,8 @@ class reader(object):
           force=force_symmetry)
         arrays[i] = array.customized_copy(crystal_symmetry=crystal_symmetry)
         arrays[i].set_info(array.info())
+      if anomalous is not None:
+        arrays[i] = array.customized_copy(anomalous_flag=anomalous)
     return arrays
 
 fast_reader = reader # XXX backward compatibility 2010-08-25

--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -127,16 +127,16 @@ class reader(object):
         list(arrays.values()) for arrays in
         self.build_miller_arrays(base_array_info=base_array_info).values()])
     other_symmetry=crystal_symmetry
-    for i, array in enumerate(arrays):
+    for i in range(len(arrays)):
       if crystal_symmetry is not None:
-        crystal_symmetry_from_file = array.crystal_symmetry()
+        crystal_symmetry_from_file = arrays[i].crystal_symmetry()
         crystal_symmetry = crystal_symmetry_from_file.join_symmetry(
           other_symmetry=other_symmetry,
           force=force_symmetry)
-        arrays[i] = array.customized_copy(crystal_symmetry=crystal_symmetry)
-        arrays[i].set_info(array.info())
+        arrays[i] = arrays[i].customized_copy(crystal_symmetry=crystal_symmetry)
+        arrays[i].set_info(arrays[i].info())
       if anomalous is not None:
-        arrays[i] = array.customized_copy(anomalous_flag=anomalous)
+        arrays[i] = arrays[i].customized_copy(anomalous_flag=anomalous)
     return arrays
 
 fast_reader = reader # XXX backward compatibility 2010-08-25

--- a/iotbx/cif/tests/tst_lex_parse_build.py
+++ b/iotbx/cif/tests/tst_lex_parse_build.py
@@ -247,8 +247,13 @@ _b 2
   f.close()
   miller_arrays = any_reflection_file(file_name=f.name).as_miller_arrays()
   assert len(miller_arrays) == 2
-  miller_arrays = any_reflection_file(file_name=f.name).as_miller_arrays(anomalous=True)
+  cs = crystal.symmetry(
+    space_group_info=sgtbx.space_group_info("P1")
+  )
+  miller_arrays = any_reflection_file(file_name=f.name).as_miller_arrays(
+    crystal_symmetry=cs, force_symmetry=True, anomalous=True)
   assert miller_arrays[0].anomalous_flag() is True
+  assert miller_arrays[0].crystal_symmetry().space_group() == cs.space_group()
 
 def exercise_parser(reader, builder):
   cif_model = reader(

--- a/iotbx/cif/tests/tst_lex_parse_build.py
+++ b/iotbx/cif/tests/tst_lex_parse_build.py
@@ -247,6 +247,8 @@ _b 2
   f.close()
   miller_arrays = any_reflection_file(file_name=f.name).as_miller_arrays()
   assert len(miller_arrays) == 2
+  miller_arrays = any_reflection_file(file_name=f.name).as_miller_arrays(anomalous=True)
+  assert miller_arrays[0].anomalous_flag() is True
 
 def exercise_parser(reader, builder):
   cif_model = reader(

--- a/iotbx/command_line/merging_statistics.py
+++ b/iotbx/command_line/merging_statistics.py
@@ -91,7 +91,9 @@ already be on a common scale, but with individual observations unmerged.
     file_name=params.file_name,
     data_labels=params.labels,
     log=out,
-    assume_shelx_observation_type_is=assume_shelx_observation_type_is)
+    assume_shelx_observation_type_is=assume_shelx_observation_type_is,
+    anomalous=params.anomalous,
+  )
   params.labels = i_obs.info().label_string()
   validate_params(params)
   symm = sg = uc = None

--- a/iotbx/merging_statistics.py
+++ b/iotbx/merging_statistics.py
@@ -919,13 +919,15 @@ class dataset_statistics(object):
     print("for refinement.", file=out)
 
 def select_data(file_name, data_labels, log=None,
-    assume_shelx_observation_type_is=None, allow_amplitudes=None):
+    assume_shelx_observation_type_is=None, allow_amplitudes=None, anomalous=None):
   if (log is None) : log = null_out()
   from iotbx import reflection_file_reader
   hkl_in = reflection_file_reader.any_reflection_file(file_name)
   print("Format:", hkl_in.file_type(), file=log)
   miller_arrays = hkl_in.as_miller_arrays(merge_equivalents=False,
-    assume_shelx_observation_type_is=assume_shelx_observation_type_is)
+    assume_shelx_observation_type_is=assume_shelx_observation_type_is,
+    anomalous=anomalous,
+  )
   if ((hkl_in.file_type() == "shelx_hklf") and (not "=" in file_name)
        and assume_shelx_observation_type_is is None):
     print("WARNING: SHELX file is assumed to contain intensities", file=log)

--- a/iotbx/reflection_file_reader.py
+++ b/iotbx/reflection_file_reader.py
@@ -311,7 +311,7 @@ class any_reflection_file(object):
       merge_equivalents=merge_equivalents,
       base_array_info=base_array_info,
       anomalous=anomalous,
-      )
+    )
     if (self.file_type() == "shelx_hklf"):
       if ((self._observation_type == "intensities") or
           (assume_shelx_observation_type_is == "intensities")):

--- a/iotbx/reflection_file_reader.py
+++ b/iotbx/reflection_file_reader.py
@@ -225,6 +225,7 @@ class any_reflection_file(object):
                        base_array_info=None,
                        assume_shelx_observation_type_is=None,
                        enforce_positive_sigmas=False,
+                       anomalous=None,
      ):
     """
     Convert the contents of the reflection file into a list of
@@ -309,6 +310,7 @@ class any_reflection_file(object):
       force_symmetry=force_symmetry,
       merge_equivalents=merge_equivalents,
       base_array_info=base_array_info,
+      anomalous=anomalous,
       )
     if (self.file_type() == "shelx_hklf"):
       if ((self._observation_type == "intensities") or

--- a/iotbx/scalepack/no_merge_original_index.py
+++ b/iotbx/scalepack/no_merge_original_index.py
@@ -162,7 +162,12 @@ class reader(object):
       unit_cell=None,
       space_group_info=self.space_group_info())
 
-  def unmerged_miller_set(self, crystal_symmetry=None, force_symmetry=False):
+  def unmerged_miller_set(self,
+                          crystal_symmetry=None,
+                          force_symmetry=False,
+                          anomalous=True):
+    if anomalous is None:
+      anomalous = True
     if (not force_symmetry
         or crystal_symmetry is None
         or crystal_symmetry.space_group_info() is None):
@@ -174,13 +179,14 @@ class reader(object):
         other_symmetry=crystal_symmetry,
         force=force_symmetry),
       indices=self.original_indices,
-      anomalous_flag=True)
+      anomalous_flag=anomalous)
 
   def as_miller_array(self,
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
+        base_array_info=None,
+        anomalous=True):
     if (base_array_info is None):
       base_array_info = miller.array_info(
         source_type="scalepack_no_merge_original_index")
@@ -191,7 +197,8 @@ class reader(object):
     result = miller.array(
       miller_set=self.unmerged_miller_set(
         crystal_symmetry=crystal_symmetry,
-        force_symmetry=True),
+        force_symmetry=True,
+        anomalous=anomalous),
       data=self.i_obs,
       sigmas=self.sigmas)
     if (merge_equivalents):
@@ -207,22 +214,29 @@ class reader(object):
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
-    return [self.as_miller_array(
-      crystal_symmetry=crystal_symmetry,
-      force_symmetry=force_symmetry,
-      merge_equivalents=merge_equivalents,
-      base_array_info=base_array_info),
-            self.batch_as_miller_array(
-      crystal_symmetry=crystal_symmetry,
-      force_symmetry=force_symmetry,
-      base_array_info=base_array_info),
-            ]
+        base_array_info=None,
+        anomalous=True):
+    return [
+      self.as_miller_array(
+        crystal_symmetry=crystal_symmetry,
+        force_symmetry=force_symmetry,
+        merge_equivalents=merge_equivalents,
+        base_array_info=base_array_info,
+        anomalous=anomalous,
+      ),
+      self.batch_as_miller_array(
+        crystal_symmetry=crystal_symmetry,
+        force_symmetry=force_symmetry,
+        base_array_info=base_array_info,
+        anomalous=anomalous,
+      ),
+    ]
 
   def batch_as_miller_array(self,
         crystal_symmetry=None,
         force_symmetry=False,
-        base_array_info=None):
+        base_array_info=None,
+        anomalous=True):
     if (base_array_info is None):
       base_array_info = miller.array_info(
         source_type="scalepack_no_merge_original_index")
@@ -233,7 +247,8 @@ class reader(object):
     return miller.array(
       miller_set=self.unmerged_miller_set(
         crystal_symmetry=crystal_symmetry,
-        force_symmetry=True),
+        force_symmetry=True,
+        anomalous=anomalous),
       data=self.batch_numbers).set_info(
         base_array_info.customized_copy(
           labels=["BATCH"],

--- a/iotbx/shelx/hklf.py
+++ b/iotbx/shelx/hklf.py
@@ -103,7 +103,8 @@ class reader(iotbx_shelx_ext.hklf_reader):
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
+        base_array_info=None,
+        anomalous=None):
     from cctbx import miller
     from cctbx import crystal
     if (crystal_symmetry is None):
@@ -112,7 +113,9 @@ class reader(iotbx_shelx_ext.hklf_reader):
       base_array_info = miller.array_info(source_type="shelx_hklf")
     miller_set = miller.set(
       crystal_symmetry=crystal_symmetry,
-      indices=self.indices()).auto_anomalous()
+      indices=self.indices(), anomalous_flag=anomalous)
+    if anomalous is not None:
+      miller_set = miller_set.auto_anomalous()
     miller_arrays = []
     obs = (miller.array(
       miller_set=miller_set,

--- a/iotbx/xds/integrate_hkl.py
+++ b/iotbx/xds/integrate_hkl.py
@@ -191,7 +191,8 @@ class reader:
                        crystal_symmetry=None,
                        force_symmetry=False,
                        merge_equivalents=True,
-                       base_array_info=None):
+                       base_array_info=None,
+                       anomalous=None):
     if (base_array_info is None):
       base_array_info = miller.array_info(source_type="xds_integrate_hkl")
     from cctbx.array_family import flex
@@ -200,7 +201,7 @@ class reader:
       unit_cell=self.unit_cell,
       space_group_info=sgtbx.space_group_info(number=self.space_group))
     indices = flex.miller_index(self.hkl)
-    miller_set = miller.set(crystal_symmetry, indices)
+    miller_set = miller.set(crystal_symmetry, indices, anomalous_flag=anomalous)
     return (miller.array(
       miller_set, data=flex.double(self.iobs), sigmas=flex.double(self.sigma))
             .set_info(base_array_info.customized_copy(

--- a/iotbx/xds/read_ascii.py
+++ b/iotbx/xds/read_ascii.py
@@ -96,8 +96,11 @@ class reader(object):
 
   def miller_set(self,
         crystal_symmetry=None,
-        force_symmetry=False):
+        force_symmetry=False,
+        anomalous=None):
     crystal_symmetry_from_file = self.crystal_symmetry()
+    if anomalous is None:
+      anomalous = self.anomalous_flag
     return miller.set(
         crystal_symmetry=crystal_symmetry_from_file.join_symmetry(
           other_symmetry=crystal_symmetry,
@@ -109,14 +112,17 @@ class reader(object):
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
+        base_array_info=None,
+        anomalous=None):
     if (base_array_info is None):
       base_array_info = miller.array_info(source_type="xds_ascii")
     crystal_symmetry_from_file = self.crystal_symmetry()
     array = (miller.array(
       miller_set=self.miller_set(
         crystal_symmetry=crystal_symmetry,
-        force_symmetry=force_symmetry),
+        force_symmetry=force_symmetry,
+        anomalous=anomalous,
+      ),
       data=self.iobs,
       sigmas=self.sigma_iobs)
       .set_info(base_array_info.customized_copy(
@@ -134,12 +140,15 @@ class reader(object):
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
+        base_array_info=None,
+        anomalous=None):
     return [self.as_miller_array(
       crystal_symmetry=crystal_symmetry,
       force_symmetry=force_symmetry,
       merge_equivalents=merge_equivalents,
-      base_array_info=base_array_info)]
+      base_array_info=base_array_info,
+      anomalous=anomalous,
+    )]
 
   def batch_as_miller_array(self,
         crystal_symmetry=None,


### PR DESCRIPTION
- Add an `anomalous=None` parameter to `iotbx.mtz.object.as_miller_arrays()`.
- If this is set to `True` or `False`, then the call to `milller.set.auto_anomalous()` in `iotbx.mtz.column_group()` is avoided. This call can potentially be expensive with particularly large reflection files with millions of observations.
- In `iotbx.merging_statistics` pass the value of the anomalous parameter to
`iotbx.mtz.object.as_miller_arrays()`.
- Add anomalous parameters to other `as_miller_arrays()` methods