### PR TITLE
UI and backend bugfixes

### DIFF
--- a/iota/__init__.py
+++ b/iota/__init__.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import, division, print_function
 '''
 Author      : Lyubimov, A.Y.
 Created     : 10/12/2014
-Last Changed: 11/15/2019
+Last Changed: 11/20/2019
 Description : IOTA initialization module (also contains app info)
 '''
 
 from datetime import datetime
 
-iota_version = '1.4.014'
+iota_version = '1.4.015'
 intx_version = '1.0.001'
 now = "{:%A, %b %d, %Y. %I:%M %p}".format(datetime.now())
 

--- a/iota/components/gui/plotter.py
+++ b/iota/components/gui/plotter.py
@@ -5,7 +5,7 @@ from six.moves import range, zip
 '''
 Author      : Lyubimov, A.Y.
 Created     : 04/07/2015
-Last Changed: 06/07/2019
+Last Changed: 11/21/2019
 Description : IOTA Plotter module. Exists to provide custom MatPlotLib plots
               that are dynamic, fast-updating, interactive, and keep up with
               local wxPython upgrades.
@@ -172,8 +172,8 @@ class Plotter(IOTABasePanel):
   def plot_res_histogram(self):
 
     # Get resolution values
-    hres = list(zip(*self.info.stats['res']['lst']))[2]
-    lres = list(zip(*self.info.stats['lres']['lst']))[2]
+    hres = list(zip(*self.info.stats['res']['lst']))[3]
+    lres = list(zip(*self.info.stats['lres']['lst']))[3]
 
     # Plot figure
     gsp = gridspec.GridSpec(2, 1)
@@ -181,7 +181,7 @@ class Plotter(IOTABasePanel):
     hr_n, hr_bins, hr_patches = hr.hist(hres, 20, facecolor='b', alpha=0.75,
                                          histtype='stepfilled')
     hr_height = (np.max(hr_n) + 9) // 10 * 10
-    hr.axis([np.min(hres), np.max(hres), 0, hr_height])
+    hr.axis([0, np.max(hres), 0, hr_height])
     reslim = 'High Resolution Limit ({})'.format(r'$\AA$')
     hr.set_xlabel(reslim, fontsize=15)
     hr.set_ylabel('No. of frames', fontsize=15)
@@ -190,7 +190,7 @@ class Plotter(IOTABasePanel):
     lr_n, lr_bins, lr_patches = lr.hist(lres, 20, facecolor='b', alpha=0.75,
                                          histtype='stepfilled')
     lr_height = (np.max(lr_n) + 9) // 10 * 10
-    lr.axis([np.min(lres), np.max(lres), 0, lr_height])
+    lr.axis([0, np.max(lres), 0, lr_height])
     reslim = 'Low Resolution Limit ({})'.format(r'$\AA$')
     lr.set_xlabel(reslim, fontsize=15)
     lr.set_ylabel('No. of frames', fontsize=15)
@@ -239,16 +239,16 @@ class Plotter(IOTABasePanel):
 
     self.draw(tight_layout=False)
 
-  def plot_beam_xy(self, write_files=False, return_values=False, threeD=False):
+  def plot_beam_xy(self, threeD=False):
     """ Plot beam center coordinates and a histogram of distances from the median
         of beam center coordinates to each set of coordinates. Superpose a
         predicted mis-indexing shift by L +/- 1 (calculated for each axis).
     """
 
     # Calculate beam center coordinates and distances
-    beamX = list(zip(*self.info.stats['beamX']['lst']))[2]
-    beamY = list(zip(*self.info.stats['beamY']['lst']))[2]
-    beamZ = list(zip(*self.info.stats['distance']['lst']))[2]
+    beamX = list(zip(*self.info.stats['beamX']['lst']))[3]
+    beamY = list(zip(*self.info.stats['beamY']['lst']))[3]
+    beamZ = list(zip(*self.info.stats['distance']['lst']))[3]
     beamXY = list(zip(beamX, beamY))
 
     beam_dist = [math.hypot(i[0] - np.median(beamX), i[1] - np.median(beamY))
@@ -274,7 +274,6 @@ class Plotter(IOTABasePanel):
     aD = det_distance * math.tan(2 * math.asin(wavelength / (2 * a)))
     bD = det_distance * math.tan(2 * math.asin(wavelength / (2 * b)))
     cD = det_distance * math.tan(2 * math.asin(wavelength / (2 * c)))
-
 
     # Plot figure
     if threeD:

--- a/iota/components/iota_analysis.py
+++ b/iota/components/iota_analysis.py
@@ -5,7 +5,7 @@ from six.moves import range, zip
 '''
 Author      : Lyubimov, A.Y.
 Created     : 04/07/2015
