### PR TITLE
Update mmcif key names in as_cif_block method of iotbx.merging_statistics.dataset_statistics

### DIFF
--- a/iotbx/merging_statistics.py
+++ b/iotbx/merging_statistics.py
@@ -801,6 +801,7 @@ class dataset_statistics(object):
       ('pdbx_Rpim_I_all', 'r_pim'),
       ('pdbx_Rrim_I_all', 'r_meas'),
       ('pdbx_netI_over_sigmaI', 'i_over_sigma_mean'),
+      ('pdbx_netI_over_av_sigmaI', 'i_mean_over_sigi_mean'),
       ('pdbx_redundancy', 'mean_redundancy'),
       ('percent_possible_obs', 'completeness'),
     ])
@@ -815,6 +816,7 @@ class dataset_statistics(object):
       ('pdbx_Rpim_I_all', 'r_pim'),
       ('pdbx_Rrim_I_all', 'r_meas'),
       ('pdbx_netI_over_sigmaI_obs', 'i_over_sigma_mean'),
+      ('meanI_over_sigI_obs', 'i_mean_over_sigi_mean'),
       ('pdbx_redundancy', 'mean_redundancy'),
       ('percent_possible_obs', 'completeness'),
     ])

--- a/iotbx/merging_statistics.py
+++ b/iotbx/merging_statistics.py
@@ -790,36 +790,49 @@ class dataset_statistics(object):
       cif_block = iotbx.cif.model.block()
 
     from collections import OrderedDict
-    mmcif_to_name = OrderedDict([
-      ('d_res_high', 'd_min'),
-      ('d_res_low', 'd_max'),
+
+    mmcif_to_name_reflns = OrderedDict([
+      ('d_resolution_high', 'd_min'),
+      ('d_resolution_low', 'd_max'),
       ('pdbx_CC_half', 'cc_one_half'),
-      ('number_unique_obs', 'n_uniq'),
-      ('pdbx_Rpim_I_obs', 'r_pim'),
-      ('pdbx_Rrim_I_obs', 'r_meas'),
-      ('Rmerge_I_obs', 'r_merge'),
-      ('meanI_over_sigI_obs', 'i_mean_over_sigi_mean'),
+      ('number_obs', 'n_uniq'),
+      ('pdbx_number_measured_all', 'n_obs'),
+      ('pdbx_Rmerge_I_obs', 'r_merge'),
+      ('pdbx_Rpim_I_all', 'r_pim'),
+      ('pdbx_Rrim_I_all', 'r_meas'),
       ('pdbx_netI_over_sigmaI', 'i_over_sigma_mean'),
-      ('number_measured_obs', 'n_obs'),
       ('pdbx_redundancy', 'mean_redundancy'),
       ('percent_possible_obs', 'completeness'),
     ])
 
-    for k, v in six.iteritems(mmcif_to_name):
+    mmcif_to_name_reflns_shell = OrderedDict([
+      ('d_res_high', 'd_min'),
+      ('d_res_low', 'd_max'),
+      ('pdbx_CC_half', 'cc_one_half'),
+      ('number_unique_obs', 'n_uniq'),
+      ('number_measured_obs', 'n_obs'),
+      ('Rmerge_I_obs', 'r_merge'),
+      ('pdbx_Rpim_I_all', 'r_pim'),
+      ('pdbx_Rrim_I_all', 'r_meas'),
+      ('pdbx_netI_over_sigmaI_obs', 'i_over_sigma_mean'),
+      ('pdbx_redundancy', 'mean_redundancy'),
+      ('percent_possible_obs', 'completeness'),
+    ])
+
+    for k, v in six.iteritems(mmcif_to_name_reflns):
       value = self.overall.__getattribute__(v)
       if 'percent' in v:
         value *= 100
-      k = k.replace('d_res_', 'd_resolution_')
       cif_block['_reflns.' + k] = value
 
     header = ['_reflns_shell.pdbx_ordinal'] + [
-      '_reflns_shell.' + k for k in mmcif_to_name.keys()]
+      '_reflns_shell.' + k for k in mmcif_to_name_reflns_shell.keys()]
     reflns_shell_loop = iotbx.cif.model.loop(header=header)
     for i, bin_stats in enumerate(self.bins):
       stats_d = bin_stats.as_dict()
       values = [bin_stats.__getattribute__(v) * 100
                 if 'percent' in k else bin_stats.__getattribute__(v)
-                for k, v in six.iteritems(mmcif_to_name)]
+                for k, v in six.iteritems(mmcif_to_name_reflns_shell)]
       reflns_shell_loop.add_row([i+1] + values)
     cif_block.add_loop(reflns_shell_loop)
 

