### PR TITLE
cc_one_half_sigma_tau bug fix

### DIFF
--- a/cctbx/miller/__init__.py
+++ b/cctbx/miller/__init__.py
@@ -5089,12 +5089,13 @@ class array(set):
         sigmas=flex.double(self.size(), 1))
       merging_internal = intensities_copy.merge_equivalents(
         use_internal_variance=True)
-      merged = merging_internal.array()
-      if merged.size() == 1:
+      merged = merging_internal.array().select(
+        merging_internal.redundancies().data() > 1
+      )
+      if merged.size() <= 1:
         cc_one_half = 0
       else:
-        internal_sigmas = merging_internal.array().sigmas()
-        internal_variances = flex.pow2(internal_sigmas)
+        internal_variances = flex.pow2(merged.sigmas())
         mav = flex.mean_and_variance(merged.data())
         var_y = mav.unweighted_sample_variance()
         var_e = 2 * flex.mean(internal_variances)

--- a/iotbx/regression/tst_merging_statistics.py
+++ b/iotbx/regression/tst_merging_statistics.py
@@ -217,13 +217,13 @@ def exercise(debug=False):
   assert result.bins[0].cc_anom_significance is True
   assert approx_equal(result.bins[0].cc_anom_critical_value, 0.0873548986308)
   assert approx_equal(result.cc_one_half_overall, 0.931122967496)
-  assert approx_equal(result.cc_one_half_sigma_tau_overall, 0.9343213900704643)
+  assert approx_equal(result.cc_one_half_sigma_tau_overall, 0.9280192675969664)
   assert approx_equal(result.bins[0].cc_one_half, 0.9969293192434535)
-  assert approx_equal(result.bins[0].cc_one_half_sigma_tau, 0.9970705896978537)
+  assert approx_equal(result.bins[0].cc_one_half_sigma_tau, 0.9968045160775104)
   assert result.bins[0].cc_one_half_significance is True
   assert result.bins[0].cc_one_half_sigma_tau_significance is True
   assert approx_equal(result.bins[-1].cc_one_half, 0.675340867481686)
-  assert approx_equal(result.bins[-1].cc_one_half_sigma_tau, 0.7360191500836607)
+  assert approx_equal(result.bins[-1].cc_one_half_sigma_tau, 0.6711734115834956)
   assert result.bins[-1].cc_one_half_significance is True
   assert result.bins[-1].cc_one_half_sigma_tau_significance is True
   #


### PR DESCRIPTION
Only use reflections with multiplicity > 1. Variance is not defined for a single observation.