### PR TITLE
Adding __hash__ to sequence class

### DIFF
--- a/iotbx/bioinformatics/__init__.py
+++ b/iotbx/bioinformatics/__init__.py
@@ -120,7 +120,7 @@ class sequence(object):
 
   def __hash__(self):
 
-    return hash(self.sequence)
+    return hash((self.name, self.sequence))
 
   def __eq__(self, other):
 

--- a/iotbx/bioinformatics/__init__.py
+++ b/iotbx/bioinformatics/__init__.py
@@ -120,7 +120,7 @@ class sequence(object):
 
   def __hash__(self):
 
-    return hash((self.name, self.sequence))
+    return hash(id(self))
 
   def __eq__(self, other):
 

--- a/iotbx/bioinformatics/__init__.py
+++ b/iotbx/bioinformatics/__init__.py
@@ -124,7 +124,7 @@ class sequence(object):
     to be implemented if __eq__ is implemented and if the object is immutable.
     Immutable objects can be then used as keys for dictionaries.
     """
-
+    
     #NOTE: To my knowledge objects of this class are used as keyword in a dictionary only
     #by Sculptor.
     

--- a/iotbx/bioinformatics/__init__.py
+++ b/iotbx/bioinformatics/__init__.py
@@ -118,6 +118,9 @@ class sequence(object):
 
     return self.format( 70 )
 
+  def __hash__(self):
+
+    return hash(self.sequence)
 
   def __eq__(self, other):
 

--- a/iotbx/bioinformatics/__init__.py
+++ b/iotbx/bioinformatics/__init__.py
@@ -119,11 +119,11 @@ class sequence(object):
     return self.format( 70 )
 
   def __hash__(self):
-    """
+    '''
     Return a UID (hash) for the instanciated object. This method is required
     to be implemented if __eq__ is implemented and if the object is immutable.
     Immutable objects can be then used as keys for dictionaries.
-    """
+    '''
     
     #NOTE: To my knowledge objects of this class are used as keyword in a dictionary only
     #by Sculptor.
@@ -136,12 +136,12 @@ class sequence(object):
     return hash(id(self))
 
   def __eq__(self, other):
-    """
+    '''
     This method is used any time the equality among two instances of this class must be tested.
     Two sequences are equal if their sequence attribute is equal. Although self and other are
     two different objects. In particular two sequences might have a different name but they are equal
     if they have the same sequence.
-    """
+    '''
     
     return isinstance( other, sequence ) and self.sequence == other.sequence
 

--- a/iotbx/bioinformatics/__init__.py
+++ b/iotbx/bioinformatics/__init__.py
@@ -119,11 +119,30 @@ class sequence(object):
     return self.format( 70 )
 
   def __hash__(self):
+    """
+    Return a UID (hash) for the instanciated object. This method is required
+    to be implemented if __eq__ is implemented and if the object is immutable.
+    Immutable objects can be then used as keys for dictionaries.
+    """
 
+    #NOTE: To my knowledge objects of this class are used as keyword in a dictionary only
+    #by Sculptor.
+    
+    #NOTE: id(self) is already unique but hash(id(self)) distributes better the hashed values
+    #this means that two consecutive id will have very different hash(id(self)) making
+    #hashtable searches more robust when using them as keys of dictionaries. Difference in 
+    #performance are irrelevant.
+    
     return hash(id(self))
 
   def __eq__(self, other):
-
+    """
+    This method is used any time the equality among two instances of this class must be tested.
+    Two sequences are equal if their sequence attribute is equal. Although self and other are
+    two different objects. In particular two sequences might have a different name but they are equal
+    if they have the same sequence.
+    """
+    
     return isinstance( other, sequence ) and self.sequence == other.sequence
 
 

--- a/iotbx/bioinformatics/__init__.py
+++ b/iotbx/bioinformatics/__init__.py
@@ -124,15 +124,15 @@ class sequence(object):
     to be implemented if __eq__ is implemented and if the object is immutable.
     Immutable objects can be then used as keys for dictionaries.
     '''
-    
+
     #NOTE: To my knowledge objects of this class are used as keyword in a dictionary only
     #by Sculptor.
-    
+
     #NOTE: id(self) is already unique but hash(id(self)) distributes better the hashed values
     #this means that two consecutive id will have very different hash(id(self)) making
-    #hashtable searches more robust when using them as keys of dictionaries. Difference in 
+    #hashtable searches more robust when using them as keys of dictionaries. Difference in
     #performance are irrelevant.
-    
+
     return hash(id(self))
 
   def __eq__(self, other):
@@ -142,7 +142,7 @@ class sequence(object):
     two different objects. In particular two sequences might have a different name but they are equal
     if they have the same sequence.
     '''
-    
+
     return isinstance( other, sequence ) and self.sequence == other.sequence
 
 


### PR DESCRIPTION
sequence (and its subclasses) objects of this module are used in other modules, such as in the function get_muscle_alignment_ordered of mmtbx/msa.py, as immutable objects and in particular as keys of dictionaries. In Python3 immutable objects are required to implement the __hash__ method (if not obvious) and the __eq__ method. So I added the __hash__ method and I can continue to use that function correctly.