### PR TITLE
Fix necessary for compiling phaser_tng

### DIFF
--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -1316,7 +1316,6 @@ Wait for the command to finish, then try again.""" % vars())
       elif (source_file.isfile()
             and (   not hasattr(os.path, "samefile")
                  or not reg.samefile(source_file))):
-        #import code, traceback; code.interact(local=locals(), banner="".join( traceback.format_stack(limit=10) ) )
         raise RuntimeError("Multiple sources for dispatcher:\n"
           + "  target file:\n"
           + "    %s\n" % show_string(abs(target_file))

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -1316,6 +1316,7 @@ Wait for the command to finish, then try again.""" % vars())
       elif (source_file.isfile()
             and (   not hasattr(os.path, "samefile")
                  or not reg.samefile(source_file))):
+        #import code, traceback; code.interact(local=locals(), banner="".join( traceback.format_stack(limit=10) ) )
         raise RuntimeError("Multiple sources for dispatcher:\n"
           + "  target file:\n"
           + "    %s\n" % show_string(abs(target_file))
@@ -2104,7 +2105,7 @@ class module:
   def command_line_directory_paths(self):
     result = []
     for dist_path in self.dist_paths_active():
-      for sub_dir in ["command_line", self.name+"/command_line"]+ \
+      for sub_dir in ["command_line", os.path.join(self.name, "command_line") ]+ \
         [os.path.join(a,"command_line") for a in getattr(self,"extra_command_line_locations",[])]:
         path = dist_path / sub_dir
         if path.isdir():


### PR DESCRIPTION
We have had this problem for more than a year and I think this change may solve the problem.
It fixes compiling phaser_tng outside of conda on Windows with the following command:

`python bootstrap.py --builder=phaser_tng`

Without it the following error is reported:

`
RuntimeError: Multiple sources for dispatcher:
  target file:
    "c:\users\phaserbuilder\phasertng2\build\bin\phaser_tng.build_dag_node"
  source files:
    "c:\users\phaserbuilder\phasertng2\modules\phaser_tng\phaser_tng\command_line\build_dag_node.py"
   =relocatable_path(anchor="c:\users\phaserbuilder\phasertng2\build", relocatable="..\modules\phaser_tng\phaser_tng/command_line\build_dag_node.py")
    "c:\users\phaserbuilder\phasertng2\modules\phaser_tng\phaser_tng\command_line\build_dag_node.py"
   =relocatable_path(anchor="c:\users\phaserbuilder\phasertng2\build", relocatable="..\modules\phaser_tng\phaser_tng\command_line\build_dag_node.py")
`

