### PR TITLE
Summit fix for libstc++

### DIFF
--- a/boost_adaptbx/boost/python.py
+++ b/boost_adaptbx/boost/python.py
@@ -11,15 +11,6 @@ from libtbx import cpp_function_name
 symbol_not_found_pat = re.compile(
   r"[Ss]ymbol[ ]not[ ]found: \s* (\w+) $", re.X | re.M | re.S)
 
-python_libstdcxx_so = None
-if (sys.platform.startswith("linux")):
-  from libtbx import easy_run
-  for line in easy_run.fully_buffered(
-                command='/usr/bin/ldd "%s"' % sys.executable).stdout_lines:
-    if (line.strip().startswith("libstdc++.so")):
-      python_libstdcxx_so = line.split()[0]
-      break
-
 def import_ext(name, optional=False):
   components = name.split(".")
   if (len(components) > 1):
@@ -44,20 +35,6 @@ def import_ext(name, optional=False):
     mod = getattr(mod, comp)
   if (previous_dlopenflags is not None):
     sys.setdlopenflags(previous_dlopenflags)
-  if (python_libstdcxx_so is not None):
-    mod_file = getattr(mod, "__file__", None)
-    if (mod_file is not None):
-      for line in easy_run.fully_buffered(
-                    command='/usr/bin/ldd "%s"' % mod_file).stdout_lines:
-        if (line.strip().startswith("libstdc++.so")):
-          mod_libstdcxx_so = line.split()[0]
-          if (mod_libstdcxx_so != python_libstdcxx_so):
-            raise SystemError("""\
-FATAL: libstdc++.so mismatch:
-  %s: %s
-  %s: %s""" % (sys.executable, python_libstdcxx_so,
-               mod_file, mod_libstdcxx_so))
-          break
   return mod
 
 ext = import_ext("boost_python_meta_ext")

--- a/libtbx/command_line/check_libcpp.py
+++ b/libtbx/command_line/check_libcpp.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from   __future__        import division
-
 import sys
 from   libtbx import easy_run
 from   os     import listdir

--- a/libtbx/command_line/check_libcpp.py
+++ b/libtbx/command_line/check_libcpp.py
@@ -3,9 +3,8 @@
 from   __future__        import division
 
 import sys
-import libtbx.env_config
-from   libtbx            import easy_run
-from   os                import listdir
+from   libtbx import easy_run
+from   os     import listdir
 
 
 

--- a/libtbx/command_line/check_libcpp.py
+++ b/libtbx/command_line/check_libcpp.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import sys
 from   libtbx import easy_run
 from   os     import listdir

--- a/libtbx/command_line/check_libcpp.py
+++ b/libtbx/command_line/check_libcpp.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from   __future__        import division
 
 import sys
 import libtbx.env_config
-from   libtbx             import easy_run
-from   os                 import listdir
+from   libtbx            import easy_run
+from   os                import listdir
 
 
 

--- a/libtbx/command_line/check_libcpp.py
+++ b/libtbx/command_line/check_libcpp.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import libtbx.env_config
+from   libtbx             import easy_run
+from   os                 import listdir
+
+
+
+def check_libcpp():
+
+  #______________________________________________________________________________
+  # get the libstd version that the python executable links against
+  #
+  python_libstdcxx_so = None
+  ldd_exec = easy_run.fully_buffered(command="ldd " + str(sys.executable))
+  for line in ldd_exec.stdout_lines:
+    if line.strip().startswith("libstdc++.so"):
+      python_libstdcxx_so = line.split()[0]
+      break
+
+  if python_libstdcxx_so is None:
+    return False
+  #
+  #------------------------------------------------------------------------------
+
+  #______________________________________________________________________________
+  # Go through all installed *.so's and ensure that they are linking to the same
+  # libstdc++ as python executable
+  #
+  lib_dir = join(
+      libtbx.env.lib_path._anchor._path, libtbx.env.lib_path.relocatable
+  )
+  libs = [join(lib_dir, name) for name in listdir(lib_dir) if name.endswith(".so")]
+  for lib in libs:
+    ldd_lib = easy_run.fully_buffered(command="ldd " + str(lib))
+    for line in ldd_lib.stdout_lines:
+      if line.strip().startswith("libstdc++.so"):
+        lib_libstdcxx_so = line.split()[0]
+        if lib_libstdcxx_so != python_libstdcxx_so:
+          raise SystemError(
+            "FATAL: libstdc++.so mismatch\n"
+            "sys.executable: " + str(sys.executable) + "\n"
+            "lib_file:" + str(lib)
+          )
+        break
+  #
+  #------------------------------------------------------------------------------
+
+  return True
+
+
+
+if __name__=="__main__":
+
+  if not sys.platform.startswith("linux"):
+    print("This test only works on Linux at the moment")
+  else:
+    if check_libcpp():
+      print("Success!")
+    else:
+      print(
+        "This test was not run because your python executable was not linked "
+        "against libstdc++ => this test is not needed."
+      )

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -3206,7 +3206,7 @@ def check_libcpp():
   # Skip if not Linux
   # TODO: this might also work on macOS
   #
-  if sys.platform.startswith("linux"):
+  if not sys.platform.startswith("linux"):
     return True
   #
   #------------------------------------------------------------------------------

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -3265,7 +3265,7 @@ if (__name__ == "__main__"):
       return (x.strip().lower() in yes)
 
     if is_true(os.environ.get("CCTBX_CHECK_LDD", "True")):
