### PR TITLE
On GPU, pre-check the exp() argument for the Gaussian shapetype

### DIFF
--- a/simtbx/nanoBragg/nanoBragg.cpp
+++ b/simtbx/nanoBragg/nanoBragg.cpp
@@ -2459,6 +2459,7 @@ nanoBragg::show_params()
     if(xtal_shape == ROUND)  printf("ellipsoidal");
     if(xtal_shape == SQUARE) printf("parallelpiped");
     if(xtal_shape == GAUSS ) printf("gaussian");
+    if(xtal_shape == GAUSS_ARGCHK ) printf("gaussian_argchk");
     if(xtal_shape == TOPHAT) printf("tophat-spot");
     printf(" xtal: %.0fx%.0fx%.0f cells\n",Na,Nb,Nc);
     printf("Unit Cell: %g %g %g %g %g %g\n", a_A[0],b_A[0],c_A[0],alpha*RTD,beta*RTD,gamma*RTD);
@@ -2745,6 +2746,14 @@ nanoBragg::add_nanoBragg_spots()
                                         /* fudge the radius so that volume and FWHM are similar to square_xtal spots */
                                         F_latt = Na*Nb*Nc*exp(-( hrad_sqr / 0.63 * fudge ));
                                     }
+                                    if (xtal_shape == GAUSS_ARGCHK)
+                                    {
+                                        /* fudge the radius so that volume and FWHM are similar to square_xtal spots */
+                                        double my_arg = hrad_sqr / 0.63 * fudge; // pre-calculate to check for no Bragg signal
+                                        if (my_arg<35.){ F_latt = Na * Nb * Nc * exp(-(my_arg));}
+                                        else { F_latt = 0.; } // not expected to give performance gain on optimized C++, only on GPU
+                                    }
+
                                     if(xtal_shape == TOPHAT)
                                     {
                                         /* make a flat-top spot of same height and volume as square_xtal spots */

--- a/simtbx/nanoBragg/nanoBragg.h
+++ b/simtbx/nanoBragg/nanoBragg.h
@@ -129,7 +129,7 @@ double sinc_conv_sinc3(double x);
 
 /* typedefs to help remember options */
 typedef enum { SAMPLE, BEAM } pivot;
-typedef enum { UNKNOWN, SQUARE, ROUND, GAUSS, TOPHAT, FIBER } shapetype;
+typedef enum { UNKNOWN, SQUARE, ROUND, GAUSS, GAUSS_ARGCHK, TOPHAT, FIBER } shapetype;
 typedef enum { CUSTOM, ADXV, MOSFLM, XDS, DIALS, DENZO } convention;
 
 /* math functions for point spread */

--- a/simtbx/nanoBragg/nanoBraggCUDA.cu
+++ b/simtbx/nanoBragg/nanoBraggCUDA.cu
@@ -764,6 +764,12 @@ CUDAREAL pixel_size, CUDAREAL subpixel_size, int steps, CUDAREAL detector_thicks
 									/* fudge the radius so that volume and FWHM are similar to square_xtal spots */
 									F_latt = Na * Nb * Nc * exp(-(hrad_sqr / 0.63 * fudge));
 								}
