### PR TITLE
Retire cmp() function

### DIFF
--- a/cctbx/euclidean_model_matching.py
+++ b/cctbx/euclidean_model_matching.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import, division, print_function
+
+import operator
 from cctbx import crystal
 from cctbx import sgtbx
 from cctbx.array_family import flex
@@ -292,7 +294,7 @@ class match_refine(object):
     self.eliminate_weak_pairs()
     self.ref_eucl_rt = sgtbx_rt_mx_as_matrix_rt(self.eucl_symop) \
                      + self.adjusted_shift
-    self.pairs.sort(key=lambda element: element[0])
+    self.pairs.sort(key=operator.itemgetter(0))
     self.singles1.sort()
     self.singles2.sort()
     self.calculate_rms()

--- a/cctbx/euclidean_model_matching.py
+++ b/cctbx/euclidean_model_matching.py
@@ -252,12 +252,8 @@ def generate_singles(n, i):
 
 def pair_sort_function(pair_a, pair_b):
   # Deprecated. Do not use
-  if pair_a[0] < pair_b[0]:
-    return -1
-  elif pair_a[0] > pair_b[0]:
-    return 1
-  else:
-    return 0
+  from libtbx.math_utils import cmp
+  return cmp(pair_a[0], pair_b[0])
 
 def inside_zero_one(c):
   new_c=[]
@@ -466,16 +462,10 @@ class match_refine(object):
 
 def match_sort_function(match_a, match_b):
   # Deprecated. Do not use
-  if len(match_a.pairs) < len(match_b.pairs):
-    return 1
-  elif len(match_a.pairs) > len(match_b.pairs):
-    return -1
-  if match_a.rms < match_b.rms:
-    return -1
-  elif match_a.rms > match_b.rms:
-    return 1
-  else:
-    return 0
+  from libtbx.math_utils import cmp
+  i = -cmp(len(match_a.pairs), len(match_b.pairs))
+  if (i): return i
+  return cmp(match_a.rms, match_b.rms)
 
 def weed_refined_matches(space_group_number, refined_matches,
                          rms_penalty_per_site):

--- a/cctbx/euclidean_model_matching.py
+++ b/cctbx/euclidean_model_matching.py
@@ -249,8 +249,13 @@ def generate_singles(n, i):
   return singles
 
 def pair_sort_function(pair_a, pair_b):
-  from past.builtins import cmp
-  return cmp(pair_a[0], pair_b[0])
+  # Deprecated. Do not use
+  if pair_a[0] < pair_b[0]:
+    return -1
+  elif pair_a[0] > pair_b[0]:
+    return 1
+  else:
+    return 0
 
 def inside_zero_one(c):
   new_c=[]
@@ -287,8 +292,7 @@ class match_refine(object):
     self.eliminate_weak_pairs()
     self.ref_eucl_rt = sgtbx_rt_mx_as_matrix_rt(self.eucl_symop) \
                      + self.adjusted_shift
-    from functools import cmp_to_key
-    self.pairs.sort(key=cmp_to_key(pair_sort_function)) # FIXME deprecate pair_sort_function()
+    self.pairs.sort(key=lambda element: element[0])
     self.singles1.sort()
     self.singles2.sort()
     self.calculate_rms()
@@ -459,10 +463,17 @@ class match_refine(object):
         return model2.as_emma_model()
 
 def match_sort_function(match_a, match_b):
-  from past.builtins import cmp
-  i = -cmp(len(match_a.pairs), len(match_b.pairs))
-  if (i): return i
-  return cmp(match_a.rms, match_b.rms)
+  # Deprecated. Do not use
+  if len(match_a.pairs) < len(match_b.pairs):
+    return 1
+  elif len(match_a.pairs) > len(match_b.pairs):
+    return -1
+  if match_a.rms < match_b.rms:
+    return -1
+  elif match_a.rms > match_b.rms:
+    return 1
+  else:
+    return 0
 
 def weed_refined_matches(space_group_number, refined_matches,
                          rms_penalty_per_site):
@@ -595,8 +606,7 @@ class delegating_model_matches(object):
       tolerance,
       models_are_diffraction_index_equivalent,
       shall_break)
-    from functools import cmp_to_key
-    self.refined_matches.sort(key=cmp_to_key(match_sort_function))
+    self.refined_matches.sort(key=lambda element: (-len(element.pairs), element.rms))
     weed_refined_matches(model1.space_group_info().type().number(),
                          self.refined_matches, rms_penalty_per_site)
 

--- a/cctbx/sgtbx/__init__.py
+++ b/cctbx/sgtbx/__init__.py
@@ -833,8 +833,5 @@ def compare_cb_op_as_hkl(a, b):
   # Deprecated. Do not use.
   if (len(a) < len(b)): return -1
   if (len(a) > len(b)): return  1
-  if a < b:
-    return -1
-  elif a > b:
-    return 1
-  return 0
+  from libtbx.math_utils import cmp
+  return cmp(a, b)

--- a/cctbx/sgtbx/__init__.py
+++ b/cctbx/sgtbx/__init__.py
@@ -829,8 +829,12 @@ class symmetry_equivalent_pair_interactions(libtbx.slots_getstate_setstate):
     rs = rt_mx_ji.multiply(sso_j)
     return rs in O.registry
 
-def compare_cb_op_as_hkl(a, b): # FIXME Py2-style compare, wrap in functools.cmp_to_key
+def compare_cb_op_as_hkl(a, b):
+  # Deprecated. Do not use.
   if (len(a) < len(b)): return -1
   if (len(a) > len(b)): return  1
-  from past.builtins import cmp
-  return cmp(a, b)
+  if a < b:
+    return -1
+  elif a > b:
+    return 1
+  return 0

--- a/cctbx/sgtbx/direct_space_asu/check_redundancies.py
+++ b/cctbx/sgtbx/direct_space_asu/check_redundancies.py
@@ -8,6 +8,7 @@ from scitbx.python_utils import command_line
 from libtbx import easy_run
 from boost import rational
 import sys, os
+from libtbx.math_utils import cmp
 from six.moves import range
 from six.moves import zip
 
