### PR TITLE
libtbx: remove -ffast-math flag for MacOS+conda

### DIFF
--- a/libtbx/SConscript
+++ b/libtbx/SConscript
@@ -791,8 +791,12 @@ int main() {
     else:
       env_etc.ccflags_base = ["-fPIC", "-fno-strict-aliasing"] + \
         gcc_common_warn_options() + \
-        ["-DNDEBUG", "-O3", "-ffast-math", "-funroll-loops"] + \
+        ["-DNDEBUG", "-O3", "-funroll-loops"] + \
         ["-DBOOST_ALL_NO_LIB"]
+      if env_etc.compiler != 'darwin_conda':
+        env_etc.ccflags_base.append("-ffast-math")
+        # -ffast-math changes scitbx/lbfgs/tst_lbfgs_fem.py behavior in Xcode 11.4
+        # minimization steps may be different than fortran standard
       env_etc.cxxflags_base = []
       env_etc.shlinkflags = ['-shared']
       env_etc.shlinkflags_bpl = env_etc.shlinkflags


### PR DESCRIPTION
I found a failing test in `scitbx/lbfgs/tst_lbfgs_fem.py` while trying out compiling dials with conda compilers (dials/dials#1235 [(comment)](https://github.com/dials/dials/pull/1235#issuecomment-614516788)) and then saw the fix in 7976f7c16d7b941a236311d8c8fad36d36f04e24 coming through.

This fix however applies when using the system-native compiler, so I've also removed the flag when running with `compiler=conda` on MacOS.

I don't know if this is the best approach, and suspect @bkpoon will probably have a more well-informed opinion here. I didn't want to tie the flag to an xcode version because the compiler will be independent of that (and on the Mac that I'm running on there seems to be no xcode installed at all? Or maybe I'm just holding it wrong)