### PR TITLE
Fix failing libtbx.containers import

### DIFF
--- a/libtbx/containers.py
+++ b/libtbx/containers.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import collections
 try:
-  from collections.abc import MutableSet, OrderedDict  # special import
+  from collections.abc import MutableSet  # special import
+  OrderedDict = dict
 except ImportError:
   from collections import MutableSet, OrderedDict  # special import
 

--- a/libtbx/containers.py
+++ b/libtbx/containers.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 import collections
+OrderedDict = collections.OrderedDict  # exported symbol
 try:
-  from collections.abc import MutableSet  # special import
-  OrderedDict = dict
+  from collections.abc import MutableSet  # exported symbol
 except ImportError:
-  from collections import MutableSet, OrderedDict  # special import
+  from collections import MutableSet  # exported symbol
 
 class OrderedSet(MutableSet):
   """


### PR DESCRIPTION
Was still seeing warnings in DIALS and realised the import line is wrong:

We try to import `OrderedDict` from `collections.abc`, but that will always fail as `OrderedDict` isn't there.
From Python 3.6+ onwards all CPython dictionaries are `OrderedDict`s anyway, so just point to `dict` instead.

(2.7 does fail the import so it bypasses that line, we do not support any Python 3.5 or any non-CPython 3.6)