### PR TITLE
Remove unused variables and typedefs

### DIFF
--- a/cbflib_adaptbx/detectors/boost_python/cbflib_ext.cpp
+++ b/cbflib_adaptbx/detectors/boost_python/cbflib_ext.cpp
@@ -57,7 +57,6 @@ scitbx::af::flex_int uncompress(const boost::python::object& packed,const int& s
     //C++ weirdness
     scitbx::af::flex_int z((scitbx::af::flex_grid<>(slow,fast)),scitbx::af::init_functor_null<int>());
     int* begin = z.begin();
-    std::size_t sz = z.size();
 
     iotbx::detectors::buffer_uncompress(strpacked.c_str(), sz_buffer, begin);
 
@@ -81,7 +80,6 @@ uncompress_sum_positive(const boost::python::object & packed,
     scitbx::af::flex_int z(scitbx::af::flex_grid<>(slow,fast),
                            scitbx::af::init_functor_null<int>());
     int* begin = z.begin();
-    std::size_t sz = z.size();
 
     iotbx::detectors::buffer_uncompress(strpacked.c_str(), sz_buffer, begin);
 

--- a/cbflib_adaptbx/detectors/mar_adaptor.h
+++ b/cbflib_adaptbx/detectors/mar_adaptor.h
@@ -25,7 +25,6 @@ class AnyImgAdaptor {
  private:
   std::string filename;
   img_handle img;
-  int img_status;
   bool read_header_ok;
   long data_read_position;
   bool read_data_ok;

--- a/cctbx/xray/each_hkl_gradients_direct.h
+++ b/cctbx/xray/each_hkl_gradients_direct.h
@@ -39,7 +39,6 @@ namespace cctbx { namespace xray { namespace structure_factors {
       typedef float_type f_t;
       typedef std::complex<f_t> c_t;
       scitbx::sym_mat3<f_t> dw_coeff;
-      c_t f0_fp_fdp_w = f0_fp_fdp * scatterer.weight();
       f_t dw_iso = 0;
       if (scatterer.flags.use_u_iso()) {
         dw_iso = adptbx::debye_waller_factor_u_iso(

--- a/iotbx/detectors/display.h
+++ b/iotbx/detectors/display.h
@@ -264,7 +264,6 @@ public:
         int idx_i = i * raw.accessor()[1];
         for (std::size_t j=0; j< raw.accessor()[1]; j++) {
           int fast = binning * j;
-          int idx = idx_slow + fast;
           int idx_ij = idx_i + j;
           if (detector_location->is_active_area(slow, fast)) {
             //fractional input value:

--- a/iotbx/detectors/image_divider.cpp
+++ b/iotbx/detectors/image_divider.cpp
@@ -78,7 +78,6 @@ Distl::image_divider::tile_data(const int& module_number)const{
   int* begin = z.begin();
   const int* icount = data.begin();
 
-  int slow_size = data.accessor().focus()[0];
   int fast_size = data.accessor().focus()[1];
 
   icount += slow_tiles[idx_slow].first * fast_size

--- a/mmtbx/scaling/absolute_scaling.h
+++ b/mmtbx/scaling/absolute_scaling.h
@@ -180,8 +180,8 @@ namespace absolute_scaling{
     f_t c_scale = 1./C;
     f_t c_scale_sq = c_scale * c_scale;
     if(C > 1.e+30) {
-      f_t c_scale = 0.0;
-      f_t c_scale_sq = 0.0;
+      c_scale = 0.0;
+      c_scale_sq = 0.0;
     }
     f_t grad_scale = 0.0;
     f_t grad_B = 0.0;

--- a/prime/ext.cpp
+++ b/prime/ext.cpp
@@ -375,10 +375,6 @@ namespace prime {
         double r_meas = 0;
         double r_meas_w = 0;
         if (multiplicity > 1) {
-          double n_obs = (double)multiplicity;
-          double r_meas_w_top_sum = 0;
-          double r_meas_top_sum = 0;
-
           for (int i = 0; i < multiplicity; i++) {
             r_meas_w_top += std::pow(((I_full_group[i] - I_avg)*SE_norm[i]),2);
             r_meas_w_btm += std::pow(I_full_group[i]*SE_norm[i],2);

--- a/rstbx/apps/integration_ext.cpp
+++ b/rstbx/apps/integration_ext.cpp
@@ -12,9 +12,6 @@ namespace rstbx { namespace integration { namespace ext {
     {
       using namespace boost::python;
 
-      typedef return_value_policy<return_by_value> rbv;
-      typedef default_call_policies dcp;
-
       class_<simple_integration>(
         "simple_integration", init<>())
          .enable_pickling()

--- a/rstbx/bandpass/ext.cpp
+++ b/rstbx/bandpass/ext.cpp
@@ -1014,7 +1014,6 @@ namespace ext {
     {
       using namespace boost::python;
       typedef return_value_policy<return_by_value> rbv;
-      typedef return_internal_reference<> rir;
       class_<parameters_bp3>("parameters_bp3",
                                   init<scitbx::af::shared<cctbx::miller::index<> >,
                                   cctbx::crystal_orientation const&,

--- a/rstbx/simulation/ext.cpp
+++ b/rstbx/simulation/ext.cpp
@@ -17,7 +17,6 @@ namespace rstbx { namespace boost_python { namespace {
     using namespace boost::python;
 
     typedef return_value_policy<return_by_value> rbv;
-    typedef default_call_policies dcp;
 
     class_<xfel1>("xfel1",init<>())
       .def("set_indices",&xfel1::set_indices)

--- a/scitbx/array_family/ref.h
+++ b/scitbx/array_family/ref.h
@@ -350,7 +350,6 @@ namespace scitbx { namespace af {
         SCITBX_ASSERT(this->n_rows() >= d.size());
         SCITBX_ASSERT(this->n_columns() >= d.size());
         this->fill(0);
-        index_value_type m = this->n_rows(), n = this->n_columns();
         for(index_value_type i=0; i < d.size(); i++) (*this)(i,i) = d[i];
       }
 

--- a/scitbx/array_family/tst_af_4.cpp
+++ b/scitbx/array_family/tst_af_4.cpp
@@ -101,7 +101,6 @@ namespace {
     ArrayType& a, ResultArrayType const&, BoolArrayType const&)
   {
     typedef typename ArrayType::value_type element_type;
-    typedef typename ResultArrayType::value_type result_element_type;
     a[0] = 0.1;
     a[1] = 0.2;
     a[2] = 0.3;

--- a/scitbx/examples/bevington/bevington_ext.cpp
+++ b/scitbx/examples/bevington/bevington_ext.cpp
@@ -22,9 +22,6 @@ namespace boost_python { namespace {
   scaling_init_module() {
     using namespace boost::python;
 
-    typedef return_value_policy<return_by_value> rbv;
-    typedef default_call_policies dcp;
-
     class_<linear_ls_eigen_wrapper>("linear_ls_eigen_wrapper", no_init)
       .def(init<int>(arg("n_parameters")))
       .def("n_parameters", &linear_ls_eigen_wrapper::n_parameters)

--- a/scitbx/examples/bevington/prototype_core.h
+++ b/scitbx/examples/bevington/prototype_core.h
@@ -162,7 +162,6 @@ class linear_ls_eigen_wrapper
     scitbx::af::shared<double> get_cholesky_lower() const {
       SCITBX_ASSERT (!solved_);
       SCITBX_ASSERT(formed_normal_matrix());
-      int N = n_parameters();
       scitbx::af::versa<double, scitbx::af::packed_l_accessor> triangular_result(n_parameters());
       Eigen::SimplicialLDLT<sparse_matrix_t> chol(eigen_normal_matrix.transpose());
       sparse_matrix_t lower = chol.matrixL();
@@ -303,7 +302,6 @@ class non_linear_ls_eigen_wrapper:  public scitbx::lstbx::normal_equations::non_
       add_residuals(r, w);
       sparse::matrix<scalar_t> a = jacobian.transpose();
       for (int ieqn = 0; ieqn < a.n_cols(); ++ieqn){
-        int ndata = a.col(ieqn).non_zeroes();
         row_iterator iend = a.col(ieqn).end();
         for (row_iterator i = a.col(ieqn).begin(); i != iend; ++i)  {
           std::size_t idx_i = i.index();

--- a/scitbx/math/2d_zernike_moments.h
+++ b/scitbx/math/2d_zernike_moments.h
@@ -8,7 +8,7 @@
 #include <iomanip>
 
 #include <scitbx/array_family/shared.h>
-#include<scitbx/array_family/versa.h>
+#include <scitbx/array_family/versa.h>
 #include <scitbx/array_family/accessors/c_grid.h>
 #include <scitbx/array_family/sort.h>
 
@@ -249,7 +249,7 @@ namespace zernike {
       FloatType space_sum(int r, int s)
       {
         int x,y;
-        FloatType tot(0.0), temp,z;
+        FloatType tot(0.0), z;
 
         for(int i=0;i<total_point_;i++) {
           x=voxel_indx_[i][0];
@@ -533,8 +533,8 @@ namespace zernike {
 
       FloatType zernike_poly(int n, int m, FloatType r)
       {
-        int in,im,ik,k, max_nu, nu, alpha, beta, d;
-        FloatType value(0),temp(0), temp1(0);
+        int in,im,ik,k;
+        FloatType value(0);
         af::shared< FloatType > gm_r(n+1,1.0);
         for(int i=1;i<=n;i++) {
           gm_r[i]=gm_r[i-1]*r;

--- a/scitbx/math/boost_python/exp_functions.cpp
+++ b/scitbx/math/boost_python/exp_functions.cpp
@@ -33,8 +33,6 @@ namespace {
   namespace float_bits {
     static const unsigned sign = 0x80000000U;
     static const unsigned expo = 0x7F800000U;
-    static const unsigned mant = 0x007FFFFFU;
-    static const unsigned expo_size = 8U;
     static const unsigned mant_size = 23U;
     static const int expo_min = -127;
     static const int expo_max = 127;

--- a/scitbx/math/chebyshev.h
+++ b/scitbx/math/chebyshev.h
@@ -170,7 +170,6 @@ namespace chebyshev{
   chebyshev_base<FloatType>
   ::cheb_base_f(scitbx::af::const_ref<FloatType> const& x_in)
   {
-    typedef FloatType f_t;
     scitbx::af::shared<FloatType> result(x_in.size(),0);
     for (unsigned ii=0;ii<x_in.size();ii++){
       result[ii]=cheb_base_f(x_in[ii]);

--- a/scitbx/math/inertia_tensor.h
+++ b/scitbx/math/inertia_tensor.h
@@ -18,7 +18,6 @@ namespace scitbx { namespace math {
     for(std::size_t i_p=0;i_p<points.size();i_p++) {
       accumulate(points[i_p]);
     }
-    sym_mat3<FloatType> it = accumulate.inertia_tensor();
     result = accumulate.inertia_tensor(pivot);
   }
 

--- a/scitbx/math/zernike.h
+++ b/scitbx/math/zernike.h
@@ -1265,7 +1265,7 @@ namespace zernike{
         rr = r;
       }
 
-      FloatType result,tmp;
+      FloatType result;
       result=0.0;
 
       for (int kk=0;kk<n_terms_;kk++){
@@ -1422,7 +1422,7 @@ namespace zernike{
     lgf_(n_max_*2+5)// factorial engine
     {
       delta_ = 1.0 / (m-1);
-      FloatType x,y,z,r,t,p;
+      FloatType r,t,p;
       scitbx::vec3<FloatType> xyz, rtp;
       scitbx::vec3<int> ijk;
       // get all indices please
@@ -1749,7 +1749,7 @@ namespace zernike{
       } else {
         rr = r;
       }
-      FloatType result,tmp;
+      FloatType result;
       result=0.0;
       for (int kk=0;kk<n_terms_;kk++){
         result+=std::pow(rr, n_ - 2*kk) * Nnlk_[kk];
@@ -1932,7 +1932,7 @@ namespace zernike{
     lgf_(n_max_*2+5)// factorial engine
     {
       delta_ = 1.0 / (m);
-      FloatType x,y,r,t;
+      FloatType r,t;
       scitbx::vec2<FloatType> xy, rt;
       scitbx::vec2<int> ij;
       // get all indices please

--- a/scitbx/math/zernike_moments.h
+++ b/scitbx/math/zernike_moments.h
@@ -8,7 +8,7 @@
 #include <iomanip>
 
 #include <scitbx/array_family/shared.h>
-#include<scitbx/array_family/versa.h>
+#include <scitbx/array_family/versa.h>
 #include <scitbx/array_family/accessors/c_grid.h>
 
 #include <scitbx/vec3.h>
@@ -166,7 +166,6 @@ namespace zernike {
       void xyz2voxel() {
         // build voxel map based on xyz coord
         int xi,yi,zi;
-        int two_NP = NP_*2;
         for(int i=0;i<natom_;i++) {
           if(scaled_xyz_[i][0] <0 )
             xi=int(scaled_xyz_[i][0]/dx_-0.5)+NP_;
@@ -271,7 +270,7 @@ namespace zernike {
 
       bool initialize_voxel() {
         int n_tot=2*NP_+1;
-        int i,j,k;
+        int i,j;
         for(i=0;i<n_tot;i++){
           af::shared< af::shared<FloatType> > voxel_i;
           for(j=0;j<n_tot;j++) {
@@ -284,13 +283,11 @@ namespace zernike {
       }
 
       void find_nbr() {
-        FloatType splat2=splat_range_*splat_range_;
         FloatType d2(0.0), this_weight(0.0);
         for(int i=-splat_range_;i<=splat_range_;i++)
           for(int j=-splat_range_;j<=splat_range_;j++)
             for(int k=-splat_range_;k<=splat_range_;k++) {
               d2 = (i*i+j*j+k*k);
-            //  if(d2 <= splat2) {
                 neighbors_.push_back(scitbx::vec3<int>(i,j,k) );
                 this_weight=std::exp(-d2/10.0);
                 weight_sum_ += this_weight;

--- a/scitbx/matrix/householder.h
+++ b/scitbx/matrix/householder.h
@@ -232,7 +232,7 @@ struct reflection
                                       af::const_ref<scalar_t> const &beta,
                                       int const off_diag=0)
   {
-    int m = a.n_rows(), n = a.n_columns();
+    int m = a.n_rows();
     SCITBX_ASSERT(q.n_rows() == m)(q.n_rows())(m); // A = Q x ...
     q.set_identity(false); // Q may be rectangular
     for (int j=beta.size()-1; j >= 0; --j) {
@@ -309,7 +309,7 @@ struct reflection
                                    int reflection_order,
                                    int const off_diag=0)
   {
-    int m = a.n_rows(), n = a.n_columns();
+    int n = a.n_columns();
     SCITBX_ASSERT(   reflection_order == product_in_row_order
                   || reflection_order == product_in_reverse_row_order);
     switch (reflection_order) {

--- a/scitbx/matrix/tests/tst_svd.cpp
+++ b/scitbx/matrix/tests/tst_svd.cpp
@@ -292,7 +292,6 @@ void exercise_golub_kahan_iterations(grading_func_t grading_func,
     }
     if (zero_on_diag) diagonal[n/2] = 0;
     matrix_t a = upper_bidiagonal(diagonal.ref(), superdiagonal.ref());
-    matrix_ref_t a_ = a.ref();
 
     matrix_t identity_n = identity<double>(n);
 

--- a/scitbx/sparse/io.h
+++ b/scitbx/sparse/io.h
@@ -76,7 +76,6 @@ std::ostream& operator<<(std::ostream& o,
                          const sparse::vector_compressed_display_t<T, C>& disp)
 {
   sparse::vector<T, C> const& v = disp.content;
-  typedef typename sparse::vector<T, C>::index_type size_type;
   typedef typename sparse::vector<T, C>::const_iterator const_iterator;
   o << "{ ";
   bool first = true;
@@ -105,7 +104,6 @@ std::ostream& operator<<(std::ostream& o,
                          const sparse::matrix_dense_display_t<T>& disp)
 {
   typedef typename sparse::matrix<T>::index_type index_type;
-  typedef typename sparse::matrix<T>::const_row_iterator const_row_iterator;
   const sparse::matrix<T>& m = disp.content;
   sparse::matrix<T> mt = m.transpose();
   std::streamsize width = o.width();

--- a/ucif/antlr3/antlr3config.h
+++ b/ucif/antlr3/antlr3config.h
@@ -2,7 +2,9 @@
 /* so as to avoid the need to run configure.  */
 
 /* Define if ANTLR debugger not required */
+#ifndef ANTLR3_NODEBUGGER
 #define ANTLR3_NODEBUGGER
+#endif
 
 #if (defined(__x86_64__) || defined(_WIN64))
 /* Define if 64 bit mode required */

--- a/xfel/clustering/ext.cpp
+++ b/xfel/clustering/ext.cpp
@@ -10,9 +10,6 @@
 #include <algorithm>
 
 namespace sx_clustering {
-  void foo2(){
-    std::cout<<"HELLO foo2"<<std::endl;
-  }
 
   struct Rodriguez_Laio_clustering_2014 {
 
@@ -145,7 +142,6 @@ namespace boost_python { namespace {
           (arg_("cluster_id"))))
     ;
 
-    def("foo2",&sx_clustering::foo2);
   }
 
 }

--- a/xfel/clustering/ext.cpp
+++ b/xfel/clustering/ext.cpp
@@ -131,8 +131,6 @@ namespace boost_python { namespace {
   void
   sx_clustering_init_module() {
     using namespace boost::python;
-    typedef return_value_policy<return_by_value> rbv;
-    typedef default_call_policies dcp;
 
     class_<Rodriguez_Laio_clustering_2014>("Rodriguez_Laio_clustering_2014",no_init)
       .def(init<>())

--- a/xfel/ext.cpp
+++ b/xfel/ext.cpp
@@ -768,12 +768,6 @@ scitbx::vec2<int> const& lower_right) {
 
 namespace boost_python { namespace {
 
-  boost::python::tuple
-  foo2()
-  {
-    return boost::python::make_tuple(1,2,3,4);
-  }
-
   void
   init_module() {
     using namespace boost::python;

--- a/xfel/merging.cpp
+++ b/xfel/merging.cpp
@@ -228,7 +228,6 @@ get_scaling_results_mark2(const shared_double& x,
      */
     const double I = data[i] / G;
     const double s = sigmas[i] / G;
-    const double w_this = G * G * w[i]; // XXX ugly!
     const double IsigI = I / s;
 
     L.summed_N[h] += 1;
@@ -257,8 +256,9 @@ get_scaling_results_mark2(const shared_double& x,
      * looped branch below.
      */
 //#define ESTIMATE_REFINED_UNCERTAINTY 1
-    const double t = I - x[n_frames + h];
 #ifdef ESTIMATE_REFINED_UNCERTAINTY
+    const double w_this = G * G * w[i]; // XXX ugly!
+    const double t = I - x[n_frames + h];
     wssq_dev[h] += w_this * t * t;
     w_tot[h] += w_this;
 #else

--- a/xfel/merging/ext.cpp
+++ b/xfel/merging/ext.cpp
@@ -194,8 +194,6 @@ namespace boost_python { namespace {
   void
   sx_merging_init_module() {
     using namespace boost::python;
-    typedef return_value_policy<return_by_value> rbv;
-    typedef default_call_policies dcp;
 
     def("get_hkl_chunks_cpp",&sx_merging::get_hkl_chunks_cpp);
     def("isigi_dict_to_reflection_table",&sx_merging::isigi_dict_to_reflection_table);

--- a/xfel/metrology/legacy_scale/a_g_conversion.h
+++ b/xfel/metrology/legacy_scale/a_g_conversion.h
@@ -79,7 +79,6 @@ struct AG { // convert orientation matrix A to metrical matrix g & reverse
     double bstry = std::sqrt(g1-bstrz*bstrz);
     double astry = (g3-astrz*bstrz)/bstry;
     if (g0 - astry*astry -astrz*astrz <= 0.){ g0 = astry*astry + astrz*astrz + 1.E-7; }
-    double astrx = std::sqrt(g0 - astry*astry -astrz*astrz);
 
     G = uc_sym_mat3(g0,g1,g2,g3,g4,g5);
     cctbx::uctbx::unit_cell ersatz_uc ( cctbx::uctbx::unit_cell(G).reciprocal() );

--- a/xfel/metrology/legacy_scale/bandpass_gaussian.h
+++ b/xfel/metrology/legacy_scale/bandpass_gaussian.h
@@ -264,13 +264,10 @@ namespace parameter {
       double s1_length = s1.length();
       SCITBX_ASSERT (s0_length > 0.);
       SCITBX_ASSERT (s1_length > 0.);
-      scitbx::vec3<double> hi_E_part_r_part_distance = s0;//initialize only; values not used
-      scitbx::vec3<double> lo_E_part_r_part_distance = s1;
       scitbx::vec3<double> mean_position_part_r_part_distance = s1;
       scitbx::vec3<double> mean_position_part_r_part_half_mos = s1;
 
       vec3* part_half_mos_ptr = gradient_mapping["half_mosaicity_rad"];
-      vec3* curv_half_mos_ptr = gradient_mapping["half_mosaicity_rad"];
 
       //  Cn, the circular section through the Ewald sphere.
       for (int idx = 0; idx < P.indices.size(); ++idx){
@@ -424,8 +421,6 @@ namespace parameter {
       scitbx::vec3<double> s0 = (1./wavelength) * P.incident_beam;
       double s0_length = s0.length();
       scitbx::vec3<double> s0_hat = s0.normalize();
-
-      double spot_resolution_ang = P.orientation.unit_cell().d(P.indices[observation_no]);
 
       scitbx::vec3<double> H(P.indices[observation_no][0],
                              P.indices[observation_no][1],

--- a/xfel/metrology/legacy_scale/ext.cpp
+++ b/xfel/metrology/legacy_scale/ext.cpp
@@ -26,7 +26,6 @@ namespace boost_python { namespace {
     using namespace boost::python;
 
     typedef return_value_policy<return_by_value> rbv;
-    typedef default_call_policies dcp;
     class_<xfel_legacy::parameter::parameter_array>(
       "parameter_array",no_init)
       .add_property("x",

--- a/xfel/metrology/legacy_scale/scale_core.cpp
+++ b/xfel/metrology/legacy_scale/scale_core.cpp
@@ -175,14 +175,12 @@ xfel_legacy::algorithm::mark5_iteration::compute_target(
     double* rotation_gradients    = &(_P["tile_rot"].gradients.ref()[0]);
     double* frame_trans_gradients = &(_P["frame_trans"].gradients.ref()[0]);
     double* frame_dist_gradients  = &(_P["frame_distance"].gradients.ref()[0]);
-    double* tile_dist_gradients   = &(_P["tile_distance"].gradients.ref()[0]);
     double* frame_rotz_gradients  = &(_P["frame_rotz"].gradients.ref()[0]);
     double* half_mos_gradients    = &(_P["half_mosaicity_rad"].gradients.ref()[0]);
     double* translation_curvatures= &(_P["tile_trans"].curvatures.ref()[0]);
     double* rotation_curvatures   = &(_P["tile_rot"].curvatures.ref()[0]);
     double* frame_trans_curvatures= &(_P["frame_trans"].curvatures.ref()[0]);
     double* frame_dist_curvatures = &(_P["frame_distance"].curvatures.ref()[0]);
-    double* tile_dist_curvatures  = &(_P["tile_distance"].curvatures.ref()[0]);
     double* frame_rotz_curvatures = &(_P["frame_rotz"].curvatures.ref()[0]);
     double* half_mos_curvatures   = &(_P["half_mosaicity_rad"].curvatures.ref()[0]);
 
@@ -239,7 +237,6 @@ xfel_legacy::algorithm::mark5_iteration::compute_target(
           delx * rotated_part_r_c_y + dely * rotated_part_r_c_x
         );//  SOMETHING IS ROTTEN IN DENMARK
       }
-      //tile_dist_gradients[itile/2] += 2.*(delx * rotated_part_r_c_y + dely * rotated_part_r_c_x);
 
       rotation_gradients[itile] += scitbx::constants::pi_180 * 2.* (
         delx * partial_partial_theta_x +
@@ -256,8 +253,6 @@ xfel_legacy::algorithm::mark5_iteration::compute_target(
         + rotated_part_r_c_y * rotated_part_r_c_y
         );
       }
-      //tile_dist_curvatures[itile/2] += 2 * (
-      //rotated_part_r_c_x * rotated_part_r_c_x + rotated_part_r_c_y * rotated_part_r_c_y);
 
       rotation_curvatures[itile] += scitbx::constants::pi_180 *
                                     scitbx::constants::pi_180 * 2. * (

--- a/xfel/metrology_ext.cpp
+++ b/xfel/metrology_ext.cpp
@@ -373,7 +373,6 @@ namespace boost_python { namespace {
     using namespace boost::python;
 
     typedef return_value_policy<return_by_value> rbv;
-    typedef default_call_policies dcp;
 
     class_<mark2_iteration>("mark2_iteration",no_init)
       .def(init< >())

--- a/xfel/mono_simulation/ext.cpp
+++ b/xfel/mono_simulation/ext.cpp
@@ -25,7 +25,6 @@ namespace boost_python { namespace {
     using namespace boost::python;
 
     typedef return_value_policy<return_by_value> rbv;
-    typedef default_call_policies dcp;
     class_<xfel::parameter::parameter_array>(
       "parameter_array",no_init)
       .add_property("x",

--- a/xfel/vonHamos/xes_ext.cpp
+++ b/xfel/vonHamos/xes_ext.cpp
@@ -236,8 +236,6 @@ namespace boost_python { namespace {
   xes_ext_init_module() {
     using namespace boost::python;
 
-    typedef return_value_policy<return_by_value> rbv;
-    typedef default_call_policies dcp;
     typedef xes::example::gaussian_fit_inheriting_from_non_linear_ls wt;
     typedef xes::example::gaussian_3fit_inheriting_from_non_linear_ls wt3;
 


### PR DESCRIPTION
A large number of compiler warnings for unused variables and typedefs makes it harder to spot warning genuine warnings for potential bugs such as that identified in f9e1677.