### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/xfel/cxi/cspad_ana/cspad_tbx.py
+++ b/xfel/cxi/cspad_ana/cspad_tbx.py
@@ -87,19 +87,19 @@ def address_split(address, env=None):
 
   # pyana
   m = re.match(
-    '^(?P<det>\S+)\-(?P<det_id>\d+)\|(?P<dev>\S+)\-(?P<dev_id>\d+)$', address)
+    r"^(?P<det>\S+)\-(?P<det_id>\d+)\|(?P<dev>\S+)\-(?P<dev_id>\d+)$", address)
   if m is not None:
     return (m.group('det'), m.group('det_id'), m.group('dev'), m.group('dev_id'))
 
   # psana
   m = re.match(
-    '^(?P<det>\S+)\.(?P<det_id>\d+)\:(?P<dev>\S+)\.(?P<dev_id>\d+)$', address)
+    r"^(?P<det>\S+)\.(?P<det_id>\d+)\:(?P<dev>\S+)\.(?P<dev_id>\d+)$", address)
   if m is not None:
     return (m.group('det'), m.group('det_id'), m.group('dev'), m.group('dev_id'))
 
   # psana DetInfo string
   m = re.match(
-    '^DetInfo\((?P<det>\S+)\.(?P<det_id>\d+)\:(?P<dev>\S+)\.(?P<dev_id>\d+)\)$', address)
+    r"^DetInfo\((?P<det>\S+)\.(?P<det_id>\d+)\:(?P<dev>\S+)\.(?P<dev_id>\d+)\)$", address)
   if m is not None:
     return (m.group('det'), m.group('det_id'), m.group('dev'), m.group('dev_id'))
 

--- a/xfel/cxi/cspad_ana/parse_calib.py
+++ b/xfel/cxi/cspad_ana/parse_calib.py
@@ -191,7 +191,7 @@ def fread_vector(stream):
   """
 
   return (numpy.array(
-      [float(d) for d in re.split("\s+", stream.readline()) if len(d) > 0]))
+      [float(d) for d in re.split(r"\s+", stream.readline()) if len(d) > 0]))
 
 
 def fread_matrix(stream):


### PR DESCRIPTION
Output from running dxtbx tests:
```
====================================== warnings summary ======================================
modules/cctbx_project/xfel/cxi/cspad_ana/cspad_tbx.py:90
  modules/cctbx_project/xfel/cxi/cspad_ana/cspad_tbx.py:90: DeprecationWarning: invalid escape sequence \S
    '^(?P<det>\S+)\-(?P<det_id>\d+)\|(?P<dev>\S+)\-(?P<dev_id>\d+)$', address)

modules/cctbx_project/xfel/cxi/cspad_ana/cspad_tbx.py:96
  modules/cctbx_project/xfel/cxi/cspad_ana/cspad_tbx.py:96: DeprecationWarning: invalid escape sequence \S
    '^(?P<det>\S+)\.(?P<det_id>\d+)\:(?P<dev>\S+)\.(?P<dev_id>\d+)$', address)

modules/cctbx_project/xfel/cxi/cspad_ana/cspad_tbx.py:102
  modules/cctbx_project/xfel/cxi/cspad_ana/cspad_tbx.py:102: DeprecationWarning: invalid escape sequence \(
    '^DetInfo\((?P<det>\S+)\.(?P<det_id>\d+)\:(?P<dev>\S+)\.(?P<dev_id>\d+)\)$', address)

modules/cctbx_project/xfel/cxi/cspad_ana/parse_calib.py:194
  modules/cctbx_project/xfel/cxi/cspad_ana/parse_calib.py:194: DeprecationWarning: invalid escape sequence \s
    [float(d) for d in re.split("\s+", stream.readline()) if len(d) > 0]))
```

The `DeprecationWarning` was added in Python 3.6+, see https://bugs.python.org/issue27364 for more background.

This commit makes the warnings disappear and the dxtbx tests still pass, however I did not run the xfel module tests.
