### PR TITLE
Update SCons to 3.0.5

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -705,12 +705,10 @@ class annlib_module(SourceModule):
 
 class scons_module(SourceModule):
   module = 'scons'
-  anonymous = ['curl', [
-    'http://cci.lbl.gov/repositories/scons.gz',
-    'https://drive.google.com/uc?id=1hPd5cMbVcsN4j0P5qaPUV71XS_aifw-J&export=download',
-  ]]
-  authentarfile = ['%(cciuser)s@cci.lbl.gov', 'scons.tar.gz', '/net/cci/auto_build/repositories/scons']
-  authenticated = ['rsync', '%(cciuser)s@cci.lbl.gov:/net/cci/auto_build/repositories/scons/']
+  anonymous = ['git', '-b 3.0.5',
+               'git@github.com:SCons/scons.git',
+               'https://github.com/SCons/scons.git',
+               'https://github.com/SCons/scons/archive/3.0.5.zip']
 
 # external modules
 class rosetta_class(SourceModule):

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -705,10 +705,8 @@ class annlib_module(SourceModule):
 
 class scons_module(SourceModule):
   module = 'scons'
-  anonymous = ['git', '-b 3.0.5',
-               'git@github.com:SCons/scons.git',
-               'https://github.com/SCons/scons.git',
-               'https://github.com/SCons/scons/archive/3.0.5.zip']
+  anonymous = ['git', '-b 3.1.1',
+               'https://github.com/SCons/scons/archive/3.1.1.zip']
 
 # external modules
 class rosetta_class(SourceModule):


### PR DESCRIPTION
We are running into build issues with SCons on Python 3. SCons 3.0 doesn't properly support Python 3, and a lot of fixes have been made to that version over the past 2 years, including one we need.
This updates SCons to the most recent 3.0 release by checking out the version directly from source, as suggested in https://github.com/cctbx/cctbx_project/pull/408#pullrequestreview-308331401

(This is currently holding up build-related work)