### PR TITLE
Longstanding bugfix for cluster.unit_cell

### DIFF
--- a/xfel/clustering/singleframe.py
+++ b/xfel/clustering/singleframe.py
@@ -307,9 +307,9 @@ class SingleFrame(InputFrame):
       a = uc[0] ** 2
       b = uc[1] ** 2
       c = uc[2] ** 2
-      d = 2 * uc[1] * uc[2] * math.cos(uc[3])
-      e = 2 * uc[0] * uc[2] * math.cos(uc[4])
-      f = 2 * uc[0] * uc[1] * math.cos(uc[5])
+      d = 2 * uc[1] * uc[2] * math.cos((math.pi/180.)*uc[3])
+      e = 2 * uc[0] * uc[2] * math.cos((math.pi/180.)*uc[4])
+      f = 2 * uc[0] * uc[1] * math.cos((math.pi/180.)*uc[5])
       return [a, b, c, d, e, f]
 
 class SingleDialsFrame(SingleFrame):

--- a/xfel/clustering/singleframe.py
+++ b/xfel/clustering/singleframe.py
@@ -303,13 +303,18 @@ class SingleFrame(InputFrame):
 
   @staticmethod
   def make_g6(uc):
-      """ Take a reduced Niggli Cell, and turn it into the G6 representation """
+      """ Take a reduced Niggli Cell, and turn it into the G6 representation. This is
+          similar but not identical to the metrical matrix.  See
+          doi:10.1107/S0567739473001063 Gruber (1973)
+          doi:10.1107/S0108767388006427 Andrews and Bernstein (1988)
+          doi:10.1107/S1600576713031002 Andrews and Bernstein (2014)
+      """
       a = uc[0] ** 2
       b = uc[1] ** 2
       c = uc[2] ** 2
-      d = 2 * uc[1] * uc[2] * math.cos((math.pi/180.)*uc[3])
-      e = 2 * uc[0] * uc[2] * math.cos((math.pi/180.)*uc[4])
-      f = 2 * uc[0] * uc[1] * math.cos((math.pi/180.)*uc[5])
+      d = 2 * uc[1] * uc[2] * math.cos(math.radians(uc[3]))
+      e = 2 * uc[0] * uc[2] * math.cos(math.radians(uc[4]))
+      f = 2 * uc[0] * uc[1] * math.cos(math.radians(uc[5]))
       return [a, b, c, d, e, f]
 
 class SingleDialsFrame(SingleFrame):


### PR DESCRIPTION
Use radians, not degrees.  Caught by @nksauter.

The dials.cosym tests still pass.  Looking at them, I don't think they are clustering differing unit cells. 
 test_cluster_unit_cell.py also still passes.  Looking at the output, the dendrogram produced by test_cluster_unit_cell.py is the same along x, meaning the same cells are associated with each other, but different along Y, meaning their relative scores are different.

If I run cluster.unit_cell on the 757 integration results in xfel_regression/prime_test_data/myo/integration, I get different numbers of singletons, so this change will affect scientific results.

@rjgildea, this is likely relevant to your interests.  Let me know if you want me to hold this.  Otherwise, I'll merge it tomorrow morning.