### PR TITLE
fix commit ffd70478

### DIFF
--- a/libtbx/auto_build/install_conda.py
+++ b/libtbx/auto_build/install_conda.py
@@ -715,7 +715,7 @@ builder.""".format(filename=filename, builder=builder))
       command_list.append('--copy')
     if offline and not yaml_format:
       command_list.append('--offline')
-    if builder in ("dials", "dials-old", "xfel") and command != "create":
+    if builder in ("dials", "dials-old", "xfel") and not yaml_format:
       command_list.append("-y")
     if builder in self.env_without_python:
       python_version = tuple(int(i) for i in (python or "36"))


### PR DESCRIPTION
If we use an environment in a yaml file, then we call `conda env
create`, which does not have a -y flag. HOWEVER if the environment is
in a .txt file, we call `conda create`, which needs -y or it will wait
forever for confirmation.

@bkpoon Does this look ok? I believe this is the correct implementation of the original fix.