### PR TITLE
Encapsulate gaussdev

### DIFF
--- a/simtbx/nanoBragg/nanoBragg.cpp
+++ b/simtbx/nanoBragg/nanoBragg.cpp
@@ -19,10 +19,11 @@ class encapsulated_gaussdev
  * class instance.
  */
   private:
-    int iset=0;
-    double gset=0.; //set value to avoid compiler warnings, but the 0 value must not be used.
+    int iset;
+    double gset; //set value to avoid compiler warnings, but the 0 value must not be used.
     double fac,rsq,v1,v2;
   public:
+    encapsulated_gaussdev() : iset(0), gset(0.) {}
     double operator()(long *idum){
     if (iset == 0) {
         /* no extra deviats handy ... */

--- a/simtbx/nanoBragg/nanoBragg.h
+++ b/simtbx/nanoBragg/nanoBragg.h
@@ -120,9 +120,6 @@ double ran1(long *idum);
 /* ln of the gamma function */
 double gammln(double xx);
 
-/* return Gaussian deviate with rms=1 and FWHM = 2/sqrt(log(2)) */
-//take this out of header.  declare and define in cpp.
-//double gaussdev(long *idum);
 /* return Poissonian deviate given expectation value */
 double poidev(double xm, long *idum);
 

--- a/simtbx/nanoBragg/nanoBragg.h
+++ b/simtbx/nanoBragg/nanoBragg.h
@@ -121,7 +121,8 @@ double ran1(long *idum);
 double gammln(double xx);
 
 /* return Gaussian deviate with rms=1 and FWHM = 2/sqrt(log(2)) */
-double gaussdev(long *idum);
+//take this out of header.  declare and define in cpp.
+//double gaussdev(long *idum);
 /* return Poissonian deviate given expectation value */
 double poidev(double xm, long *idum);
 


### PR DESCRIPTION
This pull request makes a set of nanoBragg simulated images deterministic, with respect to scrambling the order in which the simulations are performed.  Previously the add_noise() function unintentionally stored global state in the static variable "iset", which unfortunately had the effect of making the "random" image noise unpredictable.  In the new redesign, the variable "iset" is re-initialized for each image, i.e., whenever the add_noise() function is called.    