### PR TITLE
Allow specifying python flags in run_tests.py

### DIFF
--- a/libtbx/test_utils/__init__.py
+++ b/libtbx/test_utils/__init__.py
@@ -222,7 +222,7 @@ def iter_tests_cmd(co, build_dir, dist_dir, tst_list):
     cmd += tst_path
     cmd += cmd_args
 
-    if hasattr(co,'python_keyword_text') and co.python_keyword_text:
+    if getattr(co, 'python_keyword_text'):
       cmd=cmd.replace("libtbx.python","libtbx.python %s" %(
          co.python_keyword_text))
 

--- a/libtbx/test_utils/parallel.py
+++ b/libtbx/test_utils/parallel.py
@@ -50,6 +50,18 @@ def get_test_list(module_name, test_type='tst_list', valgrind=False,
   build_path = libtbx.env.under_build(module_name)
   assert (build_path is not None) and (dist_path is not None)
   commands = []
+  try:
+    python_flags = import_python_object(
+      import_path="%s.run_tests.python_flags" % (module_name),
+      error_prefix="",
+      target_must_be="",
+      where_str="").object
+    if python_keyword_text:
+      python_keyword_text += " " + python_flags
+    else:
+      python_keyword_text = python_flags
+  except AttributeError:
+    pass
   co = group_args(
     verbose=False,
     quick=True,


### PR DESCRIPTION
If specified these will be applied to all generated python commands within the relevant module, using the existing flag mechanism in `libtbx.run_tests_parallel`.

This allows modules to specify that tests should be run Python Development Mode by adding the line
```python
python_flags = "-X dev" if sys.hexversion >= 0x3070000 else ""
```
to `run_tests.py`

Context: I looked into [running DIALS tests in development mode](https://dev.azure.com/azure-dials/dials/_build/results?buildId=1518), and a lot of the resulting warnings go back to cctbx code (fixed a bunch in #553). It may therefore be of interest to the wider community to run tests of the central cctbx components in development mode, too.

Note: While the Python documentation does say the PDM makes tests run more slowly I only noticed - if anything - a decrease in test run times.