### PR TITLE
Fix ResourceWarnings

### DIFF
--- a/iotbx/xds/integrate_hkl.py
+++ b/iotbx/xds/integrate_hkl.py
@@ -32,7 +32,8 @@ class reader:
       True/False Is the file an INTEGRATE.HKL file
 
     '''
-    return open(filename, 'r').read(26) == '!OUTPUT_FILE=INTEGRATE.HKL'
+    with open(filename, 'r') as fh:
+      return fh.read(26) == '!OUTPUT_FILE=INTEGRATE.HKL'
 
   def read_file(self, filename):
     """Read the INTEGRATE.HKL file.
@@ -50,7 +51,8 @@ class reader:
       raise IOError("{0} is not an INTEGRATE.HKL file".format(filename))
 
     # Read the lines from the file
-    lines = open(filename, 'r').readlines()
+    with open(filename, 'r') as fh:
+      lines = fh.readlines()
 
     # Loop through the lines in the file. First off, parse the header
     # lines until we reach !END_OF_HEADER. Then parse the data lines

--- a/iotbx/xds/xds_inp.py
+++ b/iotbx/xds/xds_inp.py
@@ -68,7 +68,8 @@ class reader:
 
     # Check and read file
     if reader.is_xds_inp_file(filename):
-      lines = open(filename, 'r').readlines()
+      with open(filename, 'r') as fh:
+        lines = fh.readlines()
     else:
       raise IOError("{0} is not a XDS.INP file".format(filename))
 

--- a/rstbx/cftbx/coordinate_frame_helpers.py
+++ b/rstbx/cftbx/coordinate_frame_helpers.py
@@ -249,11 +249,12 @@ def import_xds_integrate_hkl(integrate_hkl_file):
 
     header = []
 
-    for record in open(integrate_hkl_file):
-        if not record.startswith('!'):
-            break
+    with open(integrate_hkl_file) as fh:
+        for record in fh:
+            if not record.startswith('!'):
+                break
 
-        header.append(record)
+            header.append(record)
 
     # now need to dig out the values I want, convert and return
 


### PR DESCRIPTION
Seeing a bunch of these in dials tests:
```
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/mtz/extract_from_symmetry_lib.py:49: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/modules/ccp4io/libccp4/data/symop.lib' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/xds/integrate_hkl.py:35: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/data/centroid_test_data/INTEGRATE.HKL' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/xds/integrate_hkl.py:53: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/data/centroid_test_data/INTEGRATE.HKL' mode='r' encoding='UTF-8'>
cctbx_project/iotbx/xds/xds_inp.py:71: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/data/centroid_test_data/XDS.INP' mode='r' encoding='UTF-8'>
cctbx_project/rstbx/cftbx/coordinate_frame_helpers.py:254: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/runner/work/1/data/centroid_test_data/INTEGRATE.HKL' mode='r' encoding='UTF-8'>
```

basically leaking file descriptors, so easily fixed with a context manager. Will merge once tests pass.