### PR TITLE
nanoBragg handedness

### DIFF
--- a/simtbx/nanoBragg/nanoBragg.cpp
+++ b/simtbx/nanoBragg/nanoBragg.cpp
@@ -96,6 +96,12 @@ nanoBragg::nanoBragg(
     Fclose = Xclose = -dot_product(pix0_vector,fdet_vector);
     Sclose = Yclose = -dot_product(pix0_vector,sdet_vector);
     close_distance = distance =  dot_product(pix0_vector,odet_vector);
+    if (close_distance < 0){
+        if(verbose)printf("WARNING: dxtbx model seems to be lefthanded. Inverting odet_vector.\n");
+        vector_rescale(odet_vector, odet_vector, -1);
+        close_distance = distance =  dot_product(pix0_vector,odet_vector);
+        detector_is_righthanded = false;
+    }
 
     /* set beam centre */
     scitbx::vec2<double> dials_bc = detector[panel_id].get_beam_centre(beam.get_s0());
@@ -384,6 +390,7 @@ nanoBragg::init_defaults()
     Xclose=NAN;Yclose=NAN;close_distance=NAN;
     Fclose=NAN;Sclose=NAN;
     ORGX=NAN;ORGY=NAN;
+    detector_is_righthanded=true;
     adc_offset = 40.0;
 
     /* use these to remember "user" inputs */
@@ -784,6 +791,8 @@ nanoBragg::init_beamcenter()
         if(verbose) printf("WARNING: auto-generating odet_vector\n");
         cross_product(fdet_vector,sdet_vector,odet_vector);
         unitize(odet_vector,odet_vector);
+        if (! detector_is_righthanded)
+            vector_rescale(odet_vector, odet_vector, -1);
     }
     unitize(polar_vector,polar_vector);
     unitize(spindle_vector,spindle_vector);

--- a/simtbx/nanoBragg/nanoBragg.h
+++ b/simtbx/nanoBragg/nanoBragg.h
@@ -281,6 +281,7 @@ class nanoBragg {
     double Fclose,Sclose; //=NAN;
     double ORGX,ORGY; //=NAN;
     double dials_origin[4];
+    double detector_is_righthanded; //true;
     double adc_offset; // = 40.0;
 
     /* use these to remember "user" inputs */


### PR DESCRIPTION
For now this code supports all use cases I have come across, including CSPAD and Jungfrau16M models. 

Things to consider:

0. Can we think of a better handedness test other than ```dot_product(pix0_vector, odet_vector)```? We have to compute the dot product regardless, so maybe this is fine as is.
1. The function ```init_beamcenter``` will sometimes recompute the ```odet_vector``` . If it does so then it checks the boolean ```detector_is_righthanded```, and rescales accordingly. 
2. Python-visible methods ```set_roi``` and ```set_beam_convention``` both call ```init_beamcenter``` under the hood. Could this get us into trouble ? 
3. Should we worry about the user that sets ```odet_vector``` manually, and unknowingly switches the hand ? 