### PR TITLE
ignore skip option if phenix is configured

### DIFF
--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -1297,7 +1297,7 @@ Wait for the command to finish, then try again.""" % vars())
                                   #'afitt.python',
                                  ]:
       return
-    if self.build_options.skip_phenix_dispatchers and 'phenix' in target_file.basename():
+    if "phenix" not in self.module_dict and self.build_options.skip_phenix_dispatchers and "phenix" in target_file.basename():
       return
     reg = self._dispatcher_registry.setdefault(target_file, source_file)
     if reg != source_file:


### PR DESCRIPTION
Suggested solution for #399:
When configured with `--skip-phenix-dispatchers` but `phenix` being configured then ignore the `--skip` setting, as in this case the user is clearly interested in having phenix dispatchers available.

Could go a step further and eliminate the `--skip-phenix-dispatchers` flag entirely and only rely on whether phenix is configured.