### PR TITLE
Enable C++11 for DIALS

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -2134,6 +2134,11 @@ class DIALSBuilder(CCIBuilder):
   def rebuild_docs(self):
     pass
 
+  def get_libtbx_configure(self):
+    configlst = super(DIALSBuilder, self).get_libtbx_configure()
+    configlst.append('--enable_cxx11')
+    return configlst
+
 class LABELITBuilder(CCIBuilder):
   CODEBASES_EXTRA = ['labelit', 'dials']
   LIBTBX_EXTRA = ['labelit', 'dials']


### PR DESCRIPTION
DIALS now builds using C++11, so update the CCTBX bootstrap to reflect
this change, cf. https://github.com/dials/dials/pull/1235

Will merge when tests pass.