### PR TITLE
Build reduce whenever we build cctbx, so we'll have it available for …

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -990,7 +990,8 @@ class suitename_module(SourceModule):
 
 class reduce_module(SourceModule):
   module = 'reduce'
-  anonymous = ['svn', 'https://github.com/rlabduke/reduce.git/trunk']
+  anonymous = ['git', '-b master',
+               'https://github.com/rlabduke/reduce.git']
 
 class king_module(SourceModule):
   module = 'king'
@@ -1902,6 +1903,7 @@ class CCIBuilder(Builder):
     'tntbx',
     'clipper',
     'eigen',
+    'reduce',
   ]
   CODEBASES_EXTRA = []
   # Copy these sources from cci.lbl.gov
@@ -1989,6 +1991,7 @@ class PhaserBuilder(CCIBuilder):
     'tntbx',
     'phaser_regression',
     'phaser',
+    'reduce',
   ]
   # Configure for these cctbx packages
   LIBTBX = [


### PR DESCRIPTION
…mmtbx.hydrogenate as we start to integrate it.  Switches the build source from svn to the current git master repository at rlabduke.