### PR TITLE
uctbx.unit_cell: Fix f-string/__format__ behaviour with empty string

### DIFF
--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -125,7 +125,9 @@ class _():
   def __repr__(self):
     return format(self, "uctbx.unit_cell(({}, {}, {}, {}, {}, {}))")
 
-  def __format__(self, format_spec="({:.6g}, {:.6g}, {:.6g}, {:.6g}, {:.6g}, {:.6g})"):
+  def __format__(self, format_spec=""):
+    if not format_spec:
+        format_spec = "({:.6g}, {:.6g}, {:.6g}, {:.6g}, {:.6g}, {:.6g})"
     return format_spec.format(*self.parameters())
 
   def show_parameters(self, f=None, prefix="Unit cell: "):


### PR DESCRIPTION
Output from:
```python
from cctbx.uctbx import unit_cell
cell = unit_cell((80, 80, 80, 90, 90, 129.0))
print(" str:", str(cell))
print("fstr:", f"{cell}")
```
is:
```
 str: (80, 80, 80, 90, 90, 129)
fstr: 
```
Reason: When converting with `f"{cell}"` it's not `str(cell)` that is called but `format(cell, "")`, so the `unit_cell.__format__` gets called with an empty format specification (which would otherwise be passed in the `{expr:format_spec}` part of the format value). This then calls `format_spec.format(...)` - since `format_spec=""` this outputs an empty string.

This isn't a comprehensive treatment - I haven't tried to define the formatting semantics when using f-strings, but avoids this problem in the simple case of no specifier at all:
```
 str: (80, 80, 80, 90, 90, 129)
fstr: (80, 80, 80, 90, 90, 129)
```