### PR TITLE
Look for conda eigen library as fallback

### DIFF
--- a/cctbx/examples/merging/SConscript
+++ b/cctbx/examples/merging/SConscript
@@ -4,6 +4,10 @@ Import("env_base", "env_etc")
 
 try:
   env_etc.eigen_dist = os.path.abspath(os.path.join(libtbx.env.dist_path("boost"),"../eigen"))
+  if not os.path.isdir(env_etc.eigen_dist) and hasattr(env_etc, "conda_cpppath"):
+    for candidate in env_etc.conda_cpppath:
+      if os.path.isdir(os.path.join(candidate, "eigen3")):
+        env_etc.eigen_dist = os.path.abspath(os.path.join(os.path.join(candidate, "eigen3")))
   if os.path.isdir(env_etc.eigen_dist):
     env_etc.eigen_include = env_etc.eigen_dist
     env_etc.large_scale_merging_common_includes = [

--- a/scitbx/examples/bevington/SConscript
+++ b/scitbx/examples/bevington/SConscript
@@ -4,6 +4,10 @@ Import("env_base", "env_etc")
 
 try:
   env_etc.eigen_dist = os.path.abspath(os.path.join(libtbx.env.dist_path("boost"),"../eigen"))
+  if not os.path.isdir(env_etc.eigen_dist) and hasattr(env_etc, "conda_cpppath"):
+    for candidate in env_etc.conda_cpppath:
+      if os.path.isdir(os.path.join(candidate, "eigen3")):
+        env_etc.eigen_dist = os.path.abspath(os.path.join(os.path.join(candidate, "eigen3")))
   if os.path.isdir(env_etc.eigen_dist):
     env_etc.eigen_include = env_etc.eigen_dist
     env_etc.scitbx_ex_bev_common_includes = [


### PR DESCRIPTION
The logic in https://github.com/cctbx/cctbx_project/blob/2ce53dc81382c4761d8cf18d71b7276077e981fb/scitbx/examples/bevington/SConscript#L6 looks for eigen sources.
When `boost` is in `modules/` then it checks `modules/eigen`, however if conda boost sources are used it attempts to find the sources in `modules/cctbx_project/eigen` - it starts looking relative to `modules/cctbx_project/boost`.

Add a fallback that checks if the conda include path contains an `eigen3` directory, if so then use that one instead.

Related: dials/dials#1307