### PR TITLE
WIP: Polarization anisotropy for fp and fdp

### DIFF
--- a/cctbx/array_family/boost_python/flex_ext.cpp
+++ b/cctbx/array_family/boost_python/flex_ext.cpp
@@ -42,6 +42,7 @@ namespace {
     tuple_mapping_fixed_size<cctbx::grid_point<> >();
     tuple_mapping_fixed_size<cctbx::hendrickson_lattman<> >();
     tuple_mapping_fixed_size<cctbx::miller::index<> >();
+    tuple_mapping_fixed_size<cctbx::miller::index<double> >();
   }
 
   void register_cctbx_c_grid_conversions()

--- a/cctbx/array_family/boost_python/flex_miller_index.cpp
+++ b/cctbx/array_family/boost_python/flex_miller_index.cpp
@@ -122,6 +122,10 @@ namespace {
         first_index, (
           bp::arg("miller_index")))
     ;
+
+    flex_wrapper<miller::index<double> >::ordered(
+        "miller_index_double", flex_root_scope)
+    ;
   }
 
 }}} // namespace scitbx::af::boost_python

--- a/cctbx/miller/__init__.py
+++ b/cctbx/miller/__init__.py
@@ -2068,21 +2068,37 @@ class array(set):
       assert sigmas.size() == self.indices().size()
     self._sigmas = sigmas
 
-  def e_incidents(self):
-    return self._e_incidents
+  def u_incs(self):
+    return self._u_incs
 
-  def set_e_incidents(self, e_incidents):
-    if e_incidents is not None:
-      assert e_incidents.size() == self.indices().size()
-    self._e_incidents = e_incidents
+  def set_u_incs(self, u_incs):
+    if u_incs is not None:
+      assert u_incs.size() == self.indices().size()
+    self._u_incs = u_incs
 
-  def e_scattereds(self):
-    return self._e_scattereds
+  def u_scats(self):
+    return self._u_scats
 
-  def set_e_scattereds(self, e_scattereds):
-    if e_scattereds is not None:
-      assert e_scattereds.size() == self.indices().size()
-    self._e_scattereds = e_scattereds
+  def set_u_scats(self, u_scats):
+    if u_scats is not None:
+      assert u_scats.size() == self.indices().size()
+    self._u_scats = u_scats
+
+  def v_scats(self):
+    return self._v_scats
+
+  def set_v_scats(self, v_scats):
+    if v_scats is not None:
+      assert v_scats.size() == self.indices().size()
+    self._v_scats = v_scats
+
+  def pol_factors(self):
+    return self._pol_factors
+
+  def set_pol_factors(self, pol_factors):
+    if pol_factors is not None:
+      assert pol_factors.size() == self.indices().size()
+    self._pol_factors = pol_factors
 
   def __iter__(self):
     if self.sigmas() is not None:
@@ -4836,12 +4852,13 @@ class array(set):
         data=result.data,
         sigmas=result.sigmas).set_observation_type(self)
     elif with_polarization: #HKLF 4 with polarization
-      print("with polarization")
-      assert self.e_scattereds().size() == self.indices().size()
-      assert self.e_incidents().size() == self.indices().size()
+      assert self.u_incs().size() == self.indices().size()
+      assert self.u_scats().size() == self.indices().size()
+      assert self.v_scats().size() == self.indices().size()
+      assert self.pol_factors().size() == self.indices().size()
       result = observations.observations(
-        self.indices(), self.data(), self.sigmas(), self.e_incidents(),
-        self.e_scattereds())
+        self.indices(), self.data(), self.sigmas(), self.u_incs(),
+        self.u_scats(), self.v_scats(), self.pol_factors())
       result.fo_sq = self
     else: #HKLF 4
       result = observations.observations(

--- a/cctbx/miller/__init__.py
+++ b/cctbx/miller/__init__.py
@@ -2068,6 +2068,22 @@ class array(set):
       assert sigmas.size() == self.indices().size()
     self._sigmas = sigmas
 
+  def e_incidents(self):
+    return self._e_incidents
+
+  def set_e_incidents(self, e_incidents):
+    if e_incidents is not None:
+      assert e_incidents.size() == self.indices().size()
+    self._e_incidents = e_incidents
+
+  def e_scattereds(self):
+    return self._e_scattereds
+
+  def set_e_scattereds(self, e_scattereds):
+    if e_scattereds is not None:
+      assert e_scattereds.size() == self.indices().size()
+    self._e_scattereds = e_scattereds
+
   def __iter__(self):
     if self.sigmas() is not None:
       for item in zip(self.indices(), self.data(), self.sigmas()):
@@ -4796,7 +4812,7 @@ class array(set):
     return result
 
   def as_xray_observations(self, scale_indices=None, twin_fractions=None,
-                           twin_components=None):
+                           twin_components=None, with_polarization=False):
     assert self.observation_type() is None or (
            self.is_xray_amplitude_array() or self.is_xray_intensity_array())
     assert self.is_real_array()
@@ -4819,6 +4835,14 @@ class array(set):
           anomalous_flag=self.anomalous_flag()),
         data=result.data,
         sigmas=result.sigmas).set_observation_type(self)
+    elif with_polarization: #HKLF 4 with polarization
+      print("with polarization")
+      assert self.e_scattereds().size() == self.indices().size()
+      assert self.e_incidents().size() == self.indices().size()
+      result = observations.observations(
+        self.indices(), self.data(), self.sigmas(), self.e_incidents(),
+        self.e_scattereds())
+      result.fo_sq = self
     else: #HKLF 4
       result = observations.observations(
         self.indices(), self.data(), self.sigmas(), tw_cmps)

--- a/cctbx/xray/boost_python/scatterer.cpp
+++ b/cctbx/xray/boost_python/scatterer.cpp
@@ -72,6 +72,10 @@ namespace {
                                make_setter(&w_t::u_iso, dcp()))
         .add_property("u_star", make_getter(&w_t::u_star, rbv()),
                                 make_setter(&w_t::u_star, dcp()))
+        .add_property("fp_star", make_getter(&w_t::fp_star, rbv()),
+                                make_setter(&w_t::fp_star, dcp()))
+        .add_property("fdp_star", make_getter(&w_t::fdp_star, rbv()),
+                                make_setter(&w_t::fdp_star, dcp()))
         .def_readwrite("flags", &w_t::flags)
         .def("set_use_u", &w_t::set_use_u, (arg("iso"),arg("aniso")))
         .def("set_use_u_iso_only", &w_t::set_use_u_iso_only)
@@ -143,6 +147,8 @@ namespace {
         .def("report_details", &w_t::report_details, (
           arg("unit_cell"),
           arg("prefix")))
+        .def("convert_to_fp_aniso", &w_t::convert_to_fp_aniso)
+        .def("convert_to_fdp_aniso", &w_t::convert_to_fdp_aniso)
       ;
     }
   };

