### PR TITLE
Some code cleanup

### DIFF
--- a/cctbx/adp_restraints/tst_ext.py
+++ b/cctbx/adp_restraints/tst_ext.py
@@ -8,12 +8,10 @@ from cctbx.adp_restraints import adp_restraint_params
 import scitbx
 from scitbx import matrix
 import libtbx.load_env
-import math, os, sys
+import math, os
 from six.moves import cStringIO as StringIO
 import cctbx.xray
 from libtbx.test_utils import approx_equal
-from six.moves import range
-from six.moves import zip
 
 def finite_difference_gradients(restraint_type,
                                 proxy,

--- a/cctbx/adp_restraints/tst_ext.py
+++ b/cctbx/adp_restraints/tst_ext.py
@@ -417,12 +417,6 @@ def exercise_isotropic_adp():
     assert approx_equal(a.residual(), expected_residual)
 
 def exercise_proxy_show():
-  if sys.platform.startswith("win") and sys.version_info[:2] < (2,6):
-    # This appears to be a windows-specific bug with string formatting
-    # for python versions prior to 2.6, where the exponent is printed
-    # with 3 digits rather than 2.
-    print("Skipping exercise_proxy_show()")
-    return
   sites_cart = flex.vec3_double((
     (-3.1739,10.8317,7.5653),(-2.5419,9.7567,6.6306),
     (-3.3369,8.8794,4.5191),(-3.4640,9.9882,5.3896)))

--- a/cctbx/geometry_restraints/tst_ext.py
+++ b/cctbx/geometry_restraints/tst_ext.py
@@ -2422,12 +2422,6 @@ def exercise_planarity_top_out():
     # assert approx_equal(g, e)
 
 def exercise_proxy_show():
-  if sys.platform.startswith("win") and sys.version_info[:2] < (2,6):
-    # This appears to be a windows-specific bug with string formatting
-    # for python versions prior to 2.6, where the exponent is printed
-    # with 3 digits rather than 2.
-    print("Skipping exercise_proxy_show()")
-    return
   # zeolite AHT
   crystal_symmetry = crystal.symmetry(
     unit_cell=(15.794, 9.206, 8.589, 90, 90, 90),

--- a/dox/rst/installation.txt
+++ b/dox/rst/installation.txt
@@ -43,7 +43,7 @@ Please note: **The following instructions are for developers!** The
 self-extracting (.selfx) source bundles perform all the steps
 automatically.
 
-Building from sources requires Python 2.4 through 2.7 and a C++
+Building from sources requires Python 2.7, 3.6 or newer and a C++
 compiler. If you like to use the most recent Python, it can be
 installed in the following way::
 

--- a/libtbx/command_line/parallel_simple.py
+++ b/libtbx/command_line/parallel_simple.py
@@ -83,10 +83,7 @@ def run_in_dir(cmd_info):
     os.chdir(d)
     from libtbx.command_line import printenv
     printenv.show(out=open("os_environ_at_start", "w"))
-    if (sys.version_info[:2] < (2,6)):
-      from libtbx.easy_run import subprocess
-    else:
-      import subprocess
+    import subprocess
     log = open("log", "w")
     t0 = time.time()
     try:

--- a/libtbx/easy_mp.py
+++ b/libtbx/easy_mp.py
@@ -8,8 +8,6 @@ import os
 import sys
 from six.moves import range
 
-_have_maxtasksperchild = (sys.version_info[:2] >= (2,7))
-
 _problem_cache = Auto
 
 # Patch Python 2.7 multiprocessing module to avoid unnecessary file operations
@@ -74,7 +72,7 @@ def get_processes(processes):
   :returns: actual number of processes to use
   """
   if (processes in [None, Auto]):
-    if (os.name == "nt") or (sys.version_info < (2,6)):
+    if os.name == "nt":
       return 1
     from libtbx import introspection
     auto_adjust = (processes is Auto)
@@ -359,7 +357,7 @@ def pool_map(
           sub_name_format=func_wrapper[16:])
       else:
         raise RuntimeError("Unknown func_wrapper keyword: %s" % func_wrapper)
-      if (maxtasksperchild is Auto and _have_maxtasksperchild):
+      if (maxtasksperchild is Auto):
         maxtasksperchild = 1
       if (chunksize is Auto):
         chunksize = 1
@@ -374,7 +372,7 @@ def pool_map(
   processes = get_processes(processes)
   # XXX since we want to be able to call this function on Windows too, reset
   # processes to 1
-  if (os.name == "nt") or (sys.version_info < (2,6)):
+  if os.name == "nt":
     processes = 1
   if (args is not None):
     iterable = args

--- a/libtbx/python_code_parsing.py
+++ b/libtbx/python_code_parsing.py
@@ -2,9 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from builtins import object
 
-import sys
-assert sys.version_info[0:2] >= (2, 6)
-
 import ast
 
 class imported_name(object):

--- a/scitbx/array_family/boost_python/tst_flex.py
+++ b/scitbx/array_family/boost_python/tst_flex.py
@@ -828,14 +828,12 @@ def exercise_push_back_etc():
   assert list(a) == [1,2]
   a.insert(-1, 3)
   assert list(a) == [1,3,2]
-  vi = sys.version_info
-  if (not (vi[0] == 2 and vi[1] < 3)): # skipping test under Python 2.2 since
-    for i in range(-3,4):             # l.insert(-2, 5) doesn't work right
-      c = a.deep_copy()
-      l = list(a)
-      c.insert(i, 5)
-      l.insert(i, 5)
-      assert list(c) == l
+  for i in range(-3,4):
+    c = a.deep_copy()
+    l = list(a)
+    c.insert(i, 5)
+    l.insert(i, 5)
+    assert list(c) == l
   for i in [-5, -4, 4, 5]:
     try: a.insert(i, 5)
     except IndexError: pass
@@ -1277,10 +1275,7 @@ def exercise_arith_inplace_operators():
   assert tuple(a) == (12, 10)
   a -= flex.int((4, 3))
   assert tuple(a) == (8, 7)
-  if ("".join([str(n) for n in sys.version_info[:3]]) > "221"):
-    a *= a
-  else:
-    a = flex.int((64, 49))
+  a *= a
   assert tuple(a) == (64, 49)
   a /= flex.int((2, 1))
   assert tuple(a) == (32, 49)

--- a/scitbx/graph/rigidity_matrix_symbolic.py
+++ b/scitbx/graph/rigidity_matrix_symbolic.py
@@ -1,24 +1,8 @@
 from __future__ import absolute_import, division, print_function
-import sys
-from six.moves import range
 
-if (getattr(sys, "api_version", 0) >= 1013):
-
-  class dict_with_default_0(dict):
-
-    def __missing__(self, key):
-      return 0
-
-else:
-
-  class dict_with_default_0(dict):
-
-    def __getitem__(self, key):
-      try: return dict.__getitem__(self, key)
-      except KeyError: pass
-      val = 0
-      dict.__setitem__(self, key, val)
-      return val
+class dict_with_default_0(dict):
+  def __missing__(self, key):
+    return 0
 
 def iiexps_mul(a, b):
   result = dict_with_default_0(a)

--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -26,7 +26,7 @@ Manually building from sources under Linux and macOS
 
 Please note: **The following instructions are for developers!**
 
-Building from sources requires Python 2.5 through 2.7 and a C++
+Building from sources requires Python 2.7, 3.6 or newer and a C++
 compiler. If you like to use the most recent Python, it can be
 installed in the following way::
 

--- a/wxtbx/plots/__init__.py
+++ b/wxtbx/plots/__init__.py
@@ -11,10 +11,6 @@ import sys
 from functools import cmp_to_key
 from past.builtins import cmp
 from six.moves import range
-if (sys.version_info[2] >= 6):
-  import warnings
-  warnings.simplefilter('ignore', DeprecationWarning)
-  warnings.simplefilter('ignore', UserWarning) # for matplotlib 1.5.1
 
 # explicitly set locale for matplotlib 2.0.0, otherwise, on macOS,
 # locale.getpreferredencoding(do_setlocale=False) returns an empty string


### PR DESCRIPTION
remove some unnecessary compatibility constructs for unsupported python versions.

In particular the one in `wxtbx` caught my attention, as this (likely accidentally) globally disables `DeprecationWarning`s and `UserWarning`s based on the patch level of the python interpreter, ie. warnings are enabled on 2.7.4, disabled on 2.7.6, enabled on 3.6.5, disabled on 3.6.6, enabled on 3.7.3, etc...

The rest is mainly Python 2.2 and 2.6 compatibility stuff. The `sys.api_version()` used at one point has been a constant value (`1013`) since 2006.