### PR TITLE
Remove platform.dist() call in installer

### DIFF
--- a/libtbx/auto_build/package_defs.py
+++ b/libtbx/auto_build/package_defs.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function
 import json
 import os
 import os.path as op
-import platform
 import sys
 try: # Python 3
   from urllib.request import urlopen
@@ -138,13 +137,6 @@ MATPLOTLIB_DEPS = [
   ("backports.functools-lru-cache", "1.6.1"),
   ("kiwisolver", "1.1.0"),
 ]
-# CentOS 5 glibc too old to support matplotlib-2.0.0 dependency (subprocess32)
-# will be fixed in subprocess32 3.5+, https://github.com/google/python-subprocess32/blob/master/ChangeLog
-if (sys.platform.startswith("linux")):
-  distribution = platform.dist()
-  if ( (distribution[0] == 'redhat') and (distribution[1].startswith('5')) ):
-    MATPLOTLIB_PKG = "matplotlib-1.5.1.tar.gz"
-    MATPLOTLIB_DEPS = []  # unknown
 
 PYOPENGL_PKG = "PyOpenGL-3.1.0.tar.gz"
 


### PR DESCRIPTION
`platform.dist` has been removed in Python 3.8, meaning that the
`create-installer` script fails. The code was only used to identify
CentOS 5, which has been out of support over three years, so this
should be safe to remove now.