### PR TITLE
libtbx: fix for Windows stdout redirection

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -1781,6 +1781,12 @@ environment exists in or is defined by {conda_env}.
         self.python_base, # default to using our python rather than system python
         self.opjoin('..', 'modules', 'cctbx_project', 'libtbx', 'configure.py')
         ] + self.get_libtbx_configure() + self.config_flags
+    if self.isPlatformWindows() and sys.hexversion >= 0x03060000:
+      # new windows console in python >= 3.6 does not work with os.dup2
+      # https://bugs.python.org/issue30555
+      env = {
+        'PYTHONLEGACYWINDOWSSTDIO': '1'
+      }
     self.add_step(self.shell(command=configcmd, workdir=[_BUILD_DIR],
       description="run configure.py", env=env))
     # Prepare saving configure.py command to file should user want to manually recompile Phenix

--- a/msvc9.0_include/inttypes.h
+++ b/msvc9.0_include/inttypes.h
@@ -34,10 +34,6 @@
 #error "Use this header only with Microsoft Visual C++ compilers!"
 #endif // _MSC_VER ]
 
-#if _MSC_VER <= 1800
-
-
-
 #ifndef _MSC_INTTYPES_H_ // [
 #define _MSC_INTTYPES_H_
 
@@ -308,5 +304,3 @@ imaxdiv_t __cdecl imaxdiv(intmax_t numer, intmax_t denom)
 
 
 #endif // _MSC_INTTYPES_H_ ]
-
-#endif // _MSC_VER <= 1800

--- a/msvc9.0_include/stdint.h
+++ b/msvc9.0_include/stdint.h
@@ -41,10 +41,6 @@
 #pragma once
 #endif
 
-#if _MSC_VER > 1800 // [
-#include <stdint.h>
-#else // ] _MSC_VER > 1800 [
-
 #include <limits.h>
 
 // For Visual Studio 6 in C++ mode and for many Visual Studio versions when
@@ -243,17 +239,10 @@ typedef uint64_t  uintmax_t;
 #define UINT64_C(val) val##ui64
 
 // 7.18.4.2 Macros for greatest-width integer constants
-// These #ifndef's are needed to prevent collisions with <boost/cstdint.hpp>.
-// Check out Issue 9 for the details.
-#ifndef INTMAX_C //   [
-#  define INTMAX_C   INT64_C
-#endif // INTMAX_C    ]
-#ifndef UINTMAX_C //  [
-#  define UINTMAX_C  UINT64_C
-#endif // UINTMAX_C   ]
+#define INTMAX_C   INT64_C
+#define UINTMAX_C  UINT64_C
 
 #endif // __STDC_CONSTANT_MACROS ]
 
-#endif // _MSC_VER > 1800 ]
 
 #endif // _MSC_STDINT_H_ ]


### PR DESCRIPTION
- New Windows console in Python 3.6 and greater does not work with os.dup2
- https://bugs.python.org/issue30555
- https://github.com/python/cpython/pull/1927
- https://stackoverflow.com/questions/52373180/python-on-windows-handle-invalid-when-redirecting-stdout-writing-to-file