### PR TITLE
Fix check that a Miller array of intensities is not already merged

### DIFF
--- a/iotbx/merging_statistics.py
+++ b/iotbx/merging_statistics.py
@@ -541,11 +541,18 @@ class dataset_statistics(object):
     self.crystal_symmetry = crystal_symmetry
     i_obs = i_obs.customized_copy(
       crystal_symmetry=crystal_symmetry).set_info(info)
-    if (assert_is_not_unique_set_under_symmetry and
-        i_obs.as_anomalous_array().is_unique_set_under_symmetry()):
-      raise Sorry(("The data in %s are already merged.  Only unmerged (but "+
-        "scaled) data may be used in this program.")%
-        i_obs.info().label_string())
+    if (
+      assert_is_not_unique_set_under_symmetry and
+      (
+        (anomalous and i_obs.as_anomalous_array().is_unique_set_under_symmetry()) or
+        i_obs.as_non_anomalous_array().is_unique_set_under_symmetry()
+      )
+    ):
+      raise Sorry(
+        "The data in %s are already merged.  Only unmerged (but scaled) data "
+        "may be used in this program." %
+        i_obs.info().label_string()
+      )
     d_min_cutoff = d_min
     d_max_cutoff = d_max
     if (d_min is not None):


### PR DESCRIPTION
If we create an instance of `iotbx.merging_statistics.dataset_statistics` with `anomalous=False` and pass an intensity array `i_obs` that is not a unique set under symmetry, but whose corresponding anomalous array is unique under symmetry (that is to say, an array in which the only symmetry-equivalent reflections are Friedel mates), we should be happy to calculate the non-anomalous merging statistics.  At present however, we raise a `Sorry` because the anomalous array is unique under symmetry, which is erroneous behaviour.