### PR TITLE
get_top_solutions bugfix for HemisphereSampler

### DIFF
--- a/rstbx/indexing_api/sampling.py
+++ b/rstbx/indexing_api/sampling.py
@@ -119,7 +119,7 @@ class HemisphereSampler(SimpleSampler):
            break
       if direction_ok:
         unique_clusters+=1
-      hemisphere_solutions_sort.append(test_item)
+        hemisphere_solutions_sort.append(test_item)
       perm_idx+=1
 
     return hemisphere_solutions_sort;


### PR DESCRIPTION
### Summary

HemisphereSampler has an indentation error that makes it accept too many candidate basis vectors. This pull request fixes the error.  Datasets with weak signal and poor spotfinding parameters may see indexing rates go down a bit, but runtimes improve dramatically.  Strong data seems unaffected.

### Details

HemisphereSampler implements the Steller 1997 algorithm for choosing candidate basis vectors. Its method `get_top_solutions` is supposed to sort the putative basis vectors by their scores (kval), then pick the top 30 that are unique directions.  However, the current implementation keeps all non-unique vectors as it searches for unique ones, due to an indentation error in the python code. In some cases, this can lead to it returning thousands of candidates.

The algorithm iterates through each candidate vector and tests if it is within 5 degrees of an already tested vector.  The bugfix here changes the indentation of `hemisphere_solutions_sort.append(test_item)` to only occur if the tested direction is actually unique.

As this change affects existing indexing results and tests, the previous behavior remains accessible using the flag `march2020_bugfix` (defaults to `True`, meaning use this bugfix).

Alternative suggestions for `march2020_bugfix` are welcome :)

(This is a long-standing bug.)

### Testing

At a recent XFEL beamtime, we found for a particular dataset that processing was taking too long.  23.4s for a miss and 66.3s for a hit.  We had limited computing available so this was making us fall behind.  After profiling the code, we found most of the time was spent in get_top_solutions.  Further investigation revealed this indentation bug.

Fixing the bug decreased processing time to 10s for a miss and 11.3s for a hit.  However, the indexing rate also decreased by 17%.  After some investigation we found that this was because the spotfinding parameters were not optimized, leading to many noisy reflections.  Fixing the spotfinding parameters without fixing the indentation bug increased indexing rate by 19% and processing speed to 0.9s per miss and 9s per hit.  Adding back in the bugfix had no further effect.  Therefore, for this dataset, the spotfinding parameters were the real problem.  However, the indentation bug is real and needs fixing, hence this request.

The bugfix on a set of strong simulated images had no significant effect on indexing rate.

Co-authored-by: Nicholas Sauter <nksauter@lbl.gov>