### PR TITLE
Correct problem with Modulated Structures dict.

### DIFF
--- a/iotbx/cif/validation.py
+++ b/iotbx/cif/validation.py
@@ -369,7 +369,10 @@ class dictionary(model.cif):
         if isinstance(references, string_types):
           references = [references]
         for reference in references:
-          ref_data = self.get_definition(reference)
+          try:
+            ref_data = self.get_definition(reference)
+          except:
+            ref_data = self.get_definition(key)
           ref_names = ref_data['_name']
           if isinstance(ref_names, string_types):
             ref_names = [ref_names]

--- a/iotbx/cif/validation.py
+++ b/iotbx/cif/validation.py
@@ -371,7 +371,7 @@ class dictionary(model.cif):
         for reference in references:
           try:
             ref_data = self.get_definition(reference)
-          except:
+          except KeyError:
             ref_data = self.get_definition(key)
           ref_names = ref_data['_name']
           if isinstance(ref_names, string_types):


### PR DESCRIPTION
In some cases the reference obtained is not present in the dictionary. 

For example, ``_geom_bond_atom_site_label_1`` tag's reference is ``_geom_bond_atom_site_label_`` but that is not present in the Modulated Structures dictionary and it raises a KeyError: ``_geom_bond_atom_site_label_``.

This change tries to correct that error.

I'm attaching a CIF file that can serve as an example.
[bp5098Isup1.cif.txt](https://github.com/cctbx/cctbx_project/files/5924572/bp5098Isup1.cif.txt)