--- a/iotbx/regression/tst_merging_statistics.py
+++ b/iotbx/regression/tst_merging_statistics.py
@@ -36,7 +36,7 @@ def exercise(debug=False):
   assert ("""  1.81   1.74  12528   2073    6.04  97.05    1449.2     5.2    0.252    0.275    0.110    0.294   0.967   0.281""" in out.getvalue()), out.getvalue()
   cif_block = result.as_cif_block()
   assert "_reflns_shell" in cif_block
-  assert approx_equal(float(cif_block["_reflns.pdbx_Rpim_I_obs"]), result.overall.r_pim)
+  assert approx_equal(float(cif_block["_reflns.pdbx_Rpim_I_all"]), result.overall.r_pim)
   assert approx_equal(float(cif_block["_reflns.pdbx_CC_half"]), result.overall.cc_one_half)
   assert approx_equal(
     flex.int(cif_block["_reflns_shell.number_measured_obs"]),


### PR DESCRIPTION
This PR updates the key names for the `as_cif_block` method of the `iotbx.merging_statistics.dataset_statistics` class, to match the definitions of the pdbx mmcif v5 dictionary for the `reflns` and `reflns_shell` categories (https://mmcif.wwpdb.org/pdbx-mmcif-home-page.html).

The output now validates against v5 of the dictionary, according to the instructions in https://sw-tools.rcsb.org/apps/MMCIF-DICT-SUITE/README-source.

As an example, this was tested within a DIALS installation: 
`xia2 image=$(dials.data get -q x4wide)/X4_wide_M1S4_2_0001.cbf:1:20`

With the `master` branch, validating the output `xia2.mmcif` against the `mmcif_pdbx_v5_next.sdb` dictionary file gives the following errors, which are no longer present when running with this `mmcif_updates` branch:
```
ERROR - In block "AUTOMATIC_DEFAULT_NATIVE", in category "reflns", item "number_unique_obs" is not defined in the reference file
ERROR - In block "AUTOMATIC_DEFAULT_NATIVE", in category "reflns", item "pdbx_Rpim_I_obs" is not defined in the reference file
ERROR - In block "AUTOMATIC_DEFAULT_NATIVE", in category "reflns", item "pdbx_Rrim_I_obs" is not defined in the reference file
ERROR - In block "AUTOMATIC_DEFAULT_NATIVE", in category "reflns", item "Rmerge_I_obs" is not defined in the reference file
ERROR - In block "AUTOMATIC_DEFAULT_NATIVE", in category "reflns", item "meanI_over_sigI_obs" is not defined in the reference file
ERROR - In block "AUTOMATIC_DEFAULT_NATIVE", in category "reflns", item "number_measured_obs" is not defined in the reference file
ERROR - In block "AUTOMATIC_DEFAULT_NATIVE", in category "reflns_shell", item "pdbx_Rpim_I_obs" is not defined in the reference file
ERROR - In block "AUTOMATIC_DEFAULT_NATIVE", in category "reflns_shell", item "pdbx_Rrim_I_obs" is not defined in the reference file
ERROR - In block "AUTOMATIC_DEFAULT_NATIVE", in category "reflns_shell", item "pdbx_netI_over_sigmaI" is not defined in the reference file
```

**Summary of name changes, reflns category**
number_unique_obs -> number_obs
pdbx_Rpim_I_obs -> pdbx_Rpim_I_all
pdbx_Rrim_I_obs -> pdbx_Rrim_I_all
Rmerge_I_obs -> pdbx_Rmerge_I_obs
meanI_over_sigI_obs -> pdbx_netI_over_sigmaI
number_measured_obs -> number_measured_all

**Summary of name changes, reflns_shell category**
pdbx_Rpim_I_obs -> pdbx_Rpim_I_all
pdbx_Rrim_I_obs -> pdbx_Rrim_I_all
pdbx_netI_over_sigmaI -> pdbx_netI_over_sigmaI_obs


