### PR TITLE
Fixes to suffixtree

### DIFF
--- a/scitbx/suffixtree/boost_python/edge_exports.hpp
+++ b/scitbx/suffixtree/boost_python/edge_exports.hpp
@@ -7,14 +7,16 @@
 #include <boost/python/list.hpp>
 #include <boost/python/errors.hpp>
 #include <boost/python/def.hpp>
-#include <boost/python/iterator.hpp>
 
+#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/functional.hpp>
 
-#include <scitbx/boost_python/iterator_range.hpp>
+#include <scitbx/suffixtree/boost_python/iterator_wrapper.hpp>
 #include <scitbx/suffixtree/edge.hpp>
 #include <scitbx/suffixtree/iterator.hpp>
+
+#include <iostream>
 
 namespace scitbx
 {
@@ -34,9 +36,7 @@ struct edge_exports
 {
   typedef edge::Edge< Glyph, Index, WordLength, SuffixLabel, NodeAdapter > edge_type;
   typedef typename edge_type::ptr_type ptr_type;
-  typedef typename edge_type::const_ptr_type const_ptr_type;
   typedef typename edge_type::weak_ptr_type weak_ptr_type;
-  typedef typename edge_type::const_weak_ptr_type const_weak_ptr_type;
   typedef typename edge_type::index_type index_type;
   typedef typename edge_type::suffix_label_type suffix_label_type;
   typedef typename edge_type::node_type node_type;
@@ -44,9 +44,10 @@ struct edge_exports
   typedef typename edge_type::glyph_type glyph_type;
 
   typedef iterator::PreOrder< edge_type > preorder_iterator;
-  typedef iterator::PreOrder< edge_type const > preorder_const_iterator;
   typedef iterator::PostOrder< edge_type > postorder_iterator;
-  typedef iterator::PostOrder< edge_type const > postorder_const_iterator;
+
+  typedef python_iterator< preorder_iterator > preorder_python_iterator;
+  typedef python_iterator< postorder_iterator > postorder_python_iterator;
 
   static void throw_python_key_error()
   {
@@ -54,59 +55,36 @@ struct edge_exports
     boost::python::throw_error_already_set();
   }
 
-  static const_ptr_type to_const_ptr(ptr_type const& edge_ptr)
-  {
-    return boost::const_pointer_cast< edge_type const >( edge_ptr );
-  }
-
-  static index_type get_start_const(const_ptr_type const& edge_ptr)
-  {
-    return edge_ptr->start();
-  }
-
   static index_type get_start(ptr_type const& edge_ptr)
   {
-    return get_start_const( to_const_ptr( edge_ptr ) );
+    return edge_ptr->get_start();
   }
 
   static void set_start(ptr_type const& edge_ptr, index_type const& start)
   {
-    edge_ptr->start() = start;
-  }
-
-  static index_type get_stop_const(const_ptr_type const& edge_ptr)
-  {
-    return edge_ptr->stop();
+    edge_ptr->set_start( start );
   }
 
   static index_type get_stop(ptr_type const& edge_ptr)
   {
-    return get_stop_const( to_const_ptr( edge_ptr ) );
-  }
-
-  static suffix_label_type get_suffix_label_const(const_ptr_type const& edge_ptr)
-  {
-    return edge_ptr->label();
+    return edge_ptr->get_stop();
   }
 
   static suffix_label_type get_suffix_label(ptr_type const& edge_ptr)
   {
-    return get_suffix_label_const( to_const_ptr( edge_ptr ) );
-  }
-
-  static bool node_contains_const(const_ptr_type const& edge_ptr, glyph_type const& key)
-  {
-    return edge_ptr->find( key ) != edge_ptr->end();
+    return edge_ptr->label();
   }
 
   static bool node_contains(ptr_type const& edge_ptr, glyph_type const& key)
   {
-    return node_contains_const( to_const_ptr( edge_ptr ), key );
-  }
-
-  static bool node_empty_const(const_ptr_type const& edge_ptr)
-  {
-    return edge_ptr->empty();
+    try
+    {
+      return edge_ptr->find( key ) != edge_ptr->end();
+    }
+    catch ( bad_edge_type& e )
+    {
+      return false;
+    }
   }
 
   static bool node_empty(ptr_type const& edge_ptr)
@@ -117,19 +95,6 @@ struct edge_exports
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type"
 
-  static const_ptr_type node_get_item_const(const_ptr_type const& edge_ptr, glyph_type const& key)
-  {
-    try
-    {
-      return edge_ptr->get_child_with_label( key );
-    }
-
-    catch ( nonexistent& e )
-    {
-        throw_python_key_error();
-    }
-  }
-
   static ptr_type node_get_item(ptr_type const& edge_ptr, glyph_type const& key)
   {
     try
@@ -139,7 +104,12 @@ struct edge_exports
 
     catch ( nonexistent& e )
     {
-        throw_python_key_error();
+      throw_python_key_error();
+    }
+
+    catch ( bad_edge_type& e )
+    {
+      throw_python_key_error();
     }
   }
 
@@ -153,61 +123,49 @@ struct edge_exports
   {
     edge_ptr->attach_child( value, key );
   }
-
-  static boost::python::list node_keys_const(const_ptr_type const& edge_ptr)
-  {
-    boost::python::list result;
-
-    for(
-      typename edge_type::const_iterator it = edge_ptr->begin();
-      it != edge_ptr->end();
-      ++it
-      )
-    {
-      const glyph_type& k = it->first;
-      result.append( k );
-    }
-
-    return result;
-  }
-
+  
   static boost::python::list node_keys(ptr_type const& edge_ptr)
   {
-    return node_keys_const( to_const_ptr( edge_ptr ) );
-  }
-
-  static boost::python::list node_values_const(const_ptr_type const& edge_ptr)
-  {
     boost::python::list result;
 
-    for(
-      typename edge_type::const_iterator it = edge_ptr->begin();
-      it != edge_ptr->end();
-      ++it
-      )
+    try
     {
-      const const_ptr_type& v = it->second;
-      result.append( v );
+      for(
+        typename edge_type::const_iterator it = edge_ptr->begin();
+        it != edge_ptr->end();
+        ++it
+        )
+      {
+        const glyph_type& k = it->first;
+        result.append( k );
+      }
     }
+    catch ( bad_edge_type& e )
+    {}
 
     return result;
   }
 
   static boost::python::list node_values(ptr_type const& edge_ptr)
   {
-    return node_values_const( to_const_ptr( edge_ptr ) );
-  }
+    boost::python::list result;
 
-  static boost::python::object const get_parent_const(const_ptr_type const& edge_ptr)
-  {
     try
     {
-      return boost::python::object( edge_ptr->get_parent() );
+      for(
+        typename edge_type::const_iterator it = edge_ptr->begin();
+        it != edge_ptr->end();
+        ++it
+        )
+      {
+        ptr_type const& v = it->second;
+        result.append( v );
+      }
     }
-    catch ( unavailable& e )
-    {
-      return boost::python::object();
-    }
+    catch ( bad_edge_type& e )
+    {}
+
+    return result;
   }
 
   static boost::python::object const get_parent(ptr_type const& edge_ptr)
@@ -224,19 +182,7 @@ struct edge_exports
 
   static void set_parent(ptr_type const& edge_ptr, ptr_type const& parent)
   {
-    edge_ptr->parent() = parent;
-  }
-
-  static boost::python::object const get_suffix_const(const_ptr_type const& edge_ptr)
-  {
-    try
-    {
-      return boost::python::object( edge_ptr->get_suffix() );
-    }
-    catch ( unavailable& e )
-    {
-      return boost::python::object();
-    }
+    edge_ptr->parent() = weak_ptr_type( parent );
   }
 
   static boost::python::object const get_suffix(ptr_type const& edge_ptr)
@@ -261,24 +207,9 @@ struct edge_exports
     return edge_ptr->is_root();
   }
 
-  static bool is_root_const(const_ptr_type const& edge_ptr)
-  {
-    return edge_ptr->is_root();
-  }
-
   static bool is_leaf(ptr_type const& edge_ptr)
   {
     return edge_ptr->is_leaf();
-  }
-
-  static bool is_leaf_const(const_ptr_type const& edge_ptr)
-  {
-    return edge_ptr->is_leaf();
-  }
-
-  static std::size_t calculate_hash_const(const_ptr_type const& edge_ptr)
-  {
-    return boost::hash_value( edge_ptr );
   }
 
   static std::size_t calculate_hash(ptr_type const& edge_ptr)
@@ -286,61 +217,62 @@ struct edge_exports
     return boost::hash_value( edge_ptr );
   }
 
