### PR TITLE
Fix treatment of NaN in histogram

### DIFF
--- a/scitbx/array_family/boost_python/tst_flex.py
+++ b/scitbx/array_family/boost_python/tst_flex.py
@@ -2097,6 +2097,11 @@ def exercise_histogram():
   assert not show_diff(t.getvalue(), s.getvalue())
   assert l.n_out_of_slot_range() == 17
 
+  # treatment of data with NaN in - cctbx/cctbx_project#478
+  d = flex.log10(flex.double(range(-10, 100)) + 0.5)
+  h = flex.histogram(d, data_min=-10, data_max=10, n_slots=20)
+  assert h.slots()[0] == 0
+
 def exercise_weighted_histogram():
   x = flex.double(range(20))
   w = 0.5 * flex.double(range(20))

--- a/scitbx/histogram.h
+++ b/scitbx/histogram.h
@@ -169,7 +169,9 @@ namespace scitbx {
       void
       assign_to_slot(ValueType const& d)
       {
-        slots_[get_i_slot(d)]++;
+	if (!std::isnan(d)) {
+	  slots_[get_i_slot(d)]++;
+	}
       }
 
       template <typename DataType>


### PR DESCRIPTION
Includes test to assert this behaviour. Means histogram behaves as expected
for #478 however issues with min() and max() remain.