### PR TITLE
Fix treatment of scale_range in hklf export

### DIFF
--- a/cctbx/miller/__init__.py
+++ b/cctbx/miller/__init__.py
@@ -4462,7 +4462,8 @@ class array(set):
   def export_as_shelx_hklf(self,
         file_object=None,
         normalise_if_format_overflow=False,
-        full_dynamic_range=False):
+        full_dynamic_range=False,
+        scale_range=None):
     """
     Write reflections to a SHELX-format .hkl file.
     """
@@ -4471,7 +4472,8 @@ class array(set):
       miller_array=self,
       file_object=file_object,
       normalise_if_format_overflow=normalise_if_format_overflow,
-      full_dynamic_range=full_dynamic_range)
+      full_dynamic_range=full_dynamic_range,
+      scale_range=scale_range)
 
   def export_as_cns_hkl(self,
         file_object,

--- a/iotbx/shelx/hklf.py
+++ b/iotbx/shelx/hklf.py
@@ -39,8 +39,9 @@ def miller_array_export_as_shelx_hklf(
     max_val = max(abs(max_val),abs(min_val))
     if (max_val > max_abs):
       scale = max_abs / max_val
-  elif scale_range is None:
-    scale_range = (-999999., 9999999.)
+  else:
+    if scale_range is None:
+      scale_range = (-999999., 9999999.)
     if (min_val < scale_range[0]):
       if not normalise_if_format_overflow:
         raise_f8_overflow(min_val)

--- a/iotbx/shelx/tst_hklf.py
+++ b/iotbx/shelx/tst_hklf.py
@@ -161,6 +161,13 @@ def exercise_miller_export_as_shelx_hklf():
    2  -3   99999999.    0.00
    0   0   0    0.00    0.00
 """)
+  # Test that setting the scale range works.
+  ma2.export_as_shelx_hklf(
+    sio,
+    scale_range=(-9999., 9999.),
+    normalise_if_format_overflow=True)
+  # Test that ignoring the scale range and normalising out-of-range values anyway works.
+  ma2.export_as_shelx_hklf(sio, full_dynamic_range=True)
 
 def run():
   exercise_hklf_reader()


### PR DESCRIPTION
A recent change (https://github.com/cctbx/cctbx_project/commit/4a7e1484d8db4c31d9d0189c7be0a9cf8cdb4e64) by @randyjread introduced a regression in the behaviour of `iotbx.shelx.hklf.miller_array_export_as_shelx_hklf`.  In introducing the `full_dynamic_range` argument, it seems he inadvertently deactivated the existing behaviour when `full_dynamic_range=False` and `scale_range` is not `None`.

This PR contains a simple fix that reinstates the option to run with `scale_range` set to a non-`None` value.  It also adds a test for that behaviour, to prevent future regressions, and also a basic test to exercise the `full_dynamic_range=True` behaviour introduced in https://github.com/cctbx/cctbx_project/commit/4a7e1484d8db4c31d9d0189c7be0a9cf8cdb4e64.

- Make it so that non-`None` values of `scale_range` are no longer ignored in `iotbx.shelx.hklf.miller_array_export_as_shelx_hklf`.
- Expose the argument `scale_range` of `iotbx.shelx.hklf.miller_array_export_as_shelx_hklf` in the method `export_as_shelx_hklf` of `miller_array` objects.
- Add a test to prevent regressions of behaviour when `scale_range` is not `None`.
- Add a test for existing behaviour of `export_as_shelx_hklf` with argument `full_dynamic_range=True`.

This also fixes https://github.com/xia2/xia2/issues/334.