### PR TITLE
Fixes for #395

### DIFF
--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -133,10 +133,11 @@ class reader(object):
         crystal_symmetry = crystal_symmetry_from_file.join_symmetry(
           other_symmetry=other_symmetry,
           force=force_symmetry)
-        arrays[i] = arrays[i].customized_copy(crystal_symmetry=crystal_symmetry)
-        arrays[i].set_info(arrays[i].info())
+        arrays[i] = arrays[i].customized_copy(
+          crystal_symmetry=crystal_symmetry, info=arrays[i].info())
       if anomalous is not None:
-        arrays[i] = arrays[i].customized_copy(anomalous_flag=anomalous)
+        arrays[i] = arrays[i].customized_copy(
+          anomalous_flag=anomalous, info=arrays[i].info())
     return arrays
 
 fast_reader = reader # XXX backward compatibility 2010-08-25

--- a/iotbx/cns/index_fobs_sigma_reader.py
+++ b/iotbx/cns/index_fobs_sigma_reader.py
@@ -63,14 +63,17 @@ class reader(object):
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
+        base_array_info=None,
+        anomalous=None):
     if (crystal_symmetry is None):
       crystal_symmetry = crystal.symmetry()
     if (base_array_info is None):
       base_array_info = miller.array_info(source_type="cns_index_fobs_sigma")
     miller_set = miller.set(
       crystal_symmetry=crystal_symmetry,
-      indices=self.indices()).auto_anomalous()
+      indices=self.indices(), anomalous_flag=anomalous)
+    if anomalous is None:
+      miller_set = miller_set.auto_anomalous()
     return [miller.array(
       miller_set=miller_set,
       data=self.data(),

--- a/iotbx/dtrek/reflnlist_reader.py
+++ b/iotbx/dtrek/reflnlist_reader.py
@@ -119,7 +119,8 @@ class reflnlist(object):
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
+        base_array_info=None,
+        anomalous=None):
     crystal_symmetry_from_file = self.crystal_symmetry()
     crystal_symmetry = crystal_symmetry_from_file.join_symmetry(
       other_symmetry=crystal_symmetry,

--- a/iotbx/scalepack/merge.py
+++ b/iotbx/scalepack/merge.py
@@ -116,11 +116,12 @@ class reader(object):
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
-    if (base_array_info is None):
+        base_array_info=None,
+        anomalous=None):
+    if base_array_info is None:
       base_array_info = miller.array_info(source_type="scalepack_merge")
     crystal_symmetry_from_file = self.crystal_symmetry()
-    if (self.anomalous):
+    if anomalous or self.anomalous:
       labels = ["I(+)", "SIGI(+)", "I(-)", "SIGI(-)"]
     else:
       labels = ["I", "SIGI"]
@@ -130,7 +131,7 @@ class reader(object):
           other_symmetry=crystal_symmetry,
           force=force_symmetry),
         indices=self.miller_indices,
-        anomalous_flag=self.anomalous),
+        anomalous_flag=anomalous or self.anomalous),
       data=self.i_obs,
       sigmas=self.sigmas)
       .set_info(base_array_info.customized_copy(
@@ -142,12 +143,15 @@ class reader(object):
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
+        base_array_info=None,
+        anomalous=None):
     return [self.as_miller_array(
       crystal_symmetry=crystal_symmetry,
       force_symmetry=force_symmetry,
       merge_equivalents=merge_equivalents,
-      base_array_info=base_array_info)]
+      base_array_info=base_array_info,
+      anomalous=anomalous,
+    )]
 
 def format_f8_1_or_i8(h, label, value):
   if (value < 1.e6): return "%8.1f" % value

--- a/iotbx/solve/fpfm_reader.py
+++ b/iotbx/solve/fpfm_reader.py
@@ -62,7 +62,8 @@ class reader(object):
         crystal_symmetry=None,
         force_symmetry=False,
         merge_equivalents=True,
-        base_array_info=None):
+        base_array_info=None,
+        anomalous=None):
     if (crystal_symmetry is None):
       crystal_symmetry = crystal.symmetry()
     if (base_array_info is None):


### PR DESCRIPTION
@phyy-nx I have fixed as much as I can, although I still get some errors which I think are related to missing dependencies (I have already checked out/configured phenix, phenix_regression, phenix_examples, elbow, plex,... and gave up after that).

It would be helpful if these particular reflection formats were exercised directly in iotbx, rather than relying on hard-to-access tests that rely on seemingly unrelated external dependencies.

