### PR TITLE
TB_3DBUTTONS is deprecated

### DIFF
--- a/crys3d/hklview/frames.py
+++ b/crys3d/hklview/frames.py
@@ -417,7 +417,7 @@ class HKLViewFrame (wx.Frame) :
     self.viewer.SetFocus()
 
   def SetupToolbar (self) :
-    self.toolbar = self.CreateToolBar(style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    self.toolbar = self.CreateToolBar(style=wx.TB_TEXT)
     if wx.VERSION < (4,0):
       self.toolbar.AddTool = self.toolbar.AddLabelTool
     self.toolbar.SetToolBitmapSize((32,32))

--- a/rstbx/slip_viewer/frame.py
+++ b/rstbx/slip_viewer/frame.py
@@ -99,7 +99,7 @@ class XrayFrame(AppFrame,XFBaseClass):
     self._img = None
 
     self._distl = None
-    self.toolbar = self.CreateToolBar(style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    self.toolbar = self.CreateToolBar(style=wx.TB_TEXT)
     self.setup_toolbar()
     self.toolbar.Realize()
     self.mb = wx.MenuBar()

--- a/rstbx/viewer/frame.py
+++ b/rstbx/viewer/frame.py
@@ -46,7 +46,7 @@ class XrayFrame(wx.Frame):
     self.plot_frame = None
     self._img = None
     self._distl = None
-    self.toolbar = self.CreateToolBar(style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    self.toolbar = self.CreateToolBar(style=wx.TB_TEXT)
     self.setup_toolbar()
     self.toolbar.Realize()
     self.mb = wx.MenuBar()

--- a/rstbx/viewer/processing.py
+++ b/rstbx/viewer/processing.py
@@ -14,7 +14,7 @@ class ProcessingFrame(wx.Frame):
   def __init__(self, *args, **kwds):
     wx.Frame.__init__(self, *args, **kwds)
     self.viewer = None
-    self.toolbar = self.CreateToolBar(style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    self.toolbar = self.CreateToolBar(style=wx.TB_TEXT)
     btn = self.toolbar.AddLabelTool(id=-1,
       label="Image viewer",
       bitmap=icons.hkl_file.GetBitmap(),

--- a/simtbx/nanoBragg/nanoBragg_gui_init.py
+++ b/simtbx/nanoBragg/nanoBragg_gui_init.py
@@ -32,7 +32,7 @@ class MainWindow(wx.Frame):
     self.main_sizer = wx.BoxSizer(wx.VERTICAL)
 
     # Setup toolbar
-    self.toolbar = self.CreateToolBar(style=wx.TB_3DBUTTONS | wx.TB_TEXT)
+    self.toolbar = self.CreateToolBar(style=wx.TB_TEXT)
     quit_bmp = bitmaps.fetch_icon_bitmap('actions', 'exit')
     self.tb_btn_quit = self.toolbar.AddLabelTool(wx.ID_EXIT, label='Quit',
                                                  bitmap=quit_bmp,

--- a/wxtbx/browser.py
+++ b/wxtbx/browser.py
@@ -71,7 +71,7 @@ class browser_frame(wx.Frame):
   def SetupToolbar(self):
     if (wxtbx.bitmaps.icon_lib is None):
       return
-    self.toolbar = self.CreateToolBar(style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    self.toolbar = self.CreateToolBar(style=wx.TB_TEXT)
     commands = [
       ("filesystems", "folder_home", "OnHome", "Home"),
       ("actions", "back", "OnBack", "Back"),

--- a/wxtbx/custom_restraints.py
+++ b/wxtbx/custom_restraints.py
@@ -566,7 +566,7 @@ class RestraintsFrame(wx.Frame):
     wx.Frame.__init__(self, *args, **kwds)
     self.sizer = wx.BoxSizer(wx.HORIZONTAL)
     self.SetSizer(self.sizer)
-    tb = wx.ToolBar(self, style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    tb = wx.ToolBar(self, style=wx.TB_TEXT)
     tb.SetToolBitmapSize((32,32))
     self.SetToolBar(tb)
     btn1 = tb.AddLabelTool(-1,

--- a/wxtbx/pdb_editor.py
+++ b/wxtbx/pdb_editor.py
@@ -1902,7 +1902,7 @@ class PDBTreeFrame(wx.Frame):
     self._tree.SetMinSize((640,400))
     pszr.Add(self._tree, 1, wx.EXPAND, 2)
     # toolbar setup
-    self.toolbar = self.CreateToolBar(style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    self.toolbar = self.CreateToolBar(style=wx.TB_TEXT)
     bmp = wxtbx.bitmaps.fetch_custom_icon_bitmap("phenix.pdbtools")
     btn = self.toolbar.AddLabelTool(-1, "Load file", bmp,
       shortHelp="Load file", kind=wx.ITEM_NORMAL)

--- a/wxtbx/plots/__init__.py
+++ b/wxtbx/plots/__init__.py
@@ -438,7 +438,7 @@ class plot_frame(wx.Frame):
       # bitmaps.fetch_icon_bitmap("devices", "printer1"),
       # self.OnPrint),
     ]
-    tb = wx.ToolBar(self, style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    tb = wx.ToolBar(self, style=wx.TB_TEXT)
     tb.SetToolBitmapSize((32,32))
     self.SetToolBar(tb)
     for (name, bitmap, function) in tb_buttons :

--- a/wxtbx/polygon.py
+++ b/wxtbx/polygon.py
@@ -193,7 +193,7 @@ class PolygonFrame(wx.Frame):
     save_icon = wxtbx.bitmaps.fetch_icon_bitmap("actions", "save_all")
     plot_icon = wxtbx.bitmaps.fetch_icon_bitmap("mimetypes", "spreadsheet")
     if (save_icon is not None) and (plot_icon is not None):
-      self.toolbar = wx.ToolBar(self, style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+      self.toolbar = wx.ToolBar(self, style=wx.TB_TEXT)
       if sys.platform == "darwin" :
         save_btn = self.toolbar.AddLabelTool(-1, "Save", save_icon,
           kind=wx.ITEM_NORMAL)

--- a/wxtbx/qstat_view.py
+++ b/wxtbx/qstat_view.py
@@ -173,7 +173,7 @@ class queue_list_frame(wx.Frame):
   def SetupToolbar(self):
     if wxtbx.bitmaps.icon_lib is None :
       return
-    self.toolbar = self.CreateToolBar(style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    self.toolbar = self.CreateToolBar(style=wx.TB_TEXT)
     commands = [
       ("actions","reload", "OnUpdate", "Refresh list"),
       ("actions","editdelete", "OnDelete", "Delete selected"),

--- a/wxtbx/wx4_compatibility.py
+++ b/wxtbx/wx4_compatibility.py
@@ -34,7 +34,7 @@ class MyFrame(wx.Frame):
   def __init__(self, parent, id, title, *args, **kwargs):
     wx.Frame.__init__(self, parent, id, title, *args, **kwargs)
 
-    self.toolbar = wx4c.ToolBar(self, style=wx.TB_3DBUTTONS | wx.TB_TEXT)
+    self.toolbar = wx4c.ToolBar(self, style=wx.TB_TEXT)
     self.quit_button = self.toolbar.AddTool(toolId=wx.ID_ANY,
                                              label='Quit',
                                              kind=wx.ITEM_NORMAL,

--- a/wxtbx/xtriage.py
+++ b/wxtbx/xtriage.py
@@ -358,7 +358,7 @@ class XtriageFrame(wx.Frame):
     return wx_output(parent=self)
 
   def SetupToolbar(self):
-    self.toolbar = self.CreateToolBar(style=wx.TB_3DBUTTONS|wx.TB_TEXT)
+    self.toolbar = self.CreateToolBar(style=wx.TB_TEXT)
     self.AddAppSpecificButtons()
     bmp = wxtbx.bitmaps.fetch_icon_bitmap("mimetypes", "spreadsheet")
     btn = self.toolbar.AddLabelTool(-1, "Save graph", bmp,


### PR DESCRIPTION
TB_3DBUTTONS is gone in wxpython 4.1.0 (dials/dials#1475).  This will affect any py3 wx4 compliant code that uses TB_3DBUTTONS.  Because of this I did a find/replace in cctbx_project to remove the style.

I tested removing TB_3DBUTTONS using cctbx.image_viewer in py2 and it worked with and without this change and without changing the toolbox visually.  So if phenix is using any of the files modified it should be ok.