### PR TITLE
fixes a bytes string incompatibility on gentoo/sabayon

### DIFF
--- a/libtbx/auto_build/install_base_packages.py
+++ b/libtbx/auto_build/install_base_packages.py
@@ -436,6 +436,8 @@ Found Python version:
   %s
 """ % self.python_exe, file=self.log)
       sys.exit(1)
+    if isinstance(python_version, bytes):
+        python_version = python_version.decode("utf-8")
     python_version = python_version.strip().split('\n')[0].split(':', 3)
     if (int(python_version[0]) == 2 and int(python_version[1]) < 7) or \
        (int(python_version[0]) > 2 and int(python_version[2]) < 0x03040000):


### PR DESCRIPTION
Without this simple patch I encounter this error during a fresh bootstrap:

[...]
===== Downloading http://cci.lbl.gov/repositories/tntbx.gz:  local copy is current (etag)
===== Running in modules: extracting files from tntbx.gz
===== Downloading http://cci.lbl.gov/repositories/clipper.gz:  local copy is current (etag)
===== Running in modules: extracting files from clipper.gz

  removing .pyc files in /home/jan/Arbeit/cctbx-dev/modules, walk? True
  removed 3 files
===== Running in .: base

  ****************************************************************************
                 Automated CCTBX dependencies build script
                 report problems to cctbx-dev@cci.lbl.gov
  ****************************************************************************

Setting up directories...
  verifying _ssl installation in /usr/lib/python-exec/python3.6/python OK
  verifying zlib installation in /usr/lib/python-exec/python3.6/python OK
Using Python interpreter: /home/jan/Arbeit/cctbx-dev/base/bin/python
Using Python: /home/jan/Arbeit/cctbx-dev/base/bin/python
  verifying Python installation in /home/jan/Arbeit/cctbx-dev/base/bin/python OK
  verifying _ssl installation in /home/jan/Arbeit/cctbx-dev/base/bin/python OK
  verifying zlib installation in /home/jan/Arbeit/cctbx-dev/base/bin/python OK
Traceback (most recent call last):
  File "modules/cctbx_project/libtbx/auto_build/install_base_packages.py", line 1674, in <module>
    installer(args=sys.argv, log=sys.stdout)
  File "modules/cctbx_project/libtbx/auto_build/install_base_packages.py", line 249, in __init__
    packages = self.configure_packages(options)
  File "modules/cctbx_project/libtbx/auto_build/install_base_packages.py", line 294, in configure_packages
    self.set_python(self.python_exe)
  File "modules/cctbx_project/libtbx/auto_build/install_base_packages.py", line 465, in set_python
    self.check_python_version()
  File "modules/cctbx_project/libtbx/auto_build/install_base_packages.py", line 439, in check_python_version
    python_version = python_version.strip().split('\n')[0].split(':', 3)
TypeError: a bytes-like object is required, not 'str'
Process failed with return code 1