### PR TITLE
Use binary mode in open

### DIFF
--- a/iotbx/xds/spot_xds.py
+++ b/iotbx/xds/spot_xds.py
@@ -54,7 +54,7 @@ class writer(object):
   def write_file(self, filename=None):
     '''Write the spot file.'''
 
-    with open(filename, 'w') as f:
+    with open(filename, 'wb') as f:
       for i in range(len(self.centroids)):
         print(" %.2f"*3 %self.centroids[i], end=' ', file=f)
         print("%.2f" %self.intensities[i], end=' ', file=f)


### PR DESCRIPTION
Use binary mode in open (current mode is `w`) to avoid encoding-related issues for written file, on Windows or with Python 3.