### PR TITLE
Add as_size_t method

### DIFF
--- a/scitbx/array_family/boost_python/flex_int.cpp
+++ b/scitbx/array_family/boost_python/flex_int.cpp
@@ -82,6 +82,21 @@ namespace scitbx { namespace af { namespace boost_python {
     return result;
   }
 
+  template <typename intType>
+  af::versa<size_t, af::flex_grid<> >
+  as_size_t(
+    af::const_ref<intType, af::flex_grid<> > const& O)
+  {
+    af::versa<size_t, af::flex_grid<> > result(
+      O.accessor(), af::init_functor_null<size_t>());
+    std::size_t n = O.accessor().size_1d();
+    size_t* r = result.begin();
+    for(std::size_t i=0; i<n; i++) {
+      r[i] = static_cast<size_t>(O[i]);
+    }
+    return result;
+  }
+
   /* For allowed syntax for the optional format_string argument see:
        http://www.boost.org/libs/format/doc/format.html#syntax
    */
@@ -235,6 +250,7 @@ template <typename intType>
         slice_to_byte_str<versa<intType, flex_grid<> > >) \
       .def("as_bool", as_bool<intType>, (arg("strict")=true)) \
       .def("as_long", as_long<intType>) \
+      .def("as_size_t", as_size_t<intType>) \
       .def("as_string", as_string<intType>, (arg("format_string")="%d")) \
       .def("as_rgb_scale_string", as_rgb_scale_string<intType>, ( \
         arg("rgb_scales_low"), \

--- a/scitbx/array_family/boost_python/tst_flex.py
+++ b/scitbx/array_family/boost_python/tst_flex.py
@@ -496,6 +496,10 @@ def exercise_misc():
     a.reshape(flex.grid(2,5))
     b = flex.long([0,1,2,-1,-2,2**30,2**31-1,-2**30,-2**31, 0])
     assert a.all_eq(b)
+  for flex_type in (flex.int, flex.int32, flex.long, flex.int64):
+    a = flex_type([0,1,2,2**30,2**31-1]).as_size_t()
+    b = flex.size_t([0,1,2,2**30,2**31-1])
+    assert a.all_eq(b)
   for flex_type in (flex.int8, flex.int16):
     a = flex_type([0,1,2,-1,-2,2**6,2**7-1,-2**6,-2**7, 0]).as_long()
     a.reshape(flex.grid(2,5))


### PR DESCRIPTION
Copies the integer array into a size_t array such that it can be used for
selections etc.

Fixes #580

Usage:

```
>>> from scitbx.array_family import flex
>>> a = flex.int(range(10))
>>> b = flex.int(reversed(range(10))
... )
>>> a.select(b)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
Boost.Python.ArgumentError: Python argument types in
    int.select(int, int)
did not match C++ signature:
    select(scitbx::af::versa<int, scitbx::af::flex_grid<scitbx::af::small<long, 10ul> > > self, scitbx::af::const_ref<unsigned long, scitbx::af::trivial_accessor> indices, bool reverse=False)
    select(scitbx::af::versa<int, scitbx::af::flex_grid<scitbx::af::small<long, 10ul> > > self, scitbx::af::const_ref<unsigned int, scitbx::af::trivial_accessor> indices, bool reverse=False)
    select(scitbx::af::versa<int, scitbx::af::flex_grid<scitbx::af::small<long, 10ul> > > self, scitbx::af::const_ref<bool, scitbx::af::trivial_accessor> flags)
>>> a.select(b.as_size_t())
<scitbx_array_family_flex_ext.int object at 0x7fc4ea437710>
```