--- a/cctbx/xray/boost_python/scatterer_flags.cpp
+++ b/cctbx/xray/boost_python/scatterer_flags.cpp
@@ -32,6 +32,8 @@ namespace {
         .def("grad_occupancy", &w_t::grad_occupancy)
         .def("grad_fp", &w_t::grad_fp)
         .def("grad_fdp", &w_t::grad_fdp)
+        .def("grad_fp_aniso", &w_t::grad_fp_aniso)
+        .def("grad_fdp_aniso", &w_t::grad_fdp_aniso)
         .def("curv_site_site", &w_t::curv_site_site)
         .def("curv_site_u_iso", &w_t::curv_site_u_iso)
         .def("curv_site_u_aniso", &w_t::curv_site_u_aniso)
@@ -55,6 +57,7 @@ namespace {
         .def("curv_fdp_fdp", &w_t::curv_fdp_fdp)
         .def("tan_u_iso", &w_t::tan_u_iso)
         .def("use_fp_fdp", &w_t::use_fp_fdp)
+        .def("use_fp_fdp_aniso", &w_t::use_fp_fdp_aniso)
         .def("use_u_iso_only", &w_t::use_u_iso_only)
         .def("use_u_aniso_only", &w_t::use_u_aniso_only)
         .def("set_use", &w_t::set_use, (arg("state")), return_self<>())
@@ -73,6 +76,10 @@ namespace {
         .def("set_grad_fp", &w_t::set_grad_fp, (
           arg("state")), return_self<>())
         .def("set_grad_fdp", &w_t::set_grad_fdp, (
+          arg("state")), return_self<>())
+        .def("set_grad_fp_aniso", &w_t::set_grad_fp_aniso, (
+          arg("state")), return_self<>())
+        .def("set_grad_fdp_aniso", &w_t::set_grad_fdp_aniso, (
           arg("state")), return_self<>())
         .def("set_curv_site_site", &w_t::set_curv_site_site, (
           arg("state")), return_self<>())
@@ -120,6 +127,8 @@ namespace {
         .def("set_tan_u_iso", &w_t::set_tan_u_iso, (
           arg("state")), return_self<>())
         .def("set_use_fp_fdp", &w_t::set_use_fp_fdp, arg("state"),
+             return_self<>())
+        .def("set_use_fp_fdp_aniso", &w_t::set_use_fp_fdp_aniso, arg("state"),
              return_self<>())
         .def("set_use_u_iso_only", &w_t::set_use_u_iso_only)
         .def("set_use_u_aniso_only", &w_t::set_use_u_aniso_only)

--- a/cctbx/xray/hr_ht_cache.h
+++ b/cctbx/xray/hr_ht_cache.h
@@ -37,6 +37,10 @@ namespace cctbx { namespace xray { namespace structure_factors {
   {
     typedef FloatType f_t;
 
+    hr_ht_cache()
+    {}
+
+
     /// Construct the cache using std::cos and std::sin.
     hr_ht_cache(sgtbx::space_group const& space_group,
                 IndexType const& h)

--- a/cctbx/xray/hr_ht_cache.h
+++ b/cctbx/xray/hr_ht_cache.h
@@ -7,11 +7,11 @@
 namespace cctbx { namespace xray { namespace structure_factors {
 
   /// A pair \f$(hR, ht)\f$ where \f$(R \mid t)\f$ is a symmetry element.
-  template <typename FloatType>
+  template <typename FloatType, typename IndexType=miller::index<> >
   struct hr_ht_group
   {
     hr_ht_group(
-      miller::index<> const& hr_,
+      IndexType const& hr_,
       FloatType const& ht_)
     :
       hr(hr_),
@@ -19,7 +19,7 @@ namespace cctbx { namespace xray { namespace structure_factors {
     {}
 
     /// \f$hR\f$
-    miller::index<> hr;
+    IndexType hr;
 
     /// \f$ht\f$
     FloatType ht;
@@ -32,14 +32,14 @@ namespace cctbx { namespace xray { namespace structure_factors {
     A centric space group is partition as the coset decomposition
     \f$G = G' \bigcup \bar{1}G''\f$ and only the elements of G' are considered.
    */
-  template <typename FloatType>
+  template <typename FloatType, typename IndexType=miller::index<> >
   struct hr_ht_cache
   {
     typedef FloatType f_t;
 
     /// Construct the cache using std::cos and std::sin.
     hr_ht_cache(sgtbx::space_group const& space_group,
-                miller::index<> const& h)
+                IndexType const& h)
     {
       math::cos_sin_exact<f_t> cos_sin;
       init(cos_sin, space_group, h);
@@ -50,7 +50,7 @@ namespace cctbx { namespace xray { namespace structure_factors {
     template<class CosSinType>
     hr_ht_cache(CosSinType const &cos_sin,
                 sgtbx::space_group const& space_group,
-                miller::index<> const& h)
+                IndexType const& h)
     {
       init(cos_sin, space_group, h);
     }
@@ -59,7 +59,7 @@ namespace cctbx { namespace xray { namespace structure_factors {
     template <class CosSinType>
     void init(CosSinType const &cos_sin,
               sgtbx::space_group const& space_group,
-              miller::index<> const& h)
+              IndexType const& h)
     {
       ltr_factor = space_group.n_ltr();
       is_centric = space_group.is_centric();
@@ -74,7 +74,7 @@ namespace cctbx { namespace xray { namespace structure_factors {
       }
       for(std::size_t i_smx=0;i_smx<space_group.n_smx();i_smx++) {
         sgtbx::rt_mx const& s = space_group.smx(i_smx);
-        groups.push_back(hr_ht_group<f_t>(
+        groups.push_back(hr_ht_group<f_t, IndexType>(
           h * s.r(),
           static_cast<f_t>(h * s.t()) / t_den));
       }
@@ -104,7 +104,7 @@ namespace cctbx { namespace xray { namespace structure_factors {
     std::complex<f_t> f_h_inv_t;
 
     /// The list of pairs \f$(hR, ht)\f$.
-    af::small<hr_ht_group<f_t>, sgtbx::n_max_repr_rot_mx> groups;
+    af::small<hr_ht_group<f_t, IndexType>, sgtbx::n_max_repr_rot_mx> groups;
   };
 
 }}} // namespace cctbx::xray::structure_factors

--- a/cctbx/xray/hr_ht_cache.h
+++ b/cctbx/xray/hr_ht_cache.h
@@ -10,6 +10,9 @@ namespace cctbx { namespace xray { namespace structure_factors {
   template <typename FloatType, typename IndexType=miller::index<> >
   struct hr_ht_group
   {
+    hr_ht_group()
+    {}
+
     hr_ht_group(
       IndexType const& hr_,
       FloatType const& ht_)

--- a/cctbx/xray/observations.h
+++ b/cctbx/xray/observations.h
@@ -444,11 +444,11 @@ namespace cctbx { namespace xray {
     scitbx::af::shared<FloatType> sigmas() const { return sigmas_; }
 
     scitbx::af::shared<scitbx::vec3<FloatType> > e_incidents() const {
-      return e_incidents_; 
+      return e_incidents_;
     }
 
     scitbx::af::shared<scitbx::vec3<FloatType> > e_scattereds() const {
-      return e_scattereds_; 
+      return e_scattereds_;
     }
 
     scitbx::af::shared<miller::index<> > indices() const { return indices_; }

--- a/cctbx/xray/observations.h
+++ b/cctbx/xray/observations.h
@@ -206,12 +206,20 @@ namespace cctbx { namespace xray {
     scitbx::af::shared<twin_fraction<FloatType>*> twin_fractions_;
     scitbx::af::shared<int> measured_scale_indices_;
     mutable FloatType prime_fraction_;
+    scitbx::af::shared<scitbx::vec3<FloatType> > e_incidents_;
+    scitbx::af::shared<scitbx::vec3<FloatType> > e_scattereds_;
 
     void validate_data() {
       CCTBX_ASSERT(indices_.size()==data_.size());
       CCTBX_ASSERT(indices_.size()==sigmas_.size());
       if (index_components_.size() != 0) {
         CCTBX_ASSERT(measured_scale_indices_.size() == indices_.size());
+      }
+      if (e_incidents_.size() != 0) {
+        CCTBX_ASSERT(e_incidents_.size() == indices_.size());
+      }
+      if (e_scattereds_.size() != 0) {
+        CCTBX_ASSERT(e_scattereds_.size() == indices_.size());
       }
     }
 
@@ -287,6 +295,22 @@ namespace cctbx { namespace xray {
       validate_data();
       process_merohedral_components(merohedral_components);
     }
+
+    // hklf 4 + polarization vectors
+    observations(scitbx::af::shared<miller::index<> > const& indices,
+      scitbx::af::shared<FloatType> const& data,
+      scitbx::af::shared<FloatType> const& sigmas,
+      scitbx::af::shared<scitbx::vec3<FloatType> > const& e_incidents,
+      scitbx::af::shared<scitbx::vec3<FloatType> > const& e_scattereds)
+      : indices_(indices),
+        data_(data),
+        sigmas_(sigmas),
+        e_incidents_(e_incidents),
+        e_scattereds_(e_scattereds)
+    {
+      validate_data();
+    }
+
 
     // hklf 5
     observations(scitbx::af::shared<miller::index<> > const& indices,

--- a/cctbx/xray/observations.h
+++ b/cctbx/xray/observations.h
@@ -394,6 +394,11 @@ namespace cctbx { namespace xray {
     // returns sigma of a measured reflection
     FloatType sig(int i) const { return sigmas_[i]; }
 
+    scitbx::vec3<FloatType> u_inc(int i) const { return u_incs_[i]; }
+    scitbx::vec3<FloatType> u_scat(int i) const { return u_scats_[i]; }
+    scitbx::vec3<FloatType> v_scat(int i) const { return v_scats_[i]; }
+    FloatType pol_factor(int i) const { return pol_factors_[i]; }
+
     // returns scale of a measured reflection
     FloatType scale(int i) const {
       FloatType rv = (measured_scale_indices_.size() == 0 ||

--- a/cctbx/xray/observations.h
+++ b/cctbx/xray/observations.h
@@ -443,6 +443,14 @@ namespace cctbx { namespace xray {
 
     scitbx::af::shared<FloatType> sigmas() const { return sigmas_; }
 
+    scitbx::af::shared<scitbx::vec3<FloatType> > e_incidents() const {
+      return e_incidents_; 
+    }
+
+    scitbx::af::shared<scitbx::vec3<FloatType> > e_scattereds() const {
+      return e_scattereds_; 
+    }
+
     scitbx::af::shared<miller::index<> > indices() const { return indices_; }
 
     scitbx::af::shared<int> measured_scale_indices() const {

--- a/cctbx/xray/observations.h
+++ b/cctbx/xray/observations.h
@@ -206,9 +206,9 @@ namespace cctbx { namespace xray {
     scitbx::af::shared<twin_fraction<FloatType>*> twin_fractions_;
     scitbx::af::shared<int> measured_scale_indices_;
     mutable FloatType prime_fraction_;
-    scitbx::af::shared<scitbx::vec3<FloatType> > u_incs_;
-    scitbx::af::shared<scitbx::vec3<FloatType> > u_scats_;
-    scitbx::af::shared<scitbx::vec3<FloatType> > v_scats_;
+    scitbx::af::shared<miller::index<FloatType> > u_incs_;
+    scitbx::af::shared<miller::index<FloatType> > u_scats_;
+    scitbx::af::shared<miller::index<FloatType> > v_scats_;
     scitbx::af::shared<FloatType> pol_factors_;
 
     void validate_data() {
@@ -308,9 +308,9 @@ namespace cctbx { namespace xray {
     observations(scitbx::af::shared<miller::index<> > const& indices,
       scitbx::af::shared<FloatType> const& data,
       scitbx::af::shared<FloatType> const& sigmas,
-      scitbx::af::shared<scitbx::vec3<FloatType> > const& u_incs,
-      scitbx::af::shared<scitbx::vec3<FloatType> > const& u_scats,
-      scitbx::af::shared<scitbx::vec3<FloatType> > const& v_scats,
+      scitbx::af::shared<miller::index<FloatType> > const& u_incs,
+      scitbx::af::shared<miller::index<FloatType> > const& u_scats,
+      scitbx::af::shared<miller::index<FloatType> > const& v_scats,
       scitbx::af::shared<FloatType> const &pol_factors)
       : indices_(indices),
         data_(data),
@@ -394,9 +394,9 @@ namespace cctbx { namespace xray {
     // returns sigma of a measured reflection
     FloatType sig(int i) const { return sigmas_[i]; }
 
-    scitbx::vec3<FloatType> u_inc(int i) const { return u_incs_[i]; }
-    scitbx::vec3<FloatType> u_scat(int i) const { return u_scats_[i]; }
-    scitbx::vec3<FloatType> v_scat(int i) const { return v_scats_[i]; }
+    miller::index<FloatType> u_inc(int i) const { return u_incs_[i]; }
+    miller::index<FloatType> u_scat(int i) const { return u_scats_[i]; }
+    miller::index<FloatType> v_scat(int i) const { return v_scats_[i]; }
     FloatType pol_factor(int i) const { return pol_factors_[i]; }
 
     // returns scale of a measured reflection
@@ -460,15 +460,15 @@ namespace cctbx { namespace xray {
 
     scitbx::af::shared<FloatType> sigmas() const { return sigmas_; }
 
-    scitbx::af::shared<scitbx::vec3<FloatType> > u_incs() const {
+    scitbx::af::shared<miller::index<FloatType> > u_incs() const {
       return u_incs_;
     }
 
-    scitbx::af::shared<scitbx::vec3<FloatType> > u_scats() const {
+    scitbx::af::shared<miller::index<FloatType> > u_scats() const {
       return u_scats_;
     }
 
-    scitbx::af::shared<scitbx::vec3<FloatType> > v_scats() const {
+    scitbx::af::shared<miller::index<FloatType> > v_scats() const {
       return v_scats_;
     }
 

--- a/cctbx/xray/observations.h
+++ b/cctbx/xray/observations.h
@@ -210,6 +210,7 @@ namespace cctbx { namespace xray {
     scitbx::af::shared<miller::index<FloatType> > u_scats_;
     scitbx::af::shared<miller::index<FloatType> > v_scats_;
     scitbx::af::shared<FloatType> pol_factors_;
+    bool has_polarisation_;
 
     void validate_data() {
       CCTBX_ASSERT(indices_.size()==data_.size());
@@ -298,7 +299,8 @@ namespace cctbx { namespace xray {
       : indices_(indices),
         data_(data),
         sigmas_(sigmas),
-        prime_fraction_(1)
+        prime_fraction_(1),
+        has_polarisation_(false)
     {
       validate_data();
       process_merohedral_components(merohedral_components);
@@ -318,7 +320,8 @@ namespace cctbx { namespace xray {
         u_incs_(u_incs),
         u_scats_(u_scats),
         v_scats_(v_scats),
-        pol_factors_(pol_factors)
+        pol_factors_(pol_factors),
+        has_polarisation_(true)
     {
       validate_data();
     }
@@ -331,7 +334,8 @@ namespace cctbx { namespace xray {
       scitbx::af::shared<int> const& scale_indices,
       scitbx::af::shared<twin_fraction<FloatType>*> const&
         twin_fractions)
-      : twin_fractions_(twin_fractions)
+      : twin_fractions_(twin_fractions),
+        has_polarisation_(false)
     {
       build_indices_twin_components(indices, data, sigmas, scale_indices);
       update_prime_fraction();
@@ -351,7 +355,8 @@ namespace cctbx { namespace xray {
         sigmas_(obs.sigmas_),
         index_components_(obs.index_components_),
         measured_scale_indices_(obs.measured_scale_indices_),
-        twin_fractions_(twin_fractions)
+        twin_fractions_(twin_fractions),
+        has_polarisation_(false)
     {
       CCTBX_ASSERT(twin_fractions.size()==obs.twin_fractions_.size());
       CCTBX_ASSERT(!(twin_fractions.size() != 0 && merohedral_components.size() != 0));
@@ -398,6 +403,7 @@ namespace cctbx { namespace xray {
     miller::index<FloatType> u_scat(int i) const { return u_scats_[i]; }
     miller::index<FloatType> v_scat(int i) const { return v_scats_[i]; }
     FloatType pol_factor(int i) const { return pol_factors_[i]; }
+    bool has_polarisation() const { return has_polarisation_; }
 
     // returns scale of a measured reflection
     FloatType scale(int i) const {

--- a/cctbx/xray/observations.h
+++ b/cctbx/xray/observations.h
@@ -206,8 +206,10 @@ namespace cctbx { namespace xray {
     scitbx::af::shared<twin_fraction<FloatType>*> twin_fractions_;
     scitbx::af::shared<int> measured_scale_indices_;
     mutable FloatType prime_fraction_;
-    scitbx::af::shared<scitbx::vec3<FloatType> > e_incidents_;
-    scitbx::af::shared<scitbx::vec3<FloatType> > e_scattereds_;
+    scitbx::af::shared<scitbx::vec3<FloatType> > u_incs_;
+    scitbx::af::shared<scitbx::vec3<FloatType> > u_scats_;
+    scitbx::af::shared<scitbx::vec3<FloatType> > v_scats_;
+    scitbx::af::shared<FloatType> pol_factors_;
 
     void validate_data() {
       CCTBX_ASSERT(indices_.size()==data_.size());
@@ -215,11 +217,17 @@ namespace cctbx { namespace xray {
       if (index_components_.size() != 0) {
         CCTBX_ASSERT(measured_scale_indices_.size() == indices_.size());
       }
-      if (e_incidents_.size() != 0) {
-        CCTBX_ASSERT(e_incidents_.size() == indices_.size());
+      if (u_incs_.size() != 0) {
+        CCTBX_ASSERT(u_incs_.size() == indices_.size());
       }
-      if (e_scattereds_.size() != 0) {
-        CCTBX_ASSERT(e_scattereds_.size() == indices_.size());
+      if (u_scats_.size() != 0) {
+        CCTBX_ASSERT(u_scats_.size() == indices_.size());
+      }
+      if (v_scats_.size() != 0) {
+        CCTBX_ASSERT(v_scats_.size() == indices_.size());
+      }
+      if (pol_factors_.size() != 0) {
+        CCTBX_ASSERT(pol_factors_.size() == indices_.size());
       }
     }
 
@@ -300,13 +308,17 @@ namespace cctbx { namespace xray {
     observations(scitbx::af::shared<miller::index<> > const& indices,
       scitbx::af::shared<FloatType> const& data,
       scitbx::af::shared<FloatType> const& sigmas,
-      scitbx::af::shared<scitbx::vec3<FloatType> > const& e_incidents,
-      scitbx::af::shared<scitbx::vec3<FloatType> > const& e_scattereds)
+      scitbx::af::shared<scitbx::vec3<FloatType> > const& u_incs,
+      scitbx::af::shared<scitbx::vec3<FloatType> > const& u_scats,
+      scitbx::af::shared<scitbx::vec3<FloatType> > const& v_scats,
+      scitbx::af::shared<FloatType> const &pol_factors)
       : indices_(indices),
         data_(data),
         sigmas_(sigmas),
-        e_incidents_(e_incidents),
-        e_scattereds_(e_scattereds)
+        u_incs_(u_incs),
+        u_scats_(u_scats),
+        v_scats_(v_scats),
+        pol_factors_(pol_factors)
     {
       validate_data();
     }
@@ -443,12 +455,20 @@ namespace cctbx { namespace xray {
 
     scitbx::af::shared<FloatType> sigmas() const { return sigmas_; }
 
-    scitbx::af::shared<scitbx::vec3<FloatType> > e_incidents() const {
-      return e_incidents_;
+    scitbx::af::shared<scitbx::vec3<FloatType> > u_incs() const {
+      return u_incs_;
     }
 
-    scitbx::af::shared<scitbx::vec3<FloatType> > e_scattereds() const {
-      return e_scattereds_;
+    scitbx::af::shared<scitbx::vec3<FloatType> > u_scats() const {
+      return u_scats_;
+    }
+
+    scitbx::af::shared<scitbx::vec3<FloatType> > v_scats() const {
+      return v_scats_;
+    }
+
+    scitbx::af::shared<FloatType> pol_factors() const {
+      return pol_factors_;
     }
 
     scitbx::af::shared<miller::index<> > indices() const { return indices_; }

--- a/cctbx/xray/observations/boost_python/observations.cpp
+++ b/cctbx/xray/observations/boost_python/observations.cpp
@@ -66,6 +66,16 @@ namespace {
                arg("scale_indices"),
                arg("twin_fractions"),
                arg("merohedral_components"))))
+        .def(init<scitbx::af::shared<cctbx::miller::index<> > const&,
+                  scitbx::af::shared<FloatType> const&,
+                  scitbx::af::shared<FloatType> const&,
+                  scitbx::af::shared<scitbx::vec3<FloatType> > const&,
+                  scitbx::af::shared<scitbx::vec3<FloatType> > const& >
+             ((arg("observations"),
+               arg("data"),
+               arg("sigmas"),
+               arg("e_incidents"),
+               arg("e_scattereds"))))
         .def(init<observations<FloatType> const&,
                   scitbx::af::shared<
                     cctbx::xray::twin_fraction<FloatType>*> const&,
@@ -78,6 +88,8 @@ namespace {
         .add_property("indices", &obst::indices)
         .add_property("data", &obst::data)
         .add_property("sigmas", &obst::sigmas)
+        .add_property("e_incidents", &obst::e_incidents)
+        .add_property("e_scattereds", &obst::e_scattereds)
         .add_property("twin_fractions", &obst::twin_fractions)
         .add_property("merohedral_components", &obst::merohedral_components)
         .add_property("measured_scale_indices", &obst::measured_scale_indices)

--- a/cctbx/xray/observations/boost_python/observations.cpp
+++ b/cctbx/xray/observations/boost_python/observations.cpp
@@ -70,12 +70,16 @@ namespace {
                   scitbx::af::shared<FloatType> const&,
                   scitbx::af::shared<FloatType> const&,
                   scitbx::af::shared<scitbx::vec3<FloatType> > const&,
-                  scitbx::af::shared<scitbx::vec3<FloatType> > const& >
+                  scitbx::af::shared<scitbx::vec3<FloatType> > const&,
+                  scitbx::af::shared<scitbx::vec3<FloatType> > const&,
+                  scitbx::af::shared<FloatType> const& >
              ((arg("observations"),
                arg("data"),
                arg("sigmas"),
-               arg("e_incidents"),
-               arg("e_scattereds"))))
+               arg("u_incs"),
+               arg("u_scats"),
+               arg("v_scats"),
+               arg("pol_factors"))))
         .def(init<observations<FloatType> const&,
                   scitbx::af::shared<
                     cctbx::xray::twin_fraction<FloatType>*> const&,
@@ -88,8 +92,10 @@ namespace {
         .add_property("indices", &obst::indices)
         .add_property("data", &obst::data)
         .add_property("sigmas", &obst::sigmas)
-        .add_property("e_incidents", &obst::e_incidents)
-        .add_property("e_scattereds", &obst::e_scattereds)
+        .add_property("u_incs", &obst::u_incs)
+        .add_property("u_scats", &obst::u_scats)
+        .add_property("v_scats", &obst::v_scats)
+        .add_property("pol_factors", &obst::pol_factors)
         .add_property("twin_fractions", &obst::twin_fractions)
         .add_property("merohedral_components", &obst::merohedral_components)
         .add_property("measured_scale_indices", &obst::measured_scale_indices)

--- a/cctbx/xray/observations/boost_python/observations.cpp
+++ b/cctbx/xray/observations/boost_python/observations.cpp
@@ -69,9 +69,9 @@ namespace {
         .def(init<scitbx::af::shared<cctbx::miller::index<> > const&,
                   scitbx::af::shared<FloatType> const&,
                   scitbx::af::shared<FloatType> const&,
-                  scitbx::af::shared<scitbx::vec3<FloatType> > const&,
-                  scitbx::af::shared<scitbx::vec3<FloatType> > const&,
-                  scitbx::af::shared<scitbx::vec3<FloatType> > const&,
+                  scitbx::af::shared<cctbx::miller::index<FloatType> > const&,
+                  scitbx::af::shared<cctbx::miller::index<FloatType> > const&,
+                  scitbx::af::shared<cctbx::miller::index<FloatType> > const&,
                   scitbx::af::shared<FloatType> const& >
              ((arg("observations"),
                arg("data"),

--- a/cctbx/xray/parameter_map.h
+++ b/cctbx/xray/parameter_map.h
@@ -12,15 +12,18 @@ struct parameter_indices
 {
   static int const invariable = -1;
 
-  int site, u_iso, u_aniso, occupancy, fp, fdp;
+  int site, u_iso, u_aniso, occupancy, fp, fdp, fp_aniso, fdp_aniso;
 
   parameter_indices()
     : site(invariable), u_iso(invariable), u_aniso(invariable),
-      occupancy(invariable), fp(invariable), fdp(invariable)
+      occupancy(invariable), fp(invariable), fdp(invariable),
+      fp_aniso(invariable), fdp_aniso(invariable)
   {}
 
   int top() {
-    return   fdp       != invariable ? fdp
+    return   fdp_aniso != invariable ? fdp_aniso
+           : fp_aniso  != invariable ? fp_aniso
+           : fdp       != invariable ? fdp
            : fp        != invariable ? fp
            : occupancy != invariable ? occupancy
            : u_aniso   != invariable ? u_aniso
@@ -73,6 +76,14 @@ private:
         if (sc.flags.grad_occupancy()) ids.occupancy = params++;
         if (sc.flags.grad_fp()) ids.fp = params++;
         if (sc.flags.grad_fdp()) ids.fdp = params++;
+        if (sc.flags.use_fp_fdp_aniso() && sc.flags.grad_fp_aniso()) {
+          ids.fp_aniso = params;
+          params += 6;
+        }
+        if (sc.flags.use_fp_fdp_aniso() && sc.flags.grad_fdp_aniso()) {
+          ids.fdp_aniso = params;
+          params += 6;
+        }
       }
     }
 

--- a/cctbx/xray/scatterer.h
+++ b/cctbx/xray/scatterer.h
@@ -61,7 +61,9 @@ namespace xray {
         u_star(-1,-1,-1,-1,-1,-1),
         flags(scatterer_flags::use_bit|scatterer_flags::use_u_iso_bit),
         multiplicity_(0),
-        weight_without_occupancy_(0)
+        weight_without_occupancy_(0),
+        fp_aniso(-1,-1,-1,-1,-1,-1),
+        fdp_aniso(-1,-1,-1,-1,-1,-1)
       {}
 
       //! Initialization with anisotropic displacement parameters.
@@ -83,7 +85,9 @@ namespace xray {
         u_star(u_star_),
         flags(scatterer_flags::use_bit|scatterer_flags::use_u_aniso_bit),
         multiplicity_(0),
-        weight_without_occupancy_(0)
+        weight_without_occupancy_(0),
+        fp_aniso(-1,-1,-1,-1,-1,-1),
+        fdp_aniso(-1,-1,-1,-1,-1,-1)
       {}
 
       //! Direct access to label.
@@ -128,6 +132,18 @@ namespace xray {
 
       //! Support for refinement.
       scatterer_flags flags;
+
+      //! Anisotropic f-prime tensor.
+      /* Near absorption edges the inelastic scattering factors may show strong
+         polarization anisotropy.
+       */
+      scitbx::sym_mat3<FloatType> fp_aniso;
+
+      //! Anisotropic f-double-prime tensor.
+      /* Near absorption edges the inelastic scattering factors may show strong
+         polarization anisotropy.
+       */
+      scitbx::sym_mat3<FloatType> fdp_aniso;
 
       void set_use_u(bool iso, bool aniso)
       {

--- a/cctbx/xray/scatterer.h
+++ b/cctbx/xray/scatterer.h
@@ -62,8 +62,8 @@ namespace xray {
         flags(scatterer_flags::use_bit|scatterer_flags::use_u_iso_bit),
         multiplicity_(0),
         weight_without_occupancy_(0),
-        fp_aniso(-1,-1,-1,-1,-1,-1),
-        fdp_aniso(-1,-1,-1,-1,-1,-1)
+        fp_star(-1,-1,-1,-1,-1,-1),
+        fdp_star(-1,-1,-1,-1,-1,-1)
       {}
 
       //! Initialization with anisotropic displacement parameters.
@@ -86,8 +86,8 @@ namespace xray {
         flags(scatterer_flags::use_bit|scatterer_flags::use_u_aniso_bit),
         multiplicity_(0),
         weight_without_occupancy_(0),
-        fp_aniso(-1,-1,-1,-1,-1,-1),
-        fdp_aniso(-1,-1,-1,-1,-1,-1)
+        fp_star(-1,-1,-1,-1,-1,-1),
+        fdp_star(-1,-1,-1,-1,-1,-1)
       {}
 
       //! Direct access to label.
@@ -137,13 +137,13 @@ namespace xray {
       /* Near absorption edges the inelastic scattering factors may show strong
          polarization anisotropy.
        */
-      scitbx::sym_mat3<FloatType> fp_aniso;
+      scitbx::sym_mat3<FloatType> fp_star;
 
       //! Anisotropic f-double-prime tensor.
       /* Near absorption edges the inelastic scattering factors may show strong
          polarization anisotropy.
        */
-      scitbx::sym_mat3<FloatType> fdp_aniso;
+      scitbx::sym_mat3<FloatType> fdp_star;
 
       void set_use_u(bool iso, bool aniso)
       {

--- a/cctbx/xray/scatterer.h
+++ b/cctbx/xray/scatterer.h
@@ -196,6 +196,30 @@ namespace xray {
         }
       }
 
+      void convert_to_fp_aniso(
+        uctbx::unit_cell const& unit_cell)
+      {
+        if (flags.use_fp_fdp()) {
+          fp_star = adptbx::u_iso_as_u_star(unit_cell, fp);
+        }
+        else {
+          fp_star = scitbx::sym_mat3<FloatType>(0,0,0,0,0,0);
+        }
+        flags.set_use_fp_fdp_aniso(true);
+      }
+
+      void convert_to_fdp_aniso(
+        uctbx::unit_cell const& unit_cell)
+      {
+        if (flags.use_fp_fdp()) {
+          fdp_star = adptbx::u_iso_as_u_star(unit_cell, fdp);
+        }
+        else {
+          fdp_star = scitbx::sym_mat3<FloatType>(0,0,0,0,0,0);
+        }
+        flags.set_use_fp_fdp_aniso(true);
+      }
+
       //! Tests u_iso > 0 or adptbx::is_positive_definite(u_cart).
       bool
       is_positive_definite_u(

--- a/cctbx/xray/scatterer_flags.h
+++ b/cctbx/xray/scatterer_flags.h
@@ -45,13 +45,19 @@ namespace cctbx { namespace xray {
 
     unsigned bits;
     int param;
+    bool use_fp_fdp_aniso_;
+    bool grad_fp_aniso_;
+    bool grad_fdp_aniso_;
 
     scatterer_flags(
       unsigned bits_=use_bit,
       int param_=0)
     :
       bits(bits_),
-      param(param_)
+      param(param_),
+      use_fp_fdp_aniso_(false),
+      grad_fp_aniso_(false),
+      grad_fdp_aniso_(false)
     {}
 
     scatterer_flags(
@@ -124,6 +130,9 @@ namespace cctbx { namespace xray {
       set_curv_fdp_fdp(curv_fdp_fdp);
       set_tan_u_iso(tan_u_iso);
       set_use_fp_fdp(use_fp_fdp);
+      set_use_fp_fdp_aniso(false);
+      set_grad_fp_aniso(false);
+      set_grad_fdp_aniso(false);
     }
 
     /// Whether for each corresponding pair of bits a and b from bits
@@ -143,6 +152,34 @@ namespace cctbx { namespace xray {
       else       bits &= ~attr##_bit; \
       return *this; \
     }
+
+    bool use_fp_fdp_aniso() const {
+      return use_fp_fdp_aniso_;
+    }
+
+    scatterer_flags& set_use_fp_fdp_aniso(bool state) {
+      use_fp_fdp_aniso_ = state;
+      return *this;
+    }
+
+    bool grad_fp_aniso() const {
+      return grad_fp_aniso_;
+    }
+
+    scatterer_flags& set_grad_fp_aniso(bool state) {
+      grad_fp_aniso_ = state;
+      return *this;
+    }
+
+    bool grad_fdp_aniso() const {
+      return grad_fdp_aniso_;
+    }
+
+    scatterer_flags& set_grad_fdp_aniso(bool state) {
+      grad_fdp_aniso_ = state;
+      return *this;
+    }
+
 
     CCTBX_XRAY_SCATTERER_FLAGS_GET_SET(use)
     CCTBX_XRAY_SCATTERER_FLAGS_GET_SET(use_u_iso)
@@ -253,11 +290,14 @@ namespace cctbx { namespace xray {
       unsigned u_aniso;
       unsigned occupancy;
       unsigned fp;
+      unsigned fp_aniso;
       unsigned fdp;
+      unsigned fdp_aniso;
       unsigned tan_u_iso;
       unsigned use_u_iso;
       unsigned use_u_aniso;
       unsigned use_fp_fdp;
+      unsigned use_fp_fdp_aniso;
 
       grad_flags_counts_core()
         : site(0),
@@ -265,11 +305,14 @@ namespace cctbx { namespace xray {
           u_aniso(0),
           occupancy(0),
           fp(0),
+          fp_aniso(0),
           fdp(0),
+          fdp_aniso(0),
           tan_u_iso(0),
           use_u_iso(0),
           use_u_aniso(0),
-          use_fp_fdp(0)
+          use_fp_fdp(0),
+          use_fp_fdp_aniso(0)
       {}
 
       void process(scatterer_flags const &f)
@@ -281,16 +324,19 @@ namespace cctbx { namespace xray {
           if (f.grad_occupancy()) occupancy++;
           if (f.grad_fp()) fp++;
           if (f.grad_fdp()) fdp++;
+          if (f.grad_fp_aniso()) fp_aniso = fp_aniso + 6;
+          if (f.grad_fdp_aniso()) fdp_aniso = fdp_aniso + 6;
           if (f.tan_u_iso()) tan_u_iso++;
           if (f.use_u_iso()) use_u_iso++;
           if (f.use_u_aniso()) use_u_aniso++;
           if (f.use_fp_fdp()) use_fp_fdp++;
+          if (f.use_fp_fdp_aniso()) use_fp_fdp_aniso++;
         }
       }
 
       unsigned
       n_parameters() const {
-        return site + u_iso + u_aniso + occupancy + fp + fdp;
+        return site + u_iso + u_aniso + occupancy + fp + fdp + fp_aniso + fdp_aniso;
       }
   };
 

--- a/iotbx/reflection_file_reader.py
+++ b/iotbx/reflection_file_reader.py
@@ -360,8 +360,8 @@ class hklf4_reflection_file_with_polarization(any_reflection_file):
     self._file_name = file_name
     self._observation_type = "intensities"
     self._file_type = "shelx_hklf"
-    self._file_content = shelx_hklf.reader(
-        file_name=file_name, unit_cell=unit_cell, with_polarization=True)
+    self._file_content = shelx_hklf.reader_with_polarization(
+        file_name=file_name, unit_cell=unit_cell)
 
 
 

--- a/iotbx/reflection_file_reader.py
+++ b/iotbx/reflection_file_reader.py
@@ -355,6 +355,18 @@ class any_reflection_file(object):
       result = result_
     return result
 
+class hklf4_reflection_file_with_polarization(any_reflection_file):
+  def __init__(self, file_name, unit_cell):
+    self._file_name = file_name
+    self._observation_type = "intensities"
+    self._file_type = "shelx_hklf"
+    self._file_content = shelx_hklf.reader(
+        file_name=file_name, unit_cell=unit_cell, with_polarization=True)
+
+
+
+
+
 def collect_arrays(
       file_names,
       crystal_symmetry,

--- a/iotbx/run_tests.py
+++ b/iotbx/run_tests.py
@@ -109,6 +109,7 @@ tst_list_base = [
   "$D/bioinformatics/test/tst_ebi_wu_blast_xml.py",
   "$D/bioinformatics/test/tst_ncbi_blast_xml.py",
   "$D/regression/tst_cif_as_pdb_1atom.py",
+  "$B/shelx/tests/tst_hklf",
   ]
 
 # failing tests on Windows, Python 2.7

--- a/iotbx/shelx/SConscript
+++ b/iotbx/shelx/SConscript
@@ -1,6 +1,16 @@
-Import("env_iotbx_boost_python_ext", "env_etc")
+Import("env_iotbx_boost_python_ext", "env_etc", "env_base")
 env = env_iotbx_boost_python_ext.Clone()
 env_etc.include_registry.append(env=env, paths=[env_etc.fable_include])
 env.SharedLibrary(target="#lib/iotbx_shelx_ext", source=[
   "shelx_ext.cpp",
 ])
+
+env_program = env_base.Clone()
+env_etc.include_registry.append(env=env_program,
+                                paths=["."] 
+                              + env_etc.iotbx_common_includes
+                              + [env_etc.fable_include])
+if (env_etc.static_libraries): builder = env_program.StaticLibrary
+else:                          builder = env_program.SharedLibrary
+env_program.Program(target="tests/tst_hklf",
+                    source="tst_hklf.cpp")

--- a/iotbx/shelx/hklf.h
+++ b/iotbx/shelx/hklf.h
@@ -156,7 +156,7 @@ class hklf_reader
         prepare_for_read(line, 40);
         fem::read_from_string(line, "(3i4,2f8.0,i4,f8.0)"),
           h[0], h[1], h[2], datum, sigma, run, frame;
-        if (h.is_zero()) break;
+        if (h.is_zero()) continue;
 
         //correct hkl frame number to match raw file
         frame -= offsets[run-1];

--- a/iotbx/shelx/hklf.h
+++ b/iotbx/shelx/hklf.h
@@ -190,7 +190,7 @@ class hklf_reader
           //std::cout<<"\n"<<line<<"\n\n"<<line_r<<std::endl;
           fem::read_from_string(line_r, raw_fstring.c_str()),
             h_r[0], h_r[1], h_r[2],  djunk, djunk, ijunk, cosines_inc[0],
-            cosines_scat[0], cosines_inc[1], cosines_scat[1], cosines_inc[2], 
+            cosines_scat[0], cosines_inc[1], cosines_scat[1], cosines_inc[2],
             cosines_scat[2], ijunk, djunk, djunk, frame_r, djunk, djunk, djunk,
             djunk, djunk, djunk, djunk, angle1_deg, scan_axis, ijunk, ijunk,
             ijunk, djunk, ijunk, djunk,  ijunk, ijunk, djunk, djunk, djunk,

--- a/iotbx/shelx/hklf.h
+++ b/iotbx/shelx/hklf.h
@@ -4,6 +4,11 @@
 #include <cctbx/miller.h>
 #include <scitbx/array_family/shared.h>
 #include <fable/fem/read.hpp>
+#include <scitbx/constants.h>
+#include <scitbx/vec3.h>
+#include <scitbx/mat3.h>
+#include <scitbx/sym_mat3.h>
+#include <math.h>
 
 namespace iotbx { namespace shelx {
 
@@ -14,6 +19,8 @@ class hklf_reader
   public:
     typedef char char_t;
     typedef cctbx::miller::index<> miller_t;
+    typedef scitbx::vec3<double> vec3_t;
+    typedef scitbx::mat3<double> mat3_t;
 
   protected:
     af::shared<miller_t> indices_;
@@ -21,6 +28,8 @@ class hklf_reader
     af::shared<double> sigmas_;
     af::shared<int> batch_numbers_or_phases_;
     af::shared<double> wavelengths_;
+    af::shared<vec3_t> e_incidents_;
+    af::shared<vec3_t> e_scattereds_;
 
     static
     void
@@ -86,6 +95,133 @@ class hklf_reader
       if (!have_wa) wavelengths_ = af::shared<double>();// free memory
     }
 
+    hklf_reader(
+        af::const_ref<std::string> const& lines,
+        af::const_ref<std::string> const& raw_lines,
+        mat3_t const& ort_matrix,
+        af::const_ref<int> const& offsets,
+        scitbx::sym_mat3<double> const& metrical_matrix)
+    {
+      mat3_t UB_inv = ort_matrix.inverse();
+      std::size_t n = lines.size();
+      indices_.reserve(n);
+      data_.reserve(n);
+      sigmas_.reserve(n);
+      e_incidents_.reserve(n);
+      e_scattereds_.reserve(n);
+      for(std::size_t i=0; i<n; i++) {
+
+        //read line from hkl
+        std::string line = lines[i];
+        miller_t h;
+        vec3_t e_inc, e_scat;
+        double datum, sigma, frame;
+        int run;
+        prepare_for_read(line, 40);
+        fem::read_from_string(line, "(3i4,2f8.0,i4,f8.0)"),
+          h[0], h[1], h[2], datum, sigma, run, frame;
+        if (h.is_zero()) break;
+
+        //correct hkl frame number to match raw file
+        for (std::size_t i_offset=0; i<run; i++) {
+          frame -= offsets[i_offset];
+        }
+
+        //find corresponding entry in raw file and store direction cosines and
+        //goniometer angles
+        vec3_t cosines_inc, cosines_scat;
+        double angle1_deg, angle2_deg;
+        double omega_deg, chi_deg, phi_deg;
+        double omega, chi, phi;
+        int scan_axis;
+        for(std::size_t i_r=0; i_r<n; i_r++) {
+          std::string line_r = raw_lines[i_r];
+          miller_t h_r;
+          double frame_r;
+          std::string junk;
+          prepare_for_read(line_r, 255);
+
+          fem::read_from_string(
+              line_r, "(3i4,20a,6f8.0,17a,f8.0,47a,f7.0,i2,74a,2f8.0)"),
+              h_r[0], h_r[1], h_r[2], junk, cosines_inc[0], cosines_inc[1],
+              cosines_inc[2], cosines_scat[0], cosines_scat[1], cosines_scat[2],
+              junk, frame_r, junk, angle1_deg, scan_axis, junk, chi_deg, 
+              angle2_deg;
+
+          if ( h==h_r && abs(frame-frame_r)<1. ) {
+            break;
+          }
+
+          std::cout<<"No match for reflection "<<h[0]<<" "<<h[1]<<" "<<h[2]<<std::endl;
+        }
+          
+        //Sort out angles and convert to radians
+        if (scan_axis==2) {
+          omega_deg = angle1_deg;
+          phi_deg = angle2_deg;
+        }
+        else if (scan_axis==3) {
+          phi_deg = angle1_deg;
+          omega_deg = angle2_deg;
+        }
+        else {
+          throw "Scan axis in .raw file should be 2 (omega) or 3 (phi)";
+        }
+        chi = scitbx::deg_as_rad(chi_deg); 
+        omega = scitbx::deg_as_rad(omega_deg); 
+        phi = scitbx::deg_as_rad(phi_deg); 
+
+
+        vec3_t hkl_zaxis = hkl_z(UB_inv, phi, chi);
+
+        e_inc = make_perpendicular(hkl_zaxis, cosines_inc, metrical_matrix);
+        e_inc = e_inc.normalize();
+        e_scat = make_perpendicular(hkl_zaxis, cosines_scat, metrical_matrix);
+        e_scat = e_scat.normalize();
+
+
+
+      }
+    }
+
+    vec3_t make_perpendicular(
+        vec3_t const &v1, vec3_t const &v2, scitbx::sym_mat3<double> const &g) {
+      //Construct the vector normal to v1 and v2 in a non-orthogonal system.
+      //Note that the argument g is the reciprocal of the metric tensor of
+      //the coordinate system for this problem. In other words we're making
+      //an hkl vector so we use the direct-space metric tensor.
+
+      vec3_t c = v1.cross(v2);
+      mat3_t K = mat3_t(
+          v1[0], v2[0], c[0],
+          v1[1], v2[1], c[1],
+          v1[2], v2[2], c[2]);
+      return vec3_t(0,0,1) * K.inverse() * g;
+
+    }
+
+
+    vec3_t hkl_z(
+        mat3_t const &UB_inv,
+        double const &phi,
+        double const &chi) {
+      //Compute the hkl indices of the laboratory z axis. Ort_matrix is similar
+      //to the Busing/Levy UB-matrix but conforms to the Bruker convention in
+      //which chi is a rotation around the Y axis instead of X.
+
+      double sin_phi = sin(phi);
+      double cos_phi = cos(phi);
+      double sin_chi = sin(chi);
+      double cos_chi = cos(chi);
+      vec3_t v = vec3_t(
+          sin_phi * sin_chi,
+          -1 * cos_phi * sin_chi,
+          cos_chi);
+      vec3_t h_z = UB_inv * v;
+      return h_z;
+    }
+
+
     af::shared<miller_t> indices() { return indices_; };
 
     af::shared<double> data() { return data_; }
@@ -97,6 +233,10 @@ class hklf_reader
     af::shared<int> batch_numbers() { return batch_numbers_or_phases_; }
 
     af::shared<double> wavelengths() { return wavelengths_; }
+
+    af::shared<vec3_t> e_incidents() { return e_incidents_; }
+
+    af::shared<vec3_t> e_scattereds() { return e_scattereds_; }
 };
 
 }} // iotbx::shelx

--- a/iotbx/shelx/hklf.h
+++ b/iotbx/shelx/hklf.h
@@ -103,6 +103,7 @@ class hklf_reader
         scitbx::sym_mat3<double> const& metrical_matrix)
     {
       mat3_t UB_inv = ort_matrix.inverse();
+      scitbx::sym_mat3<double> g_star = metrical_matrix.inverse();
       std::size_t n = lines.size();
       indices_.reserve(n);
       data_.reserve(n);
@@ -138,21 +139,63 @@ class hklf_reader
           std::string line_r = raw_lines[i_r];
           miller_t h_r;
           double frame_r;
-          std::string junk;
+          double djunk;
+          int ijunk;
           prepare_for_read(line_r, 255);
 
+          /*
           fem::read_from_string(
               line_r, "(3i4,20a,6f8.0,17a,f8.0,47a,f7.0,i2,74a,2f8.0)"),
-              h_r[0], h_r[1], h_r[2], junk, cosines_inc[0], cosines_inc[1],
+              h_r[0], h_r[1], h_r[2], junk1, cosines_inc[0], cosines_inc[1],
               cosines_inc[2], cosines_scat[0], cosines_scat[1], cosines_scat[2],
-              junk, frame_r, junk, angle1_deg, scan_axis, junk, chi_deg, 
+              junk2, frame_r, junk3, angle1_deg, scan_axis, junk4, chi_deg, 
               angle2_deg;
+              */
 
-          if ( h==h_r && abs(frame-frame_r)<1. ) {
+          std::string fstring =
+            std::string("(3i4,")     + // h_r
+            "2f8.0,"    + // i and sigma
+            "i4,"       + // batch number
+            "6f8.0,"    + // cosines_inc and cosines_scat
+            "i2,"       + // status mask
+            "2f7.0,"    + // detector coordinates
+            "f8.0,"     + // frame number of refln centroid
+            "2f7.0,"    + // detector coordinates (reduced)
+            "f8.0,"     + // frame number (predicted)
+            "f6.0,"     + // LP factor
+            "f5.0,"     + // profile correlation
+            "3f7.0,"    + // cumul. exp. time, det. angle, scan axis angle 
+                          // (omega for omega scan, phi for phi scan)
+            "i2,"       + // scan axis: 2 for omega, 3 for phi
+            "i5,"       + // 10000*sin(th)/lambda
+            "i9,"       + // total counts
+            "i7,"       + // background
+            "f7.2,"     + // scan axis relat. to start of run
+            "i4,"       + // crystal number
+            "f6.0,"     + // fraction of peak vol. nearest this hkl
+            "i11,"      + // sort key
+            "i3,"       + // point-group multiplicity of refln
+            "f6.0,"     + // Lorentz factor
+            "4f8.0,"    + // corrected det. coordinates, chi, "other angle"
+                          // (phi for omega scan, omega for phi scan)
+            "i3)";        // twin comp. number
+              
+
+          fem::read_from_string(line_r, fstring.c_str()),
+            h_r[0], h_r[1], h_r[2],  djunk, djunk, ijunk, cosines_inc[0], 
+            cosines_inc[1], cosines_inc[2], cosines_scat[0], cosines_scat[1], 
+            cosines_scat[2], ijunk, djunk, djunk, frame_r, djunk, djunk, djunk, 
+            djunk, djunk, djunk, djunk, angle1_deg, scan_axis, ijunk, ijunk, 
+            ijunk, djunk, ijunk, djunk,  ijunk, ijunk, djunk, djunk, djunk, 
+            chi_deg, angle2_deg, ijunk;
+
+
+
+          if ( h==h_r && abs(frame-frame_r)<.1 ) {
             break;
           }
 
-          std::cout<<"No match for reflection "<<h[0]<<" "<<h[1]<<" "<<h[2]<<std::endl;
+          //std::cout<<"No match for reflection "<<h[0]<<" "<<h[1]<<" "<<h[2]<<std::endl;
         }
           
         //Sort out angles and convert to radians
@@ -165,6 +208,7 @@ class hklf_reader
           omega_deg = angle2_deg;
         }
         else {
+          std::cout<<"What a nice day for scan axis "<<scan_axis<<std::endl;
           throw "Scan axis in .raw file should be 2 (omega) or 3 (phi)";
         }
         chi = scitbx::deg_as_rad(chi_deg); 
@@ -174,9 +218,9 @@ class hklf_reader
 
         vec3_t hkl_zaxis = hkl_z(UB_inv, phi, chi);
 
-        e_inc = make_perpendicular(hkl_zaxis, cosines_inc, metrical_matrix);
+        e_inc = make_perpendicular(hkl_zaxis, cosines_inc, g_star);
         e_inc = e_inc.normalize();
-        e_scat = make_perpendicular(hkl_zaxis, cosines_scat, metrical_matrix);
+        e_scat = make_perpendicular(hkl_zaxis, cosines_scat, g_star);
         e_scat = e_scat.normalize();
 
 
@@ -184,19 +228,19 @@ class hklf_reader
       }
     }
 
+    static
     vec3_t make_perpendicular(
         vec3_t const &v1, vec3_t const &v2, scitbx::sym_mat3<double> const &g) {
-      //Construct the vector normal to v1 and v2 in a non-orthogonal system.
-      //Note that the argument g is the reciprocal of the metric tensor of
-      //the coordinate system for this problem. In other words we're making
-      //an hkl vector so we use the direct-space metric tensor.
+      //Construct a unit vector normal to v1 and v2 in a non-orthogonal system
+      //described by the metric tensor g.
 
       vec3_t c = v1.cross(v2);
       mat3_t K = mat3_t(
           v1[0], v2[0], c[0],
           v1[1], v2[1], c[1],
           v1[2], v2[2], c[2]);
-      return vec3_t(0,0,1) * K.inverse() * g;
+      vec3_t perp = vec3_t(0,0,1) * K.inverse() * g.inverse();
+      return perp.normalize();
 
     }
 
@@ -214,9 +258,9 @@ class hklf_reader
       double sin_chi = sin(chi);
       double cos_chi = cos(chi);
       vec3_t v = vec3_t(
-          sin_phi * sin_chi,
-          -1 * cos_phi * sin_chi,
-          cos_chi);
+          sin(phi) * sin(chi),
+          -1 * cos(phi) * sin(chi),
+          cos(chi));
       vec3_t h_z = UB_inv * v;
       return h_z;
     }

--- a/iotbx/shelx/hklf.h
+++ b/iotbx/shelx/hklf.h
@@ -113,7 +113,7 @@ class hklf_reader
 
       std::string raw_fstring;
       if (1) {          //just to fold this huge string
-        raw_fstring = 
+        raw_fstring =
           std::string("(3i4,") + // h_r
           "2f8.0,"    + // i and sigma
           "i4,"       + // batch number
@@ -125,7 +125,7 @@ class hklf_reader
           "f8.0,"     + // frame number (predicted)
           "f6.0,"     + // LP factor
           "f5.0,"     + // profile correlation
-          "3f7.0,"    + // cumul. exp. time, det. angle, scan axis angle 
+          "3f7.0,"    + // cumul. exp. time, det. angle, scan axis angle
                         // (omega for omega scan, phi for phi scan)
           "i2,"       + // scan axis: 2 for omega, 3 for phi
           "i5,"       + // 10000*sin(th)/lambda
@@ -177,17 +177,17 @@ class hklf_reader
         for (
             std::size_t i_r=(i<5 ? 0 : i-5);
             i_r<raw_lines.size();
-            i_r++) 
+            i_r++)
         {
           std::string line_r = raw_lines[i_r];
           prepare_for_read(line_r, 255);
 
           fem::read_from_string(line_r, raw_fstring.c_str()),
-            h_r[0], h_r[1], h_r[2],  djunk, djunk, ijunk, cosines_inc[0], 
-            cosines_inc[1], cosines_inc[2], cosines_scat[0], cosines_scat[1], 
-            cosines_scat[2], ijunk, djunk, djunk, frame_r, djunk, djunk, djunk, 
-            djunk, djunk, djunk, djunk, angle1_deg, scan_axis, ijunk, ijunk, 
-            ijunk, djunk, ijunk, djunk,  ijunk, ijunk, djunk, djunk, djunk, 
+            h_r[0], h_r[1], h_r[2],  djunk, djunk, ijunk, cosines_inc[0],
+            cosines_inc[1], cosines_inc[2], cosines_scat[0], cosines_scat[1],
+            cosines_scat[2], ijunk, djunk, djunk, frame_r, djunk, djunk, djunk,
+            djunk, djunk, djunk, djunk, angle1_deg, scan_axis, ijunk, ijunk,
+            ijunk, djunk, ijunk, djunk,  ijunk, ijunk, djunk, djunk, djunk,
             chi_deg, angle2_deg, ijunk;
 
           //found match
@@ -200,7 +200,7 @@ class hklf_reader
             throw std::runtime_error("No matching .raw entry for reflection");
           }
         }
-          
+
         //Sort out angles and convert to radians
         if (scan_axis==2) {
           omega_deg = angle1_deg;
@@ -210,9 +210,9 @@ class hklf_reader
           phi_deg = angle1_deg;
           omega_deg = angle2_deg;
         }
-        chi = scitbx::deg_as_rad(chi_deg); 
-        omega = scitbx::deg_as_rad(omega_deg); 
-        phi = scitbx::deg_as_rad(phi_deg); 
+        chi = scitbx::deg_as_rad(chi_deg);
+        omega = scitbx::deg_as_rad(omega_deg);
+        phi = scitbx::deg_as_rad(phi_deg);
 
         //compute the polarization vectors
         vec3_t hkl_zaxis = hkl_z(UB_inv, phi, chi);

--- a/iotbx/shelx/hklf.h
+++ b/iotbx/shelx/hklf.h
@@ -19,7 +19,7 @@ class hklf_reader
   public:
     typedef char char_t;
     typedef cctbx::miller::index<> miller_t;
-    typedef scitbx::vec3<double> vec3_t;
+    typedef cctbx::miller::index<double> vec3_t;
     typedef scitbx::mat3<double> mat3_t;
 
   protected:
@@ -184,6 +184,7 @@ class hklf_reader
           std::string line_r = raw_lines[i_r];
           prepare_for_read(line_r, 255);
 
+          //std::cout<<"\n"<<line<<"\n\n"<<line_r<<std::endl;
           fem::read_from_string(line_r, raw_fstring.c_str()),
             h_r[0], h_r[1], h_r[2],  djunk, djunk, ijunk, cosines_inc[0],
             cosines_inc[1], cosines_inc[2], cosines_scat[0], cosines_scat[1],
@@ -200,6 +201,7 @@ class hklf_reader
           //crash if we didn't find a matching .raw entry
           if (i_r==raw_lines.size()-1) {
             throw std::runtime_error("No matching .raw entry for reflection");
+
           }
         }
 
@@ -221,11 +223,22 @@ class hklf_reader
         vec3_t u_inc = make_perpendicular(hkl_zaxis, cosines_inc, g_star);
         vec3_t u_scat = plane_projection(u_inc, cosines_scat, g_star);
         vec3_t v_scat = make_perpendicular(u_scat, cosines_scat, g_star);
+        //std::cout<<"u_inc:"<<' '<<u_inc[0]<<' '<<u_inc[1]<<' '<<u_inc[2]<<std::endl;
+        //std::cout<<"u_scat:"<<' '<<u_scat[0]<<' '<<u_scat[1]<<' '<<u_scat[2]<<std::endl;
+        //std::cout<<"v_scat:"<<' '<<v_scat[0]<<' '<<v_scat[1]<<' '<<v_scat[2]<<std::endl;
 
         u_inc = length1(u_inc, g_star);
         u_scat = length1(u_scat, g_star);
         v_scat = length1(v_scat, g_star);
         double pol_factor = u_inc * g_star * u_scat;
+        //std::cout<<"Normalizing..."<<std::endl;
+        //std::cout<<"u_inc:"<<' '<<u_inc[0]<<' '<<u_inc[1]<<' '<<u_inc[2]<<std::endl;
+        //std::cout<<"u_scat:"<<' '<<u_scat[0]<<' '<<u_scat[1]<<' '<<u_scat[2]<<std::endl;
+        //std::cout<<"v_scat:"<<' '<<v_scat[0]<<' '<<v_scat[1]<<' '<<v_scat[2]<<std::endl;
+        //std::cout<<"pol_factor: "<<pol_factor<<std::endl;
+
+        double pol2 = u_inc * g_star * v_scat;
+        //std::cout<<"pol factor, second beam: "<<pol2<<std::endl;
 
         //done
         indices_.push_back(h);

--- a/iotbx/shelx/hklf.py
+++ b/iotbx/shelx/hklf.py
@@ -170,12 +170,18 @@ def args_for_polarization_run(file_name, unit_cell):
   # Read .hkl file, sort, and store as flex array
   with open(file_name) as f:
     hl = f.readlines()
-  hkl_lines = flex.std_string(sorted(hl, key=_sortkey))
+  try:
+    hkl_lines = flex.std_string(sorted(hl, key=_sortkey))
+  except ValueError:
+    raise RuntimeError("No extra data allowed in hkl file")
 
   # Read .raw file, sort, and store as flex array
   with open(raw_filename) as f:
     rl = f.readlines()
-  raw_lines = flex.std_string(sorted(rl, key=_sortkey))
+  try:
+    raw_lines = flex.std_string(sorted(rl, key=_sortkey))
+  except ValueError:
+    raise RuntimeError("No extra data allowed in raw file")
 
   # Store orientation matrix as list of elements
   with open(p4p_filename) as p4pfile:
@@ -240,9 +246,6 @@ class reader_with_polarization(iotbx_shelx_ext.hklf_reader):
       miller_set=miller_set,
       data=self.data(),
       sigmas=self.sigmas()))
-    import ipdb
-    ipdb.set_trace()
-    junk = self.indices()
     obs.set_u_incs(self.u_incs())
     obs.set_u_scats(self.u_scats())
     obs.set_v_scats(self.v_scats())

--- a/iotbx/shelx/hklf.py
+++ b/iotbx/shelx/hklf.py
@@ -240,6 +240,9 @@ class reader_with_polarization(iotbx_shelx_ext.hklf_reader):
       miller_set=miller_set,
       data=self.data(),
       sigmas=self.sigmas()))
+    import ipdb
+    ipdb.set_trace()
+    junk = self.indices()
     obs.set_u_incs(self.u_incs())
     obs.set_u_scats(self.u_scats())
     obs.set_v_scats(self.v_scats())

--- a/iotbx/shelx/hklf.py
+++ b/iotbx/shelx/hklf.py
@@ -194,8 +194,8 @@ def args_for_polarization_run(file_name, unit_cell):
     line = p4pfile.readline()
     ormx_list.extend([float(x) for x in line.split()[1:4]])
 
-  # Read frame # offsets from file_root.offsets. Entries are added to the 
-  # frame number in the hkl file (all frames numbered consecutively) to give 
+  # Read frame # offsets from file_root.offsets. Entries are added to the
+  # frame number in the hkl file (all frames numbered consecutively) to give
   # the frame number in the .raw file (frames numbered from start of run).
   with open(offsets_filename) as offsetsfile:
     offsets = flex.int([int(x) for x in offsetsfile.readline().split()])

--- a/iotbx/shelx/hklf.py
+++ b/iotbx/shelx/hklf.py
@@ -240,9 +240,11 @@ class reader_with_polarization(iotbx_shelx_ext.hklf_reader):
       miller_set=miller_set,
       data=self.data(),
       sigmas=self.sigmas()))
-    obs.set_e_incidents(self.e_incidents())
-    obs.set_e_scattereds(self.e_scattereds())
+    obs.set_u_incs(self.u_incs())
+    obs.set_u_scats(self.u_scats())
+    obs.set_v_scats(self.v_scats())
+    obs.set_pol_factors(self.pol_factors())
     obs.set_info(base_array_info.customized_copy(
-      labels=["obs", "sigmas", "e_incidents", "e_scattereds"]))
+      labels=["obs", "sigmas", "u_incs", "u_scats", "v_scats", "pol_factors"]))
     miller_arrays.append(obs)
     return miller_arrays

--- a/iotbx/shelx/hklf.py
+++ b/iotbx/shelx/hklf.py
@@ -186,8 +186,8 @@ def args_for_polarization_run(file_name, unit_cell):
         line = p4pfile.readline()
         head = line.split()[0]
     except StopIteration:
-      raise RuntimeError, \
-          "Orientation matrix not found in {}".format(p4p_filename)
+      raise RuntimeError(
+          "Orientation matrix not found in {}".format(p4p_filename))
     ormx_list.extend([float(x) for x in line.split()[1:4]])
     line = p4pfile.readline()
     ormx_list.extend([float(x) for x in line.split()[1:4]])

--- a/iotbx/shelx/hklf.py
+++ b/iotbx/shelx/hklf.py
@@ -90,7 +90,59 @@ def miller_array_export_as_shelx_hklf(
     print(line, file=file_object)
   print("   0   0   0    0.00    0.00", file=file_object)
 
+
+def args_for_polarization_run(file_name, unit_cell):
+  from libtbx import smart_open
+
+  # Process and check filenames
+  import os
+  file_root = os.path.splitext(file_name)[0]
+  p4p_filename = file_root + '.p4p'
+  raw_filename = file_root + '.raw'
+  offsets_filename = file_root + '.offsets'
+  assert os.path.exists(p4p_filename), \
+      "{} not found".format(p4p_filename)
+  assert os.path.exists(raw_filename), \
+      "{} not found".format(raw_filename)
+  assert os.path.exists(offsets_filename), \
+      "{} not found".format(offsets_filename)
+
+  # Read .raw file and store as flex array
+  raw_lines = flex.split_lines(
+      smart_open.for_reading(file_name=raw_filename).read())
+
+  # Store orientation matrix as list of elements
+  with open(p4p_filename) as p4pfile:
+    head, line = '', ''
+    ormx_list = []
+    try:
+      while head != 'ORT1':
+        line = p4pfile.readline()
+        head = line.split()[0]
+    except StopIteration:
+      raise RuntimeError, \
+          "Orientation matrix not found in {}".format(p4p_filename)
+    ormx_list.extend([float(x) for x in line.split()[1:4]])
+    line = p4pfile.readline()
+    ormx_list.extend([float(x) for x in line.split()[1:4]])
+    line = p4pfile.readline()
+    ormx_list.extend([float(x) for x in line.split()[1:4]])
+    #ort_matrix = flex.mat3_double([ormx_list])
+
+  # Read frame # offsets from file_root.offsets. Each entry is added to the 
+  # frame number in the hkl file (all frames numbered consecutively) to give 
+  # the frame number in the .raw file (frames numbered from start of run).
+  with open(offsets_filename) as offsetsfile:
+    offsets = flex.int([int(x) for x in offsetsfile.readline().split()])
+
+  # We keep the metrical matrix as a tuple, it will be implicitly converted
+  metrical_matrix = unit_cell.metrical_matrix()
+
+
+  return (raw_lines, ormx_list, offsets, metrical_matrix)
+
 class reader(iotbx_shelx_ext.hklf_reader):
+
 
   def __init__(self, 
       file_object=None, 
@@ -110,63 +162,15 @@ class reader(iotbx_shelx_ext.hklf_reader):
           "reader to load intensities with polarization"
       assert unit_cell is not None, "Must supply a unit cell to iotbx.shelx." \
           "reader to load intensities with polarization"
-      raw_lines, ort_matrix, offsets, metrical_matrix = \
+      raw_lines, ormx_list, offsets, metrical_matrix = \
           args_for_polarization_run(file_name, unit_cell)
       super(reader, self).__init__(
-          lines=hkl_lines,
-          raw_lines=raw_lines,
-          ort_matrix=ort_matrix,
-          offsets=offsets,
-          metrical_matrix=metrical_matrix)
+          hkl_lines,
+          raw_lines,
+          ormx_list,
+          offsets,
+          metrical_matrix)
 
-  def args_for_polarization_run(file_name, unit_cell):
-
-    # Process and check filenames
-    import os
-    file_root = os.path.splitext(file_name)[0]
-    p4p_filename = file_root + '.p4p'
-    raw_filename = file_root + '.raw'
-    offsets_filename = file_root + '.offsets'
-    assert os.path.exists(p4p_filename), \
-        "{} not found".format(p4p_filename)
-    assert os.path.exists(raw_filename), \
-        "{} not found".format(raw_filename)
-    assert os.path.exists(offsets_filename), \
-        "{} not found".format(offsets_filename)
-
-    # Read .raw file and store as flex array
-    raw_lines = flex.split_lines(
-        smart_open.for_reading(file_name=raw_filename).read())
-
-    # Store orientation matrix as flex.mat3_double
-    with open(p4p_filename) as p4pfile:
-      head, line = '', ''
-      ormx_list = []
-      try:
-        while head != 'ORT1':
-          line = p4pfile.readline()
-          head = line.split()[0]
-      except StopIteration:
-        raise RuntimeError, \
-            "Orientation matrix not found in {}".format(p4p_filename)
-      ormx_list.extend([float(x) for x in line.split()[1:4]])
-      line = p4pfile.readline()
-      ormx_list.extend([float(x) for x in line.split()[1:4]])
-      line = p4pfile.readline()
-      ormx_list.extend([float(x) for x in line.split()[1:4]])
-      ort_matrix = flex.mat3_double([ormx_list])
-
-    # Read frame # offsets from file_root.offsets. Each entry is added to the 
-    # frame number in the hkl file (all frames numbered consecutively) to give 
-    # the frame number in the .raw file (frames numbered from start of run).
-    with open(offsets_filename) as offsetsfile:
-      offsets = flex.int([int(x) for x in offsetsfile.readline().split()])
-
-    # We keep the metrical matrix as a tuple, it will be implicitly converted
-    metrical_matrix = unit_cell.metrical_matrix()
-
-
-    return (raw_lines, ort_matrix, offsets, metrical_matrix)
 
 
 

--- a/iotbx/shelx/shelx_ext.cpp
+++ b/iotbx/shelx/shelx_ext.cpp
@@ -22,7 +22,7 @@ namespace iotbx { namespace shelx { namespace boost_python {
             af::const_ref<std::string> const&,
             scitbx::mat3<double> const&,
             af::const_ref<int> const&,
-            scitbx::sym_mat3<double> const& >()) 
+            scitbx::sym_mat3<double> const& >())
         .def("indices", &wt::indices)
         .def("data", &wt::data)
         .def("sigmas", &wt::sigmas)

--- a/iotbx/shelx/shelx_ext.cpp
+++ b/iotbx/shelx/shelx_ext.cpp
@@ -29,8 +29,10 @@ namespace iotbx { namespace shelx { namespace boost_python {
         .def("alphas", &wt::alphas)
         .def("batch_numbers", &wt::batch_numbers)
         .def("wavelengths", &wt::wavelengths)
-        .def("e_incidents", &wt::e_incidents)
-        .def("e_scattereds", &wt::e_scattereds)
+        .def("u_incs", &wt::u_incs)
+        .def("u_scats", &wt::u_scats)
+        .def("v_scats", &wt::v_scats)
+        .def("pol_factors", &wt::pol_factors)
       ;
     }
   };

--- a/iotbx/shelx/shelx_ext.cpp
+++ b/iotbx/shelx/shelx_ext.cpp
@@ -17,6 +17,12 @@ namespace iotbx { namespace shelx { namespace boost_python {
       using namespace boost::python;
       class_<wt>("hklf_reader", no_init)
         .def(init<af::const_ref<std::string> const&>((arg("lines"))))
+        .def(init<
+            af::const_ref<std::string> const&,
+            af::const_ref<std::string> const&,
+            scitbx::mat3<double> const&,
+            af::const_ref<int> const&,
+            scitbx::sym_mat3<double> const& >()) 
         .def("indices", &wt::indices)
         .def("data", &wt::data)
         .def("sigmas", &wt::sigmas)

--- a/iotbx/shelx/shelx_ext.cpp
+++ b/iotbx/shelx/shelx_ext.cpp
@@ -29,6 +29,8 @@ namespace iotbx { namespace shelx { namespace boost_python {
         .def("alphas", &wt::alphas)
         .def("batch_numbers", &wt::batch_numbers)
         .def("wavelengths", &wt::wavelengths)
+        .def("e_incidents", &wt::e_incidents)
+        .def("e_scattereds", &wt::e_scattereds)
       ;
     }
   };

--- a/iotbx/shelx/tst_hklf.cpp
+++ b/iotbx/shelx/tst_hklf.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <iotbx/shelx/hklf.h>
+#include <scitbx/sym_mat3.h>
+#include <scitbx/mat3.h>
+#include <scitbx/vec3.h>
+#include <scitbx/math/approx_equal.h>
+#include <iotbx/error.h>
+
+class test_case1 {
+  public:
+    typedef scitbx::vec3<double> vec3_t;
+    typedef scitbx::mat3<double> mat3_t;
+    typedef scitbx::sym_mat3<double> sym_mat3_t;
+
+    void run() {
+      std::cout<<"########################################"<<std::endl;
+      vec3_t a(1,2,3);
+      vec3_t b(4,5,6);
+      sym_mat3_t g(1,1,1,0,0,0);
+      vec3_t v(-3,6,-3);
+
+      vec3_t out = iotbx::shelx::hklf_reader::make_perpendicular(a, b, g);
+      v = v.normalize();
+      for (int i=0; i<3; i++) {
+        IOTBX_ASSERT(scitbx::math::approx_equal_absolutely<double>(1e-12)(v[i], out[i]));
+      }
+      IOTBX_ASSERT(scitbx::math::approx_equal_absolutely<double>(1e-12)(out.length(), 1));
+
+
+      g = sym_mat3_t(10,11,12,1,2,3);
+      out = iotbx::shelx::hklf_reader::make_perpendicular(a, b, g);
+      IOTBX_ASSERT(scitbx::math::approx_equal_absolutely<double>(1e-12)(0, a*g*out));
+      IOTBX_ASSERT(scitbx::math::approx_equal_absolutely<double>(1e-12)(0, b*g*out));
+
+    }
+};
+
+
+
+int main()
+{
+  using namespace iotbx::shelx;
+
+
+  test_case1 t;
+  t.run();
+
+  return 0;
+}

--- a/smtbx/command_line/aniso_refine.py
+++ b/smtbx/command_line/aniso_refine.py
@@ -1,0 +1,205 @@
+from __future__ import absolute_import, division, print_function
+# LIBTBX_SET_DISPATCHER_NAME smtbx.aniso_refine
+
+import os, sys, argparse
+from scitbx import lstbx
+import scitbx.lstbx.normal_eqns_solving
+from smtbx import refinement
+from timeit import default_timer as current_time
+
+
+allowed_input_file_extensions = ('.ins', '.res', '.cif')
+
+class command_line_error(RuntimeError): pass
+
+class number_of_arguments_error(command_line_error): pass
+
+class energy_missing_error(RuntimeError): pass
+
+def make_parser():
+  parser = argparse.ArgumentParser(
+      description='''Refinement of inelastic scattering factors. Contact: Daniel
+Paley (dwp2111@columbia.edu)''')
+  parser.add_argument(
+      'ref_structure',
+      type=str,
+      help='''A structure in .cif or .ins format determined far from any
+absorption edge. Coordinates, displacements, and occupancies will be fixed
+at their values in this file.'''
+      )
+  parser.add_argument(
+      'reflections',
+      type=str,
+      help='''A .hkl file containing intensities (ShelX HKLF 4 format).'''
+      )
+  parser.add_argument(
+      'anom_atom',
+      type=str,
+      help='''The atom type for which f' and f" will be refined. All atoms of
+this type will be refined independently.'''
+      )
+  group = parser.add_mutually_exclusive_group()
+  group.add_argument(
+    '-e', '--energy',
+    type=float,
+    default=None,
+    help='''Beam energy in eV.'''
+    )
+  group.add_argument(
+    '-E', '--energy-in-fname',
+    type=str,
+    default=None,
+    help='''First digit and length of energy if given in hkl filename. Format
+start,length.'''
+    )
+  parser.add_argument(
+    '-t', '--table',
+    action='store_true',
+    help='Output in condensed format suitable for further processing')
+  parser.add_argument(
+    '-c', '--max-cycles',
+    type=int,
+    default=100,
+    help='Stop refinement as soon as the given number of cycles have been '
+         'performed')
+  parser.add_argument(
+    '-o', '--outfile',
+    type=str,
+    default=None,
+    help='Write output to filename OUTFILE (default: print to stdout)')
+  parser.add_argument(
+    '-O', '--overwrite',
+    action='store_true',
+    help='No error if OUTFILE exists')
+  parser.add_argument(
+    '-d', '--stop-deriv',
+    type=float,
+    default=1e-7,
+    help='Stop refinement as soon as the largest absolute value of objective '
+         'derivatives is below the given threshold.')
+  parser.add_argument(
+    '-s', '--stop-shift',
+    type=float,
+    default=1e-7,
+    help='Stop refinement as soon as the Euclidean norm of the vector '
+         'of parameter shifts is below the given threshold.')
+  return parser
+
+def run(args):
+
+  # adjust file names
+  in_root, in_ext = os.path.splitext(args.ref_structure)
+
+  # Check that input files exist
+  for filename in (args.ref_structure, args.reflections):
+    if not os.path.isfile(filename):
+      raise command_line_error("No such file %s" % filename)
+
+  # Check output file
+  if args.outfile and os.path.isfile(args.outfile) and not args.overwrite:
+    raise command_line_error("Output file {} exists.".format(args.outfile))
+
+  # Load input model and reflections
+  if in_ext == '.cif':
+    xm = refinement.model.from_cif(model=args.ref_structure)
+    xm.add_reflections_with_polarization(args.reflections)
+  else:
+    raise NotImplementedError("Only .cif input supported")
+
+  # Look for beam energy
+  if args.energy:
+    energy = args.energy
+    wvl = 12398 / energy
+  elif args.energy_in_fname:
+    estart,elength = args.energy_in_fname.split(',')
+    estart = int(estart)
+    elength = int(elength)
+    energy = float(args.reflections[estart:estart+elength])
+    wvl = 12398 / energy
+  else:
+    energy = None
+    sys.stderr.write('''WARNING: Using beam energy from reference model. \
+Inelastic form factors for \n non-refined atoms may be inaccurate.\n''')
+    wvl = xm.wavelength
+
+
+
+
+  # Load default anomalous scattering factors if wavelength is available
+  if wvl:
+    xm.xray_structure.set_inelastic_form_factors(wvl, 'sasaki')
+  else:
+    raise energy_missing_error()
+
+  # At last...
+  anom_sc_list=[]
+  for sc in xm.xray_structure.scatterers():
+    sc.flags.set_grad_site(False)
+    sc.flags.set_grad_u_iso(False)
+    sc.flags.set_grad_u_aniso(False)
+    sc.flags.set_grad_occupancy(False)
+    if sc.element_symbol().lower() == args.anom_atom.lower():
+      sc.convert_to_fp_aniso(xm.xray_structure.unit_cell())
+      sc.convert_to_fdp_aniso(xm.xray_structure.unit_cell())
+      sc.flags.set_use_fp_fdp_aniso(True)
+      sc.flags.set_grad_fp_aniso(True)
+      sc.flags.set_grad_fdp_aniso(True)
+      anom_sc_list.append(sc)
+
+  ls = xm.least_squares()
+  import IPython
+  IPython.embed()
+  steps = lstbx.normal_eqns_solving.levenberg_marquardt_iterations(
+    non_linear_ls=ls,
+    n_max_iterations=args.max_cycles,
+    gradient_threshold=args.stop_deriv,
+    step_threshold=args.stop_shift)
+
+  # Prepare output
+  result = ''
+
+  if args.table:
+    if energy: result += "{:.1f} ".format(energy)
+    else: result += "{} ".format(args.reflections)
+    for sc in anom_sc_list:
+      result += "{:.3f} ".format(sc.fp)
+    for sc in anom_sc_list:
+      result += "{:.3f} ".format(sc.fdp)
+    result += '\n'
+
+  else:
+    result += "\n### REFINE ANOMALOUS SCATTERING FACTORS ###\n"
+    result += "Reflections: {}\n\n".format(args.reflections)
+    for sc in anom_sc_list:
+      result += "{}:\n\tfp: {:.3f}\n\tfdp: {:.3f}\n".format(sc.label, sc.fp, sc.fdp)
+
+  # Write to file or stdout
+  if args.outfile:
+    with open(args.outfile, 'w') as f:
+      f.write(result)
+  else:
+    print(result)
+
+
+
+if __name__ == '__main__':
+  from timeit import default_timer as current_time
+  t0 = current_time()
+  parser = make_parser()
+  args = parser.parse_args()
+  try:
+    run(args)
+  except number_of_arguments_error:
+    parser.print_usage()
+    sys.exit(1)
+  except command_line_error as err:
+    print("\nERROR: %s\n" % err, file=sys.stderr)
+    parser.print_help()
+    sys.exit(1)
+  except energy_missing_error as err:
+    print('Must provide beam energy on the command line or in the reference '
+        'structure.')
+    sys.exit(1)
+  t1 = current_time()
+  if not args.table:
+    print("Total time: %.3f s" % (t1 - t0))

--- a/smtbx/command_line/aniso_refine.py
+++ b/smtbx/command_line/aniso_refine.py
@@ -147,16 +147,32 @@ Inelastic form factors for \n non-refined atoms may be inaccurate.\n''')
       anom_sc_list.append(sc)
 
   ls = xm.least_squares()
-  import IPython
-  IPython.embed()
   steps = lstbx.normal_eqns_solving.levenberg_marquardt_iterations(
     non_linear_ls=ls,
     n_max_iterations=args.max_cycles,
     gradient_threshold=args.stop_deriv,
     step_threshold=args.stop_shift)
+  print(ls.r1_factor())
 
+  import ipdb
+  ipdb.set_trace()
   # Prepare output
   result = ''
+
+  from cctbx import adptbx
+  uc = xm.xray_structure.unit_cell()
+  for sc in anom_sc_list:
+    fp_cif = adptbx.u_star_as_u_cif(uc, sc.fp_star)
+    fp_s = [x * -.01 for x in fp_cif]
+    print("{} 3 {:.5f} {:.5f} {:.5f} 11 {:.5f} {:.5f} {:.5f} =\n {:.5f} {:.5f} {:.5f} ".format(
+      sc.label, sc.site[0], sc.site[1], sc.site[2], fp_s[0], fp_s[1], fp_s[2], fp_s[5], fp_s[4], fp_s[3]))
+
+  for sc in anom_sc_list:
+    fdp_cif = adptbx.u_star_as_u_cif(uc, sc.fdp_star)
+    fdp_s = [x * .02 for x in fdp_cif]
+    print("{} 3 {:.5f} {:.5f} {:.5f} 11 {:.5f} {:.5f} {:.5f} =\n {:.5f} {:.5f} {:.5f} ".format(
+      sc.label, sc.site[0], sc.site[1], sc.site[2], fdp_s[0], fdp_s[1], fdp_s[2], fdp_s[5], fdp_s[4], fdp_s[3]))
+
 
   if args.table:
     if energy: result += "{:.1f} ".format(energy)

--- a/smtbx/refinement/__init__.py
+++ b/smtbx/refinement/__init__.py
@@ -45,7 +45,7 @@ class model(object):
     mas = reflections.as_miller_arrays(crystal_symmetry=cs)
     for ma in mas:
       if ma.is_xray_intensity_array() and ma.sigmas() is not None:
-        fo_sq = ma.as_xray_observations()
+        fo_sq = ma.as_xray_observations(with_polarization=True)
         break
     assert fo_sq is not None
     self.fo_sq = fo_sq

--- a/smtbx/refinement/__init__.py
+++ b/smtbx/refinement/__init__.py
@@ -11,7 +11,7 @@ class model(object):
     return _(cls, *args, **kwds)
 
   @classmethod
-  def from_cif(cls, model, reflections):
+  def from_cif(cls, model, reflections=None):
     """
     We could try to read in the weighting scheme.
     As for constraints and restraints, the CIF format does not support them

--- a/smtbx/refinement/constraints/__init__.py
+++ b/smtbx/refinement/constraints/__init__.py
@@ -307,7 +307,10 @@ class reparametrisation(ext.reparametrisation):
     fp = self.asu_scatterer_parameters[i_sc].fp
     if fp is None:
       sc = self.structure.scatterers()[i_sc]
-      fp = self.add(independent_fp_parameter, sc)
+      if sc.flags.use_fp_fdp_aniso():
+        fp = self.add(independent_fp_star_parameter, sc)
+      else:
+        fp = self.add(independent_fp_parameter, sc)
       self.asu_scatterer_parameters[i_sc].fp = fp
     return fp
 
@@ -317,7 +320,10 @@ class reparametrisation(ext.reparametrisation):
     fdp = self.asu_scatterer_parameters[i_sc].fdp
     if fdp is None:
       sc = self.structure.scatterers()[i_sc]
-      fdp = self.add(independent_fdp_parameter, sc)
+      if sc.flags.use_fp_fdp_aniso():
+        fdp = self.add(independent_fdp_star_parameter, sc)
+      else:
+        fdp = self.add(independent_fdp_parameter, sc)
       self.asu_scatterer_parameters[i_sc].fdp = fdp
     return fdp
 

--- a/smtbx/refinement/constraints/boost_python/reparametrisation.cpp
+++ b/smtbx/refinement/constraints/boost_python/reparametrisation.cpp
@@ -411,6 +411,97 @@ namespace boost_python {
     }
   };
 
+  struct fp_star_parameter_wrapper
+  {
+    typedef fp_star_parameter wt;
+
+    static void wrap() {
+      using namespace boost::python;
+      return_value_policy<return_by_value> rbv;
+      class_<wt,
+             bases<parameter>,
+             boost::noncopyable>("fp_star_parameter", no_init)
+        .add_property("value",
+                      make_getter(&wt::value, rbv),
+                      make_setter(&wt::value, rbv));
+        ;
+    }
+  };
+
+  struct asu_fp_star_parameter_wrapper
+  {
+    typedef asu_fp_star_parameter wt;
+
+    static void wrap() {
+      using namespace boost::python;
+      class_<wt,
+             bases<fp_star_parameter, single_asu_scatterer_parameter>,
+             boost::noncopyable>("asu_fp_star_parameter", no_init)
+        ;
+    }
+  };
+
+  struct independent_fp_star_parameter_wrapper
+  {
+    typedef independent_fp_star_parameter wt;
+
+    static void wrap() {
+      using namespace boost::python;
+      class_<wt,
+             bases<asu_fp_star_parameter>,
+             std::auto_ptr<wt> >("independent_fp_star_parameter", no_init)
+        .def(init<asu_parameter::scatterer_type *>(arg("scatterer")))
+        ;
+      implicitly_convertible<std::auto_ptr<wt>, std::auto_ptr<parameter> >();
+    }
+  };
+
+  struct fdp_star_parameter_wrapper
+  {
+    typedef fdp_star_parameter wt;
+
+    static void wrap() {
+      using namespace boost::python;
+      return_value_policy<return_by_value> rbv;
+      class_<wt,
+             bases<parameter>,
+             boost::noncopyable>("fdp_star_parameter", no_init)
+        .add_property("value",
+                      make_getter(&wt::value, rbv),
+                      make_setter(&wt::value, rbv));
+        ;
+    }
+  };
+
+  struct asu_fdp_star_parameter_wrapper
+  {
+    typedef asu_fdp_star_parameter wt;
+
+    static void wrap() {
+      using namespace boost::python;
+      class_<wt,
+             bases<fdp_star_parameter, single_asu_scatterer_parameter>,
+             boost::noncopyable>("asu_fdp_star_parameter", no_init)
+        ;
+    }
+  };
+
+  struct independent_fdp_star_parameter_wrapper
+  {
+    typedef independent_fdp_star_parameter wt;
+
+    static void wrap() {
+      using namespace boost::python;
+      class_<wt,
+             bases<asu_fdp_star_parameter>,
+             std::auto_ptr<wt> >("independent_fdp_star_parameter", no_init)
+        .def(init<asu_parameter::scatterer_type *>(arg("scatterer")))
+        ;
+      implicitly_convertible<std::auto_ptr<wt>, std::auto_ptr<parameter> >();
+    }
+  };
+
+
   struct index_range_to_tuple
   {
     static PyObject *convert(index_range const &ir) {
@@ -549,6 +640,14 @@ namespace boost_python {
 
     asu_fdp_parameter_wrapper::wrap();
     independent_fdp_parameter_wrapper::wrap();
+
+    fp_star_parameter_wrapper::wrap();
+    asu_fp_star_parameter_wrapper::wrap();
+    independent_fp_star_parameter_wrapper::wrap();
+
+    fdp_star_parameter_wrapper::wrap();
+    asu_fdp_star_parameter_wrapper::wrap();
+    independent_fdp_star_parameter_wrapper::wrap();
 
     reparametrisation_wrapper::wrap();
 

--- a/smtbx/refinement/constraints/reparametrisation.cpp
+++ b/smtbx/refinement/constraints/reparametrisation.cpp
@@ -236,6 +236,95 @@ namespace smtbx { namespace refinement { namespace constraints {
     if (value < 0) value *= -1;
   }
 
+  // fp_star
+
+  af::ref<double> fp_star_parameter::components() { return value.ref(); }
+
+  // asu fp_star
+
+  void asu_fp_star_parameter::set_variable(bool f) {
+    if (f) scatterer->flags.set_use_fp_fdp_aniso(true);
+    scatterer->flags.set_grad_fp_aniso(f);
+  }
+
+  bool asu_fp_star_parameter::is_variable() const {
+    return scatterer->flags.use_fp_fdp_aniso() &&
+           scatterer->flags.grad_fp_aniso();
+  }
+
+
+  // asu_fp_star_parameter
+
+  void asu_fp_star_parameter
+    ::write_component_annotations_for(scatterer_type const *scatterer,
+        std::ostream &output) const
+  {
+    if (scatterer == this->scatterer) {
+      output << scatterer->label << ".fp11,"
+             << scatterer->label << ".fp22,"
+             << scatterer->label << ".fp33,"
+             << scatterer->label << ".fp12,"
+             << scatterer->label << ".fp13,"
+             << scatterer->label << ".fp23,";
+    }
+  }
+
+  void asu_fp_star_parameter::store(uctbx::unit_cell const &unit_cell) const {
+    scatterer->fp_star = value;
+  }
+
+  // independent fp_star
+
+  void independent_fp_star_parameter
+  ::linearise(uctbx::unit_cell const &unit_cell,
+              sparse_matrix_type *jacobian_transpose)
+  {}
+
+
+  // fdp_star
+
+  af::ref<double> fdp_star_parameter::components() { return value.ref(); }
+
+  // asu fdp_star
+
+  void asu_fdp_star_parameter::set_variable(bool f) {
+    if (f) scatterer->flags.set_use_fp_fdp_aniso(true);
+    scatterer->flags.set_grad_fdp_aniso(f);
+  }
+
+  bool asu_fdp_star_parameter::is_variable() const {
+    return scatterer->flags.use_fp_fdp_aniso() &&
+           scatterer->flags.grad_fdp_aniso();
+  }
+
+
+  // asu_fdp_star_parameter
+  //
+  void asu_fdp_star_parameter
+    ::write_component_annotations_for(scatterer_type const *scatterer,
+        std::ostream &output) const
+  {
+    if (scatterer == this->scatterer) {
+      output << scatterer->label << ".fdp11,"
+             << scatterer->label << ".fdp22,"
+             << scatterer->label << ".fdp33,"
+             << scatterer->label << ".fdp12,"
+             << scatterer->label << ".fdp13,"
+             << scatterer->label << ".fdp23,";
+    }
+  }
+
+  void asu_fdp_star_parameter::store(uctbx::unit_cell const &unit_cell) const {
+    scatterer->fdp_star = value;
+  }
+
+  // independent fdp_star
+
+  void independent_fdp_star_parameter
+  ::linearise(uctbx::unit_cell const &unit_cell,
+              sparse_matrix_type *jacobian_transpose)
+  {}
+
 
   // reparametrisation
 

--- a/smtbx/refinement/constraints/reparametrisation.h
+++ b/smtbx/refinement/constraints/reparametrisation.h
@@ -492,7 +492,6 @@ public:
                          sparse_matrix_type *jacobian_transpose);
 };
 
-
 /// Anisotropic displacement parameters of a site
 /** A parameter whose components are the coefficients of the tensor
     in fractional coordinates.
@@ -712,6 +711,104 @@ public:
   virtual void linearise(uctbx::unit_cell const &unit_cell,
     sparse_matrix_type *jacobian_transpose)
   {}
+};
+
+/// Anisotropic fp parameter of a site
+/** A tensor written so that it measures fp as e1(T) * fp_star * e2 when
+ * e1 and e2 are polarisation vectors with length 1 A-1.
+ * */
+class fp_star_parameter : public virtual parameter
+{
+public:
+  virtual af::ref<double> components();
+
+  tensor_rank_2_t value;
+};
+
+/// Anisotropic fp parameters of a site in the asu
+class asu_fp_star_parameter : public fp_star_parameter,
+                              public virtual single_asu_scatterer_parameter
+{
+public:
+  /// Variability property, directly linked to the scatterer grad_site flag
+  //@{
+  virtual void set_variable(bool f);
+
+  virtual bool is_variable() const;
+  //@}
+
+  virtual void
+  write_component_annotations_for(scatterer_type const *scatterer,
+                                  std::ostream &output) const;
+
+  virtual void store(uctbx::unit_cell const &unit_cell) const;
+
+};
+
+class independent_fp_star_parameter : public asu_fp_star_parameter
+{
+public:
+  independent_fp_star_parameter(scatterer_type *scatterer)
+  : parameter(0),
+    single_asu_scatterer_parameter(scatterer)
+  {
+    value = scatterer->fp_star;
+  }
+
+  /// Does nothing in this class
+  /** This optimisation relies on class reparametrisation implementation
+   */
+  virtual void linearise(uctbx::unit_cell const &unit_cell,
+                         sparse_matrix_type *jacobian_transpose);
+};
+
+/// Anisotropic fdp parameter of a site
+/** A tensor written so that it measures fdp as e1(T) * fdp_star * e2 when
+ * e1 and e2 are polarisation vectors with length 1 A-1.
+ * */
+class fdp_star_parameter : public virtual parameter
+{
+public:
+  virtual af::ref<double> components();
+
+  tensor_rank_2_t value;
+};
+
+/// Anisotropic fdp parameters of a site in the asu
+class asu_fdp_star_parameter : public fdp_star_parameter,
+                              public virtual single_asu_scatterer_parameter
+{
+public:
+  /// Variability property, directly linked to the scatterer grad_site flag
+  //@{
+  virtual void set_variable(bool f);
+
+  virtual bool is_variable() const;
+  //@}
+
+  virtual void
+  write_component_annotations_for(scatterer_type const *scatterer,
+                                  std::ostream &output) const;
+
+  virtual void store(uctbx::unit_cell const &unit_cell) const;
+
+};
+
+class independent_fdp_star_parameter : public asu_fdp_star_parameter
+{
+public:
+  independent_fdp_star_parameter(scatterer_type *scatterer)
+  : parameter(0),
+    single_asu_scatterer_parameter(scatterer)
+  {
+    value = scatterer->fdp_star;
+  }
+
+  /// Does nothing in this class
+  /** This optimisation relies on class reparametrisation implementation
+   */
+  virtual void linearise(uctbx::unit_cell const &unit_cell,
+                         sparse_matrix_type *jacobian_transpose);
 };
 
 class computing_graph_has_cycle_error : public error

--- a/smtbx/refinement/constraints/scatterer_parameters.h
+++ b/smtbx/refinement/constraints/scatterer_parameters.h
@@ -53,6 +53,9 @@ struct scatterer_parameters
 
   scatterer_type const *scatterer;
   asu_parameter *site, *occupancy, *u, *fp, *fdp;
+  // Be careful: In scatterer_parameters, fp and fdp can refer to EITHER
+  // scatterer.fp or scatterer.fp_star (analogous to u, which can refer
+  // to scatterer.u_iso or scatterer.u_star)
 
   scatterer_parameters() {}
 

--- a/smtbx/refinement/least_squares.h
+++ b/smtbx/refinement/least_squares.h
@@ -205,6 +205,15 @@ namespace smtbx { namespace refinement { namespace least_squares {
           if (f_mask.size()) {
             f_calc_function.compute(h, f_mask[i_h], compute_grad);
           }
+          else if (reflections.u_incs().size()) {
+            f_calc_function.compute(h,
+                                    reflections.u_inc(i_h),
+                                    reflections.u_scat(i_h),
+                                    reflections.v_scat(i_h),
+                                    reflections.pol_factor(i_h),
+                                    boost::none,
+                                    compute_grad);
+          }
           else {
             f_calc_function.compute(h, boost::none, compute_grad);
           }

--- a/smtbx/refinement/least_squares.h
+++ b/smtbx/refinement/least_squares.h
@@ -205,7 +205,7 @@ namespace smtbx { namespace refinement { namespace least_squares {
           if (f_mask.size()) {
             f_calc_function.compute(h, f_mask[i_h], compute_grad);
           }
-          else if (reflections.u_incs().size()) {
+          else if (reflections.has_polarisation()) {
             f_calc_function.compute(h,
                                     reflections.u_inc(i_h),
                                     reflections.u_scat(i_h),

--- a/smtbx/structure_factors/direct/standard_xray.h
+++ b/smtbx/structure_factors/direct/standard_xray.h
@@ -13,6 +13,22 @@
 #include <boost/shared_ptr.hpp>
 #include <iostream>
 
+#define SMTBX_STRUCTURE_FACTORS_DIRECT_TYPEDEFS                            \
+  typedef FloatType float_type;                                            \
+  typedef std::complex<float_type> complex_type;                           \
+  typedef scitbx::sym_mat3<complex_type> grad_u_star_type;                 \
+  typedef af::tiny<complex_type, 3> grad_site_type;                        \
+  typedef xray::scatterer<float_type> scatterer_type;
+
+#define SMTBX_STRUCTURE_FACTORS_DIRECT_ONE_SCATTERER_ONE_H_USING           \
+  using core<float_type>::structure_factor;                                \
+  using core<float_type>::grad_site;                                       \
+  using core<float_type>::grad_u_star;                                     \
+  using core<float_type>::grad_u_iso;                                      \
+  using core<float_type>::grad_occ;                                        \
+  using base_t::hr_ht;                                                     \
+  using base_t::d_star_sq;
+
 namespace smtbx { namespace structure_factors { namespace direct {
 
   using cctbx::xray::structure_factors::hr_ht_group;
@@ -20,13 +36,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
 
 
   namespace one_scatterer_one_h {
-
-    #define SMTBX_STRUCTURE_FACTORS_DIRECT_TYPEDEFS                            \
-      typedef FloatType float_type;                                            \
-      typedef std::complex<float_type> complex_type;                           \
-      typedef scitbx::sym_mat3<complex_type> grad_u_star_type;                 \
-      typedef af::tiny<complex_type, 3> grad_site_type;                        \
-      typedef xray::scatterer<float_type> scatterer_type;
 
     /** Bare bundle of the structure factor of one scatterer
         for a given Miller index and its gradient wrt to the crystallagraphic
@@ -107,15 +116,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
       }
     };
 
-
-    #define SMTBX_STRUCTURE_FACTORS_DIRECT_ONE_SCATTERER_ONE_H_USING           \
-      using core<float_type>::structure_factor;                                \
-      using core<float_type>::grad_site;                                       \
-      using core<float_type>::grad_u_star;                                     \
-      using core<float_type>::grad_u_iso;                                      \
-      using core<float_type>::grad_occ;                                        \
-      using base_t::hr_ht;                                                     \
-      using base_t::d_star_sq;
 
 
     /** Key steps of the evaluation or linearisation of the structure factor
@@ -216,6 +216,11 @@ namespace smtbx { namespace structure_factors { namespace direct {
             }
           }
         }
+
+        // This balances the extra (conditional) curly brace that follows
+        #if (0)
+        {
+        #endif
 
         #if (   defined(__linux__) && defined(__GNUC__) \
              && __GNUC__ == 4 && __GNUC_MINOR__ == 0 && __GNUC_PATCHLEVEL__ == 0)

--- a/smtbx/structure_factors/direct/standard_xray.h
+++ b/smtbx/structure_factors/direct/standard_xray.h
@@ -133,6 +133,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
       {
         Heir &heir = static_cast<Heir &> (*this);
 
+        m_f0 = f0;
         this->structure_factor = 0;
         if (compute_grad) {
           this->grad_site = grad_site_type(0, 0, 0);
@@ -145,7 +146,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
 
         if (scatterer.flags.use_fp_fdp_aniso()) {
           SMTBX_ASSERT(has_polarisation);
-          m_f0 = f0;
           heir.compute_anisotropic_part(scatterer, compute_grad);
           FloatType dummy_ff = 1; //form factor was already used in aniso part
           heir.multiply_by_isotropic_part(scatterer, dummy_ff, compute_grad);

--- a/smtbx/structure_factors/direct/standard_xray.h
+++ b/smtbx/structure_factors/direct/standard_xray.h
@@ -29,6 +29,8 @@
   using core<float_type>::grad_u_star;                                     \
   using core<float_type>::grad_u_iso;                                      \
   using core<float_type>::grad_occ;                                        \
+  using core<float_type>::grad_fp_star;                                    \
+  using core<float_type>::grad_fdp_star;                                   \
   using base_t::hr_ht;                                                     \
   using base_t::d_star_sq;
 
@@ -55,6 +57,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
       complex_type grad_fdp;
       grad_u_star_type grad_u_star;
       complex_type grad_u_iso, grad_occ;
+      grad_u_star_type grad_fp_star, grad_fdp_star;
     };
 
     /** Base class for the linearisation or the evaluation of the structure
@@ -134,6 +137,8 @@ namespace smtbx { namespace structure_factors { namespace direct {
           this->grad_u_star = grad_u_star_type(0, 0, 0, 0, 0, 0);
           this->grad_fp = 0;
           this->grad_fdp = 0;
+          this->grad_fp_star = grad_u_star_type(0, 0, 0, 0, 0, 0);
+          this->grad_fdp_star = grad_u_star_type(0, 0, 0, 0, 0, 0);
         }
 
         if (scatterer.flags.use_fp_fdp_aniso()) {
@@ -218,7 +223,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
       {
         using namespace adptbx;
         using namespace scitbx::constants;
-        scitbx::math::imaginary_unit_t i;
+        complex_type const i(0,1);
 
         // Compute S'
         for (int k=0; k < hr_ht.groups.size(); ++k) {
@@ -250,6 +255,40 @@ namespace smtbx { namespace structure_factors { namespace direct {
             float_type fdp =
               e1_g.hr * scatterer.fdp_aniso * e2_g.hr / base_t::pol_factor;
             complex_type formfactor(base_t::m_f0 + fp, fdp);
+            if(scatterer.flags.grad_fp_aniso()) {
+              grad_fp_star[0] += 
+                  e1_g.hr[0] * e2_g.hr[0] * f / base_t::pol_factor;
+              grad_fp_star[1] += 
+                  e1_g.hr[1] * e2_g.hr[1] * f / base_t::pol_factor;
+              grad_fp_star[2] += 
+                  e1_g.hr[2] * e2_g.hr[2] * f / base_t::pol_factor;
+              grad_fp_star[3] +=
+                  (e1_g.hr[0]*e2_g.hr[1] + e1_g.hr[1]*e2_g.hr[0])
+                  * f / base_t::pol_factor;
+              grad_fp_star[4] +=
+                  (e1_g.hr[0]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[0])
+                  * f / base_t::pol_factor;
+              grad_fp_star[5] +=
+                  (e1_g.hr[1]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[1])
+                  * f / base_t::pol_factor;
+            }
+            if(scatterer.flags.grad_fdp_aniso()) {
+              grad_fdp_star[0] +=
+                  i * e1_g.hr[0] * e2_g.hr[0] * f / base_t::pol_factor;
+              grad_fdp_star[1] +=
+                  i * e1_g.hr[1] * e2_g.hr[1] * f / base_t::pol_factor;
+              grad_fdp_star[2] +=
+                  i * e1_g.hr[2] * e2_g.hr[2] * f / base_t::pol_factor;
+              grad_fdp_star[3] +=
+                  i * (e1_g.hr[0]*e2_g.hr[1] + e1_g.hr[1]*e2_g.hr[0])
+                  * f / base_t::pol_factor;
+              grad_fdp_star[4] +=
+                  i * (e1_g.hr[0]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[0])
+                  * f / base_t::pol_factor;
+              grad_fdp_star[5] +=
+                  i * (e1_g.hr[1]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[1])
+                  * f / base_t::pol_factor;
+            }
             f *= formfactor;
           }
 

--- a/smtbx/structure_factors/direct/standard_xray.h
+++ b/smtbx/structure_factors/direct/standard_xray.h
@@ -447,17 +447,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
         : base_t(space_group, h, d_star_sq, exp_i_2pi_functor)
       {}
 
-      in_generic_space_group(sgtbx::space_group const &space_group,
-                             miller::index<> const &h,
-                             float_type d_star_sq,
-                             ExpI2PiFunctor const &exp_i_2pi_functor,
-                             pol_vec_type const &pol_inc,
-                             pol_vec_type const &pol_scat,
-                             float_type pol_factor)
-        : base_t(space_group, h, d_star_sq, exp_i_2pi_functor, pol_inc,
-            pol_scat, pol_factor)
-      {}
-
       /** Sum of Debye-Waller * Fourier basis function,
          over the Miller indices equivalent to h, and its gradients.
 
@@ -479,29 +468,10 @@ namespace smtbx { namespace structure_factors { namespace direct {
       {
         using namespace adptbx;
         using namespace scitbx::constants;
-        complex_type const i(0,1);
+        scitbx::math::imaginary_unit_t i;
 
         // Compute S'
         for (int k=0; k < hr_ht.groups.size(); ++k) {
-
-          /* If f' and/or f" are polarisation-anisotropic, then the form factor
-           * depends on hR and further we need it before calculating grad_site,
-           * etc. Thus we calculate it right away.
-           * */
-          complex_type formfactor;
-          hr_ht_group<float_type, pol_vec_type> e1_g;
-          hr_ht_group<float_type, pol_vec_type> e2_g;
-          if (scatterer.flags.use_fp_fdp_aniso()) {
-            e1_g = base_t::e1r_e1t.groups[k];
-            e2_g = base_t::e2r_e2t.groups[k];
-            float_type fp =
-              e1_g.hr * scatterer.fp_aniso * e2_g.hr / base_t::pol_factor;
-            float_type fdp =
-              e1_g.hr * scatterer.fdp_aniso * e2_g.hr / base_t::pol_factor;
-            formfactor =  complex_type(base_t::m_f0 + fp, fdp);
-          }
-
-
           hr_ht_group<float_type> const &g = hr_ht.groups[k];
           float_type hrx = g.hr * scatterer.site;
           complex_type f = this->exp_i_2pi(hrx + g.ht);
@@ -514,77 +484,23 @@ namespace smtbx { namespace structure_factors { namespace direct {
                   = debye_waller_factor_u_star_gradient_coefficients<
                       float_type>(g.hr);
                 complex_type grad_u_star_factor = -two_pi_sq * f;
-                if (scatterer.flags.use_fp_fdp_aniso()) {
-                  grad_u_star_factor *= formfactor;
-                }
                 for (int j=0; j<6; ++j) {
                   grad_u_star[j] += grad_u_star_factor * log_grad_u_star[j];
                 }
               }
             }
           }
-
+          structure_factor += f;
           if (compute_grad && scatterer.flags.grad_site()) {
             complex_type grad_site_factor = i * two_pi * f;
-            if (scatterer.flags.use_fp_fdp_aniso()) {
-              grad_site_factor *= formfactor;
-            }
             for (int j=0; j<3; ++j) {
               float_type h_j = g.hr[j];
               grad_site[j] += grad_site_factor * h_j;
             }
           }
-
-          if (scatterer.flags.use_fp_fdp_aniso()) {
-            if(compute_grad && scatterer.flags.grad_fp_aniso()) {
-              grad_fp_star[0] += 
-                  e1_g.hr[0] * e2_g.hr[0] * f / base_t::pol_factor;
-              grad_fp_star[1] += 
-                  e1_g.hr[1] * e2_g.hr[1] * f / base_t::pol_factor;
-              grad_fp_star[2] += 
-                  e1_g.hr[2] * e2_g.hr[2] * f / base_t::pol_factor;
-              grad_fp_star[3] +=
-                  (e1_g.hr[0]*e2_g.hr[1] + e1_g.hr[1]*e2_g.hr[0])
-                  * f / base_t::pol_factor;
-              grad_fp_star[4] +=
-                  (e1_g.hr[0]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[0])
-                  * f / base_t::pol_factor;
-              grad_fp_star[5] +=
-                  (e1_g.hr[1]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[1])
-                  * f / base_t::pol_factor;
-            }
-            if(compute_grad && scatterer.flags.grad_fdp_aniso()) {
-              grad_fdp_star[0] +=
-                  i * e1_g.hr[0] * e2_g.hr[0] * f / base_t::pol_factor;
-              grad_fdp_star[1] +=
-                  i * e1_g.hr[1] * e2_g.hr[1] * f / base_t::pol_factor;
-              grad_fdp_star[2] +=
-                  i * e1_g.hr[2] * e2_g.hr[2] * f / base_t::pol_factor;
-              grad_fdp_star[3] +=
-                  i * (e1_g.hr[0]*e2_g.hr[1] + e1_g.hr[1]*e2_g.hr[0])
-                  * f / base_t::pol_factor;
-              grad_fdp_star[4] +=
-                  i * (e1_g.hr[0]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[0])
-                  * f / base_t::pol_factor;
-              grad_fdp_star[5] +=
-                  i * (e1_g.hr[1]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[1])
-                  * f / base_t::pol_factor;
-            }
-            f *= formfactor;
-          }
-
-          structure_factor += f;
         }
 
         if (hr_ht.is_centric) {
-          /*
-           * This is a major problem! Might need to add the conjugate after each
-           * hr_ht_group is processed. The basic problem is that we're factoring
-           * in the form factor while looping over each operator, then lumping 
-           * everything together and forgetting the contribution of the form
-           * factor. Then you take the conj of the whole thing. Instead we need
-           * to apply form factor to pairs (f + conj(f)).
-           * */
           // Compute S = S' + conj(S') exp(i 2pi h.t_inv) and its gradients
           structure_factor += std::conj(structure_factor) * hr_ht.f_h_inv_t;
           if (compute_grad) {
@@ -597,24 +513,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
             {
               for (int j=0; j<6; ++j) {
                 grad_u_star[j] += std::conj(grad_u_star[j]) * hr_ht.f_h_inv_t;
-              }
-            }
-            if (scatterer.flags.use_fp_fdp_aniso()
-                && scatterer.flags.grad_fp_aniso())
-            {
-              for (int j=0; j<6; ++j)
-              {
-                grad_fp_star[j] +=
-                  std::conj(grad_fp_star[j]) * hr_ht.f_h_inv_t;
-              }
-            }
-            if (scatterer.flags.use_fp_fdp_aniso()
-                && scatterer.flags.grad_fdp_aniso())
-            {
-              for (int j=0; j<6; ++j)
-              {
-                grad_fdp_star[j] +=
-                  std::conj(grad_fdp_star[j]) * hr_ht.f_h_inv_t;
               }
             }
           }
@@ -706,12 +604,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
           if (scatterer.flags.grad_u_aniso()) {
             for (int j=0; j<6; ++j) grad_u_star[j] *= ff_iso;
           }
-          if (scatterer.flags.grad_fp_aniso()) {
-            for (int j=0; j<6; ++j) grad_fp_star[j] *= ff_iso;
-          }
-          if (scatterer.flags.grad_fdp_aniso()) {
-            for (int j=0; j<6; ++j) grad_fdp_star[j] *= ff_iso;
-          }
         }
       }
     };
@@ -747,17 +639,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
         : base_t(space_group, h, d_star_sq, exp_i_2pi_functor)
       {}
 
-      in_origin_centric_space_group(sgtbx::space_group const &space_group,
-                             miller::index<> const &h,
-                             float_type d_star_sq,
-                             ExpI2PiFunctor const &exp_i_2pi_functor,
-                             pol_vec_type const &pol_inc,
-                             pol_vec_type const &pol_scat,
-                             float_type pol_factor)
-        : base_t(space_group, h, d_star_sq, exp_i_2pi_functor, pol_inc,
-            pol_scat, pol_factor)
-      {}
-
       /** Sum of Debye-Waller * Fourier basis function,
        over the Miller indices equivalent to h, and its gradients.
 
@@ -776,112 +657,38 @@ namespace smtbx { namespace structure_factors { namespace direct {
       {
         using namespace adptbx;
         using namespace scitbx::constants;
-        complex_type const i(0,1);
 
         /* Compute the real part of S' and its gradients
          We only ever touch the real part of structure_factors and grad_xxx
          members. So this code should be as efficient as working with
          real numbers.
          */
-
-
-
         for (int k=0; k < hr_ht.groups.size(); ++k) {
-
-          /* If f' and/or f" are polarisation-anisotropic, then the form factor
-           * depends on hR and further we need it before calculating grad_site,
-           * etc. Thus we calculate it right away.
-           * */
-          complex_type formfactor;
-          hr_ht_group<float_type, pol_vec_type> e1_g;
-          hr_ht_group<float_type, pol_vec_type> e2_g;
-          if (scatterer.flags.use_fp_fdp_aniso()) {
-            e1_g = base_t::e1r_e1t.groups[k];
-            e2_g = base_t::e2r_e2t.groups[k];
-            float_type fp =
-              e1_g.hr * scatterer.fp_aniso * e2_g.hr / base_t::pol_factor;
-            float_type fdp =
-              e1_g.hr * scatterer.fdp_aniso * e2_g.hr / base_t::pol_factor;
-            formfactor =  complex_type(base_t::m_f0 + fp, fdp);
-          }
-
           hr_ht_group<float_type> const &g = hr_ht.groups[k];
           float_type hrx = g.hr * scatterer.site;
           complex_type f = this->exp_i_2pi(hrx + g.ht);
           if (scatterer.flags.use_u_aniso()) {
             float_type dw = debye_waller_factor_u_star(g.hr, scatterer.u_star);
             f *= dw;
-            if (compute_grad && scatterer.flags.grad_u_aniso()) {
-              scitbx::sym_mat3<float_type> log_grad_u_star
-                = debye_waller_factor_u_star_gradient_coefficients<
-                    float_type>(g.hr);
-              complex_type grad_u_star_factor = -two_pi_sq * f.real();
-              if (scatterer.flags.use_fp_fdp_aniso()) {
-                grad_u_star_factor *= formfactor;
-              }
-              for (int j=0; j<6; ++j) {
-                grad_u_star[j] += grad_u_star_factor * log_grad_u_star[j];
+            if (compute_grad) {
+              if (scatterer.flags.grad_u_aniso()) {
+                scitbx::sym_mat3<float_type> log_grad_u_star
+                  = debye_waller_factor_u_star_gradient_coefficients<
+                      float_type>(g.hr);
+                float_type grad_u_star_factor = -two_pi_sq * f.real();
+                for (int j=0; j<6; ++j) {
+                  grad_u_star[j] += grad_u_star_factor * log_grad_u_star[j];
+                }
               }
             }
           }
-
+          structure_factor += f.real();
           if (compute_grad && scatterer.flags.grad_site()) {
-            complex_type grad_site_factor = -two_pi * f.imag();
-            if (scatterer.flags.use_fp_fdp_aniso()) {
-              grad_site_factor *= formfactor;
-            }
+            float_type grad_site_factor = -two_pi * f.imag();
             for (int j=0; j<3; ++j) {
-              float_type h_j = g.hr[j];
-              grad_site[j] += grad_site_factor * h_j;
+              grad_site[j] += grad_site_factor * g.hr[j];
             }
           }
-
-          complex_type f_r(f.real(), 0.);
-
-
-
-          if (scatterer.flags.use_fp_fdp_aniso()) {
-
-            if(compute_grad && scatterer.flags.grad_fp_aniso()) {
-              grad_fp_star[0] += 
-                  e1_g.hr[0] * e2_g.hr[0] * f_r / base_t::pol_factor;
-              grad_fp_star[1] += 
-                  e1_g.hr[1] * e2_g.hr[1] * f_r / base_t::pol_factor;
-              grad_fp_star[2] += 
-                  e1_g.hr[2] * e2_g.hr[2] * f_r / base_t::pol_factor;
-              grad_fp_star[3] +=
-                  (e1_g.hr[0]*e2_g.hr[1] + e1_g.hr[1]*e2_g.hr[0])
-                  * f_r / base_t::pol_factor;
-              grad_fp_star[4] +=
-                  (e1_g.hr[0]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[0])
-                  * f_r / base_t::pol_factor;
-              grad_fp_star[5] +=
-                  (e1_g.hr[1]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[1])
-                  * f_r / base_t::pol_factor;
-            }
-            if(compute_grad && scatterer.flags.grad_fdp_aniso()) {
-              grad_fdp_star[0] +=
-                  i * e1_g.hr[0] * e2_g.hr[0] * f_r / base_t::pol_factor;
-              grad_fdp_star[1] +=
-                  i * e1_g.hr[1] * e2_g.hr[1] * f_r / base_t::pol_factor;
-              grad_fdp_star[2] +=
-                  i * e1_g.hr[2] * e2_g.hr[2] * f_r / base_t::pol_factor;
-              grad_fdp_star[3] +=
-                  i * (e1_g.hr[0]*e2_g.hr[1] + e1_g.hr[1]*e2_g.hr[0])
-                  * f_r / base_t::pol_factor;
-              grad_fdp_star[4] +=
-                  i * (e1_g.hr[0]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[0])
-                  * f_r / base_t::pol_factor;
-              grad_fdp_star[5] +=
-                  i * (e1_g.hr[1]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[1])
-                  * f_r / base_t::pol_factor;
-            }
-
-            f_r *= formfactor;
-          }
-
-
-          structure_factor += f_r;
         }
 
         /* We should now multiply S' and its gradients by 2
@@ -933,7 +740,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
         FormFactorType ff_iso = ff_iso_p * scatterer.occupancy;
 
         // Finish
-        structure_factor = ff_iso * structure_factor;
+        structure_factor = ff_iso * structure_factor.real();
 
         if (!compute_grad) return;
 
@@ -942,22 +749,12 @@ namespace smtbx { namespace structure_factors { namespace direct {
         }
         if (scatterer.flags.grad_site()) {
           for (int j=0; j<3; ++j) {
-            grad_site[j] = ff_iso * grad_site[j];
+            grad_site[j] = ff_iso * grad_site[j].real();
           }
         }
         if (scatterer.flags.grad_u_aniso()) {
           for (int j=0; j<6; ++j) {
-            grad_u_star[j] = ff_iso * grad_u_star[j];
-          }
-        }
-        if (scatterer.flags.grad_fp_aniso()) {
-          for (int j=0; j<6; ++j) {
-            grad_fp_star[j] *= ff_iso;
-          }
-        }
-        if (scatterer.flags.grad_fdp_aniso()) {
-          for (int j=0; j<6; ++j) {
-            grad_fdp_star[j] *= ff_iso;
+            grad_u_star[j] = ff_iso * grad_u_star[j].real();
           }
         }
       }

--- a/smtbx/structure_factors/direct/standard_xray.h
+++ b/smtbx/structure_factors/direct/standard_xray.h
@@ -199,13 +199,13 @@ namespace smtbx { namespace structure_factors { namespace direct {
         complex_type const i(0,1);
         float_type f0 = base_t::m_f0;
 
-        
+
         for (int k=0; k < hr_ht.groups.size(); ++k) {
 
           /* Partial structure factor and grads for this atom and symop. We
            * store the partial contributions because we may have to multiply
            * them by their conj (if centric SG) and /then/ multiply by the
-           * (possibly anisotropic) form factor before accumulating the 
+           * (possibly anisotropic) form factor before accumulating the
            * contribution into the sum.
            * */
           complex_type f_k;
@@ -299,11 +299,11 @@ namespace smtbx { namespace structure_factors { namespace direct {
 
             if (scatterer.flags_use_fp_fdp_aniso()
                 && scatterer.flags.grad_fp_aniso()) {
-              grad_fp_star[0] += 
+              grad_fp_star[0] +=
                   e1_g.hr[0] * e2_g.hr[0] * f_k / base_t::pol_factor;
-              grad_fp_star[1] += 
+              grad_fp_star[1] +=
                   e1_g.hr[1] * e2_g.hr[1] * f_k / base_t::pol_factor;
-              grad_fp_star[2] += 
+              grad_fp_star[2] +=
                   e1_g.hr[2] * e2_g.hr[2] * f_k / base_t::pol_factor;
               grad_fp_star[3] +=
                   (e1_g.hr[0]*e2_g.hr[1] + e1_g.hr[1]*e2_g.hr[0])
@@ -417,8 +417,8 @@ namespace smtbx { namespace structure_factors { namespace direct {
       }
     };
 
-                                         
-      
+
+
     /** Key steps of the evaluation or linearisation of the structure factor
         of one scatterer for a given Miller index in any space group.
      */

--- a/smtbx/structure_factors/direct/standard_xray.h
+++ b/smtbx/structure_factors/direct/standard_xray.h
@@ -198,6 +198,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
         using namespace scitbx::constants;
         complex_type const i(0,1);
         float_type f0 = base_t::m_f0;
+        grad_site = grad_site_type(0,0,0);
 
 
         for (int k=0; k < hr_ht.groups.size(); ++k) {
@@ -469,6 +470,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
         using namespace adptbx;
         using namespace scitbx::constants;
         scitbx::math::imaginary_unit_t i;
+        grad_site = grad_site_type(0,0,0);
 
         // Compute S'
         for (int k=0; k < hr_ht.groups.size(); ++k) {
@@ -657,6 +659,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
       {
         using namespace adptbx;
         using namespace scitbx::constants;
+        grad_site = grad_site_type(0,0,0);
 
         /* Compute the real part of S' and its gradients
          We only ever touch the real part of structure_factors and grad_xxx

--- a/smtbx/structure_factors/direct/standard_xray.h
+++ b/smtbx/structure_factors/direct/standard_xray.h
@@ -1068,6 +1068,18 @@ namespace smtbx { namespace structure_factors { namespace direct {
             *grad_f_calc_prime_cursor++ =
                 (ff_aniso ? l_prime.grad_fdp : 0);
           }
+          if (ff_aniso && sc.flags.grad_fp_aniso()) {
+            for (int j=0; j<6; ++j) {
+              *grad_f_calc_cursor++ = l.grad_fp_star[j];
+              *grad_f_calc_prime_cursor++ = l_prime.grad_fp_star[j];
+            }
+          }
+          if (ff_aniso && sc.flags.grad_fdp_aniso()) {
+            for (int j=0; j<6; ++j) {
+              *grad_f_calc_cursor++ = l.grad_fdp_star[j];
+              *grad_f_calc_prime_cursor++ = l_prime.grad_fdp_star[j];
+            }
+          }
         }
 
         observable_type::compute(origin_centric_case,

--- a/smtbx/structure_factors/direct/standard_xray.h
+++ b/smtbx/structure_factors/direct/standard_xray.h
@@ -198,7 +198,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
         using namespace scitbx::constants;
         complex_type const i(0,1);
         float_type f0 = base_t::m_f0;
-        grad_site = grad_site_type(0,0,0);
 
 
         for (int k=0; k < hr_ht.groups.size(); ++k) {
@@ -470,7 +469,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
         using namespace adptbx;
         using namespace scitbx::constants;
         scitbx::math::imaginary_unit_t i;
-        grad_site = grad_site_type(0,0,0);
 
         // Compute S'
         for (int k=0; k < hr_ht.groups.size(); ++k) {
@@ -659,7 +657,6 @@ namespace smtbx { namespace structure_factors { namespace direct {
       {
         using namespace adptbx;
         using namespace scitbx::constants;
-        grad_site = grad_site_type(0,0,0);
 
         /* Compute the real part of S' and its gradients
          We only ever touch the real part of structure_factors and grad_xxx

--- a/smtbx/structure_factors/direct/standard_xray.h
+++ b/smtbx/structure_factors/direct/standard_xray.h
@@ -20,7 +20,7 @@
   typedef scitbx::sym_mat3<complex_type> grad_u_star_type;                 \
   typedef af::tiny<complex_type, 3> grad_site_type;                        \
   typedef xray::scatterer<float_type> scatterer_type;                      \
-  typedef scitbx::vec3<float_type> pol_vec_type;
+  typedef miller::index<float_type> pol_vec_type;
 
 
 #define SMTBX_STRUCTURE_FACTORS_DIRECT_ONE_SCATTERER_ONE_H_USING           \
@@ -214,13 +214,13 @@ namespace smtbx { namespace structure_factors { namespace direct {
 
 
           float_type fp, fdp;
-          hr_ht_group<float_t, pol_vec_type> const &e1_g =
+          hr_ht_group<float_type, pol_vec_type> const &e1_g =
             base_t::e1r_e1t.groups[k];
-          hr_ht_group<float_t, pol_vec_type> const &e2_g =
+          hr_ht_group<float_type, pol_vec_type> const &e2_g =
             base_t::e2r_e2t.groups[k];
           if (scatterer.flags.use_fp_fdp_aniso()) {
-            fp = e1_g.hr * scatterer.fp_aniso * e2_g.hr / base_t::pol_factor;
-            fdp = e1_g.hr * scatterer.fdp_aniso * e2_g.hr / base_t::pol_factor;
+            fp = e1_g.hr * scatterer.fp_star * e2_g.hr / base_t::pol_factor;
+            fdp = e1_g.hr * scatterer.fdp_star * e2_g.hr / base_t::pol_factor;
           }
           else {
             fp = scatterer.fp;
@@ -297,7 +297,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
             }
 
 
-            if (scatterer.flags_use_fp_fdp_aniso()
+            if (scatterer.flags.use_fp_fdp_aniso()
                 && scatterer.flags.grad_fp_aniso()) {
               grad_fp_star[0] +=
                   e1_g.hr[0] * e2_g.hr[0] * f_k / base_t::pol_factor;
@@ -315,7 +315,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
                   (e1_g.hr[1]*e2_g.hr[2] + e1_g.hr[2]*e2_g.hr[1])
                   * f_k / base_t::pol_factor;
             }
-            if (scatterer.flags_use_fp_fdp_aniso()
+            if (scatterer.flags.use_fp_fdp_aniso()
                 && scatterer.flags.grad_fdp_aniso()) {
               grad_fdp_star[0] +=
                   i * e1_g.hr[0] * e2_g.hr[0] * f_k / base_t::pol_factor;
@@ -372,7 +372,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
 
         // isotropic D-W factor
         if (scatterer.flags.use_u_iso()) {
-          float_type dw_iso = debye_waller_factor_iso(d_star_sq/4,
+          float_type dw_iso = debye_waller_factor_u_iso(d_star_sq/4,
                                                       scatterer.u_iso);
           f_iso *= dw_iso;
         }
@@ -801,7 +801,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
       typedef ObservableType<float_type> observable_type;
       typedef ExpI2PiFunctor<float_type> exp_i_2pi_functor;
       typedef boost::shared_ptr<Heir> pointer_type;
-      typedef scitbx::vec3<float_type> pol_vec_type;
+      typedef miller::index<float_type> pol_vec_type;
 
     protected:
       cctbx::xray::scatterer_grad_flags_counts grad_flags_counts;
@@ -1264,7 +1264,7 @@ namespace smtbx { namespace structure_factors { namespace direct {
               if (f_calc.imag() && grad_f_calc[j].imag()) {
                 grad += f_calc.imag() * grad_f_calc[j].imag();
               }
-              if (f_calc_prime.imag() && grad_f_calc_prime.imag()) {
+              if (f_calc_prime.imag() && grad_f_calc_prime[j].imag()) {
                 grad += f_calc_prime.imag() * grad_f_calc_prime[j].imag();
               }
               grad *= 2;


### PR DESCRIPTION
This adds refinement of polarization anisotropy for f' and f" using smtbx tools. For now I'd like to ask for input on anything that should be significantly refactored. 

The biggest changes are the following:

- In iotbx/shelx/hklf.h, add a reader (actually an overloaded constructor for existing reader) that considers a .p4p and .raw file and constructs vectors for the polarization of incident and diffracted beams. 

- In cctbx/xray/observations.h, add data members to hold those polarization vectors

- In cctbx/xray/scatterer_flags.h, add flags use_fp_fdp_aniso, grad_fp_aniso, and grad_fdp_aniso. The bits in the existing data structure (a long unsigned int) were all used up, so these are implemented as bools.

- In cctbx/xray/scatterer.h, add fp_star and fdp_star. As suggested by the name these are meant to be analogous to u_star.

- Many changes in smtbx/structure_factors/direct/standard_xray.h. Where possible, the changes are separated out: a new heir to one_scatterer_one_h::base called in_any_sg_with_polarization, and overloads for one_h::base::compute and one_h::modulus_squared::compute. I believe the existing code doesn't ever touch these. A few new data members were added to one_h::base and one_scatterer_one_h::base

Existing tests pass, but there is essentially no test coverage yet for the new code. That is the biggest reason for the WIP but I will be checking the correctness, stability etc of the calculations and adding some usability features as well. The major changes that touch existing/common code are 99% or 100% finished.

@bkpoon @pcxod @olegsobolev @luc-j-bourhis I think some or all of you will want to look at this.

Thanks,
Dan Paley