-  static boost::python::object get_preorder_range(ptr_type const& root)
+  static preorder_python_iterator get_preorder_range(ptr_type const& root)
   {
-    return scitbx::boost_python::as_iterator< preorder_iterator >(
+    return preorder_python_iterator(
       preorder_iterator::begin( root ),
       preorder_iterator::end( root )
       );
   }
 
-  static boost::python::object get_preorder_const_range(const_ptr_type const& root)
-  {
-    return scitbx::boost_python::as_iterator< preorder_const_iterator >(
-      preorder_const_iterator::begin( root ),
-      preorder_const_iterator::end( root )
-      );
-  }
 
-  static boost::python::object get_postorder_range(ptr_type const& root)
+  static postorder_python_iterator get_postorder_range(ptr_type const& root)
   {
-    return scitbx::boost_python::as_iterator< postorder_iterator >(
+    return postorder_python_iterator(
       postorder_iterator::begin( root ),
       postorder_iterator::end( root )
       );
   }
-
-  static boost::python::object get_postorder_const_range(const_ptr_type const& root)
+/*
+  static bool operator_eq_nonconst(ptr_type const& lhs, ptr_type const& rhs)
   {
-    return scitbx::boost_python::as_iterator< postorder_const_iterator >(
-      postorder_const_iterator::begin( root ),
-      postorder_const_iterator::end( root )
-      );
+    return lhs == rhs;
   }
 
+  static bool operator_eq_mixed(ptr_type const& lhs, const_ptr_type const& rhs)
+  {
+    return lhs == rhs;
+  }
+
+  static bool operator_eq_const(const_ptr_type const& lhs, const_ptr_type const& rhs)
+  {
+    return lhs == rhs;
+  }
+*/
   static void wrap()
   {
     using namespace boost::python;
-    scitbx::boost_python::export_range_as_iterator< preorder_iterator >(
-      "preorder_iteration_range"
-      );
-    scitbx::boost_python::export_range_as_iterator< preorder_const_iterator >(
-      "preorder_const_iteration_range"
-      );
 
-    scitbx::boost_python::export_range_as_iterator< postorder_iterator >(
-      "postorder_iteration_range"
-      );
-    scitbx::boost_python::export_range_as_iterator< postorder_const_iterator >(
-      "postorder_const_iteration_range"
-      );
+    preorder_python_iterator::wrap( "preorder_iteration_range" );
+    postorder_python_iterator::wrap( "postorder_iteration_range" );
 
     class_< ptr_type >( "edge", no_init )
-      .def( "root", edge_type::root )
+      .def(
+        "root",
+        edge_type::root
+        )
       .staticmethod( "root" )
-      .def( "branch", edge_type::branch, ( arg( "start" ), arg( "stop" ) ) )
+      .def(
+        "branch",
+        edge_type::branch,
+        ( arg( "start" ), arg( "stop" ) )
+        )
       .staticmethod( "branch" )
-      .def( "leaf", edge_type::leaf, ( arg( "start" ), arg( "length" ), arg( "label" ) ) )
+      .def(
+        "leaf",
+        edge_type::leaf,
+        ( arg( "start" ), arg( "length" ), arg( "label" ) )
+        )
       .staticmethod( "leaf" )
       .add_property( "start",get_start, set_start )
       .add_property( "stop", get_stop )
@@ -359,33 +291,7 @@ struct edge_exports
       .def( "postorder_iteration", get_postorder_range )
       .def( self == self )
       .def( self != self )
-      .def( self == other< const_ptr_type >() )
-      .def( self != other< const_ptr_type >() )
       .def( "__hash__", calculate_hash )
-      ;
-
-    class_< const_ptr_type >( "const_edge", no_init )
-      .def( "from_edge", to_const_ptr )
-      .staticmethod( "from_edge" )
-      .add_property( "start",get_start_const )
-      .add_property( "stop", get_stop_const )
-      .add_property( "label", get_suffix_label_const )
-      .add_property( "parent", get_parent_const )
-      .add_property( "suffix", get_suffix_const )
-      .def( "is_leaf", is_leaf_const )
-      .def( "is_root", is_root_const )
-      .def( "is_empty", node_empty_const )
-      .def( "__contains__", node_contains_const, arg( "key" ) )
-      .def( "__getitem__", node_get_item_const, arg( "key" ) )
-      .def( "keys", node_keys_const )
-      .def( "values", node_values_const )
-      .def( "preorder_iteration", get_preorder_const_range )
-      .def( "postorder_iteration", get_postorder_const_range )
-      .def( self == self )
-      .def( self != self )
-      .def( self == other< ptr_type >() )
-      .def( self != other< ptr_type >() )
-      .def( "__hash__", calculate_hash_const )
       ;
   }
 };

--- a/scitbx/suffixtree/boost_python/edge_exports.hpp
+++ b/scitbx/suffixtree/boost_python/edge_exports.hpp
@@ -123,7 +123,7 @@ struct edge_exports
   {
     edge_ptr->attach_child( value, key );
   }
-  
+
   static boost::python::list node_keys(ptr_type const& edge_ptr)
   {
     boost::python::list result;

--- a/scitbx/suffixtree/boost_python/iterator_wrapper.hpp
+++ b/scitbx/suffixtree/boost_python/iterator_wrapper.hpp
@@ -4,7 +4,6 @@
 #include <boost/python/class.hpp>
 #include <boost/python/object.hpp>
 #include <boost/python/errors.hpp>
-#include <boost/python/def.hpp>
 
 namespace scitbx
 {
@@ -21,7 +20,7 @@ boost::python::object passthrough(boost::python::object const& o )
 template<
   typename InputIterator
   >
-struct python_iterator 
+struct python_iterator
 {
   typedef InputIterator iterator;
   typedef typename InputIterator::value_type value_type;
@@ -46,8 +45,13 @@ struct python_iterator
 
   static void wrap(const char* name)
   {
+#if PY_MAJOR_VERSION >= 3
+      const char* nextname = "__next__";
+#else
+      const char* nextname = "next";
+#endif
       boost::python::class_< python_iterator >( name, boost::python::no_init )
-        .def( "next", &python_iterator::next )
+        .def( nextname, &python_iterator::next )
         .def( "__iter__", passthrough )
         ;
   }

--- a/scitbx/suffixtree/boost_python/iterator_wrapper.hpp
+++ b/scitbx/suffixtree/boost_python/iterator_wrapper.hpp
@@ -1,0 +1,60 @@
+#ifndef SUFFIXTREE_PYTHON_ITERATOR_WRAPPER_HPP_
+#define SUFFIXTREE_PYTHON_ITERATOR_WRAPPER_HPP_
+
+#include <boost/python/class.hpp>
+#include <boost/python/object.hpp>
+#include <boost/python/errors.hpp>
+#include <boost/python/def.hpp>
+
+namespace scitbx
+{
+namespace suffixtree
+{
+namespace python
+{
+
+boost::python::object passthrough(boost::python::object const& o )
+{
+    return o;
+}
+
+template<
+  typename InputIterator
+  >
+struct python_iterator 
+{
+  typedef InputIterator iterator;
+  typedef typename InputIterator::value_type value_type;
+
+  iterator pos_;
+  iterator end_;
+
+  python_iterator(iterator const& begin, iterator const& end)
+  : pos_( begin ), end_( end )
+  {}
+
+  value_type next()
+  {
+      if ( pos_ == end_ )
+      {
+        PyErr_SetString( PyExc_StopIteration, "" );
+        boost::python::throw_error_already_set();
+      }
+
+      return *( pos_++ );
+  }
+
+  static void wrap(const char* name)
+  {
+      boost::python::class_< python_iterator >( name, boost::python::no_init )
+        .def( "next", &python_iterator::next )
+        .def( "__iter__", passthrough )
+        ;
+  }
+};
+
+} // namespace python
+} // namespace suffixtree
+} // namespace scitbx
+
+#endif // SUFFIXTREE_PYTHON_ITERATOR_WRAPPER_HPP_

--- a/scitbx/suffixtree/boost_python/object_extensions.cpp
+++ b/scitbx/suffixtree/boost_python/object_extensions.cpp
@@ -13,8 +13,7 @@ namespace python
 std::size_t
 hash_value(const object& obj)
 {
-  long raw = extract< long >( obj.attr( "__hash__" )() );
-  return boost::hash_value( raw );
+  return boost::hash_value( PyObject_Hash( obj.ptr() ) );
 }
 
 std::ostream&

--- a/scitbx/suffixtree/boost_python/suffixtree_single_ext.cpp
+++ b/scitbx/suffixtree/boost_python/suffixtree_single_ext.cpp
@@ -8,13 +8,13 @@
 
 #include <boost_adaptbx/boost_range_python.hpp>
 #include <scitbx/boost_python/pair_as_tuple.hpp>
-#include <scitbx/boost_python/iterator_range.hpp>
 
 #include <scitbx/suffixtree/word.hpp>
 #include <scitbx/suffixtree/boost_python/edge_exports.hpp>
 #include <scitbx/suffixtree/boost_python/tree_exports.hpp>
 #include <scitbx/suffixtree/boost_python/object_extensions.hpp>
 #include <scitbx/suffixtree/matching_statistics.hpp>
+#include <scitbx/suffixtree/boost_python/iterator_wrapper.hpp>
 
 namespace scitbx
 {
@@ -41,8 +41,9 @@ struct python_exports
   typedef std::size_t suffix_label_type;
   typedef Tree< word_type, suffix_label_type, BoostHashMapAdapter > tree_type;
   typedef MSI< tree_type, boost::python::stl_input_iterator< glyph_type > > msi_type;
+  typedef scitbx::suffixtree::python::python_iterator< msi_type > msi_python_iterator;
 
-  static boost::python::object get_matching_statistics_range(
+  static msi_python_iterator get_matching_statistics_range(
     tree_type const& tree,
     boost::python::object const& iterable
     )
@@ -52,7 +53,7 @@ struct python_exports
     iter_type begin( iterable );
     iter_type end;
 
-    return scitbx::boost_python::as_iterator(
+    return msi_python_iterator(
       msi_type( tree, begin, end),
       msi_type( tree, end, end )
       );
@@ -109,9 +110,14 @@ struct python_exports
     python::tree_exports< word_type, suffix_label_type, BoostHashMapAdapter >::wrap();
     python::ukkonen_builder_exports< tree_type >::wrap();
 
-    scitbx::boost_python::export_range_as_iterator< msi_type >(
-      "matching_statistics_iterator"
-      );
+/*  class_< msi_range >(
+      "matching_statistics_iterator",
+      no_init
+      )
+      .def( "__iter__", boost::python::iterator< msi_range >() )
+      ; */
+
+    msi_python_iterator::wrap( "matching_statistics_iterator" );
 
     to_python_converter<
       typename msi_type::position_type,

--- a/scitbx/suffixtree/iterator.hpp
+++ b/scitbx/suffixtree/iterator.hpp
@@ -18,51 +18,42 @@ namespace iterator
 {
 
 template< typename Edge >
-struct Selector
+struct IteratorTraits
 {
-  typedef edge::Traits< Edge > traits;
-  typedef typename traits::iterator iterator;
-  typedef typename traits::ptr_type value_type;
-  typedef value_type ptr_type;
+  typedef Edge edge_type;
+  typedef typename edge_type::const_iterator underlying_const_iterator;
+  typedef typename std::forward_iterator_tag iterator_category;
+  typedef typename edge_type::ptr_type ptr_type;
+  typedef ptr_type const value_type;
 
-  typedef typename boost::mpl::if_<
-    typename traits::selector_type,
-    typename Edge::const_ptr_type const&,
-    typename Edge::ptr_type&
-    >::type reference;
+  typedef std::ptrdiff_t difference_type;
 
-  typedef typename boost::mpl::if_<
-    typename traits::selector_type,
-    typename Edge::const_ptr_type* const,
-    typename Edge::ptr_type*
-    >::type pointer;
+  typedef value_type& reference;
+  typedef value_type* pointer;
 };
 
 template< typename Edge >
-class PreOrder : public std::iterator<
-  std::forward_iterator_tag,
-  typename Selector< Edge >::value_type,
-  std::ptrdiff_t,
-  typename Selector< Edge >::reference,
-  typename Selector< Edge >::pointer
-  >
+class PreOrder
 {
 public:
   typedef Edge edge_type;
-  typedef Selector< Edge > selector_type;
-  typedef typename selector_type::value_type value_type;
-  typedef typename selector_type::reference reference_type;
-  typedef typename selector_type::pointer pointer_type;
-  typedef typename selector_type::iterator underlying_iterator;
-  typedef typename selector_type::ptr_type ptr_type;
+  typedef IteratorTraits< Edge > traits_type;
+  typedef typename traits_type::iterator_category iterator_category;
+  typedef typename traits_type::value_type value_type;
+  typedef typename traits_type::difference_type difference_type;
+  typedef typename traits_type::reference reference;
+  typedef typename traits_type::pointer pointer;
+  typedef typename traits_type::underlying_const_iterator
+    underlying_const_iterator;
+  typedef typename traits_type::ptr_type ptr_type;
 
   typedef PreOrder iterator;
 
 private:
   ptr_type root_;
   bool at_top_;
-  underlying_iterator pos_;
-  std::deque< underlying_iterator > underlying_iterators_deque_;
+  underlying_const_iterator pos_;
+  std::deque< underlying_const_iterator > underlying_iterators_deque_;
 
 private:
   PreOrder(ptr_type const& root, bool at_top);
@@ -74,8 +65,8 @@ public:
 public:
   ~PreOrder();
 
-  reference_type operator *();
-  pointer_type operator ->();
+  reference operator *() const;
+  pointer operator ->() const;
 
   iterator& operator ++();
   iterator operator ++(int);
@@ -88,30 +79,27 @@ template< typename Edge >
 bool operator !=(PreOrder< Edge > const& lhs, PreOrder< Edge > const& rhs);
 
 template< typename Edge >
-class PostOrder : public std::iterator<
-  std::forward_iterator_tag,
-  typename Selector< Edge >::value_type,
-  std::ptrdiff_t,
-  typename Selector< Edge >::reference,
-  typename Selector< Edge >::pointer
-  >
+class PostOrder
 {
 public:
   typedef Edge edge_type;
-  typedef Selector< Edge > selector_type;
-  typedef typename selector_type::value_type value_type;
-  typedef typename selector_type::reference reference_type;
-  typedef typename selector_type::pointer pointer_type;
-  typedef typename selector_type::iterator underlying_iterator;
-  typedef typename selector_type::ptr_type ptr_type;
+  typedef IteratorTraits< Edge > traits_type;
+  typedef typename traits_type::iterator_category iterator_category;
+  typedef typename traits_type::value_type value_type;
+  typedef typename traits_type::difference_type difference_type;
+  typedef typename traits_type::reference reference;
+  typedef typename traits_type::pointer pointer;
+  typedef typename traits_type::underlying_const_iterator
+    underlying_const_iterator;
+  typedef typename traits_type::ptr_type ptr_type;
 
   typedef PostOrder iterator;
 
 private:
   ptr_type root_;
   bool at_top_;
-  underlying_iterator pos_;
-  std::deque< underlying_iterator > underlying_iterators_deque_;
+  underlying_const_iterator pos_;
+  std::deque< underlying_const_iterator > underlying_iterators_deque_;
 
 private:
   PostOrder(ptr_type const& root, bool at_top);
@@ -123,8 +111,8 @@ public:
 public:
   ~PostOrder();
 
-  reference_type operator *();
-  pointer_type operator ->();
+  reference operator *() const;
+  pointer operator ->() const;
 
   iterator& operator ++();
   iterator operator ++(int);

--- a/scitbx/suffixtree/iterator.hxx
+++ b/scitbx/suffixtree/iterator.hxx
@@ -54,15 +54,15 @@ PreOrder< Edge >::operator ++(int)
 
 
 template< typename Edge >
-typename PreOrder< Edge >::reference_type
-PreOrder< Edge >::operator *()
+typename PreOrder< Edge >::reference
+PreOrder< Edge >::operator *() const
 {
   return at_top_ ? root_ : pos_->second;
 }
 
 template< typename Edge >
-typename PreOrder< Edge >::pointer_type
-PreOrder< Edge >::operator ->()
+typename PreOrder< Edge >::pointer
+PreOrder< Edge >::operator ->() const
 {
   return at_top_ ? &root_ : &( pos_->second );
 }
@@ -145,7 +145,7 @@ PostOrder< Edge >::operator ++()
   }
   else
   {
-    const underlying_iterator& parent = underlying_iterators_deque_.back();
+    const underlying_const_iterator& parent = underlying_iterators_deque_.back();
 
     if ( pos_ != ( parent->second )->end() )
     {
@@ -172,15 +172,15 @@ PostOrder< Edge >::operator ++(int)
 
 
 template< typename Edge >
-typename PostOrder< Edge >::reference_type
-PostOrder< Edge >::operator *()
+typename PostOrder< Edge >::reference
+PostOrder< Edge >::operator *() const
 {
   return at_top_ ? root_ : pos_->second;
 }
 
 template< typename Edge >
-typename PostOrder< Edge >::pointer_type
-PostOrder< Edge >::operator ->()
+typename PostOrder< Edge >::pointer
+PostOrder< Edge >::operator ->() const
 {
   return at_top_ ? &root_ : &( pos_->second );
 }

--- a/scitbx/suffixtree/matching_statistics.hpp
+++ b/scitbx/suffixtree/matching_statistics.hpp
@@ -18,14 +18,14 @@ class MSI : public std::iterator<
   std::input_iterator_tag,
   std::pair<
     typename Tree::length_type,
-    std::pair< typename Tree::const_edge_ptr_type, typename Tree::index_type >
-    >
+    std::pair< typename Tree::edge_ptr_type, typename Tree::index_type >
+    > const
   >
 {
 public:
   typedef Tree tree_type;
   typedef typename tree_type::length_type length_type;
-  typedef typename tree_type::const_edge_ptr_type edge_ptr_type;
+  typedef typename tree_type::edge_ptr_type edge_ptr_type;
   typedef typename tree_type::index_type index_type;
   typedef typename tree_type::word_type word_type;
   typedef typename tree_type::glyph_type glyph_type;
@@ -33,8 +33,8 @@ public:
 
   typedef std::pair< edge_ptr_type, index_type > position_type;
   typedef std::pair< length_type, position_type > value_type;
-  typedef value_type* pointer_type;
-  typedef value_type& reference_type;
+  typedef value_type const* pointer_type;
+  typedef value_type const& reference_type;
 
   typedef InputIterator text_iterator_type;
 
@@ -57,8 +57,8 @@ public:
     );
   ~MSI();
 
-  reference_type operator *();
-  pointer_type operator ->();
+  reference_type operator *() const;
+  pointer_type operator ->() const;
 
   iterator& operator ++();
   iterator operator ++(int);
@@ -128,14 +128,14 @@ MSI< Tree, InputIterator >::operator ++(int)
 
 template< typename Tree, typename InputIterator >
 typename MSI< Tree, InputIterator >::reference_type
-MSI< Tree, InputIterator >::operator *()
+MSI< Tree, InputIterator >::operator *() const
 {
   return result_;
 }
 
 template< typename Tree, typename InputIterator >
 typename MSI< Tree, InputIterator >::pointer_type
-MSI< Tree, InputIterator >::operator ->()
+MSI< Tree, InputIterator >::operator ->() const
 {
   return &result_;
 }

--- a/scitbx/suffixtree/test/tst_single.py
+++ b/scitbx/suffixtree/test/tst_single.py
@@ -82,31 +82,6 @@ class TestEdge(unittest.TestCase):
     self.assertEqual( self.root[2], self.branch )
 
 
-  def test_const_root(self):
-
-    cr = single.const_edge.from_edge( self.root )
-
-    self.assertEqual( self.root, cr )
-    self.assertEqual( hash( self.root ), hash( cr ) )
-    self.assertNotEqual( single.edge.root(), cr )
-
-    self.assertEqual( cr.start, 0 )
-    self.assertEqual( cr.stop, 0 )
-    self.assertRaises( RuntimeError, getattr, cr, "label" )
-    self.assertRaises( RuntimeError, getattr, cr, "parent" )
-    self.assertRaises( RuntimeError, getattr, cr, "suffix" )
-
-    self.assertTrue( cr.is_root() )
-    self.assertFalse( cr.is_leaf() )
-
-    self.assertTrue( cr.is_empty() )
-    self.assertEqual( cr.keys(), [] )
-    self.assertEqual( cr.values(), [] )
-    self.assertFalse( 1 in cr )
-    self.assertTrue( 1 not in cr )
-    self.assertRaises( KeyError, cr.__getitem__, 1 )
-
-
   def test_branch(self):
 
     self.assertEqual( self.branch.start, 1 )
@@ -146,39 +121,6 @@ class TestEdge(unittest.TestCase):
     self.assertEqual( self.branch[2], self.root )
 
 
-  def test_const_branch(self):
-
-    cb = single.const_edge.from_edge( self.branch )
-
-    self.assertEqual( self.branch, cb )
-    self.assertEqual( hash( self.branch ), hash( cb ) )
-    self.assertNotEqual( single.edge.branch( start = 1, stop = 2 ), cb )
-
-    self.assertEqual( cb.start, 1 )
-    self.assertEqual( cb.stop, 2 )
-    self.assertRaises( RuntimeError, getattr, cb, "label" )
-
-    self.assertEqual( cb.parent, None )
-    self.branch.parent = self.root
-    self.assertTrue( isinstance( cb.parent, single.const_edge ) )
-    self.assertEqual( cb.parent, self.root )
-
-    self.assertEqual( cb.suffix, None )
-    self.branch.suffix = self.root
-    self.assertTrue( isinstance( cb.suffix, single.const_edge ) )
-    self.assertEqual( cb.suffix, self.root )
-
-    self.assertFalse( cb.is_root() )
-    self.assertFalse( cb.is_leaf() )
-
-    self.assertTrue( cb.is_empty() )
-    self.assertEqual( cb.keys(), [] )
-    self.assertEqual( cb.values(), [] )
-    self.assertFalse( 1 in cb )
-    self.assertTrue( 1 not in cb )
-    self.assertRaises( KeyError, cb.__getitem__, 1 )
-
-
   def test_leaf(self):
 
     self.assertEqual( self.leaf.start, 4 )
@@ -208,46 +150,8 @@ class TestEdge(unittest.TestCase):
     self.assertEqual( self.leaf.values(), [] )
     self.assertFalse( 1 in self.leaf )
     self.assertTrue( 1 not in self.leaf )
-    self.assertRaises( RuntimeError, self.leaf.__getitem__, 1 )
+    self.assertRaises( KeyError, self.leaf.__getitem__, 1 )
     self.assertRaises( RuntimeError, self.leaf.__setitem__, 1, self.root )
-
-
-  def test_const_leaf(self):
-
-    cl = single.const_edge.from_edge( self.leaf )
-
-    self.assertEqual( self.leaf, cl )
-    self.assertEqual( hash( self.leaf ), hash( cl ) )
-    self.assertNotEqual(
-      single.edge.leaf( start = 4, length = self.word.length_descriptor(), label = 6 ),
-      cl,
-      )
-
-    self.assertEqual( cl.start, 4 )
-    ld = self.word.length_descriptor()
-    self.assertEqual( cl.stop, ld() )
-    self.word.append( 1 )
-    self.word.append( 2 )
-    self.assertEqual( cl.stop, ld() )
-
-    self.assertEqual( cl.label, 6 )
-
-    self.assertEqual( cl.parent, None )
-    self.leaf.parent = self.root
-    self.assertTrue( isinstance( cl.parent, single.const_edge ) )
-    self.assertEqual( cl.parent, self.root )
-
-    self.assertRaises( RuntimeError, getattr, cl, "suffix" )
-
-    self.assertFalse( cl.is_root() )
-    self.assertTrue( cl.is_leaf() )
-
-    self.assertTrue( cl.is_empty() )
-    self.assertEqual( cl.keys(), [] )
-    self.assertEqual( cl.values(), [] )
-    self.assertFalse( 1 in cl )
-    self.assertTrue( 1 not in cl )
-    self.assertRaises( KeyError, cl.__getitem__, 1 )
 
 
 class TestPreOrder(unittest.TestCase):
@@ -291,11 +195,6 @@ class TestPreOrder(unittest.TestCase):
     self.assertEqual( res, [ root ] )
     self.assertTrue( isinstance( res[0], single.edge ) )
 
-    cr = single.const_edge.from_edge( root )
-    res = list( cr.preorder_iteration() )
-    self.assertEqual( res, [ cr ] )
-    self.assertTrue( isinstance( res[0], single.const_edge ) )
-
 
   def test_single_branch(self):
 
@@ -303,11 +202,6 @@ class TestPreOrder(unittest.TestCase):
     res = list( branch.preorder_iteration() )
     self.assertEqual( res, [ branch ] )
     self.assertTrue( isinstance( res[0], single.edge ) )
-
-    cb = single.const_edge.from_edge( branch )
-    res = list( cb.preorder_iteration() )
-    self.assertEqual( res, [ cb ] )
-    self.assertTrue( isinstance( res[0], single.const_edge ) )
 
 
   def test_single_leaf(self):
@@ -317,11 +211,6 @@ class TestPreOrder(unittest.TestCase):
     res = list( leaf.preorder_iteration() )
     self.assertEqual( res, [ leaf ] )
     self.assertTrue( isinstance( res[0], single.edge ) )
-
-    cl = single.const_edge.from_edge( leaf )
-    res = list( cl.preorder_iteration() )
-    self.assertEqual( res, [ cl ] )
-    self.assertTrue( isinstance( res[0], single.const_edge ) )
 
 
   def check_leaf_named(self, result, leafname):
@@ -420,16 +309,6 @@ class TestPreOrder(unittest.TestCase):
     self.assertEqual( result, [] )
 
 
-  def test_const_root(self):
-
-    cr = single.const_edge.from_edge( self.root )
-    result = list( cr.preorder_iteration() )
-    self.assertEqual( len( result ), 10 )
-    self.assertTrue( all( isinstance( e, single.const_edge ) for e in result ) )
-    self.check_root( result )
-    self.assertEqual( result, [] )
-
-
 class TestPostOrder(unittest.TestCase):
 
   def setUp(self):
@@ -471,11 +350,6 @@ class TestPostOrder(unittest.TestCase):
     self.assertEqual( res, [ root ] )
     self.assertTrue( isinstance( res[0], single.edge ) )
 
-    cr = single.const_edge.from_edge( root )
-    res = list( cr.postorder_iteration() )
-    self.assertEqual( res, [ cr ] )
-    self.assertTrue( isinstance( res[0], single.const_edge ) )
-
 
   def test_single_branch(self):
 
@@ -483,11 +357,6 @@ class TestPostOrder(unittest.TestCase):
     res = list( branch.postorder_iteration() )
     self.assertEqual( res, [ branch ] )
     self.assertTrue( isinstance( res[0], single.edge ) )
-
-    cb = single.const_edge.from_edge( branch )
-    res = list( cb.postorder_iteration() )
-    self.assertEqual( res, [ cb ] )
-    self.assertTrue( isinstance( res[0], single.const_edge ) )
 
 
   def test_single_leaf(self):
@@ -497,11 +366,6 @@ class TestPostOrder(unittest.TestCase):
     res = list( leaf.postorder_iteration() )
     self.assertEqual( res, [ leaf ] )
     self.assertTrue( isinstance( res[0], single.edge ) )
-
-    cl = single.const_edge.from_edge( leaf )
-    res = list( cl.postorder_iteration() )
-    self.assertEqual( res, [ cl ] )
-    self.assertTrue( isinstance( res[0], single.const_edge ) )
 
 
   def check_leaf_named(self, result, leafname):
@@ -600,16 +464,6 @@ class TestPostOrder(unittest.TestCase):
     self.assertEqual( result, [] )
 
 
-  def test_const_root(self):
-
-    cr = single.const_edge.from_edge( self.root )
-    result = list( cr.postorder_iteration() )
-    self.assertEqual( len( result ), 10 )
-    self.assertTrue( all( isinstance( e, single.const_edge ) for e in result ) )
-    self.check_root( result )
-    self.assertEqual( result, [] )
-
-
 class TestTree(unittest.TestCase):
 
   def test_tree(self):
@@ -620,7 +474,7 @@ class TestTree(unittest.TestCase):
     self.assertTrue( isinstance( w, single.word ) )
     self.assertEqual( w.length_descriptor()(), 0 )
     r = tree.root
-    self.assertTrue( isinstance( r, single.const_edge ) )
+    self.assertTrue( isinstance( r, single.edge ) )
     self.assertEqual( r.keys(), [] )
 
 

--- a/scitbx/suffixtree/tree.hpp
+++ b/scitbx/suffixtree/tree.hpp
@@ -27,10 +27,9 @@ class Cursor
 {
 public:
   typedef Edge edge_type;
-  typedef edge::Traits< Edge > edge_traits;
-  typedef typename edge_traits::ptr_type edge_ptr_type;
-  typedef typename edge_traits::weak_ptr_type edge_weak_ptr_type;
-  typedef typename edge_traits::iterator edge_iterator;
+  typedef typename edge_type::ptr_type edge_ptr_type;
+  typedef typename edge_type::weak_ptr_type edge_weak_ptr_type;
+  typedef typename edge_type::iterator edge_iterator;
   typedef typename edge_type::glyph_type glyph_type;
   typedef typename edge_type::index_type index_type;
 
@@ -101,11 +100,9 @@ public:
     edge_type;
 
   typedef typename edge_type::ptr_type edge_ptr_type;
-  typedef typename edge_type::const_ptr_type const_edge_ptr_type;
   typedef typename edge_type::weak_ptr_type edge_weak_ptr_type;
-  typedef typename edge_type::const_weak_ptr_type const_edge_weak_ptr_type;
 
-  typedef Cursor< edge_type const, word_type const> cursor_type;
+  typedef Cursor< edge_type, word_type > cursor_type;
 
 private:
   edge_ptr_type root_;
@@ -116,7 +113,7 @@ public:
   Tree();
   ~Tree();
 
-  const_edge_ptr_type root() const;
+  edge_ptr_type root() const;
   word_type const& word() const;
   bool in_construction() const;
   cursor_type cursor() const;

--- a/scitbx/suffixtree/tree.hxx
+++ b/scitbx/suffixtree/tree.hxx
@@ -1,7 +1,7 @@
 template< typename Edge, typename Word >
 Cursor< Edge, Word >::Cursor(edge_ptr_type const& edge_ptr, word_ptr_type const& word_ptr)
   : word_ptr_( word_ptr ), edge_ptr_( edge_ptr ),
-    index_( const_cast< edge_type const& >( *edge_ptr_ ).start() )
+    index_( edge_ptr_->get_start() )
 {}
 
 template< typename Edge, typename Word >
@@ -27,14 +27,14 @@ template< typename Edge, typename Word >
 bool
 Cursor< Edge, Word >::is_at_edge_top() const
 {
-  return get_edge_ptr()->start() == get_index();
+  return get_edge_ptr()->get_start() == get_index();
 }
 
 template< typename Edge, typename Word >
 bool
 Cursor< Edge, Word >::is_at_edge_bottom() const
 {
-  return get_edge_ptr()->stop() == get_index();
+  return get_edge_ptr()->get_stop() == get_index();
 }
 
 template< typename Edge, typename Word >
@@ -43,7 +43,7 @@ Cursor< Edge, Word >::is_at_leaf_bottom() const
 {
   edge_ptr_type const& edge_ptr = get_edge_ptr();
 
-  return ( edge_ptr->is_leaf() && edge_ptr->stop() == get_index() );
+  return ( edge_ptr->is_leaf() && edge_ptr->get_stop() == get_index() );
 }
 
 template< typename Edge, typename Word >
@@ -77,7 +77,7 @@ void
 Cursor< Edge, Word >::forth_to_child(glyph_type const& label)
 {
   edge_ptr_ = get_edge_ptr()->get_child_with_label( label );
-  index_ = edge_ptr_->start();
+  index_ = edge_ptr_->get_start();
 }
 
 template< typename Edge, typename Word >
@@ -123,7 +123,7 @@ Cursor< Edge, Word >::break_edge_here()
     throw bad_state();
   }
 
-  index_type start = edge_ptr_->start();
+  index_type start = edge_ptr_->get_start();
   edge_ptr_type new_branch_ptr = edge_type::branch( start, index_ );
 
   edge_weak_ptr_type parent_weak_ptr = edge_ptr_->parent();
@@ -140,7 +140,7 @@ Cursor< Edge, Word >::break_edge_here()
   assert ( pit != parent_ptr->end() );
   pit->second = new_branch_ptr;
 
-  edge_ptr_->start() = index_;
+  edge_ptr_->set_start( index_ );
   edge_ptr_->parent() = new_branch_ptr;
 
   bool res = new_branch_ptr->attach_child_if_not_present( edge_ptr_, word[ index_ ] );
@@ -159,7 +159,7 @@ Cursor< Edge, Word >::to_suffix_position()
   {
     edge_ptr_type suffix_ptr;
     edge_ptr_type parent_ptr = edge_ptr_->get_parent();
-    word_iterator path_begin = word.get_iterator_to( edge_ptr_->start() );
+    word_iterator path_begin = word.get_iterator_to( edge_ptr_->get_start() );
 
     if ( parent_ptr->is_root() )
     {
@@ -176,7 +176,7 @@ Cursor< Edge, Word >::to_suffix_position()
     if ( path_begin == path_end )
     {
       edge_ptr_ = suffix_ptr;
-      index_ = suffix_ptr->stop();
+      index_ = suffix_ptr->get_stop();
     }
     else
     {
@@ -199,14 +199,13 @@ Cursor< Edge, Word >::path_jump_from_top_of(
 {
   while ( true )
   {
-    edge_type const& edge = *edge_ptr;
-    length_type edge_length = edge.stop() - edge.start();
+    length_type edge_length = edge_ptr->get_stop() - edge_ptr->get_start();
     typename word_iterator::difference_type path_length = path_end - path_begin;
 
     if ( path_length <= edge_length )
     {
       edge_ptr_ = edge_ptr;
-      index_ = edge.start() + path_length;
+      index_ = edge_ptr->get_start() + path_length;
       break;
     }
 
@@ -240,7 +239,7 @@ template<
   typename SuffixLabel,
   template< typename, typename > class NodeAdaptor
   >
-typename Tree< Word, SuffixLabel, NodeAdaptor >::const_edge_ptr_type
+typename Tree< Word, SuffixLabel, NodeAdaptor >::edge_ptr_type
 Tree< Word, SuffixLabel, NodeAdaptor >::root() const
 {
   return root_;

--- a/scitbx/suffixtree/word.hpp
+++ b/scitbx/suffixtree/word.hpp
@@ -24,10 +24,11 @@ public:
   typedef Glyph glyph_type;
   typedef std::vector< glyph_type > data_type;
   typedef typename data_type::const_iterator const_iterator;
-  typedef std::size_t index_type;
-  typedef std::size_t length_type;
+  typedef typename data_type::size_type index_type;
+  typedef typename data_type::size_type length_type;
+  typedef length_type const const_length_type;
   typedef boost::shared_ptr< length_type > length_ptr_type;
-  typedef boost::shared_ptr< const index_type > const_length_ptr_type;
+  typedef boost::shared_ptr< const_length_type > const_length_ptr_type;
   typedef boost::iterator_range< const_iterator > substring_type;
   typedef Single type;
 
@@ -39,49 +40,16 @@ public:
   Single();
   ~Single();
 
-  inline void push_back(const glyph_type& ch);
+  inline void push_back(glyph_type const& ch);
 
   const_length_ptr_type length_ptr() const;
-  index_type size() const;
-  substring_type substring(const index_type& begin, const index_type& end) const;
+  length_type size() const;
+  substring_type substring(index_type const& begin, index_type const& end) const;
 
-  const_iterator get_iterator_to(const index_type& index) const;
+  const_iterator get_iterator_to(index_type const& index) const;
 
-  const glyph_type& operator [](const index_type& index) const;
-  glyph_type& operator [](const index_type& index);
-};
-
-template< typename Glyph, typename Traits >
-class Multiple
-{
-public:
-  typedef Glyph glyph_type;
-  typedef Traits traits_type;
-  typedef std::vector< glyph_type > data_type;
-  typedef typename data_type::const_iterator const_iterator;
-  typedef std::size_t index_type;
-  typedef boost::shared_ptr< index_type > length_ptr_type;
-  typedef boost::shared_ptr< const index_type > length_type;
-  typedef boost::iterator_range< const_iterator > substring_type;
-
-private:
-  data_type data_;
-  length_ptr_type length_ptr_;
-
-public:
-  Multiple();
-  ~Multiple();
-
-  inline void push_back(const glyph_type& glyph);
-
-  length_type length() const;
-  substring_type substring(const index_type& begin, const index_type& end) const;
-
-  const glyph_type& operator [](const index_type& index) const;
-  glyph_type& operator [](const index_type& index);
-
-private:
-  void set_word_boundary();
+  glyph_type const& operator [](index_type const& index) const;
+  glyph_type& operator [](index_type const& index);
 };
 
 #include "word.hxx"

--- a/scitbx/suffixtree/word.hxx
+++ b/scitbx/suffixtree/word.hxx
@@ -1,6 +1,6 @@
 template< typename Glyph >
 Single< Glyph >::Single()
-  : length_ptr_( new index_type() )
+  : length_ptr_( new length_type() )
 {}
 
 template< typename Glyph >
@@ -9,7 +9,7 @@ Single< Glyph >::~Single()
 
 template< typename Glyph >
 void
-Single< Glyph >::push_back(const glyph_type& glyph)
+Single< Glyph >::push_back(glyph_type const& glyph)
 {
   data_.push_back( glyph );
   ++( *length_ptr_ );
@@ -26,12 +26,12 @@ template< typename Glyph >
 typename Single< Glyph >::const_length_ptr_type
 Single< Glyph >::length_ptr() const
 {
-  return boost::const_pointer_cast< const index_type >( length_ptr_ );
+  return boost::const_pointer_cast< const_length_type >( length_ptr_ );
 }
 
 template< typename Glyph >
 typename Single< Glyph >::substring_type
-Single< Glyph >::substring(const index_type& begin, const index_type& end)
+Single< Glyph >::substring(index_type const& begin, index_type const& end)
   const
 {
   return substring_type(  get_iterator_to( begin ), get_iterator_to( end ) );
@@ -39,7 +39,7 @@ Single< Glyph >::substring(const index_type& begin, const index_type& end)
 
 template< typename Glyph >
 typename Single< Glyph >::const_iterator
-Single< Glyph >::get_iterator_to(const index_type& index)
+Single< Glyph >::get_iterator_to(index_type const& index)
   const
 {
   const_iterator cit = data_.begin();
@@ -48,81 +48,16 @@ Single< Glyph >::get_iterator_to(const index_type& index)
 }
 
 template< typename Glyph >
-const typename Single< Glyph >::glyph_type&
-Single< Glyph >::operator [](const index_type& index) const
+typename Single< Glyph >::glyph_type const&
+Single< Glyph >::operator [](index_type const& index) const
 {
   return data_[ index ];
 }
 
 template< typename Glyph >
 typename Single< Glyph >::glyph_type&
-Single< Glyph >::operator [](const index_type& index)
+Single< Glyph >::operator [](index_type const& index)
 {
   return data_[ index ];
-}
-
-
-template< typename Glyph, typename Traits >
-Multiple< Glyph, Traits >::Multiple()
-  : length_ptr_( new index_type() )
-{}
-
-template< typename Glyph, typename Traits >
-Multiple< Glyph, Traits >::~Multiple()
-{}
-
-template< typename Glyph, typename Traits >
-void
-Multiple< Glyph, Traits >::push_back(const glyph_type& glyph)
-{
-  data_.push_back( glyph );
-  ++( *length_ptr_ );
-
-  if (Traits::is_terminator( glyph ) )
-  {
-    set_word_boundary();
-  }
-}
-
-template< typename Glyph, typename Traits >
-typename Multiple< Glyph, Traits >::length_type
-Multiple< Glyph, Traits >::length() const
-{
-  return boost::const_pointer_cast< const index_type >( length_ptr_ );
-}
-
-template< typename Glyph, typename Traits >
-typename Multiple< Glyph, Traits >::substring_type
-Multiple< Glyph, Traits >::substring(const index_type& begin, const index_type& end)
-  const
-{
-  const_iterator b = data_.begin();
-  std::advance( b, begin );
-
-  const_iterator e = data_.begin();
-  std::advance( e, end );
-
-  return substring_type( b, e );
-}
-
-template< typename Glyph, typename Traits >
-const typename Multiple< Glyph, Traits >::glyph_type&
-Multiple< Glyph, Traits >::operator [](const index_type& index) const
-{
-  return data_[ index ];
-}
-
-template< typename Glyph, typename Traits >
-typename Multiple< Glyph, Traits >::glyph_type&
-Multiple< Glyph, Traits >::operator [](const index_type& index)
-{
-  return data_[ index ];
-}
-
-template< typename Glyph, typename Traits >
-void
-Multiple< Glyph, Traits >::set_word_boundary()
-{
-  length_ptr_ = boost::make_shared< index_type >( *length_ptr_ );
 }
 


### PR DESCRIPTION
This fixes segfaults with Python2 and Python3 (tried with gcc 4.8 and 8.1 with debug and release modes).