```
Traceback (most recent call last):
  File "/Users/rjgildea/software/cctbx/build/../modules/phenix/phenix/command_line/refine.py", line 11, in <module>
    command_line.run(command_name="phenix.refine", args=sys.argv[1:])
  File "/Users/rjgildea/software/cctbx/modules/phenix/phenix/refinement/command_line.py", line 86, in run
    skip_write_data_mtz_file=skip_write_data_mtz_file)
  File "/Users/rjgildea/software/cctbx/modules/phenix/phenix/refinement/command_line.py", line 252, in __init__
    enable_dev_options=("--developer" in args))
  File "/Users/rjgildea/software/cctbx/modules/phenix/phenix/refinement/__init__.py", line 23, in master_params
    _master_params = iotbx.phil.read_default(__file__)
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/iotbx/phil.py", line 97, in read_default
    process_includes=process_includes)
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/phil/__init__.py", line 2213, in read_default
    process_includes=process_includes)
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/phil/__init__.py", line 2197, in parse
    include_stack=include_stack)
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/phil/__init__.py", line 2007, in process_includes
    include_stack=include_stack))
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/phil/__init__.py", line 2007, in process_includes
    include_stack=include_stack))
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/phil/__init__.py", line 2007, in process_includes
    include_stack=include_stack))
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/phil/__init__.py", line 1999, in process_includes
    phil_path=phil_path).objects)
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/phil/__init__.py", line 2039, in process_include_scope
    where_str=object.where_str)
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/utils.py", line 1604, in __init__
    error_prefix, module_path, where_str, module_path))
ImportError: include scope: no module elbow.command_line.ready_set (file "/Users/rjgildea/software/cctbx/modules/phenix/phenix/refinement/__init__.params", line 930) or possibly import errors in module elbow.command_line.ready_set
Traceback (most recent call last):
  File "../modules/phenix_regression/refinement/tst_089.py", line 113, in <module>
    run()
  File "../modules/phenix_regression/refinement/tst_089.py", line 99, in run
    r = run_phenix_refine(args = args, prefix = prefix)
  File "/Users/rjgildea/software/cctbx/modules/phenix_regression/refinement/__init__.py", line 131, in __init__
    show_diff_log_stdout = True)
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/test_utils/__init__.py", line 658, in run_command
    sorry_expected=sorry_expected)
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/test_utils/__init__.py", line 577, in _check_command_output
    show_and_raise(detected="Traceback")
  File "/Users/rjgildea/software/cctbx/modules/cctbx_project/libtbx/test_utils/__init__.py", line 573, in show_and_raise
    raise RunCommandError(msg)
libtbx.test_utils.RunCommandError: Traceback detected in output: "tst_089.log"
modules/phenix_regression/refinement/autobuild/tst.py
Skipping autobuild test: solve_resolve not available.
```

```
cctbx.euclidean_model_matching 12_se.pickle gere_MAD_hyss_consensus_model.pickle
libtbx.assert_stdin_contains_strings match_list: [12/12]
BEGIN OF INPUT (libtbx.assert_stdin_contains_strings)
vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
Reference model:
Number of scatterers: 12
At special positions: 0
Unit cell: (108.742, 61.679, 71.652, 90, 97.151, 90)
Space group: C 1 2 1 (No. 5)

Number of scatterers: 12
At special positions: 0
Unit cell: (108.742, 61.679, 71.652, 90, 97.151, 90)
Space group: C 1 2 1 (No. 5)

Match summary:
  Operator:
       rotation: {{-1, 0, 0}, {0, -1, 0}, {0, 0, -1}}
    translation: {1.50463*^-36, 0.198902, 0}
  rms coordinate differences: 0.41
  Pairs: 10
    pdb="PEAK PEAK    1 " segid="PEAK" site002 0.140
    pdb="PEAK PEAK    3 " segid="PEAK" site005 0.466
    pdb="PEAK PEAK    4 " segid="PEAK" site010 0.368
    pdb="PEAK PEAK    5 " segid="PEAK" site003 0.139
    pdb="PEAK PEAK    6 " segid="PEAK" site004 0.279
    pdb="PEAK PEAK    7 " segid="PEAK" site001 0.431
    pdb="PEAK PEAK    8 " segid="PEAK" site008 0.289
    pdb="PEAK PEAK    9 " segid="PEAK" site009 0.921
    pdb="PEAK PEAK   10 " segid="PEAK" site007 0.147
    pdb="PEAK PEAK   11 " segid="PEAK" site006 0.325
  Singles model 1: 2 
    pdb="PEAK PEAK    2 " segid="PEAK"   pdb="PEAK PEAK   12 " segid="PEAK" 
  Singles model 2: 2 
    site011   site012 


match_list: [10/12]
matches: frequency
   10:   1 = 100.0%, 100.0%

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
END OF INPUT (libtbx.assert_stdin_contains_strings)
```