### PR TITLE
Fix more ResourceWarnings

### DIFF
--- a/libtbx/introspection.py
+++ b/libtbx/introspection.py
@@ -229,7 +229,8 @@ class machine_memory_info(proc_file_reader):
     self._memory_free = Auto
     if os.path.isfile("/proc/meminfo"):
       try:
-        self.proc_status = open("/proc/meminfo").read()
+        with open("/proc/meminfo") as fh:
+          self.proc_status = fh.read()
       except IOError:
         pass
     else:
@@ -281,11 +282,12 @@ def number_of_processors(return_value_if_unknown=None):
       cpuinfo = "/proc/cpuinfo" # Linux
       if os.path.isfile(cpuinfo):
         n = 0
-        for line in open(cpuinfo).read().splitlines():
-          if (not line.startswith("processor")): continue
-          line = line[9:].replace(" ", "").replace("\t", "")
-          if (not line.startswith(":")): continue
-          n += 1
+        with open(cpuinfo) as fh:
+          for line in fh.read().splitlines():
+            if (not line.startswith("processor")): continue
+            line = line[9:].replace(" ", "").replace("\t", "")
+            if (not line.startswith(":")): continue
+            n += 1
         if (n != 0):
           _number_of_processors = n
     if (_number_of_processors is None):


### PR DESCRIPTION
observed a set of these in dxtbx tests
```
modules/cctbx_project/libtbx/introspection.py:232: ResourceWarning: unclosed file <_io.TextIOWrapper name='/proc/meminfo' mode='r' encoding='UTF-8'>
```

Again this is just using basic context managers, so will merge once tests pass.