### PR TITLE
No longer automatically update dependencies

### DIFF
--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -2222,17 +2222,6 @@ selfx:
         # Reload the libtbx_config in case dependencies have changed
         module.process_libtbx_config()
 
-      # Resolve python dependencies in advance of potential use in refresh scripts
-      # Lazy-load the import here as we might not have an environment before this
-      try:
-        from . import pkg_utils
-      except ImportError:
-        from libtbx import pkg_utils
-      if self.build_options.use_conda:
-        pkg_utils.resolve_module_conda_dependencies(self.module_list)
-      else:
-        pkg_utils.resolve_module_python_dependencies(self.module_list)
-
       for path in self.pythonpath:
         sys.path.insert(0, abs(path))
       for module in self.module_list:

--- a/libtbx/pkg_utils.py
+++ b/libtbx/pkg_utils.py
@@ -6,16 +6,10 @@ from __future__ import absolute_import, division, print_function
 
 import contextlib
 import itertools
-import json
 import os
 import sys
 
 import libtbx.load_env
-
-try:
-  import conda.cli.python_api
-except ImportError:
-  conda = None
 
 try:
   import pip
@@ -296,28 +290,6 @@ def _merge_requirements(requirements, new_req):
   else:
     requirements.append(new_req)
 
-def collate_conda_requirements(modules):
-  # type: (List[libtbx.env_config.module]) -> List[pkg_resources.Requirement]
-  """Combine conda requirements from a module list.
-
-  An attempt will be made to merge any joint requirements. The requirement
-  objects will have an added property 'modules', which is a set of module
-  names that formed the requirement.
-
-  Attr:
-      modules (Iterable[libtbx.env_config.module]): The module list
-
-  Returns:
-      List[pkg_resources.Requirement]: The merged requirements
-  """
-  requirements = []
-  for module, spec in itertools.chain(*[[(x.name, y) for y in x.conda_required] for x in modules if hasattr(x, "conda_required")]):
-    requirement = pkg_resources.Requirement.parse(spec)
-    # Track where dependencies came from
-    requirement.modules = {module}
-    # Attempt to merge this with any other requirements to avoid double-specifying
-    _merge_requirements(requirements, requirement)
-  return requirements
 
 def collate_python_requirements(modules):
   # type: (List[libtbx.env_config.module]) -> List[packaging.requirements.Requirement]
@@ -341,118 +313,3 @@ def collate_python_requirements(modules):
     # Attempt to merge this with any other requirements to avoid double-specifying
     _merge_requirements(requirements, requirement)
   return requirements
