### PR TITLE
fix wxPython deprecation warning

### DIFF
--- a/wxtbx/segmentedctrl.py
+++ b/wxtbx/segmentedctrl.py
@@ -31,7 +31,7 @@ elif wx.Platform == '__WXGTK__' :
 else :
   _DEFAULT_PADDING = 6
 
-class SegmentedControl(wx.PyControl):
+class SegmentedControl(wx.Control):
   def __init__(self,
                 parent,
                 id=wx.ID_ANY,
@@ -41,7 +41,7 @@ class SegmentedControl(wx.PyControl):
                 name=wx.ButtonNameStr,
                 border=0,
                 pad=_DEFAULT_PADDING):
-    wx.PyControl.__init__(self, parent, id, pos=pos, size=size,
+    wx.Control.__init__(self, parent, id, pos=pos, size=size,
       style=wx.NO_BORDER,
       name=name)
     self.SetBackgroundStyle(wx.BG_STYLE_CUSTOM)


### PR DESCRIPTION
fix wxPython deprecation warning that is shown when using wxPython 4:

```
$ dials.reciprocal_lattice_viewer imported.expt strong.refl 
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
The following parameters have been modified:

input {
  experiments = imported.expt
  reflections = strong.refl
}

Gtk-Message: 11:55:56.135: Failed to load module "pk-gtk-module"
Gtk-Message: 11:55:56.136: Failed to load module "canberra-gtk-module"
(...)/cctbx_project/wxtbx/segmentedctrl.py:46: wxPyDeprecationWarning: Using deprecated class. Use Control instead.
  name=name)
```

Change seems to work on wxPython 3, so is probably harmless.