### PR TITLE
Reordering include files to avoid failure due to cbf.h undefining ULL…

### DIFF
--- a/cbflib_adaptbx/detectors/tst_memory.cpp
+++ b/cbflib_adaptbx/detectors/tst_memory.cpp
@@ -1,9 +1,9 @@
-#include <include/cbf.h>
-#include <include/cbf_simple.h>
 #include <cstdio>
 #include <string>
 #include <exception>
 #include <iostream>
+#include <include/cbf.h>
+#include <include/cbf_simple.h>
 
 struct Error : public std::exception {
   std::string s;


### PR DESCRIPTION
…ONG_MAX as a side effect.

Workaround for https://github.com/cctbx/cctbx_project/issues/575