### PR TITLE
Add pickling support for sparse matrices. For #195

### DIFF
--- a/scitbx/sparse/boost_python/matrix.cpp
+++ b/scitbx/sparse/boost_python/matrix.cpp
@@ -117,6 +117,42 @@ struct matrix_wrapper
     return m.permute_rows(p);
   }
 
+  struct SparseMatrixPickleSuite : boost::python::pickle_suite {
+
+    typedef vector<T, copy_semantic_vector_container> column_type;
+    typedef typename column_type::const_iterator const_row_iterator;
+    typedef typename column_type::index_type index_type;
+    typedef T value_type;
+
+    static boost::python::tuple getinitargs(const matrix<T> &obj){
+      return boost::python::make_tuple(
+        obj.n_rows(),
+        obj.n_cols());
+    }
+
+    static boost::python::list getstate(const matrix<T> &obj){
+      boost::python::list state;
+      /// state is given by (row_index, col_index, value) for nonzero elements
+      for (index_type j=0; j < obj.n_cols(); j++) {
+        for(const_row_iterator p = obj.col(j).begin(); p != obj.col(j).end(); p++) {
+          state.append(boost::python::make_tuple(p.index(), j, *p));
+        }
+      }
+      return state;
+    }
+
+    static void setstate(matrix<T>& obj, boost::python::list state){
+      boost::python::ssize_t n = boost::python::len(state);
+      for (boost::python::ssize_t i = 0; i<n; i++){
+        boost::python::object elem = state[i];
+        int row_idx = boost::python::extract<int>(elem[0]);
+        int col_idx = boost::python::extract<int>(elem[1]);
+        value_type value = boost::python::extract<value_type>(elem[2]);
+        obj(row_idx, col_idx) = value;
+      }
+    }
+  };
+
   static void wrap() {
     using namespace boost::python;
     return_internal_reference<> rir;
@@ -170,6 +206,7 @@ struct matrix_wrapper
            &wt::this_times_diagonal_times_this_transpose)
       .def("__str__", str_)
       .def("__repr__", repr)
+      .def_pickle(SparseMatrixPickleSuite())
     ;
   }
 

--- a/scitbx/sparse/boost_python/matrix.cpp
+++ b/scitbx/sparse/boost_python/matrix.cpp
@@ -150,6 +150,7 @@ struct matrix_wrapper
         value_type value = boost::python::extract<value_type>(elem[2]);
         obj(row_idx, col_idx) = value;
       }
+      obj.compact();
     }
   };
 

--- a/scitbx/sparse/tests/tst_sparse.py
+++ b/scitbx/sparse/tests/tst_sparse.py
@@ -6,6 +6,7 @@ from libtbx.test_utils import approx_equal, Exception_expected
 import random
 import scitbx.random
 import itertools
+from six.moves import cPickle as pickle
 from six.moves import range
 
 def exercise_vector():
@@ -433,6 +434,17 @@ def exercise_block_assignment():
   assert a.is_structural_zero(2, 1)
   assert a.is_structural_zero(3, 2)
 
+def exercise_python_pickle():
+  m = sparse.matrix(6, 3,
+      elements_by_columns = [ { 0: 1, 3:2, 5:3 },
+                              { 1:-1, 3:3, 4:-2 },
+                              { 2:1, } ])
+  p = pickle.dumps(m)
+  b = pickle.loads(p)
+  assert m.non_zeroes == b.non_zeroes
+  assert list(b.as_dense_matrix()) == list(m.as_dense_matrix())
+
+
 def run():
   libtbx.utils.show_times_at_exit()
   exercise_block_assignment()
@@ -447,6 +459,7 @@ def run():
   exercise_matrix_x_matrix()
   exercise_a_tr_b_a()
   exercise_a_b_a_tr()
+  exercise_python_pickle()
 
 if __name__ == '__main__':
   run()


### PR DESCRIPTION
This pull requests adds pickling support for sparse matrices, which allows them to be used in multiprocessing, for example in sparse refinement code.

The state of the sparse matrix is stored as a list of tuples of row_index, column_index, value. I'm unsure how to reliably test the speeds of various implementations, but this seems the obvious choice to me.