### PR TITLE
allow relative paths for compilers

### DIFF
--- a/libtbx/SConscript
+++ b/libtbx/SConscript
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -772,7 +773,8 @@ int main() {
     if sys.platform.startswith("darwin"):
       cc = os.environ.get('CLANG', '')
       cxx = os.environ.get('CLANGXX', '')
-    if not os.path.isfile(cc) or not os.path.isfile(cxx):
+    validate = getattr(shutil, "which", os.path.isfile)
+    if not validate(cc) or not validate(cxx):
       print("Compiler settings:")
       print("  CC: ", cc)
       print("  CXX:", cxx)


### PR DESCRIPTION
Currently [MacOS conda builds are failing](https://dev.azure.com/azure-dials/dials/_build/results?buildId=1846&view=logs&j=ce2f6e73-8d2c-5881-d443-cea2c974a599&t=446b1ed1-c087-5c54-2034-4a043fb919b8&l=289) with
```
Done.
scons: Reading SConscript files ...
Compiler settings:
  CC:  x86_64-apple-darwin13.4.0-clang
  CXX: x86_64-apple-darwin13.4.0-clang++
RuntimeError: conda compilers are not installed.:
  File "/Users/runner/work/1/build/SConstruct", line 6:
    SConscript("libtbx/SConscript")
  File "/Users/runner/work/1/conda_base/lib/python3.6/site-packages/SCons/Script/SConscript.py", line 661:
    return method(*args, **kw)
  File "/Users/runner/work/1/conda_base/lib/python3.6/site-packages/SCons/Script/SConscript.py", line 598:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/Users/runner/work/1/conda_base/lib/python3.6/site-packages/SCons/Script/SConscript.py", line 287:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/Users/runner/work/1/modules/cctbx_project/libtbx/SConscript", line 779:
    raise RuntimeError('conda compilers are not installed.')
```

this is because CC/CXX are now just aliases instead of absolute paths, and the check in libtbx (`os.path.isfile`) is too strong.
This PR changes the check to a `which` equivalent, which is only available on Python 3.3+, so stay on `isfile` for 2.7 fallback.

Although I believe a much better solution would be to just drop the check - if compilers are missing then this will be picked up during compilation.