-      print("Checking that extension of python libstdc++ mathc")
+      print("Checking that extension modules and python executabel link to same version of libstdc++")
       print("Set CCTBX_CHECK_LDD=false to disable this step")
       check_libcpp()
 

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -3219,7 +3219,7 @@ def check_libcpp():
   # get the libstd version that the python executable links against
   #
   python_libstdcxx_so = None
-  ldd_exec = easy_run.fully_buffered(command=f"ldd {sys.executable}")
+  ldd_exec = easy_run.fully_buffered(command="ldd " + str(sys.executable))
   for line in ldd_exec.stdout_lines:
     if line.strip().startswith("libstdc++.so"):
       python_libstdcxx_so = line.split()[0]
@@ -3239,15 +3239,15 @@ def check_libcpp():
   )
   libs = [join(lib_dir, name) for name in listdir(lib_dir) if name.endswith(".so")]
   for lib in libs:
-    ldd_lib = easy_run.fully_buffered(command=f"ldd {lib}")
+    ldd_lib = easy_run.fully_buffered(command="ldd " + str(lib))
     for line in ldd_lib.stdout_lines:
       if line.strip().startswith("libstdc++.so"):
         lib_libstdcxx_so = line.split()[0]
         if lib_libstdcxx_so != python_libstdcxx_so:
           raise SystemError(
-            f"FATAL: libstdc++.so mismatch\n"
-            f"sys.executable: {sys.executable}\n"
-            f"lib_file: {lib}"
+            "FATAL: libstdc++.so mismatch\n"
+            "sys.executable: " + str(sys.executable) + "\n"
+            "lib_file:" + str(lib)
           )
         break
   #
@@ -3265,7 +3265,10 @@ if (__name__ == "__main__"):
       return (x.strip().lower() in yes)
 
     if is_true(os.environ.get("CCTBX_CHECK_LDD", "True")):
-      print("Checking that extension modules and python executabel link to same version of libstdc++")
+      print(
+          "Checking that extension modules and python executable link to same "
+          "version of libstdc++"
+      )
       print("Set CCTBX_CHECK_LDD=false to disable this step")
       check_libcpp()
 

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -3200,7 +3200,6 @@ def get_boost_library_with_python_version(name, libpath):
         return name_version
   return name
 
-
 if (__name__ == "__main__"):
   if (len(sys.argv) == 2 and sys.argv[1] == "__libtbx_refresh__"):
     unpickle().refresh()

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -3200,9 +3200,75 @@ def get_boost_library_with_python_version(name, libpath):
         return name_version
   return name
 
+def check_libcpp():
+
+  #______________________________________________________________________________
+  # Skip if not Linux
+  # TODO: this might also work on macOS
+  #
+  if sys.platform.startswith("linux"):
+    return True
+  #
+  #------------------------------------------------------------------------------
+
+  import libtbx.env_config
+  from   libtbx             import easy_run
+  from   os                 import listdir
+
+  #______________________________________________________________________________
+  # get the libstd version that the python executable links against
+  #
+  python_libstdcxx_so = None
+  ldd_exec = easy_run.fully_buffered(command=f"ldd {sys.executable}")
+  for line in ldd_exec.stdout_lines:
+    if line.strip().startswith("libstdc++.so"):
+      python_libstdcxx_so = line.split()[0]
+      break
+
+  if python_libstdcxx_so is None:
+    return False
+  #
+  #------------------------------------------------------------------------------
+
+  #______________________________________________________________________________
+  # Go through all installed *.so's and ensure that they are linking to the same
+  # libstdc++ as python executable
+  #
+  lib_dir = join(
+      libtbx.env.lib_path._anchor._path, libtbx.env.lib_path.relocatable
+  )
+  libs = [join(lib_dir, name) for name in listdir(lib_dir) if name.endswith(".so")]
+  for lib in libs:
+    ldd_lib = easy_run.fully_buffered(command=f"ldd {lib}")
+    for line in ldd_lib.stdout_lines:
+      if line.strip().startswith("libstdc++.so"):
+        lib_libstdcxx_so = line.split()[0]
+        if lib_libstdcxx_so != python_libstdcxx_so:
+          raise SystemError(
+            f"FATAL: libstdc++.so mismatch\n"
+            f"sys.executable: {sys.executable}\n"
+            f"lib_file: {lib}"
+          )
+        break
+  #
+  #------------------------------------------------------------------------------
+
+  return True
+
+
 if (__name__ == "__main__"):
   if (len(sys.argv) == 2 and sys.argv[1] == "__libtbx_refresh__"):
     unpickle().refresh()
+
+    def is_true(x):
+      yes = {"1", "on", "true"}
+      return (x.strip().lower() in yes)
+
+    if is_true(os.environ.get("CCTBX_CHECK_LDD", "True")):
+      print("Checking that extension of python libstdc++ mathc")
+      print("Set CCTBX_CHECK_LDD=false to disable this step")
+      check_libcpp()
+
   else:
     warm_start(sys.argv)
   print("Done.")


### PR DESCRIPTION
Problem statement: On Summit, "import boost.python" fails.
This is likely due to the practice, in high-performance computing centers, of linking the Python extension modules against one stdc++ library, whereas the system Python is linked against a different library behind the scene.
Solution: do not use ldd to check the libstc++ version in import-ext
The referenced code is part of the original cctbx design, but is likely not applicable to modern systems.
Removing it will save an external call to "ldd" during every boost python import.