-
-def resolve_module_conda_dependencies(modules):
-  # type: (List[libtbx.env_config.module]) -> None
-  """Resolve all python dependencies from the list of modules"""
-  # Check we can do anything here
-  if not libtbx.env.build_options.use_conda:
-    return
-
-  if conda is None:
-    _notice("  WARNING: Can not find conda package in your environment",
-            "  You will have to keep track of dependencies yourself")
-    return
-
-  conda_list, error, return_code = conda.cli.python_api.run_command(
-    conda.cli.python_api.Commands.LIST,
-    "--json",
-    use_exception_handler=True,
-  )
-  if error or return_code:
-    _notice("  WARNING: Could not obtain list of conda packages in your environment",
-            error)
-    return
-  conda_environment = {package["name"]: package["version"] for package in json.loads(conda_list)}
-
-  requirements = collate_conda_requirements(modules)
-  # Now we should have an unduplicated set of requirements
-  action_list = []
-  for requirement in requirements:
-    # Check if package is installed in development mode
-    if pkg_resources:
-      try:
-        currentversion = pkg_resources.require(requirement.name)[0].version
-      except Exception:
-        pass
-      else:
-        location = None
-        for path_item in sys.path:
-          egg_link = os.path.join(path_item, requirement.name + '.egg-link')
-          if os.path.isfile(egg_link):
-            with open(egg_link, 'r') as fh:
-              location = fh.readline().strip()
-              break
-        if location and currentversion in requirement:
-          print("requires conda package %s, has %s as developer installation" % (requirement, currentversion))
-          continue
-        elif location and currentversion not in requirement:
-          _notice(
-            "    WARNING: Can not update package {package} automatically.", "",
-            "It is installed as editable package for development purposes. The currently",
-            "installed version, {currentversion}, is too old. The required version is {requirement}.",
-            "Please update the package manually in its installed location:", "",
-            "    {location}",
-            package=requirement.name, currentversion=currentversion,
-            requirement=requirement, location=location)
-          continue
-
-    # Check if package is installed with conda
-    if requirement.name in conda_environment:
-      if conda_environment[requirement.name] in requirement:
-        print("requires conda package %s, has %s" % (requirement, conda_environment[requirement.name]))
-        continue
-      print("conda requirement %s is not currently met, current version %s" % (requirement, conda_environment[requirement.name]))
-
-    # Install/update required
-    print("conda requirement %s is not currently met, package not installed" % (requirement))
-    action_list.append(str(requirement))
-
-  if not action_list:
-    print("All conda requirements satisfied")
-    return
-
-  if not os.path.isdir(libtbx.env.under_base('.')):
-    _notice("    WARNING: Can not update conda packages automatically.", "",
-            "You are running in a base-less installation, which disables automatic package",
-            "management by convention, see https://github.com/cctbx/cctbx_project/issues/151", "",
-            "Please update the following packages manually:",
-            "  {action_list}",
-            action_list=", ".join(action_list))
-    return
-
-  if os.getenv('LIBTBX_DISABLE_UPDATES') and os.getenv('LIBTBX_DISABLE_UPDATES').strip() not in ('0', ''):
-    _notice("    WARNING: Can not automatically update conda environment", "",
-            "Environment variable LIBTBX_DISABLE_UPDATES is set.",
-            "Please update the following packages manually:",
-            "  {action_list}",
-            action_list=", ".join(action_list))
-    return
-
-  print("\nUpdating conda environment for packages:" + "".join("\n - " + a for a in action_list) + "\n")
-  _, _, return_code = conda.cli.python_api.run_command(
-    conda.cli.python_api.Commands.INSTALL,
-    *action_list,
-    stdout=None,
-    stderr=None,
-    use_exception_handler=True
-  )
-  if return_code:
-    _notice("    WARNING: Could not automatically update conda environment", "",
-            "Please check your environment manually.")
-
-def resolve_module_python_dependencies(modules):
-  # type: (List[libtbx.env_config.module]) -> None
-  """Resolve all python dependencies from the list of modules"""
-  # Check we can do anything here
-  if Requirement is None:
-    _notice("  WARNING: Can not find package requirements tools - pip/setuptools out of date?",
-            "  Please update pip and setuptools by running:", "",
-            "    libtbx.python -m pip install pip setuptools --upgrade", "",
-            "  or following the instructions at https://pip.pypa.io/en/stable/installing/")
-    return
-  requirements = collate_python_requirements(modules)
-  # Now we should have an unduplicated set of requirements
-  for requirement in requirements:
-    # Pass everything as the requirement string rather than trying to reconstruct
-    result = require(str(requirement), "")


### PR DESCRIPTION

This pull request reverts [#290](https://github.com/cctbx/cctbx_project/pull/290) and [#438](https://github.com/cctbx/cctbx_project/pull/438). The code in these pull requests was put in to ensure that software could declare its dependencies and when these dependencies change (as the software is living) the dependencies would auto-update. While this was useful for more than just DLS admin it was percieved at the time to be a DLS-only tool and met some resistance though has never been formally rejected or even properly discussed. 

We have however decided to revert these commits in the spirit of trying to improve the "mood" of the collaboration. Clearly this will have the side-effect that people using tools where the auto-update would have done something will now have to do this manually, however with the move to Conda this should be rather more straightforward for the average end user. 

This PR therefore proposes the reversion of the change sets above and removal of automated dependency updating.