+                                                                if (s_xtal_shape == GAUSS_ARGCHK) {
+                                                                        /* fudge the radius so that volume and FWHM are similar to square_xtal spots */
+                                                                        double my_arg = hrad_sqr / 0.63 * fudge;
+                                                                        if (my_arg<35.){ F_latt = Na * Nb * Nc * exp(-(my_arg));
+                                                                        } else { F_latt = 0.; } // warps coalesce when blocks of 32 pixels have no Bragg signal
+                                                                }
 								if (s_xtal_shape == TOPHAT) {
 									/* make a flat-top spot of same height and volume as square_xtal spots */
 									F_latt = Na * Nb * Nc * (hrad_sqr * fudge < 0.3969);

--- a/simtbx/nanoBragg/nanoBraggCUDA.cu
+++ b/simtbx/nanoBragg/nanoBraggCUDA.cu
@@ -854,9 +854,9 @@ CUDAREAL pixel_size, CUDAREAL subpixel_size, int steps, CUDAREAL detector_thicks
 										F_cell = quickFcell_ldg(s_hkls, s_h_max, s_h_min, s_k_max, s_k_min, s_l_max, s_l_min, h0, k0, l0, s_h_range, s_k_range, s_l_range, default_F, Fhkl);
 									} else {
 										/* integer versions of nearest HKL indicies */
-										int h_interp[] = { 0.0, 0.0, 0.0, 0.0 };
-										int k_interp[] = { 0.0, 0.0, 0.0, 0.0 };
-										int l_interp[] = { 0.0, 0.0, 0.0, 0.0 };
+										int h_interp[] = { 0, 0, 0, 0 };
+										int k_interp[] = { 0, 0, 0, 0 };
+										int l_interp[] = { 0, 0, 0, 0 };
 										h_interp[0] = h0_flr - 1;
 										h_interp[1] = h0_flr;
 										h_interp[2] = h0_flr + 1;

--- a/simtbx/nanoBragg/nanoBragg_ext.cpp
+++ b/simtbx/nanoBragg/nanoBragg_ext.cpp
@@ -1330,6 +1330,7 @@ printf("DEBUG: pythony_stolFbg[1]=(%g,%g)\n",nanoBragg.pythony_stolFbg[1][0],nan
       .value("Square",SQUARE)
       .value("Round",ROUND)
       .value("Gauss",GAUSS)
+      .value("Gauss_argchk",GAUSS_ARGCHK)
       .value("Tophat",TOPHAT)
       .value("Fiber",FIBER)
       .value("Unknown",UNKNOWN)

--- a/simtbx/nanoBragg/nanotypes.h
+++ b/simtbx/nanoBragg/nanotypes.h
@@ -9,7 +9,9 @@
 #define NANOTYPES_H_
 
 typedef enum { SAMPLE, BEAM } pivot;
-typedef enum { UNKNOWN, SQUARE, ROUND, GAUSS, TOPHAT, FIBER } shapetype;
+typedef enum { UNKNOWN, SQUARE, ROUND, GAUSS, GAUSS_ARGCHK, TOPHAT, FIBER } shapetype;
+// GAUSS_ARGCHK provides a lightweight backdoor for efficient implementation of
+// the GAUSS shapetype in CUDA. Developers cautioned accordingly.
 typedef enum { CUSTOM, ADXV, MOSFLM, XDS, DIALS, DENZO } convention;
 
 #endif /* NANOTYPES_H_ */

--- a/simtbx/nanoBragg/nanotypes.h
+++ b/simtbx/nanoBragg/nanotypes.h
@@ -11,7 +11,7 @@
 typedef enum { SAMPLE, BEAM } pivot;
 typedef enum { UNKNOWN, SQUARE, ROUND, GAUSS, GAUSS_ARGCHK, TOPHAT, FIBER } shapetype;
 // GAUSS_ARGCHK provides a lightweight backdoor for efficient implementation of
-// the GAUSS shapetype in CUDA. Developers cautioned accordingly.
+// the GAUSS shapetype in CUDA. Precaluates the argument of the exponential.
 typedef enum { CUSTOM, ADXV, MOSFLM, XDS, DIALS, DENZO } convention;
 
 #endif /* NANOTYPES_H_ */

--- a/simtbx/nanoBragg/tst_gauss_argchk.py
+++ b/simtbx/nanoBragg/tst_gauss_argchk.py
@@ -1,0 +1,376 @@
+"""
+Test the GAUSS_ARGCHK facility.  Basic idea:
+The GAUSS shapetype uses a call to exp() measuring RLP distance to Ewald sphere.
+Most pixels on a typical pattern are far from Bragg spots, so exp() evaluates to 0.
+On GPU (but not CPU) we can save lots of execution time by pretesting the argument,
+    for exp(-arg), evaluate to zero if arg >= 35
+Provide a backdoor to the Mullen-Holton kernel, by defining shapetype=GAUSS_ARGCHK
+Test 1) standard C++ result
+     3) exafel api interface to GPU, allowing fast evaluation on many energy channels
+     4) exafel api interface to GPU, with GAUSS_ARGCHK
+
+The test is derived from tst_nanoBragg_cbf_write.py
+Makes dxtbx models for detector, beam , crystal
+Verifies pixel intensities are reproduced
+"""
+from __future__ import absolute_import, division, print_function
+import numpy as np
+from scipy import constants
+from scitbx.array_family import flex
+from libtbx.test_utils import approx_equal
+
+from cctbx import sgtbx, miller
+from cctbx.crystal import symmetry
+import dxtbx
+from dxtbx.model.beam import BeamFactory
+from dxtbx.model.crystal import CrystalFactory
+from dxtbx.model.detector import DetectorFactory
+from scitbx.array_family import flex
+from scitbx.matrix import sqr, col
+from simtbx.nanoBragg import nanoBragg, shapetype
+
+# rough approximation to water: interpolation points for sin(theta/lambda) vs structure factor
+water = flex.vec2_double([(0,2.57),(0.0365,2.58),(0.07,2.8),(0.12,5),(0.162,8),(0.18,7.32),(0.2,6.75),(0.216,6.75),(0.236,6.5),(0.28,4.5),(0.3,4.3),(0.345,4.36),(0.436,3.77),(0.5,3.17)])
+
+def basic_crystal():
+  print("Make a randomly oriented xtal")
+  # make a randomly oriented crystal..
+  np.random.seed(3142019)
+  # make random rotation about principle axes
+  x = col((-1, 0, 0))
+  y = col((0, -1, 0))
+  z = col((0, 0, -1))
+  rx, ry, rz = np.random.uniform(-180, 180, 3)
+  RX = x.axis_and_angle_as_r3_rotation_matrix(rx, deg=True)
+  RY = y.axis_and_angle_as_r3_rotation_matrix(ry, deg=True)
+  RZ = z.axis_and_angle_as_r3_rotation_matrix(rz, deg=True)
+  M = RX*RY*RZ
+  real_a = M*col((79, 0, 0))
+  real_b = M*col((0, 79, 0))
+  real_c = M*col((0, 0, 38))
+  # dxtbx crystal description
+  cryst_descr = {'__id__': 'crystal',
+               'real_space_a': real_a.elems,
+               'real_space_b': real_b.elems,
+               'real_space_c': real_c.elems,
+               'space_group_hall_symbol': ' P 4nw 2abw'}
+  return CrystalFactory.from_dict(cryst_descr)
+
+def basic_beam():
+  print("Make a beam")
+  # make a beam
+  ENERGY = 9000
+  ENERGY_CONV = 1e10*constants.c*constants.h / constants.electron_volt
+  WAVELEN = ENERGY_CONV/ENERGY
+  # dxtbx beam model description
+  beam_descr = {'direction': (0.0, 0.0, 1.0),
+             'divergence': 0.0,
+             'flux': 1e11,
+             'polarization_fraction': 1.,
+             'polarization_normal': (0.0, 1.0, 0.0),
+             'sigma_divergence': 0.0,
+             'transmission': 1.0,
+             'wavelength': WAVELEN}
+  return BeamFactory.from_dict(beam_descr)
+
+def basic_detector():
+  # make a detector panel
+  # monolithic camera description
+  print("Make a dxtbx detector")
+  detdist = 100.
+  pixsize = 0.1
+  im_shape = 1536, 1536
+  det_descr = {'panels':
+               [{'fast_axis': (1.0, 0.0, 0.0),
+                 'slow_axis': (0.0, -1.0, 0.0),
+                 'gain': 1.0,
+                 'identifier': '',
+                 'image_size': im_shape,
+                 'mask': [],
+                 'material': '',
+                 'mu': 0.0,
+                 'name': 'Panel',
+                 'origin': (-im_shape[0]*pixsize/2., im_shape[1]*pixsize/2., -detdist),
+                 'pedestal': 0.0,
+                 'pixel_size': (pixsize, pixsize),
+                 'px_mm_strategy': {'type': 'SimplePxMmStrategy'},
+                 'raw_image_offset': (0, 0),
+                 'thickness': 0.0,
+                 'trusted_range': (-1e7, 1e7),
+                 'type': ''}]}
+  return DetectorFactory.from_dict(det_descr)
+
+class amplitudes:
+  def __init__(self, CRYSTAL):
+    # make a dummy HKL table with constant HKL intensity
+    # this is just to make spots
+    DEFAULT_F = 1e2
+    symbol = CRYSTAL.get_space_group().info().type().lookup_symbol()  # this is just P43212
+    assert symbol == "P 43 21 2" # test case, start with P43212, make P1 for nanoBragg
+    sgi = sgtbx.space_group_info(symbol)
+    symm = symmetry(unit_cell=CRYSTAL.get_unit_cell(), space_group_info=sgi)
+    miller_set = symm.build_miller_set(anomalous_flag=True, d_min=1.6, d_max=999)
+    Famp = flex.double(np.ones(len(miller_set.indices())) * DEFAULT_F)
+    self.Famp = miller.array(miller_set=miller_set, data=Famp).set_observation_type_xray_amplitude()
+
+  def random_structure(self,crystal):
+    """We're going to do some very approximate stuff here.  Given a unit
+     cell & SG, will put typical atomic contents in the unit cell & get
+     structure factors.
+    """
+    import random
+    random.seed(0)
+    from scitbx.array_family import flex
+    flex.set_random_seed(0)
+    from cctbx.development import random_structure
+
+    uc_volume = crystal.get_unit_cell().volume()
+    asu_volume = uc_volume / crystal.get_space_group().order_z()
+    target_number_scatterers = int(asu_volume)//128 # Very approximate rule of thumb for proteins with ~50% solvent content
+    element_unit = ['O']*19 + ['N']*18 + ['C']*62 + ['S']*1 + ['Fe']*1
+    element_pallet = element_unit * (1 + ( target_number_scatterers//len(element_unit) ))
+    assert len(element_pallet) >= target_number_scatterers
+    # Ersatz hard limit to prevent excessive execution time of xray_structure() below.
+    elements = element_pallet[:min(1000, target_number_scatterers)]
+
+    xs = random_structure.xray_structure(
+      space_group_info = crystal.get_space_group().info(), unit_cell = crystal.get_unit_cell(),
+      elements=elements, min_distance=1.2)
+    self.xs = xs
+
+  def ersatz_correct_to_P1(self):
+    primitive_xray_structure = self.xs.primitive_setting()
+    P1_primitive_xray_structure = primitive_xray_structure.expand_to_p1()
+    self.xs = P1_primitive_xray_structure
+
+  def get_amplitudes(self, at_angstrom):
+    # Since we are getting amplitudes for nanoBragg, let us assure they are in P1
+    symbol = self.xs.space_group().info().type().lookup_symbol()
+    assert symbol=="P 1", "Must be in P1 to accept amplitudes for ExaFEL GPU interface"
+    # take a detour to insist on calculating anomalous contribution of every atom
+    scatterers = self.xs.scatterers()
+    for sc in scatterers:
+      from cctbx.eltbx import henke
+      expected_henke = henke.table(sc.element_symbol()).at_angstrom(at_angstrom)
+      sc.fp = expected_henke.fp()
+      sc.fdp = expected_henke.fdp()
+
+    import mmtbx.command_line.fmodel
+    phil2 = mmtbx.command_line.fmodel.fmodel_from_xray_structure_master_params
+    params2 = phil2.extract()
+    params2.high_resolution = 1.6
+    params2.fmodel.k_sol = 0.35
+    params2.fmodel.b_sol = 46.
+    params2.structure_factors_accuracy.algorithm = "fft"
+    params2.output.type = "real"
+    import mmtbx
+    f_model = mmtbx.utils.fmodel_from_xray_structure(
+      xray_structure = self.xs,
+      f_obs          = None,
+      add_sigmas     = True,
+      params         = params2).f_model
+    #f_model.show_summary()
+    return f_model
+
+def simple_monochromatic_case(BEAM, DETECTOR, CRYSTAL, SF_model):
+  Famp = SF_model.get_amplitudes(at_angstrom=BEAM.get_wavelength())
+
+  # do the simulation
+  print("\nsimple_monochromatic_case, CPU")
+  SIM = nanoBragg(DETECTOR, BEAM, panel_id=0)
+  SIM.Ncells_abc = (20,20,20)
+  SIM.Fhkl = Famp
+  SIM.Amatrix = sqr(CRYSTAL.get_A()).transpose()
+  SIM.oversample = 2
+  SIM.xtal_shape = shapetype.Gauss
+  SIM.add_nanoBragg_spots()
+
+  SIM.Fbg_vs_stol = water
+  SIM.amorphous_sample_thick_mm = 0.02
+  SIM.amorphous_density_gcm3 = 1
+  SIM.amorphous_molecular_weight_Da = 18
+  SIM.flux=1e12
+  SIM.beamsize_mm=0.003 # square (not user specified)
+  SIM.exposure_s=1.0 # multiplies flux x exposure
+  SIM.progress_meter=False
+  SIM.add_background()
+  return SIM
+
+def simple_monochromatic_case_GPU(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False):
+  Famp = SF_model.get_amplitudes(at_angstrom=BEAM.get_wavelength())
+
+  # do the simulation
+  SIM = nanoBragg(DETECTOR, BEAM, panel_id=0)
+  SIM.Ncells_abc = (20,20,20)
+  SIM.Fhkl = Famp
+  SIM.Amatrix = sqr(CRYSTAL.get_A()).transpose()
+  SIM.oversample = 2
+  if argchk:
+    print("\nmonochromatic case, GPU argchk")
+    SIM.xtal_shape = shapetype.Gauss_argchk
+  else:
+    print("\nmonochromatic case, GPU no argchk")
+    SIM.xtal_shape = shapetype.Gauss
+  SIM.add_nanoBragg_spots_cuda()
+
+  SIM.Fbg_vs_stol = water
+  SIM.amorphous_sample_thick_mm = 0.02
+  SIM.amorphous_density_gcm3 = 1
+  SIM.amorphous_molecular_weight_Da = 18
+  SIM.flux=1e12
+  SIM.beamsize_mm=0.003 # square (not user specified)
+  SIM.exposure_s=1.0 # multiplies flux x exposure
+  SIM.progress_meter=False
+  SIM.add_background()
+  return SIM
+
+class several_wavelength_case:
+ def __init__(self, BEAM, DETECTOR, CRYSTAL, SF_model):
+  SIM = nanoBragg(DETECTOR, BEAM, panel_id=0)
+  print("\nassume three energy channels")
+  self.wavlen = flex.double([BEAM.get_wavelength()-0.002, BEAM.get_wavelength(), BEAM.get_wavelength()+0.002])
+  self.flux = flex.double([(1./6.)*SIM.flux, (3./6.)*SIM.flux, (2./6.)*SIM.flux])
+  self.sfall_channels = {}
+  for x in range(len(self.wavlen)):
+    self.sfall_channels[x] = SF_model.get_amplitudes(at_angstrom = self.wavlen[x])
+  self.DETECTOR = DETECTOR
+  self.BEAM = BEAM
+  self.CRYSTAL = CRYSTAL
+
+ def several_wavelength_case_for_CPU(self):
+  SIM = nanoBragg(self.DETECTOR, self.BEAM, panel_id=0)
+  for x in range(len(self.wavlen)):
+    SIM.flux = self.flux[x]
+    SIM.wavelength_A = self.wavlen[x]
+    print("CPUnanoBragg_API+++++++++++++ Wavelength %d=%.6f, Flux %.6e, Fluence %.6e"%(
+            x, SIM.wavelength_A, SIM.flux, SIM.fluence))
+    SIM.Fhkl = self.sfall_channels[x]
+    SIM.Ncells_abc = (20,20,20)
+    SIM.Amatrix = sqr(self.CRYSTAL.get_A()).transpose()
+    SIM.oversample = 2
+    SIM.xtal_shape = shapetype.Gauss
+    SIM.interpolate = 0
+    SIM.add_nanoBragg_spots()
+
+  SIM.wavelength_A = self.BEAM.get_wavelength()
+  SIM.Fbg_vs_stol = water
+  SIM.amorphous_sample_thick_mm = 0.02
+  SIM.amorphous_density_gcm3 = 1
+  SIM.amorphous_molecular_weight_Da = 18
+  SIM.flux=1e12
+  SIM.beamsize_mm=0.003 # square (not user specified)
+  SIM.exposure_s=1.0 # multiplies flux x exposure
+  SIM.progress_meter=False
+  SIM.add_background()
+  return SIM
+
+ def several_wavelength_case_exafel_api_for_GPU(self, argchk=False):
+  from simtbx.nanoBragg import gpu_energy_channels
+  gpu_channels_singleton = gpu_energy_channels (deviceId = 0)
+
+  SIM = nanoBragg(self.DETECTOR, self.BEAM, panel_id=0)
+  SIM.device_Id = 0
+
+  assert gpu_channels_singleton.get_deviceID()==SIM.device_Id
+  assert gpu_channels_singleton.get_nchannels() == 0 # uninitialized
+  for x in range(len(self.flux)):
+          gpu_channels_singleton.structure_factors_to_GPU_direct_cuda(
+           x, self.sfall_channels[x].indices(), self.sfall_channels[x].data())
+  assert gpu_channels_singleton.get_nchannels() == len(self.flux)
+  SIM.Ncells_abc = (20,20,20)
+  SIM.Amatrix = sqr(self.CRYSTAL.get_A()).transpose()
+  SIM.oversample = 2
+  if argchk:
+    print("\npolychromatic GPU argchk")
+    SIM.xtal_shape = shapetype.Gauss_argchk
+  else:
+    print("\npolychromatic GPU no argchk")
+    SIM.xtal_shape = shapetype.Gauss
+  SIM.interpolate = 0
+  # allocate GPU arrays
+  SIM.allocate_cuda()
+
+  # loop over energies
+  for x in range(len(self.flux)):
+      SIM.flux = self.flux[x]
+      SIM.wavelength_A = self.wavlen[x]
+      print("USE_EXASCALE_API+++++++++++++ Wavelength %d=%.6f, Flux %.6e, Fluence %.6e"%(
+            x, SIM.wavelength_A, SIM.flux, SIM.fluence))
+      SIM.add_energy_channel_from_gpu_amplitudes_cuda(x,gpu_channels_singleton)
+  per_image_scale_factor = 1.0
+  SIM.scale_in_place_cuda(per_image_scale_factor) # apply scale directly on GPU
+  SIM.wavelength_A = self.BEAM.get_wavelength() # return to canonical energy for subsequent background
+
+  cuda_background = True
+  if cuda_background:
+      SIM.Fbg_vs_stol = water
+      SIM.amorphous_sample_thick_mm = 0.02
+      SIM.amorphous_density_gcm3 = 1
+      SIM.amorphous_molecular_weight_Da = 18
+      SIM.flux=1e12
+      SIM.beamsize_mm=0.003 # square (not user specified)
+      SIM.exposure_s=1.0 # multiplies flux x exposure
+      SIM.add_background_cuda()
+
+      # deallocate GPU arrays
+      SIM.get_raw_pixels_cuda()  # updates SIM.raw_pixels from GPU
+      SIM.deallocate_cuda()
+  else:
+      # deallocate GPU arrays
+      SIM.get_raw_pixels_cuda()  # updates SIM.raw_pixels from GPU
+      SIM.deallocate_cuda()
+
+      SIM.Fbg_vs_stol = water
+      SIM.amorphous_sample_thick_mm = 0.02
+      SIM.amorphous_density_gcm3 = 1
+      SIM.amorphous_molecular_weight_Da = 18
+      SIM.flux=1e12
+      SIM.beamsize_mm=0.003 # square (not user specified)
+      SIM.exposure_s=1.0 # multiplies flux x exposure
+      SIM.progress_meter=False
+      SIM.add_background()
+  return SIM
+
+def diffs(labelA, A, labelB, B):
+  diff = A-B
+  min = flex.min(diff); mean = flex.mean(diff); max = flex.max(diff)
+  print("Pixel differences between %s and %s, minimum=%.4f mean=%.4f maximum=%.4f"%(
+       labelA, labelB, min, mean, max))
+  assert min > -1.0
+  assert max < 1.0
+
+if __name__=="__main__":
+  # make the dxtbx objects
+  BEAM = basic_beam()
+  DETECTOR = basic_detector()
+  CRYSTAL = basic_crystal()
+  SF_model = amplitudes(CRYSTAL)
+  # Famp = SF_model.Famp # simple uniform amplitudes
+  SF_model.random_structure(CRYSTAL)
+  SF_model.ersatz_correct_to_P1()
+
+  # Use case 1.  Simple monochromatic X-rays
+  SIM = simple_monochromatic_case(BEAM, DETECTOR, CRYSTAL, SF_model)
+  SIM.to_smv_format(fileout="test_full_001.img")
+  SIM.to_cbf("test_full_001.cbf")
+
+  SIM2 = simple_monochromatic_case_GPU(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False)
+  SIM3 = simple_monochromatic_case_GPU(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=True)
+  assert approx_equal(SIM.raw_pixels, SIM2.raw_pixels)
+  assert approx_equal(SIM.raw_pixels, SIM3.raw_pixels)
+
+  # Use case 2.  Three-wavelength polychromatic source
+  SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model)
+  SIM = SWC.several_wavelength_case_for_CPU()
+  SIM.to_smv_format(fileout="test_full_002.img")
+  SIM.to_cbf("test_full_002.cbf")
+
+  SIM2 = SWC.several_wavelength_case_exafel_api_for_GPU(argchk=False)
+  SIM2.to_cbf("test_full_0022.cbf")
+  diffs("CPU",SIM.raw_pixels, "GPU",SIM2.raw_pixels)
+  SIM3 = SWC.several_wavelength_case_exafel_api_for_GPU(argchk=True)
+  diffs("CPU",SIM.raw_pixels, "GPU argchk",SIM3.raw_pixels)
+  #assert approx_equal(SIM.raw_pixels, SIM2.raw_pixels)
+  #assert approx_equal(SIM.raw_pixels, SIM3.raw_pixels)
+
+print("OK")

--- a/simtbx/run_tests.py
+++ b/simtbx/run_tests.py
@@ -10,6 +10,14 @@ tst_list = (
     "$D/nanoBragg/tst_nanoBragg_cbf_write.py",
     )
 
+OPT = libtbx.env.build_options
+if OPT.enable_cuda:
+  tst_list_parallel = [
+   "$D/nanoBragg/tst_gauss_argchk.py", # tests GPU, argchk optimization,
+                                       # exafel api optimization, and
+                                       # both the mono- and polychromatic cases
+  ]
+
 def run():
   build_dir = libtbx.env.under_build("simtbx")
   dist_dir = libtbx.env.dist_path("simtbx")

--- a/simtbx/run_tests.py
+++ b/simtbx/run_tests.py
@@ -2,21 +2,24 @@ from __future__ import absolute_import, division, print_function
 from libtbx import test_utils
 import libtbx.load_env
 
-tst_list = (
+tst_list = [
     "$D/nanoBragg/tst_nanoBragg_minimal.py",
     "$D/nanoBragg/tst_nanoBragg_mosaic.py",
     "$D/nanoBragg/tst_gaussian_mosaicity.py",
     "$D/nanoBragg/tst_gaussian_mosaicity2.py",
     "$D/nanoBragg/tst_nanoBragg_cbf_write.py",
-    )
+    ]
 
 OPT = libtbx.env.build_options
 if OPT.enable_cuda:
+
   tst_list_parallel = [
-   "$D/nanoBragg/tst_gauss_argchk.py", # tests GPU, argchk optimization,
-                                       # exafel api optimization, and
-                                       # both the mono- and polychromatic cases
+    ["$D/nanoBragg/tst_gauss_argchk_gpu.py","GPU"] # tests CPU+GPU, argchk optimization
   ]
+else:
+  tst_list.append(
+    ["$D/nanoBragg/tst_gauss_argchk.py","CPU"]
+  )
 
 def run():
   build_dir = libtbx.env.under_build("simtbx")


### PR DESCRIPTION
In analyzing the GPU performance of the Mullen-Holton CUDA kernel, it was discovered that significant time is spent evaluating the exp() function in double precision, signifying the offset from the Ewald sphere.  This only applies to the GAUSS shapetype for the reciprocal lattice point.  Furthermore, the argument can be checked before evaluation; if the exp() result will be essentially zero, it can be skipped.  Thread warps where all exp() values are insignificant (away from reciprocal lattice points) will coalesce, saving measurable GPU wall clock time.  The new code offers a new shapetype, GAUSS_ARGCHK where the exp() argument is pre-evaluated.

Also modified:  correctly initializing integer arrays with integer literals