-Last Changed: 10/31/2019
+Last Changed: 11/21/2019
 Description : Analyzes integration results and outputs them in an accessible
               format. Includes (optional) unit cell analysis by hierarchical
               clustering (Zeldin, et al., Acta Cryst D, 2013). In case of
@@ -396,7 +396,7 @@ class Analyzer(object):
 
       # Calculate dataset stats
       for k in self.info.stats:
-        stat_list = list(zip(*self.info.stats[k]['lst']))[2]
+        stat_list = list(zip(*self.info.stats[k]['lst']))[3]
         stats = dict(lst=self.info.stats[k]['lst'],
                      median=np.median(stat_list),
                      mean=np.mean(stat_list),

--- a/iota/components/iota_init.py
+++ b/iota/components/iota_init.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 '''
 Author      : Lyubimov, A.Y.
 Created     : 10/12/2014
-Last Changed: 10/31/2019
+Last Changed: 11/21/2019
 Description : Interprets command line arguments. Initializes all IOTA starting
               parameters. Starts main log. Options for a variety of running
               modes, including resuming an aborted run.
@@ -17,21 +17,6 @@ assert time
 import iota.components.iota_input as inp
 from iota.components import iota_utils as util
 from iota.components.iota_base import ProcInfo
-
-# from contextlib import contextmanager
-# import dials.util.command_line as cmd
-# @contextmanager    # Will print start / stop messages around some processes
-# def prog_message(msg, mode='xterm'):
-#   if mode == 'xterm':
-#     cmd.Command.start(msg)
-#     yield
-#     cmd.Command.end('{} -- DONE'.format(msg))
-#   elif mode == 'verbose':
-#     print ('IOTA: {}'.format(msg))
-#     yield
-#     print ('IOTA: {} -- DONE'.format(msg))
-#   else:
-#     yield
 
 
 def initialize_interface(args, phil_args=None, gui=False):
@@ -190,7 +175,15 @@ def initialize_processing(paramfile, run_no):
   # Generate input list and input base
   if not hasattr(info, 'input_list'):
     info.generate_input_list(params=params)
-  filepath_list = zip(*info.input_list)[0]
+  filepath_list = []
+  for item in info.input_list:
+    if isinstance(item, list) or isinstance(item, tuple):
+      fp = [i for i in item if os.path.exists(str(i))]
+      if fp and len(fp) == 1:
+        filepath_list.append(fp[0])
+    else:
+      if os.path.exists(item):
+        filepath_list.append(item)
   common_pfx = os.path.abspath(
     os.path.dirname(os.path.commonprefix(filepath_list)))
 
@@ -312,6 +305,8 @@ def generate_stat_containers(info, params):
       failed_triage=([], 'failed triage', 'failed_triage.lst', '#d73027'),
       failed_spotfinding=([], 'failed spotfinding', 'failed_spotfinding.lst', '#f46d43'),
       failed_indexing=([], 'failed indexing', 'failed_indexing.lst', '#fdae61'),
+      failed_refinement=([], 'failed refinement', 'failed_refinement.lst',
+                         '#fdae6b'),
       failed_grid_search=([], 'failed grid search', 'failed_integration.lst', '#fee090'),
       failed_integration=([], 'failed integration', 'failed_integration.lst', '#fee090'),
       failed_filter=([], 'failed filter', 'failed_filter.lst', '#ffffbf'),

--- a/iota/components/iota_processing.py
+++ b/iota/components/iota_processing.py
@@ -4,7 +4,7 @@ from six.moves import range
 '''
 Author      : Lyubimov, A.Y.
 Created     : 10/10/2014
-Last Changed: 10/31/2019
+Last Changed: 11/21/2019
 Description : Runs spotfinding, indexing, refinement and integration using
               subclassed DIALS Stills Processor module. Selector class
               applies filters based on unit cell, space group, etc.
@@ -19,8 +19,8 @@ import copy
 
 from dials.util import log
 from dials.array_family import flex
-from dials.algorithms.indexing.symmetry import \
-  refined_settings_factory_from_refined_triclinic
+from dials.algorithms.indexing.bravais_settings import \
+  refined_settings_from_refined_triclinic
 from dials.command_line.stills_process import phil_scope, Processor
 from dials.command_line.refine_bravais_settings import phil_scope as sg_scope
 from dials.command_line.refine_bravais_settings import \
@@ -222,41 +222,54 @@ class IOTAImageProcessor(Processor):
 
     # configure DIALS logging
     if self.dials_log:
-      log.config(verbosity=0, logfile=self.dials_log)
+      log.config(verbosity=1, logfile=self.dials_log)
 
     proc_scope = phil_scope.format(python_object=self.params)
     sgparams = sg_scope.fetch(proc_scope).extract()
     sgparams.refinement.reflections.outlier.algorithm = 'tukey'
 
     crystal_P1 = copy.deepcopy(experiments[0].crystal)
-
-    # Generate Bravais settings
     try:
-      Lfat = refined_settings_factory_from_refined_triclinic(sgparams,
-                                                             experiments,
-                                                             reflections,
-                                                             lepage_max_delta=5)
+      refined_settings = refined_settings_from_refined_triclinic(
+        experiments=experiments,
+        reflections=reflections,
+        params=sgparams
+      )
+      possible_bravais_settings = {s["bravais"] for s in refined_settings}
+      bravais_lattice_to_space_group_table(possible_bravais_settings)
     except Exception as e:
-      # If refinement fails, reset to P1 (experiments remain modified by Lfat
-      # if there's a refinement failure, which causes issues down the line)
       for expt in experiments:
         expt.crystal = crystal_P1
       return None
 
-    Lfat.labelit_printout()
+    # Generate Bravais settings
+    # try:
+    #   Lfat = refined_settings_factory_from_refined_triclinic(sgparams,
+    #                                                          experiments,
+    #                                                          reflections,
+    #                                                          lepage_max_delta=5)
+    # except Exception as e:
+    #   # If refinement fails, reset to P1 (experiments remain modified by Lfat
+    #   # if there's a refinement failure, which causes issues down the line)
+    #   for expt in experiments:
+    #     expt.crystal = crystal_P1
+    #   return None
+    #
+    # Lfat.labelit_printout()
+    #
+    # # Filter out not-recommended (i.e. too-high rmsd and too-high max angular
+    # # difference) solutions
+    # Lfat_recommended = [s for s in Lfat if s.recommended]
+    #
+    # # If none are recommended, return None (do not reindex)
+    # if len(Lfat_recommended) == 0:
+    #   return None
+    #
+    # # Find the highest symmetry group
+    # possible_bravais_settings = set(solution['bravais'] for solution in
+    #                                 Lfat_recommended)
+    # bravais_lattice_to_space_group_table(possible_bravais_settings)
 
-    # Filter out not-recommended (i.e. too-high rmsd and too-high max angular
-    # difference) solutions
-    Lfat_recommended = [s for s in Lfat if s.recommended]
-
-    # If none are recommended, return None (do not reindex)
-    if len(Lfat_recommended) == 0:
-      return None
-
-    # Find the highest symmetry group
-    possible_bravais_settings = set(solution['bravais'] for solution in
-                                    Lfat_recommended)
-    bravais_lattice_to_space_group_table(possible_bravais_settings)
     lattice_to_sg_number = {
       'aP': 1, 'mP': 3, 'mC': 5, 'oP': 16, 'oC': 20, 'oF': 22, 'oI': 23,
       'tP': 75, 'tI': 79, 'hP': 143, 'hR': 146, 'cP': 195, 'cF': 196, 'cI': 197
@@ -267,7 +280,8 @@ class IOTAImageProcessor(Processor):
         filtered_lattices[key] = value
 
     highest_sym_lattice = max(filtered_lattices, key=filtered_lattices.get)
-    highest_sym_solutions = [s for s in Lfat if s['bravais'] == highest_sym_lattice]
+    highest_sym_solutions = [s for s in refined_settings
+                             if s['bravais'] == highest_sym_lattice]
     if len(highest_sym_solutions) > 1:
       highest_sym_solution = sorted(highest_sym_solutions,
                                     key=lambda x: x['max_angular_difference'])[0]
@@ -376,7 +390,7 @@ class IOTAImageProcessor(Processor):
     # configure DIALS logging
     self.dials_log = getattr(img_object, 'dials_log', None)
     if self.dials_log:
-      log.config(verbosity=0, logfile=self.dials_log)
+      log.config(verbosity=1, logfile=self.dials_log)
 
     # Create output folder if one does not exist
     if self.write_pickle:
@@ -525,15 +539,27 @@ class IOTAImageProcessor(Processor):
         else:
           return self.error_handler(e_ridx, 'indexing', img_object, output)
 
-    # **** INTEGRATION **** #
+    # **** REFINEMENT **** #
     with util.Capturing() as output:
       try:
         experiments, indexed = self.refine(experiments, indexed)
+        refined = True
+      except Exception as e_ref:
+        refined = False
+    if refined:
+      if self.write_logs:
+        self.write_int_log(path=img_object.int_log, output=output,
+                           dials_log=self.dials_log)
+    else:
+      return self.error_handler(e_ref, 'refinement', img_object, output)
+
+    # **** INTEGRATION **** #
+    with util.Capturing() as output:
+      try:
         print ("{:-^100}\n".format(" INTEGRATING "))
         print ('<--->')
         integrated = self.integrate(experiments, indexed)
       except Exception as e_int:
-
         integrated = None
       else:
         if integrated:

--- a/iota/components/iota_ui_frames.py
+++ b/iota/components/iota_ui_frames.py
@@ -5,7 +5,7 @@ from six.moves import range
 '''
 Author      : Lyubimov, A.Y.
 Created     : 01/17/2017
-Last Changed: 11/15/2019
+Last Changed: 11/21/2019
 Description : IOTA GUI Windows / frames
 '''
 
@@ -558,6 +558,16 @@ class MainWindow(IOTABaseFrame):
 
     # Update gparams here, to include new stuff from PHIL
     self.gparams = self.iota_index.get_python_object(make_copy=True)
+
+    # Pass input from IOTA PHIL through Input Finder to resolve wildcards, etc.
+    if self.gparams.input is not None:
+      inputs = [
+        self.gparams.input.pop(i) for i in range(len(self.gparams.input))]
+      phil_input_dict = ut.ginp.process_mixed_input(paths=inputs)
+      if input_dict:
+        input_dict.update(phil_input_dict)
+      else:
+        input_dict = phil_input_dict
 
     # Read input OR update from window params
     if input_dict:

--- a/iota/doc/NOTES.txt
+++ b/iota/doc/NOTES.txt
@@ -1,6 +1,14 @@
-IOTA v1.4.014 - bugfixes to monitor mode
+IOTA v1.4.015 - bugfixes
 
-- fixed bug where new images added twice while in monitor mode
+- fixed output path structure bug (integrated files, logs, etc. no longer
+  include pre-pended absolute path)
+- input list is now sorted by filename (and then by image index if a multi-image
+  file)
+- stdout capture no longer returns a "'unicode' does not have the buffer
+  interface" TypeError
+- fixed plotting to account for an extra parameter (image index) when
+  calculating stats
+- add picture file extensions (e.g. png, tiff, etc.) to image file tests
 
-11.08.2019
+11.20.2019
 # -- end


### PR DESCRIPTION
- fixed output path structure bug (integrated files, logs, etc. no longer
  include pre-pended absolute path)
- input list is now sorted by filename (and then by image index if a multi-image
  file)
- stdout capture no longer returns a "'unicode' does not have the buffer
  interface" TypeError
- fixed plotting to account for an extra parameter (image index) when
  calculating stats
- add picture file extensions (e.g. png, tiff, etc.) to image file tests