### PR TITLE
Add R_{Friedel}

### DIFF
--- a/cctbx/miller/__init__.py
+++ b/cctbx/miller/__init__.py
@@ -2953,8 +2953,8 @@ class array(set):
 
   def anomalous_differences(self, enforce_positive_sigmas=False):
     """
-    Returns an array object with DANO (i.e. F(+) - F(-)) as data, and
-    optionally SIGDANO as sigmas.
+    If self is an amplitude array, return an array object with DANO
+    (i.e. F(+) - F(-)) as data, and optionally SIGDANO as sigmas.
     """
     assert self.data() is not None
     tmp_array = self


### PR DESCRIPTION
Following #541 I noted the similarity in calculation between R_{anom} and R_{Friedel}. The latter is used in electron diffraction experiment quality assessments. It is possibly too niche to add to `iotbx.merging_statistics` at this point, but having the function available for calculation seems useful.