### PR TITLE
Nano bragg cbfwrite

### DIFF
--- a/simtbx/nanoBragg/__init__.py
+++ b/simtbx/nanoBragg/__init__.py
@@ -167,7 +167,7 @@ class _():
   @property
   def imageset(self):
     format_class = FormatBraggInMemory(self.raw_pixels)
-    reader = MemReader([format_class])
+    reader = MemReaderNamedPath("virtual_Bragg_path", [format_class])
     reader.format_class = FormatBraggInMemory
     imageset_data = ImageSetData(reader, None)
     imageset = ImageSet(imageset_data)
@@ -200,7 +200,14 @@ class FormatBraggInMemory:
   def __init__(self, raw_pixels):
     self.raw_pixels = raw_pixels
     panel_shape = self.raw_pixels.focus()
+    #self._filenames = ["InMemoryBraggPath"]  # TODO: CBFLib complains if no datablock path provided which comes from path
     self.mask = flex.bool(flex.grid(panel_shape), True)  # TODO: use nanoBragg internal mask
+
+  def get_path(self, index):
+    if index == 0:
+      return "Virtual"
+    else:
+      raise ValueError("index must be 0 for format %s" % self.__name__)
 
   def get_raw_data(self):
     """
@@ -213,3 +220,16 @@ class FormatBraggInMemory:
   def get_mask(self, goniometer=None):
     """dummie place holder for mask, consider using internal nanoBragg mask"""
     return self.mask,
+
+  #def paths(self):
+  #  return ["InMemoryBraggPath"]  # TODO: CBFLib complains if no datablock path provided which comes from path
+
+class MemReaderNamedPath(MemReader):
+
+  def __init__(self, path,  *args, **kwargs):
+    self.dummie_path_name = path
+    super(MemReaderNamedPath, self).__init__(*args, **kwargs)
+
+  def paths(self):
+    """Necessary to have non zero string for CBFLib writer for some reason..."""
+    return ["%s_%d" % (self.dummie_path_name, i) for i, _ in enumerate(self._images)]

--- a/simtbx/nanoBragg/__init__.py
+++ b/simtbx/nanoBragg/__init__.py
@@ -122,7 +122,7 @@ class _():
     # dxtbx crystal description
     if self.Amatrix is not None:
       A = sqr(self.Amatrix).inverse().elems
-      # this is always P-1 correct ?
+      # is this always P-1 ?
       real_a = A[0], A[3], A[6]
       real_b = A[1], A[4], A[7]
       real_c = A[2], A[5], A[8]
@@ -130,14 +130,13 @@ class _():
                      'real_space_a': real_a,
                      'real_space_b': real_b,
                      'real_space_c': real_c,
-                     'space_group_hall_symbol': 'P 1'}
+                     'space_group_hall_symbol': ' P 1'}
       crystal = CrystalFactory.from_dict(cryst_dict)
     return crystal
 
   @property
   def detector(self):
     # monolithic camera description
-    detdist = self.distance_mm
     pixsize = self.pixel_size_mm
     im_shape = self.detpixels_fastslow
     fdet = self.fdet_vector
@@ -159,7 +158,7 @@ class _():
                      'px_mm_strategy': {'type': 'SimplePxMmStrategy'},
                      'raw_image_offset': (0, 0),  # TODO
                      'thickness': 0.0,  # TODO
-                     'trusted_range': (-1e7, 1e7), # TODO
+                     'trusted_range': (-1e3, 1e10),  # TODO
                      'type': ''}]}
     detector = DetectorFactory.from_dict(det_descr)
     return detector

--- a/simtbx/nanoBragg/__init__.py
+++ b/simtbx/nanoBragg/__init__.py
@@ -2,7 +2,18 @@ from __future__ import absolute_import, division, print_function
 import boost.python
 import cctbx.uctbx # possibly implicit
 ext = boost.python.import_ext("simtbx_nanoBragg_ext")
+from scitbx.array_family import flex
 from simtbx_nanoBragg_ext import *
+from scitbx.matrix import col, sqr
+
+from dxtbx.imageset import MemReader
+from dxtbx.imageset import ImageSet, ImageSetData
+from dxtbx.model.experiment_list import Experiment, ExperimentList
+from dxtbx.model import CrystalFactory
+from dxtbx.model import BeamFactory
+from dxtbx.model import DetectorFactory
+from dxtbx.format import cbf_writer
+
 
 @boost.python.inject_into(ext.nanoBragg)
 class _():
@@ -46,7 +57,7 @@ class _():
       from libtbx.smart_open import for_writing
       outfile = for_writing(file_name=fileout+".gz", gzip_mode="wb")
     else:
-      outfile = open(fileout,"w");
+      outfile = open(fileout,"wb");
 
     outfile.write(("{\nHEADER_BYTES=1024;\nDIM=2;\nBYTE_ORDER=%s;\nTYPE=unsigned_short;\n"%byte_order).encode());
     outfile.write(b"SIZE1=%d;\nSIZE2=%d;\nPIXEL_SIZE=%g;\nDISTANCE=%g;\n"%(
@@ -90,3 +101,115 @@ class _():
     self.to_smv_format_streambuf(streambuf(outfile),intfile_scale,debug_x,debug_y)
 
     outfile.close();
+
+  @property
+  def beam(self):
+    # Does this handle the conventions ? Im always confused about where the beam is pointing, whats s0 and whats beam_vector
+    beam_dict = {'direction': tuple([-1*x for x in self.beam_vector]),  # TODO: is this correct?
+                  'divergence': 0.0,  # TODO
+                  'flux': self.flux,
+                  'polarization_fraction': self.polarization,  #TODO
+                  'polarization_normal': col(self.polar_vector).cross(col(self.beam_vector)),
+                  'sigma_divergence': 0.0,  # TODO
+                  'transmission': 1.0,  #TODO ?
+                  'wavelength': self.wavelength_A}
+    beam = BeamFactory.from_dict(beam_dict)
+    return beam
+
+  @property
+  def crystal(self):
+    crystal = None
+    # dxtbx crystal description
+    if self.Amatrix is not None:
+      A = sqr(self.Amatrix).inverse().elems
+      # this is always P-1 correct ?
+      real_a = A[0], A[3], A[6]
+      real_b = A[1], A[4], A[7]
+      real_c = A[2], A[5], A[8]
+      cryst_dict = {'__id__': 'crystal',
+                     'real_space_a': real_a,
+                     'real_space_b': real_b,
+                     'real_space_c': real_c,
+                     'space_group_hall_symbol': 'P 1'}
+      crystal = CrystalFactory.from_dict(cryst_dict)
+    return crystal
+
+  @property
+  def detector(self):
+    # monolithic camera description
+    detdist = self.distance_mm
+    pixsize = self.pixel_size_mm
+    im_shape = self.detpixels_fastslow
+    fdet = self.fdet_vector
+    sdet = self.sdet_vector
+    origin = self.dials_origin_mm
+    det_descr = {'panels':
+                   [{'fast_axis': fdet,
+                     'slow_axis': sdet,
+                     'gain': self.quantum_gain,
+                     'identifier': '',
+                     'image_size': im_shape,
+                     'mask': [],
+                     'material': '',  # TODO
+                     'mu': 0.0,  # TODO
+                     'name': 'Panel',
+                     'origin': origin,
+                     'pedestal': 0.0,
+                     'pixel_size': (pixsize, pixsize),
+                     'px_mm_strategy': {'type': 'SimplePxMmStrategy'},
+                     'raw_image_offset': (0, 0),  # TODO
+                     'thickness': 0.0,  # TODO
+                     'trusted_range': (-1e7, 1e7), # TODO
+                     'type': ''}]}
+    detector = DetectorFactory.from_dict(det_descr)
+    return detector
+
+  @property
+  def imageset(self):
+    format_class = FormatBraggInMemory(self.raw_pixels)
+    reader = MemReader([format_class])
+    reader.format_class = FormatBraggInMemory
+    imageset_data = ImageSetData(reader, None)
+    imageset = ImageSet(imageset_data)
+    imageset.set_beam(self.beam)
+    imageset.set_detector(self.detector)
+
+    return imageset
+
+  def as_explist(self):
+    """
+    return experiment list for simulated image
+    """
+    exp = Experiment()
+    exp.crystal = self.crystal
+    exp.beam = self.beam
+    exp.detector = self.detector
+    exp.imageset = self.imageset
+    explist = ExperimentList()
+    explist.append(exp)
+
+    return explist
+
+  def to_cbf(self, cbf_filename):
+    writer = cbf_writer.FullCBFWriter(imageset=self.imageset)
+    writer.write_cbf(cbf_filename, index=0)
+
+
+class FormatBraggInMemory:
+
+  def __init__(self, raw_pixels):
+    self.raw_pixels = raw_pixels
+    panel_shape = self.raw_pixels.focus()
+    self.mask = flex.bool(flex.grid(panel_shape), True)  # TODO: use nanoBragg internal mask
+
+  def get_raw_data(self):
+    """
+    return as a tuple, multi panel with 1 panel
+    currently nanoBragg doesnt support simulating directly to a multi panel detector
+    so this is the best we can do..
+    """
+    return self.raw_pixels,
+
+  def get_mask(self, goniometer=None):
+    """dummie place holder for mask, consider using internal nanoBragg mask"""
+    return self.mask,

--- a/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
+++ b/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
@@ -1,0 +1,130 @@
+"""
+Makes dxtbx models for detector, beam , crystal
+
+Uses models to instantiate nanoBragg and compute Bragg spots
+
+Writes results to a full CBF using new nanoBragg method to_cbf (in nanoBragg/__init__.py)
+
+Loads CBF with dxtbx, and uses the loaded detector and beam to recompute the Bragg spots
+
+Verifies pixel intensities are reproduced
+"""
+import numpy as np
+from scipy import constants
+
+from cctbx import sgtbx, miller
+from cctbx.crystal import symmetry
+import dxtbx
+from dxtbx.model.beam import BeamFactory
+from dxtbx.model.crystal import CrystalFactory
+from dxtbx.model.detector import DetectorFactory
+from scitbx.array_family import flex
+from scitbx.matrix import sqr, col
+from simtbx.nanoBragg import nanoBragg, shapetype
+
+# make a randomly oriented crystal..
+np.random.seed(3142019)
+# make random rotation about principle axes
+x = col((-1, 0, 0))
+y = col((0, -1, 0))
+z = col((0, 0, -1))
+rx, ry, rz = np.random.uniform(-180, 180, 3)
+RX = x.axis_and_angle_as_r3_rotation_matrix(rx, deg=True)
+RY = y.axis_and_angle_as_r3_rotation_matrix(ry, deg=True)
+RZ = z.axis_and_angle_as_r3_rotation_matrix(rz, deg=True)
+M = RX*RY*RZ
+real_a = M*col((79, 0, 0))
+real_b = M*col((0, 79, 0))
+real_c = M*col((0, 0, 38))
+# dxtbx crystal description
+cryst_descr = {'__id__': 'crystal',
+               'real_space_a': real_a.elems,
+               'real_space_b': real_b.elems,
+               'real_space_c': real_c.elems,
+               'space_group_hall_symbol': ' P 4nw 2abw'}
+
+# make a beam
+ENERGY = 9000
+ENERGY_CONV = 1e10*constants.c*constants.h / constants.electron_volt
+WAVELEN = ENERGY_CONV/ENERGY
+# dxtbx beam model description
+beam_descr = {'direction': (0.0, 0.0, 1.0),
+             'divergence': 0.0,
+             'flux': 1e11,
+             'polarization_fraction': 1.,
+             'polarization_normal': (0.0, 1.0, 0.0),
+             'sigma_divergence': 0.0,
+             'transmission': 1.0,
+             'wavelength': WAVELEN}
+
+# make a detector panel
+# monolithic camera description
+detdist = 100.
+pixsize = 0.1
+im_shape = 1536, 1536
+det_descr = {'panels':
+               [{'fast_axis': (1.0, 0.0, 0.0),
+                 'slow_axis': (0.0, -1.0, 0.0),
+                 'gain': 1.0,
+                 'identifier': '',
+                 'image_size': im_shape,
+                 'mask': [],
+                 'material': '',
+                 'mu': 0.0,
+                 'name': 'Panel',
+                 'origin': (-im_shape[0]*pixsize/2., im_shape[1]*pixsize/2., -detdist),
+                 'pedestal': 0.0,
+                 'pixel_size': (pixsize, pixsize),
+                 'px_mm_strategy': {'type': 'SimplePxMmStrategy'},
+                 'raw_image_offset': (0, 0),
+                 'thickness': 0.0,
+                 'trusted_range': (-1e7, 1e7),
+                 'type': ''}]}
+
+# make the dxtbx objects
+BEAM = BeamFactory.from_dict(beam_descr)
+DETECTOR = DetectorFactory.from_dict(det_descr)
+CRYSTAL = CrystalFactory.from_dict(cryst_descr)
+
+# make a dummie HKL table with constant HKL intensity
+# this is just to make spots
+DEFAULT_F = 1e2
+symbol = CRYSTAL.get_space_group().info().type().lookup_symbol()  # this is just P43212
+sgi = sgtbx.space_group_info(symbol)
+symm = symmetry(unit_cell=CRYSTAL.get_unit_cell(), space_group_info=sgi)
+miller_set = symm.build_miller_set(anomalous_flag=True, d_min=1.6, d_max=999)
+Famp = flex.double(np.ones(len(miller_set.indices())) * DEFAULT_F)
+Famp = miller.array(miller_set=miller_set, data=Famp).set_observation_type_xray_amplitude()
+
+Ncells_abc = 20, 20, 20
+oversmaple = 2
+
+# do the simulation
+SIM = nanoBragg(DETECTOR, BEAM, panel_id=0)
+SIM.Ncells_abc = Ncells_abc
+SIM.Fhkl = Famp
+SIM.Amatrix = sqr(CRYSTAL.get_A()).transpose()
+SIM.oversample = oversmaple
+SIM.xtal_shape = shapetype.Gauss
+SIM.add_nanoBragg_spots()
+
+# write the simulation to disk using cbf writer
+cbf_filename = "test_full.cbf"
+SIM.to_cbf(cbf_filename)
+
+# load the CBF from disk
+loader = dxtbx.load(cbf_filename)
+test_cbf = nanoBragg(loader.get_detector(), loader.get_beam(), panel_id=0)
+test_cbf.Ncells_abc = Ncells_abc
+test_cbf.Fhkl = Famp
+# FIXME: for some reason cbf_writer converts the beam polarization fraction to 0.999,
+# which would break this test hence we must set it back to 1..
+test_cbf.polarization = 1
+test_cbf.Amatrix = sqr(CRYSTAL.get_A()).transpose()
+test_cbf.oversample = oversmaple
+test_cbf.xtal_shape = shapetype.Gauss
+test_cbf.add_nanoBragg_spots()
+
+# verify test_cbf and SIM produce the same Bragg spot image
+assert np.allclose(SIM.raw_pixels.as_numpy_array(), test_cbf.raw_pixels.as_numpy_array())
+print("OK!")

--- a/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
+++ b/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
@@ -22,6 +22,7 @@ from scitbx.array_family import flex
 from scitbx.matrix import sqr, col
 from simtbx.nanoBragg import nanoBragg, shapetype
 
+print("Make a randomly oriented xtal")
 # make a randomly oriented crystal..
 np.random.seed(3142019)
 # make random rotation about principle axes
@@ -43,6 +44,7 @@ cryst_descr = {'__id__': 'crystal',
                'real_space_c': real_c.elems,
                'space_group_hall_symbol': ' P 4nw 2abw'}
 
+print("Make a beam")
 # make a beam
 ENERGY = 9000
 ENERGY_CONV = 1e10*constants.c*constants.h / constants.electron_volt
@@ -59,6 +61,7 @@ beam_descr = {'direction': (0.0, 0.0, 1.0),
 
 # make a detector panel
 # monolithic camera description
+print("Make a dxtbx detector")
 detdist = 100.
 pixsize = 0.1
 im_shape = 1536, 1536
@@ -100,6 +103,7 @@ Ncells_abc = 20, 20, 20
 oversmaple = 2
 
 # do the simulation
+print("Do the initial simulation")
 SIM = nanoBragg(DETECTOR, BEAM, panel_id=0)
 SIM.Ncells_abc = Ncells_abc
 SIM.Fhkl = Famp
@@ -110,10 +114,14 @@ SIM.add_nanoBragg_spots()
 
 # write the simulation to disk using cbf writer
 cbf_filename = "test_full.cbf"
+print("write simulation to disk (%s)" % cbf_filename)
 SIM.to_cbf(cbf_filename)
 
 # load the CBF from disk
+print("Open file %s using dxtbx" % cbf_filename)
 loader = dxtbx.load(cbf_filename)
+
+print("Perform second simulation using dxtbx loaded detector and beam")
 test_cbf = nanoBragg(loader.get_detector(), loader.get_beam(), panel_id=0)
 test_cbf.Ncells_abc = Ncells_abc
 test_cbf.Fhkl = Famp
@@ -126,5 +134,6 @@ test_cbf.xtal_shape = shapetype.Gauss
 test_cbf.add_nanoBragg_spots()
 
 # verify test_cbf and SIM produce the same Bragg spot image
+print("Check the intensities haven't changed, and that  cbf writing preserved geometry")
 assert np.allclose(SIM.raw_pixels.as_numpy_array(), test_cbf.raw_pixels.as_numpy_array())
 print("OK!")


### PR DESCRIPTION
Ful CBF writer for nanoBragg simulation, requires a change in dxtbx to be py2/3 compatible, which should be merged into dxtbx master shortly (relevant dxtbx branch is dxtbx_cbfwrite_py3compat)