### PR TITLE
Synch with dials/dials#952

### DIFF
--- a/xfel/command_line/detector_residuals.py
+++ b/xfel/command_line/detector_residuals.py
@@ -795,7 +795,7 @@ class ResidualsPlotter(object):
         reflections['xyzcal.px'] = reflections['xyzcal.px.%s'%dest]
 
     if 'xyzobs.mm.value' not in reflections:
-      reflections.centroid_px_to_mm(detector)
+      reflections.centroid_px_to_mm(experiments)
     reflections['difference_vector_norms'] = (reflections['xyzcal.mm']-reflections['xyzobs.mm.value']).norms()
 
     n = len(reflections)

--- a/xfel/small_cell/small_cell.py
+++ b/xfel/small_cell/small_cell.py
@@ -438,8 +438,8 @@ def small_cell_index_detail(experiments, reflections, horiz_phil, write_output =
 
   from dials.algorithms.indexing.assign_indices import AssignIndicesGlobal
   reflections['imageset_id'] = reflections['id']
-  reflections.centroid_px_to_mm(detector)
-  reflections.map_centroids_to_reciprocal_space(detector, beam)
+  reflections.centroid_px_to_mm(experiments)
+  reflections.map_centroids_to_reciprocal_space(experiments)
 
   all_spots = []
   for i, ref in enumerate(reflections):
@@ -1100,7 +1100,7 @@ def small_cell_index_detail(experiments, reflections, horiz_phil, write_output =
         refls['s1'] = s1
         refls['bbox'] = bbox
 
-        refls.centroid_px_to_mm(detector)
+        refls.centroid_px_to_mm(experiments)
 
         refls.set_flags(flex.bool(len(refls), True), refls.flags.indexed)
         if write_output:


### PR DESCRIPTION
`flex.reflection_table.centroid_px_to_mm()` and `flex.reflection_table.map_centroids_to_reciprocal_space()` now take an `ExperimentList` as input instead of individual dxtbx models.

There don't appear to be any tests in the xfel module, so I wasn't able to verify that these changes actually work.