### PR TITLE
Handle case where LIBTBX_BUILD is set empty for conda install

### DIFF
--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -3019,7 +3019,7 @@ def unpickle(build_path=None, env_name="libtbx_env"):
   if build_path is None:
     build_path = os.getenv("LIBTBX_BUILD")
   # try default installed location
-  if build_path is None:
+  if not build_path:
     build_path = get_installed_path()
   set_preferred_sys_prefix_and_sys_executable(build_path=build_path)
   with open(op.join(build_path, env_name), "rb") as libtbx_env:


### PR DESCRIPTION
Had a user who was having issues running the conda cctbx package. Tracked down to the environment variable `LIBTBX_BUILD` being set, but empty, somewhere. Reproduction of same stacktrace:
```python
import os
os.environ["LIBTBX_BUILD"] = ""
import libtbx.load_env
```
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../ENV/lib/python3.9/site-packages/libtbx/load_env.py", line 5, in <module>
    libtbx.env = libtbx.env_config.unpickle()
  File ".../ENV/lib/python3.9/site-packages/libtbx/env_config.py", line 3024, in unpickle
    set_preferred_sys_prefix_and_sys_executable(build_path=build_path)
  File ".../ENV/lib/python3.9/site-packages/libtbx/env_config.py", line 2920, in set_preferred_sys_prefix_and_sys_executable
    if (dirname and op.samefile(build_path, dirname)):
  File ".../ENV/lib/python3.9/genericpath.py", line 100, in samefile
    s1 = os.stat(f1)
FileNotFoundError: [Errno 2] No such file or directory: ''
```
(note that this causes a _different_ error on non-conda builds, because `get_installed_path` is only the _expected_ install path, and so `unpickle` falls over without `LIBTBX_ENV` set)