@@ -236,12 +237,7 @@ def grid_asu(
 
 def compare_redundancies(a, b):
   # Deprecated. Do not use
-  if len(b[1]) < len(a[1]):
-    return -1
-  elif len(b[1]) > len(a[1]):
-    return 1
-  else:
-    return 0
+  return cmp(len(b[1]), len(a[1]))
 
 def sort_redundancies(redundancies):
   return sorted(redundancies.items(), key=lambda element: len(element[1]), reverse=True)

--- a/cctbx/sgtbx/direct_space_asu/check_redundancies.py
+++ b/cctbx/sgtbx/direct_space_asu/check_redundancies.py
@@ -8,8 +8,6 @@ from scitbx.python_utils import command_line
 from libtbx import easy_run
 from boost import rational
 import sys, os
-from past.builtins import cmp
-from functools import cmp_to_key
 from six.moves import range
 from six.moves import zip
 
@@ -237,12 +235,16 @@ def grid_asu(
   return result
 
 def compare_redundancies(a, b):
-  return cmp(len(b[1]), len(a[1]))
+  # Deprecated. Do not use
+  if len(b[1]) < len(a[1]):
+    return -1
+  elif len(b[1]) > len(a[1]):
+    return 1
+  else:
+    return 0
 
 def sort_redundancies(redundancies):
-  redundancies = list(redundancies.items())
-  redundancies.sort(key=cmp_to_key(compare_redundancies))
-  return redundancies
+  return sorted(redundancies.items(), key=lambda element: len(element[1]), reverse=True)
 
 def str_ev(ev):
   return "[%d,%d,%d]" % ev

--- a/fable/cout.py
+++ b/fable/cout.py
@@ -2545,21 +2545,7 @@ def generate_common_report(
     for common_name,sizes in common_fdecl_list_sizes.items():
       size_sums[common_name] = sum(sizes)
 
-    # vv_cmp incompatible with Py3. Create vv_key workaround, revisit later with comprehensive example.
-    #def vv_cmp(a, b):
-    #  result = cmp(size_sums[b], size_sums[a])
-    #  if (result == 0): result = cmp(a, b)
-    #  return result
-    #vv.sort(vv_cmp)
-
-    from past.builtins import cmp
-    from functools import cmp_to_key
-    def vv_cmp(a, b):
-      result = cmp(size_sums[b], size_sums[a])
-      if (result == 0): result = cmp(a, b)
-      return result
-
-    vv.sort(key=cmp_to_key(vv_cmp))
+    vv.sort(key=lambda element: (-size_sums[element], element))
     print("  %-20s   procedures    sum of members" % "common name", file=report)
     for common_name in vv:
       print("  %-20s   %8d         %8d" % (

--- a/iotbx/pdb/hierarchy.py
+++ b/iotbx/pdb/hierarchy.py
@@ -14,6 +14,7 @@ import six
 from six.moves import cStringIO as StringIO
 from six.moves import range, zip
 import collections
+import operator
 import warnings
 import math
 import sys
@@ -1291,7 +1292,7 @@ class _():
                 continue
               mean_occ = flex.mean(atom_group.atoms().extract_occ())
               atom_groups_and_occupancies.append((atom_group, mean_occ))
-            atom_groups_and_occupancies.sort(key=lambda element: element[1], reverse=True)
+            atom_groups_and_occupancies.sort(key=operator.itemgetter(1), reverse=True)
             for atom_group, occ in atom_groups_and_occupancies[1:] :
               residue_group.remove_atom_group(atom_group=atom_group)
             single_conf, occ = atom_groups_and_occupancies[0]
@@ -1834,7 +1835,7 @@ class _():
       groups = list(groups.values())
       if (len(groups) != 0):
         for group in groups: group.sort()
-        groups.sort(key=lambda element: element[0])
+        groups.sort(key=operator.itemgetter(0))
         result.append(groups)
       for i in isolated_var_occ:
         result.append([[i]])

--- a/iotbx/pdb/hierarchy.py
+++ b/iotbx/pdb/hierarchy.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 import boost.python
-from functools import cmp_to_key
 ext = boost.python.import_ext("iotbx_pdb_hierarchy_ext")
 from iotbx_pdb_hierarchy_ext import *
 from libtbx.str_utils import show_sorted_by_counts
@@ -14,7 +13,6 @@ from cctbx.array_family import flex
 import six
 from six.moves import cStringIO as StringIO
 from six.moves import range, zip
-from past.builtins import cmp
 import collections
 import warnings
 import math
@@ -1293,8 +1291,7 @@ class _():
                 continue
               mean_occ = flex.mean(atom_group.atoms().extract_occ())
               atom_groups_and_occupancies.append((atom_group, mean_occ))
-            cmp_fn = lambda a,b: cmp(b[1], a[1])
-            atom_groups_and_occupancies.sort(key=cmp_to_key(cmp_fn))
+            atom_groups_and_occupancies.sort(key=lambda element: element[1], reverse=True)
             for atom_group, occ in atom_groups_and_occupancies[1:] :
               residue_group.remove_atom_group(atom_group=atom_group)
             single_conf, occ = atom_groups_and_occupancies[0]
@@ -1837,8 +1834,7 @@ class _():
       groups = list(groups.values())
       if (len(groups) != 0):
         for group in groups: group.sort()
-        def group_cmp(a, b): return cmp(a[0], b[0])
-        groups.sort(key=cmp_to_key(group_cmp))
+        groups.sort(key=lambda element: element[0])
         result.append(groups)
       for i in isolated_var_occ:
         result.append([[i]])
@@ -1863,9 +1859,7 @@ class _():
     for i_rg in range(n_rg):
       if (done[i_rg]): continue
       process_range(i_rg, i_rg+1)
-    def groups_cmp(a, b):
-      return cmp(a[0][0], b[0][0])
-    result.sort(key=cmp_to_key(groups_cmp))
+    result.sort(key=lambda element: element[0][0])
     return result
 
   def get_residue_names_and_classes(self):

--- a/iotbx/pdb/tst_ext.py
+++ b/iotbx/pdb/tst_ext.py
@@ -8,8 +8,6 @@ from libtbx.utils import Sorry, \
   user_plus_sys_time, format_cpu_times
 from libtbx.test_utils import Exception_expected, approx_equal, show_diff
 import libtbx.load_env
-from past.builtins import cmp
-from functools import cmp_to_key
 from six.moves import cStringIO as StringIO
 from six.moves import range
 from six.moves import zip
@@ -80,15 +78,12 @@ def exercise_base_256_ordinal():
     assert o(s) == po(s)
     assert o("-"+s) == -o(s)
   #
-  from past.builtins import cmp
-  from functools import cmp_to_key
-  def o_cmp(a, b): return cmp(o(a), o(b))
   char4s = ["%4s" % i for i in range(-999,9999+1)]
-  assert sorted(char4s, key = cmp_to_key(o_cmp)) == char4s
+  assert sorted(char4s, key=o) == char4s
   m = pdb.hy36decode(width=4, s="zzzz")
   e = pdb.hy36encode
   char4s = [e(width=4, value=i) for i in range(-999,m+1,51)]
-  assert sorted(char4s, key = cmp_to_key(o_cmp)) == char4s
+  assert sorted(char4s, key=o) == char4s
 
 def exercise_columns_73_76_evaluator(pdb_file_names):
   if (pdb_file_names is None):

--- a/libtbx/command_line/find_unused_imports_crude.py
+++ b/libtbx/command_line/find_unused_imports_crude.py
@@ -5,10 +5,6 @@ op = os.path
 
 import re
 
-from functools import cmp_to_key
-from past.builtins import cmp
-
-
 # Finds flake8-style ignore directives
 # Taken from flake8 source code
 RE_FLAKE8 = re.compile(
@@ -116,9 +112,7 @@ def inspect(py_lines):
     flds = "".join(filtered).split()
     used_names.update(imported_names.intersection(flds))
   unused_names = list(imported_names - used_names)
-  def cmp_input_order(a, b):
-    return cmp(*(imported_names_dict[a], imported_names_dict[b]))
-  unused_names.sort(key=cmp_to_key(cmp_input_order))  # keeps import order
+  unused_names.sort(key=lambda element: imported_names_dict[element])  # keeps import order
   return unused_names
 
 def show_unused_imports(file_name):

--- a/libtbx/math_utils.py
+++ b/libtbx/math_utils.py
@@ -3,6 +3,14 @@ from builtins import object
 import math
 from six.moves import range
 
+def cmp(x, y):
+  """
+  cmp(x, y) -> integer
+
+  Return negative if x<y, zero if x==y, positive if x>y.
+  """
+  return (x > y) - (x < y)
+
 def round2(x, d=0):
   '''
   Python 3 defaults to rounding to the nearest even number (round half to even),

--- a/mmtbx/building/alternate_conformations/altloc_labeling.py
+++ b/mmtbx/building/alternate_conformations/altloc_labeling.py
@@ -1,10 +1,7 @@
-
 from __future__ import absolute_import, division, print_function
 from libtbx import slots_getstate_setstate, \
     slots_getstate_setstate_default_initializer
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import zip
 
 class conformer(slots_getstate_setstate):
@@ -69,8 +66,7 @@ def get_sorted_clashes(
         id_str_j=site_labels[proxy.j_seq], #pdb_atoms[proxy.j_seq].id_str(),
         overlap=overlap)
       clashes.append(clash)
-  cmp_fn = lambda a,b: cmp(b.overlap, a.overlap)
-  clashes.sort(key=cmp_to_key(cmp_fn))
+  clashes.sort(key=lambda element: element.overlap, reverse=True)
   return clashes
 
 def show_altloc_clashes(

--- a/mmtbx/building/alternate_conformations/altloc_labeling.py
+++ b/mmtbx/building/alternate_conformations/altloc_labeling.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 from libtbx import slots_getstate_setstate, \
     slots_getstate_setstate_default_initializer
+import operator
 import sys
 from six.moves import zip
 
@@ -66,7 +67,7 @@ def get_sorted_clashes(
         id_str_j=site_labels[proxy.j_seq], #pdb_atoms[proxy.j_seq].id_str(),
         overlap=overlap)
       clashes.append(clash)
-  clashes.sort(key=lambda element: element.overlap, reverse=True)
+  clashes.sort(key=operator.attrgetter("overlap"), reverse=True)
   return clashes
 
 def show_altloc_clashes(

--- a/mmtbx/building/alternate_conformations/density_sampling.py
+++ b/mmtbx/building/alternate_conformations/density_sampling.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 import libtbx.phil
+import operator
 import time
 import sys
 from six.moves import range
@@ -126,7 +127,7 @@ def screen_residue(
       if (good_maps) : #and (conf_trans.rmsd > params.rmsd_min):
         translations.append(conf_trans)
     if (len(translations) > 0):
-      translations.sort(key=lambda element: element.mean_fofc, reverse=True)
+      translations.sort(key=operator.attrgetter("mean_fofc"), reverse=True)
       good_confs.append(translations[0])
   if (n_confs > 1) and (len(good_confs) != 0):
     for conf in good_confs :

--- a/mmtbx/building/alternate_conformations/density_sampling.py
+++ b/mmtbx/building/alternate_conformations/density_sampling.py
@@ -1,10 +1,7 @@
-
 from __future__ import absolute_import, division, print_function
 import libtbx.phil
 import time
 import sys
-from past.builtins import cmp
-from functools import cmp_to_key
 from six.moves import range
 
 sidechain_density_params = """
@@ -129,8 +126,7 @@ def screen_residue(
       if (good_maps) : #and (conf_trans.rmsd > params.rmsd_min):
         translations.append(conf_trans)
     if (len(translations) > 0):
-      cmp_fn = lambda a,b: cmp(b.mean_fofc, a.mean_fofc)
-      translations.sort(key=cmp_to_key(cmp_fn))
+      translations.sort(key=lambda element: element.mean_fofc, reverse=True)
       good_confs.append(translations[0])
   if (n_confs > 1) and (len(good_confs) != 0):
     for conf in good_confs :

--- a/mmtbx/building/alternate_conformations/real_space_annealing.py
+++ b/mmtbx/building/alternate_conformations/real_space_annealing.py
@@ -7,6 +7,7 @@ from libtbx.utils import null_out
 from libtbx import easy_mp
 import random
 import time
+import operator
 import os
 import sys
 from six.moves import range
@@ -196,7 +197,7 @@ class refine_into_difference_density(object):
               hierarchy.
     """
     if (log is None) : log = null_out()
-    trials = sorted(self.get_trials(), key=lambda element: element.cc, reverse=True)
+    trials = sorted(self.get_trials(), key=operator.attrgetter("cc"), reverse=True)
     filtered = []
     for k, trial in enumerate(trials):
       hierarchy = self.pdb_hierarchy.deep_copy()

--- a/mmtbx/building/alternate_conformations/real_space_annealing.py
+++ b/mmtbx/building/alternate_conformations/real_space_annealing.py
@@ -1,4 +1,3 @@
-
 from __future__ import absolute_import, division, print_function
 from mmtbx.building import alternate_conformations as alt_confs
 import mmtbx.building
@@ -10,8 +9,6 @@ import random
 import time
 import os
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import range
 
 master_params_str = """
@@ -199,8 +196,7 @@ class refine_into_difference_density(object):
               hierarchy.
     """
     if (log is None) : log = null_out()
-    cmp_fn = lambda a,b: cmp(b.cc, a.cc)
-    trials = sorted(self.get_trials(), key=cmp_to_key(cmp_fn))
+    trials = sorted(self.get_trials(), key=lambda element: element.cc, reverse=True)
     filtered = []
     for k, trial in enumerate(trials):
       hierarchy = self.pdb_hierarchy.deep_copy()

--- a/mmtbx/building/alternate_conformations/sliding_window.py
+++ b/mmtbx/building/alternate_conformations/sliding_window.py
@@ -8,8 +8,6 @@ from libtbx import adopt_init_args, Auto, slots_getstate_setstate
 from libtbx.utils import null_out
 import string
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import zip
 
 master_params_str = """
@@ -501,8 +499,7 @@ class ensemble_group(object):
           raise RuntimeError("No matching atoms found for %s" %
             atom_group.id_str())
         # XXX sort by maximum deviation, or rmsd?
-        cmp_fn = lambda a,b: cmp(b.max_dev, a.max_dev)
-        all_trials.sort(key=cmp_to_key(cmp_fn))
+        all_trials.sort(key=lambda element: element.max_dev, reverse=True)
         k = 0
         while (n_confs < n_max) and (k < len(all_trials)):
           trial = all_trials[k]

--- a/mmtbx/building/alternate_conformations/sliding_window.py
+++ b/mmtbx/building/alternate_conformations/sliding_window.py
@@ -6,6 +6,7 @@ from mmtbx.building import alternate_conformations as alt_confs
 import mmtbx.building
 from libtbx import adopt_init_args, Auto, slots_getstate_setstate
 from libtbx.utils import null_out
+import operator
 import string
 import sys
 from six.moves import zip
@@ -499,7 +500,7 @@ class ensemble_group(object):
           raise RuntimeError("No matching atoms found for %s" %
             atom_group.id_str())
         # XXX sort by maximum deviation, or rmsd?
-        all_trials.sort(key=lambda element: element.max_dev, reverse=True)
+        all_trials.sort(key=operator.attrgetter("max_dev"), reverse=True)
         k = 0
         while (n_confs < n_max) and (k < len(all_trials)):
           trial = all_trials[k]

--- a/mmtbx/command_line/find_peaks_holes.py
+++ b/mmtbx/command_line/find_peaks_holes.py
@@ -15,8 +15,6 @@ from libtbx import adopt_init_args, group_args
 from iotbx.pdb.hybrid_36 import hy36encode
 import os
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import zip
 
 def get_master_phil():
@@ -86,12 +84,11 @@ class peaks_holes_container(object):
     if (self.anom_peaks is not None):
       self.anom_peaks.sort(reverse=True)
     if (self.water_peaks is not None):
-      cmp_fn = lambda x,y: cmp(y.peak_height, x.peak_height)
-      self.water_peaks = sorted(self.water_peaks, key=cmp_to_key(cmp_fn))
+      self.water_peaks = sorted(self.water_peaks, key=lambda element: element.peak_height, reverse=True)
     if (self.water_anom_peaks is not None):
-      cmp_fn = lambda x,y: cmp(y.peak_height, x.peak_height)
       self.water_anom_peaks = sorted(self.water_anom_peaks,
-                                     key=cmp_to_key(cmp_fn))
+                                     key=lambda element: element.peak_height,
+                                     reverse=True)
     self.pdb_file = None
     self.map_file = None
 

--- a/mmtbx/command_line/find_peaks_holes.py
+++ b/mmtbx/command_line/find_peaks_holes.py
@@ -13,6 +13,7 @@ from libtbx.utils import Sorry
 import libtbx.phil
 from libtbx import adopt_init_args, group_args
 from iotbx.pdb.hybrid_36 import hy36encode
+import operator
 import os
 import sys
 from six.moves import zip
@@ -84,10 +85,10 @@ class peaks_holes_container(object):
     if (self.anom_peaks is not None):
       self.anom_peaks.sort(reverse=True)
     if (self.water_peaks is not None):
-      self.water_peaks = sorted(self.water_peaks, key=lambda element: element.peak_height, reverse=True)
+      self.water_peaks = sorted(self.water_peaks, key=operator.attrgetter("peak_height"), reverse=True)
     if (self.water_anom_peaks is not None):
       self.water_anom_peaks = sorted(self.water_anom_peaks,
-                                     key=lambda element: element.peak_height,
+                                     key=operator.attrgetter("peak_height"),
                                      reverse=True)
     self.pdb_file = None
     self.map_file = None

--- a/mmtbx/command_line/sort_hetatms.py
+++ b/mmtbx/command_line/sort_hetatms.py
@@ -10,8 +10,6 @@ from libtbx import runtime_utils
 import libtbx.phil
 import os
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import zip
 
 sorting_params_str = """
@@ -310,8 +308,7 @@ def sort_hetatms(
         chain.remove_residue_group(rg)
     if (len(waters_and_b_iso) > 0):
       if (params.sort_waters_by != "none"):
-        cmp_fn = lambda x,y: cmp(x[1], y[1])
-        waters_and_b_iso.sort(key=cmp_to_key(cmp_fn))
+        waters_and_b_iso.sort(key=lambda element: element[1])
       for water, b_iso in waters_and_b_iso :
         chain.append_residue_group(water)
   if (params.renumber):

--- a/mmtbx/command_line/sort_hetatms.py
+++ b/mmtbx/command_line/sort_hetatms.py
@@ -8,6 +8,7 @@ from libtbx.utils import Sorry, Usage, null_out
 from libtbx import adopt_init_args
 from libtbx import runtime_utils
 import libtbx.phil
+import operator
 import os
 import sys
 from six.moves import zip
@@ -308,7 +309,7 @@ def sort_hetatms(
         chain.remove_residue_group(rg)
     if (len(waters_and_b_iso) > 0):
       if (params.sort_waters_by != "none"):
-        waters_and_b_iso.sort(key=lambda element: element[1])
+        waters_and_b_iso.sort(key=operator.itemgetter(1))
       for water, b_iso in waters_and_b_iso :
         chain.append_residue_group(water)
   if (params.renumber):

--- a/mmtbx/ions/identify.py
+++ b/mmtbx/ions/identify.py
@@ -29,6 +29,7 @@ import libtbx.load_env
 import libtbx.phil
 from math import sqrt
 from six.moves import cStringIO as StringIO
+import operator
 import time
 import sys
 from six.moves import zip
@@ -1303,7 +1304,7 @@ class manager(object):
           map_stats = self.map_stats(water_i_seq)
           ions.append((water_i_seq, [final_choice], map_stats.two_fofc))
 
-    return sorted(ions, key=lambda element: element[2], reverse=True)
+    return sorted(ions, key=operator.itemgetter(2), reverse=True)
 
   def validate_ion(self, i_seq, out = sys.stdout, debug = True):
     """

--- a/mmtbx/ions/identify.py
+++ b/mmtbx/ions/identify.py
@@ -31,8 +31,6 @@ from math import sqrt
 from six.moves import cStringIO as StringIO
 import time
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import zip
 from six.moves import range
 from six import string_types
@@ -158,6 +156,11 @@ def ion_master_phil():
 # various constants
 WATER, WATER_POOR, LIGHT_ION, HEAVY_ION = range(4)
 NUC_PHOSPHATE_BINDING = ["MG", "CA", "MN"]
+
+def _sign(x):
+  if x > 0: return 1
+  if x < 0: return -1
+  return 0
 
 class manager(object):
   """
@@ -1300,8 +1303,7 @@ class manager(object):
           map_stats = self.map_stats(water_i_seq)
           ions.append((water_i_seq, [final_choice], map_stats.two_fofc))
 
-    cmp_fn = lambda a, b: cmp(b[2], a[2])
-    return sorted(ions, key=cmp_to_key(cmp_fn))
+    return sorted(ions, key=lambda element: element[2], reverse=True)
 
   def validate_ion(self, i_seq, out = sys.stdout, debug = True):
     """
@@ -1957,8 +1959,8 @@ class AtomProperties(object):
                 # XXX probably just O
               self.bad_coords[identity].append(contact)
               inaccuracies.add(self.BAD_COORD_RESIDUE)
-        elif (cmp(0, mmtbx.ions.server.get_charge(contact.atom)) ==
-              cmp(0, ion_params.charge)):
+        elif (_sign(mmtbx.ions.server.get_charge(contact.atom)) ==
+              _sign(ion_params.charge)):
           # Check if coordinating atom is of opposite charge
           self.bad_coords[identity].append(contact)
           inaccuracies.add(self.LIKE_COORD)

--- a/mmtbx/ions/identify.py
+++ b/mmtbx/ions/identify.py
@@ -32,6 +32,7 @@ from six.moves import cStringIO as StringIO
 import operator
 import time
 import sys
+from libtbx.math_utils import cmp
 from six.moves import zip
 from six.moves import range
 from six import string_types
@@ -157,11 +158,6 @@ def ion_master_phil():
 # various constants
 WATER, WATER_POOR, LIGHT_ION, HEAVY_ION = range(4)
 NUC_PHOSPHATE_BINDING = ["MG", "CA", "MN"]
-
-def _sign(x):
-  if x > 0: return 1
-  if x < 0: return -1
-  return 0
 
 class manager(object):
   """
@@ -1960,8 +1956,8 @@ class AtomProperties(object):
                 # XXX probably just O
               self.bad_coords[identity].append(contact)
               inaccuracies.add(self.BAD_COORD_RESIDUE)
-        elif (_sign(mmtbx.ions.server.get_charge(contact.atom)) ==
-              _sign(ion_params.charge)):
+        elif (cmp(0, mmtbx.ions.server.get_charge(contact.atom)) ==
+              cmp(0, ion_params.charge)):
           # Check if coordinating atom is of opposite charge
           self.bad_coords[identity].append(contact)
           inaccuracies.add(self.LIKE_COORD)

--- a/mmtbx/lattice.py
+++ b/mmtbx/lattice.py
@@ -10,8 +10,6 @@ crystallography. Proc Natl Acad Sci U S A. 2011 Sep 27;108(39):16247-52.
 
 from __future__ import absolute_import, division, print_function
 import sys
-from past.builtins import cmp
-from functools import cmp_to_key
 
 def find_crystal_contacts(xray_structure,
                            pdb_atoms, # atom_with_labels, not atom!
@@ -89,8 +87,7 @@ def extract_closest_contacting_residues(residue_contacts,
     if (len(contacts) == 0):
       reduced_contacts.append((residue_key, None, None, None))
     else :
-      cmp_fn = lambda x,y: cmp(x[2], y[2])
-      contacts.sort(key=cmp_to_key(cmp))
+      contacts.sort(key=lambda element: element[2])
       (j_seq, sym_op, distance) = contacts[0]
       atom_rec = pdb_atoms[j_seq].fetch_labels()
       contact_key = (atom_rec.chain_id, atom_rec.resname, atom_rec.resid(),

--- a/mmtbx/lattice.py
+++ b/mmtbx/lattice.py
@@ -9,6 +9,7 @@ crystallography. Proc Natl Acad Sci U S A. 2011 Sep 27;108(39):16247-52.
 """
 
 from __future__ import absolute_import, division, print_function
+import operator
 import sys
 
 def find_crystal_contacts(xray_structure,
@@ -87,7 +88,7 @@ def extract_closest_contacting_residues(residue_contacts,
     if (len(contacts) == 0):
       reduced_contacts.append((residue_key, None, None, None))
     else :
-      contacts.sort(key=lambda element: element[2])
+      contacts.sort(key=operator.itemgetter(2))
       (j_seq, sym_op, distance) = contacts[0]
       atom_rec = pdb_atoms[j_seq].fetch_labels()
       contact_key = (atom_rec.chain_id, atom_rec.resname, atom_rec.resid(),

--- a/mmtbx/maps/composite_omit_map.py
+++ b/mmtbx/maps/composite_omit_map.py
@@ -12,8 +12,6 @@ from cctbx import maptbx
 import cctbx.miller
 from scitbx.array_family import flex
 import boost.python
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import zip
 from six.moves import range
 asu_map_ext = boost.python.import_ext("cctbx_asymmetric_map_ext")
@@ -404,8 +402,7 @@ def create_omit_regions(xray_structure,
     groups.append(group)
   if (optimize_binning):
     # http://en.wikipedia.org/wiki/Bin_packing_problem
-    cmp_fn = lambda a,b: cmp(b.n_atoms, a.n_atoms)
-    groups = sorted(groups, key=cmp_to_key(cmp_fn))
+    groups = sorted(groups, key=lambda element: element.n_atoms, reverse=True)
     while True :
       n_combined = 0
       i_group = 0

--- a/mmtbx/maps/composite_omit_map.py
+++ b/mmtbx/maps/composite_omit_map.py
@@ -19,6 +19,7 @@ from libtbx import slots_getstate_setstate, \
   slots_getstate_setstate_default_initializer
 from libtbx.utils import null_out
 import libtbx.phil
+import operator
 import sys
 from libtbx import adopt_init_args
 import mmtbx.real_space
@@ -402,7 +403,7 @@ def create_omit_regions(xray_structure,
     groups.append(group)
   if (optimize_binning):
     # http://en.wikipedia.org/wiki/Bin_packing_problem
-    groups = sorted(groups, key=lambda element: element.n_atoms, reverse=True)
+    groups = sorted(groups, key=operator.attrgetter("n_atoms"), reverse=True)
     while True :
       n_combined = 0
       i_group = 0

--- a/mmtbx/monomer_library/pdb_interpretation.py
+++ b/mmtbx/monomer_library/pdb_interpretation.py
@@ -21,7 +21,6 @@ from libtbx.str_utils import show_string
 from libtbx.utils import flat_list, Sorry, user_plus_sys_time, plural_s
 from libtbx.utils import format_exception
 from libtbx import Auto, group_args, slots_getstate_setstate
-from past.builtins import cmp
 from six.moves import cStringIO as StringIO
 import string
 import sys, os
@@ -1826,7 +1825,7 @@ Corrupt CIF link definition:
     print('_'*80)
   for m in matches:
     if verbose: _show_match(m)
-    if (cmp(m, matches[0]) != 0): break
+    if m != matches[0]: break
     best_matches.append(m)
   match = best_matches[0]
   if (not match.is_proper_match()):

--- a/mmtbx/pdb_symmetry.py
+++ b/mmtbx/pdb_symmetry.py
@@ -10,6 +10,7 @@ import libtbx.load_env
 from libtbx import easy_pickle
 from libtbx import group_args
 from math import sqrt
+import operator
 import os
 import sys
 from six.moves import zip
@@ -101,7 +102,7 @@ def symmetry_search(
     scores.append(group_args(entry=entry,
       rmsd=rmsd,
       volume_ratio=entry_volume/input_volume))
-  scores.sort(key=lambda element: element.rmsd)
+  scores.sort(key=operator.attrgetter("rmsd"))
   return scores
 
 def download_crystal_db():

--- a/mmtbx/pdb_symmetry.py
+++ b/mmtbx/pdb_symmetry.py
@@ -12,8 +12,6 @@ from libtbx import group_args
 from math import sqrt
 import os
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import zip
 
 def parse_database(file_name):
@@ -103,8 +101,7 @@ def symmetry_search(
     scores.append(group_args(entry=entry,
       rmsd=rmsd,
       volume_ratio=entry_volume/input_volume))
-  cmp_fn = lambda x,y: cmp(x.rmsd, y.rmsd)
-  scores.sort(key=cmp_to_key(cmp_fn))
+  scores.sort(key=lambda element: element.rmsd)
   return scores
 
 def download_crystal_db():

--- a/mmtbx/refinement/select_best_starting_model.py
+++ b/mmtbx/refinement/select_best_starting_model.py
@@ -14,8 +14,6 @@ from libtbx import easy_mp
 import libtbx.phil
 import os.path
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import zip
 
 master_phil = libtbx.phil.parse("""
@@ -213,8 +211,7 @@ class select_model(object):
           if (result.r_free <= params.max_r_free):
             passed.append((k, result))
       if (len(passed) > 0):
-        cmp_fn = lambda a,b: cmp(a[1].r_free, b[1].r_free)
-        passed.sort(key=cmp_to_key(cmp_fn))
+        passed.sort(key=lambda element: element[1].r_free)
         i_result, result = passed[0]
         self.evaluations = passed
         self.best_xray_structure = result.xray_structure

--- a/mmtbx/scaling/xtriage.py
+++ b/mmtbx/scaling/xtriage.py
@@ -25,8 +25,6 @@ from libtbx.str_utils import StringIO, wordwrap
 from libtbx.utils import null_out
 from libtbx import runtime_utils
 import libtbx.callbacks # import dependency
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import cStringIO as StringIO
 import os
 import sys
@@ -1005,8 +1003,7 @@ class summary(mmtbx.scaling.xtriage_analysis):
   def __init__(self, issues, sort=True):
     self._issues = issues
     if (sort):
-      cmp_fn = lambda a,b: cmp(b[0], a[0])
-      self._issues.sort(key=cmp_to_key(cmp_fn))
+      self._issues.sort(key=lambda element: element[0], reverse=True)
 
   @property
   def n_problems(self):

--- a/mmtbx/scaling/xtriage.py
+++ b/mmtbx/scaling/xtriage.py
@@ -26,6 +26,7 @@ from libtbx.utils import null_out
 from libtbx import runtime_utils
 import libtbx.callbacks # import dependency
 from six.moves import cStringIO as StringIO
+import operator
 import os
 import sys
 
@@ -1003,7 +1004,7 @@ class summary(mmtbx.scaling.xtriage_analysis):
   def __init__(self, issues, sort=True):
     self._issues = issues
     if (sort):
-      self._issues.sort(key=lambda element: element[0], reverse=True)
+      self._issues.sort(key=operator.itemgetter(0), reverse=True)
 
   @property
   def n_problems(self):

--- a/mmtbx/secondary_structure/dssp.py
+++ b/mmtbx/secondary_structure/dssp.py
@@ -14,6 +14,7 @@ import libtbx.phil
 from libtbx.utils import null_out
 from libtbx import group_args, adopt_init_args
 from six.moves import cStringIO as StringIO
+import operator
 import time
 import sys
 
@@ -580,7 +581,7 @@ class dssp(object):
     t2 = time.time()
     if (self.params.verbosity >= 1):
       print("Time to find bridges: %.3fs" % (t2-t1), file=self.log)
-    bridges.sort(key=lambda element: element.i_res)
+    bridges.sort(key=operator.attrgetter("i_res"))
     if (self.params.verbosity >= 2):
       for B in bridges :
         B.show(out=self.log)

--- a/mmtbx/secondary_structure/dssp.py
+++ b/mmtbx/secondary_structure/dssp.py
@@ -16,8 +16,6 @@ from libtbx import group_args, adopt_init_args
 from six.moves import cStringIO as StringIO
 import time
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 
 master_phil = libtbx.phil.parse("""
 file_name = None
@@ -582,8 +580,7 @@ class dssp(object):
     t2 = time.time()
     if (self.params.verbosity >= 1):
       print("Time to find bridges: %.3fs" % (t2-t1), file=self.log)
-    cmp_fn = lambda a,b: cmp(a.i_res, b.i_res)
-    bridges.sort(key=cmp_to_key(cmp_fn))
+    bridges.sort(key=lambda element: element.i_res)
     if (self.params.verbosity >= 2):
       for B in bridges :
         B.show(out=self.log)

--- a/mmtbx/validation/clashscore.py
+++ b/mmtbx/validation/clashscore.py
@@ -13,7 +13,6 @@ import iotbx.pdb
 import os
 import re
 import sys
-from past.builtins import cmp
 import six
 
 class clash(atoms):
@@ -48,7 +47,9 @@ class clash(atoms):
              abs(self.overlap) ]
 
   def __cmp__(self, other) : # sort in descending order
-    return cmp(self.overlap, other.overlap)
+    if self.overlap < other.overlap: return -1
+    if self.overlap > other.overlap: return 1
+    return 0
 
 class clashscore(validation):
   __slots__ = validation.__slots__ + [
@@ -220,7 +221,7 @@ class probe_line_info(object): # this is parent
     assert self.overlap_value is not None
     atom1 = decode_atom_string(self.srcAtom,  use_segids)
     atom2 = decode_atom_string(self.targAtom, use_segids)
-    if (cmp(self.srcAtom, self.targAtom) < 0):
+    if (self.srcAtom < self.targAtom):
       atoms = [ atom1, atom2 ]
     else:
       atoms = [ atom2, atom1 ]
@@ -337,7 +338,7 @@ class probe_clashscore_manager(object):
 
   def put_group_into_dict(self, line_info, clash_hash, hbond_hash):
     key = line_info.targAtom+line_info.srcAtom
-    if (cmp(line_info.srcAtom,line_info.targAtom) < 0):
+    if (line_info.srcAtom < line_info.targAtom):
       key = line_info.srcAtom+line_info.targAtom
     if self.condensed_probe:
       if (line_info.type == "bo"):

--- a/mmtbx/validation/clashscore.py
+++ b/mmtbx/validation/clashscore.py
@@ -9,6 +9,7 @@ from mmtbx.utils import run_reduce_with_timeout
 from libtbx.utils import Sorry
 from libtbx import easy_run
 import libtbx.load_env
+import libtbx.math_utils
 import iotbx.pdb
 import os
 import re
@@ -47,9 +48,7 @@ class clash(atoms):
              abs(self.overlap) ]
 
   def __cmp__(self, other) : # sort in descending order
-    if self.overlap < other.overlap: return -1
-    if self.overlap > other.overlap: return 1
-    return 0
+    return libtbx.math_utils.cmp(self.overlap, other.overlap)
 
 class clashscore(validation):
   __slots__ = validation.__slots__ + [

--- a/mmtbx/validation/clashscore.py
+++ b/mmtbx/validation/clashscore.py
@@ -6,10 +6,10 @@ All-atom contact analysis.  Requires Reduce and Probe (installed separately).
 from __future__ import absolute_import, division, print_function
 from mmtbx.validation import validation, atoms, atom_info, residue
 from mmtbx.utils import run_reduce_with_timeout
+from libtbx.math_utils import cmp
 from libtbx.utils import Sorry
 from libtbx import easy_run
 import libtbx.load_env
-import libtbx.math_utils
 import iotbx.pdb
 import os
 import re
@@ -48,7 +48,7 @@ class clash(atoms):
              abs(self.overlap) ]
 
   def __cmp__(self, other) : # sort in descending order
-    return libtbx.math_utils.cmp(self.overlap, other.overlap)
+    return cmp(self.overlap, other.overlap)
 
 class clashscore(validation):
   __slots__ = validation.__slots__ + [

--- a/mmtbx/validation/rotalyze.py
+++ b/mmtbx/validation/rotalyze.py
@@ -1,11 +1,9 @@
-
 from __future__ import absolute_import, division, print_function
 from mmtbx.validation import residue, validation
 from mmtbx.validation import graphics
 from iotbx import data_plots
 from libtbx.str_utils import format_value
 from libtbx.utils import Sorry
-from past.builtins import cmp
 import os, sys
 
 OUTLIER_THRESHOLD = 0.003
@@ -80,8 +78,7 @@ class rotamer_ensemble(residue):
     for rot_id in set(self.rotamer_name):
       n_rotamer = self.rotamer_name.count(rot_id)
       rotamers.append((rot_id, n_rotamer))
-    cmp_fn = lambda a,b: cmp(b[1], a[1])
-    return sorted(rotamers, key=cmp_to_key(cmp_fn))
+    return sorted(rotamers, key=lambda element: element[1], reverse=True)
 
   def as_string(self):
     rotamers = self.rotamer_frequencies()

--- a/mmtbx/validation/rotalyze.py
+++ b/mmtbx/validation/rotalyze.py
@@ -4,6 +4,7 @@ from mmtbx.validation import graphics
 from iotbx import data_plots
 from libtbx.str_utils import format_value
 from libtbx.utils import Sorry
+import operator
 import os, sys
 
 OUTLIER_THRESHOLD = 0.003
@@ -78,7 +79,7 @@ class rotamer_ensemble(residue):
     for rot_id in set(self.rotamer_name):
       n_rotamer = self.rotamer_name.count(rot_id)
       rotamers.append((rot_id, n_rotamer))
-    return sorted(rotamers, key=lambda element: element[1], reverse=True)
+    return sorted(rotamers, key=operator.itemgetter(1), reverse=True)
 
   def as_string(self):
     rotamers = self.rotamer_frequencies()

--- a/rstbx/viewer/results_base.py
+++ b/rstbx/viewer/results_base.py
@@ -4,8 +4,6 @@ from libtbx import easy_pickle
 from libtbx.utils import Sorry
 import re
 import os
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import zip
 
 class result(object):
@@ -108,8 +106,7 @@ def load_integration_results(dir_name, base_name, image_id=1):
     summary = get_integration_summary(result, int(sol_id_))
     summaries.append(summary)
   r_s = list(zip(results, summaries))
-  cmp_fn = lambda x,y: cmp(y[1]['solution'], x[1]['solution'])
-  r_s_sorted = sorted(r_s, key=cmp_to_key(cmp_fn))
+  r_s_sorted = sorted(r_s, key=lambda element: element[1]['solution'], reverse=True)
   return [ r for r,s in r_s_sorted ], [ s for r, s in r_s_sorted ]
 
 class TableData(object):

--- a/scitbx/array_family/boost_python/tst_flex.py
+++ b/scitbx/array_family/boost_python/tst_flex.py
@@ -6,7 +6,6 @@ from libtbx.test_utils import Exception_expected, approx_equal, \
   not_approx_equal, show_diff
 import libtbx.math_utils
 from six.moves import cStringIO as StringIO
-from past.builtins import cmp
 from six.moves import range
 from six.moves import cPickle as pickle
 import six
@@ -1113,8 +1112,15 @@ def exercise_operators():
   assert a.all_le(9)
   assert not a.all_ge(b)
   assert a.all_ge(2)
-  assert flex.order(a, b) == cmp(tuple(a), tuple(b))
-  assert flex.order(b, a) == cmp(tuple(b), tuple(a))
+  if tuple(a) < tuple(b):
+      assert flex.order(a, b) == -1
+      assert flex.order(b, a) == 1
+  elif tuple(a) > tuple(b):
+      assert flex.order(a, b) == 1
+      assert flex.order(b, a) == -1
+  else:
+      assert flex.order(a, b) == 0
+      assert flex.order(b, a) == 0
   assert flex.order(a, a) == 0
   b = a.deep_copy()
   assert flex.order(a, b) == 0

--- a/scitbx/array_family/boost_python/tst_flex.py
+++ b/scitbx/array_family/boost_python/tst_flex.py
@@ -6,6 +6,7 @@ from libtbx.test_utils import Exception_expected, approx_equal, \
   not_approx_equal, show_diff
 import libtbx.math_utils
 from six.moves import cStringIO as StringIO
+from libtbx.math_utils import cmp
 from six.moves import range
 from six.moves import cPickle as pickle
 import six
@@ -1112,15 +1113,8 @@ def exercise_operators():
   assert a.all_le(9)
   assert not a.all_ge(b)
   assert a.all_ge(2)
-  if tuple(a) < tuple(b):
-      assert flex.order(a, b) == -1
-      assert flex.order(b, a) == 1
-  elif tuple(a) > tuple(b):
-      assert flex.order(a, b) == 1
-      assert flex.order(b, a) == -1
-  else:
-      assert flex.order(a, b) == 0
-      assert flex.order(b, a) == 0
+  assert flex.order(a, b) == cmp(tuple(a), tuple(b))
+  assert flex.order(b, a) == cmp(tuple(b), tuple(a))
   assert flex.order(a, a) == 0
   b = a.deep_copy()
   assert flex.order(a, b) == 0

--- a/scitbx/graph/rigidity_matrix_symbolic.py
+++ b/scitbx/graph/rigidity_matrix_symbolic.py
@@ -27,15 +27,7 @@ def iiexps_mul(a, b):
   return result
 
 def iiexps_as_tuples(iiexps):
-  from past.builtins import cmp
-  from functools import cmp_to_key
-  def cmp_iiexp(a, b):
-    result = cmp(a[0], b[0])
-    if (result != 0): return result
-    return cmp(a[1], b[1])
-  result = list(iiexps.items())
-  result.sort(key=cmp_to_key(cmp_iiexp))
-  return tuple(result)
+  return tuple(sorted(iiexps.items()))
 
 class term(object):
 

--- a/scitbx/graph/tardy_tree.py
+++ b/scitbx/graph/tardy_tree.py
@@ -4,7 +4,6 @@ from scitbx.graph.utils import \
 from libtbx import slots_getstate_setstate
 import math
 from six.moves import range
-from past.builtins import cmp
 from functools import cmp_to_key
 
 class cluster_manager(slots_getstate_setstate):
@@ -146,7 +145,9 @@ class cluster_manager(slots_getstate_setstate):
           if (fb): return 1
       if (len(a) > len(b)): return -1
       if (len(a) < len(b)): return 1
-      if (len(a) != 0): return cmp(a[0], b[0])
+      if len(a):
+        if a[0] > b[0]: return 1
+        if a[0] < b[0]: return -1
       return 0
     O.clusters.sort(key=cmp_to_key(cmp_clusters))
     for ic in range(len(O.clusters)-1,-1,-1):
@@ -243,7 +244,9 @@ class cluster_manager(slots_getstate_setstate):
       if (fa < fb): return 1
       if (a[1] > b[1]): return -1
       if (a[1] < b[1]): return 1
-      return cmp(a[0], b[0])
+      if (a[0] > b[0]): return 1
+      if (a[0] < b[0]): return -1
+      return 0
     cii_orcs.sort(key=cmp_to_key(cmp_elems))
     return cii_orcs, fixed_vertex_info
 

--- a/scitbx/graph/tardy_tree.py
+++ b/scitbx/graph/tardy_tree.py
@@ -4,6 +4,7 @@ from scitbx.graph.utils import \
 from libtbx import slots_getstate_setstate
 import math
 from six.moves import range
+from libtbx.math_utils import cmp
 from functools import cmp_to_key
 
 class cluster_manager(slots_getstate_setstate):
@@ -145,9 +146,7 @@ class cluster_manager(slots_getstate_setstate):
           if (fb): return 1
       if (len(a) > len(b)): return -1
       if (len(a) < len(b)): return 1
-      if len(a):
-        if a[0] > b[0]: return 1
-        if a[0] < b[0]: return -1
+      if len(a): return cmp(a[0], b[0])
       return 0
     O.clusters.sort(key=cmp_to_key(cmp_clusters))
     for ic in range(len(O.clusters)-1,-1,-1):
@@ -244,9 +243,7 @@ class cluster_manager(slots_getstate_setstate):
       if (fa < fb): return 1
       if (a[1] > b[1]): return -1
       if (a[1] < b[1]): return 1
-      if (a[0] > b[0]): return 1
-      if (a[0] < b[0]): return -1
-      return 0
+      return cmp(a[0], b[0])
     cii_orcs.sort(key=cmp_to_key(cmp_elems))
     return cii_orcs, fixed_vertex_info
 

--- a/wxtbx/plots/__init__.py
+++ b/wxtbx/plots/__init__.py
@@ -5,6 +5,7 @@ import wx
 from libtbx import object_oriented_patterns as oop
 from libtbx.math_utils import ifloor
 from libtbx import adopt_init_args
+import operator
 import math
 import sys
 from six.moves import range
@@ -183,7 +184,7 @@ class histogram(plot_container):
 
 def convert_xyz_value_list(values, null_value=0.0):
   import numpy
-  values = sorted(values, key=lambda element: element[0])
+  values = sorted(values, key=operator.itemgetter(0))
   x_rows = [[values[0]]]
   for i, xyz in enumerate(values[1:]):
     if (xyz[0] != x_rows[-1][-1][0]):
@@ -196,7 +197,7 @@ def convert_xyz_value_list(values, null_value=0.0):
   for j in range(len(y_values)):
     z_values.append([])
   for i, x_row in enumerate(x_rows):
-    x_row = sorted(x_row, key=lambda element: element[1])
+    x_row = sorted(x_row, key=operator.itemgetter(1))
     for j, (x,y,z) in enumerate(x_row):
       assert (y in y_values)
       if (z is not None):

--- a/wxtbx/plots/__init__.py
+++ b/wxtbx/plots/__init__.py
@@ -1,4 +1,3 @@
-
 from __future__ import absolute_import, division, print_function
 from wxtbx import bitmaps
 import wxtbx
@@ -8,8 +7,6 @@ from libtbx.math_utils import ifloor
 from libtbx import adopt_init_args
 import math
 import sys
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import range
 if (sys.version_info[2] >= 6):
   import warnings
@@ -186,8 +183,7 @@ class histogram(plot_container):
 
 def convert_xyz_value_list(values, null_value=0.0):
   import numpy
-  cmp_fn = lambda x,y: cmp(x[0], y[0])
-  values = sorted(list(values), key=cmp_to_key(cmp_fn))
+  values = sorted(values, key=lambda element: element[0])
   x_rows = [[values[0]]]
   for i, xyz in enumerate(values[1:]):
     if (xyz[0] != x_rows[-1][-1][0]):
@@ -200,8 +196,7 @@ def convert_xyz_value_list(values, null_value=0.0):
   for j in range(len(y_values)):
     z_values.append([])
   for i, x_row in enumerate(x_rows):
-    cmp_fn = lambda x,y: cmp(x[1], y[1])
-    x_row = sorted(x_row, key=cmp_to_key(cmp_fn))
+    x_row = sorted(x_row, key=lambda element: element[1])
     for j, (x,y,z) in enumerate(x_row):
       assert (y in y_values)
       if (z is not None):

--- a/wxtbx/qstat_view.py
+++ b/wxtbx/qstat_view.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import, division, print_function
 import wxtbx.bitmaps
 from libtbx.queuing_system_utils import sge_utils
 from libtbx.utils import Sorry
-from functools import cmp_to_key
-from past.builtins import cmp
 import wx
 try :
   from wx.lib.agw.genericmessagedialog import GenericMessageDialog
@@ -53,17 +51,13 @@ class qsub_list_data(object):
       else :
         self._sort_descending = False
     if col == 0 :
-      cmp_fn = lambda x, y: cmp(int(x.job_id), int(y.job_id))
-      self._data.sort(key=cmp_to_key(cmp_fn))
+      self._data.sort(key=lambda element: int(element.job_id))
     elif col == 4 :
       fmt = "%m/%d/%Y %H:%M:%S"
-      cmp_fn = lambda x, y: cmp(time.strptime(x.submit, fmt),
-                                time.strptime(y.submit, fmt))
-      self._data.sort(key=cmp_to_key(cmp_fn))
+      self._data.sort(key=lambda element: time.strptime(element.submit, fmt))
     else :
       attr = job_attrs[col]
-      cmp_fn = lambda x, y: cmp(getattr(x, attr), getattr(y, attr))
-      self._data.sort(key=cmp_to_key(cmp_fn))
+      self._data.sort(key=lambda element: getattr(element, attr))
     if self._sort_descending :
       self._data.reverse()
     self._sortby = col

--- a/xfel/small_cell/small_cell.py
+++ b/xfel/small_cell/small_cell.py
@@ -1,6 +1,4 @@
 from __future__ import absolute_import, division, print_function
-from functools import cmp_to_key
-from past.builtins import cmp
 from six.moves import range
 from six.moves import zip
 #-*- Mode: Python; c-basic-offset: 2; indent-tabs-mode: nil; tab-width: 8 -*-
@@ -657,9 +655,8 @@ def small_cell_index_detail(experiments, reflections, horiz_phil, write_output =
       degrees.append(len(hkl1.connections))
 
     # sort the mapping based on degeneracy. this should speed clique finding.
-    cmp_fn = lambda x, y: cmp(len(sub_clique[x[0]].hkls[x[1]].connections),
-                              len(sub_clique[y[0]].hkls[y[1]].connections))
-    mapping = sorted(mapping, key=cmp_to_key(cmp_fn))
+    mapping = sorted(mapping,
+                     key=lambda element: len(sub_clique[element[0]].hkls[element[1]].connections))
     degrees = flex.size_t(sorted(degrees))
 
 


### PR DESCRIPTION
I rewrote all places where `cmp` is used and removed the `cmp` import.

In the interest of maximum compatibility I did not remove the declarations of the following functions that are now no longer needed, but are declared in public namespaces:
https://github.com/cctbx/cctbx_project/blob/62adfccbbbd622275f8a7166361c644a1cf11511/cctbx/euclidean_model_matching.py#L251-L252
https://github.com/cctbx/cctbx_project/blob/62adfccbbbd622275f8a7166361c644a1cf11511/cctbx/euclidean_model_matching.py#L465-L466
https://github.com/cctbx/cctbx_project/blob/62adfccbbbd622275f8a7166361c644a1cf11511/cctbx/sgtbx/__init__.py#L832-L833
https://github.com/cctbx/cctbx_project/blob/62adfccbbbd622275f8a7166361c644a1cf11511/cctbx/sgtbx/direct_space_asu/check_redundancies.py#L237-L238

#### Background:
The [`cmp`](https://docs.python.org/2/library/functions.html#cmp) function is gone. Importing it from `past` (which is part of the `future` package) is causing deprecation warnings all over the place due to https://github.com/PythonCharmers/python-future/issues/551. The `imp` module [will be removed in Python 3.10](https://www.python.org/dev/peps/pep-0594).

This also -as far as I can tell- would allow retiring the dependency on the `future` package. This is a good thing as [the `future` package is a bit special](https://github.com/cctbx/dxtbx/blob/2a6b0d34ffde908d2e40072d3de0acfd9ee502c4/libtbx_refresh.py#L12).

Closes #493 