### PR TITLE
Use alternate pixel value for masking for multi-panel images

### DIFF
--- a/iotbx/detectors/display.h
+++ b/iotbx/detectors/display.h
@@ -1028,11 +1028,11 @@ class generic_flex_image: public FlexImage<double>{
       std::size_t data_sz = rawdata.size();
       double qsum = 0;
       std::size_t good_sz = 0;
-      data_t* data_ptr = rawdata.begin();
+      const data_t* data_ptr = rawdata.begin();
       data_t px_val;
       for (std::size_t i = 0; i < data_sz; i++) {
         px_val = *data_ptr++;
-        if (px_val == std::numeric_limits<int>::min()) continue;
+        if (px_val == std::numeric_limits<int>::min()) {continue;}
         qsum += px_val;
         good_sz++;
       }
@@ -1047,7 +1047,7 @@ class generic_flex_image: public FlexImage<double>{
       int temp;
       for (std::size_t i = 0; i < data_sz; i++) {
           px_val = *data_ptr++;
-          if (px_val == std::numeric_limits<int>::min()) continue;
+          if (px_val == std::numeric_limits<int>::min()) {continue;}
           temp = int(bins_per_pixel_unit*(px_val));
           if (temp<0){histogram[0]+=1;}
           else if (temp>=hsize){histogram[hsize-1]+=1;}
@@ -1059,7 +1059,7 @@ class generic_flex_image: public FlexImage<double>{
       double accum=0;
       for (std::size_t i = 0; i<hsize; i++) {
         accum+=histogram[i];
-        if (accum > 0.9*rawdata.size()) { percentile=i*qave/(hsize/2); break; }
+        if (accum > 0.9*good_sz) { percentile=i*qave/(hsize/2); break; }
       }
       //std::cout<<"the 90-percentile pixel value is "<<percentile<<std::endl;
 

--- a/iotbx/detectors/display.h
+++ b/iotbx/detectors/display.h
@@ -1025,18 +1025,30 @@ class generic_flex_image: public FlexImage<double>{
   void followup_brightness_scale(){
 
       //first pass through data calculate average
-      double qave = af::mean(rawdata.const_ref());
+      std::size_t data_sz = rawdata.size();
+      double qsum = 0;
+      std::size_t good_sz = 0;
+      data_t* data_ptr = rawdata.begin();
+      data_t px_val;
+      for (std::size_t i = 0; i < data_sz; i++) {
+        px_val = *data_ptr++;
+        if (px_val == std::numeric_limits<int>::min()) continue;
+        qsum += px_val;
+        good_sz++;
+      }
+      double qave = (good_sz > 0) ? qsum/good_sz : 0;
       //std::cout<<"ave shown pixel value is "<<qave<<std::endl;
 
       //second pass calculate histogram
-      data_t* data_ptr = rawdata.begin();
+      data_ptr = rawdata.begin();
       int hsize=100;
       array_t histogram(hsize);
-      std::size_t data_sz = rawdata.size();
       double bins_per_pixel_unit = (hsize/2)/qave;
       int temp;
       for (std::size_t i = 0; i < data_sz; i++) {
-          temp = int(bins_per_pixel_unit*(*data_ptr++));
+          px_val = *data_ptr++;
+          if (px_val == std::numeric_limits<int>::min()) continue;
+          temp = int(bins_per_pixel_unit*(px_val));
           if (temp<0){histogram[0]+=1;}
           else if (temp>=hsize){histogram[hsize-1]+=1;}
           else {histogram[temp]+=1;}


### PR DESCRIPTION
Equivalent work to #415 but for multi-panel images.

Symptom: when clicking the 'show mask' button in the image viewer while a mask was loaded, the whole image would turn black for multi-panel images.  This is because the histogramming wasn't respecting the flag used to represent pixel values that have been masked, which is essentially the system's largest negative int.

Already reviewed by @nksauter.  He reports the additional time spent per image with this branch (due to the 2 new tests for the mask pixel value) is 0.023 seconds/ image for a Jungfrau 16M.  Any other comments welcome.