### PR TITLE
Make d_max and d_min the right way round

### DIFF
--- a/cctbx/miller/__init__.py
+++ b/cctbx/miller/__init__.py
@@ -1729,16 +1729,17 @@ class set(crystal.symmetry):
       assert d_star_sq_step > 0 or (d_star_sq_step is None)
     if auto_binning:
       d_spacings = self.d_spacings().data()
-      d_max=flex.min(d_spacings)
-      d_min=flex.max(d_spacings)
+      d_max=flex.max(d_spacings)
+      d_min=flex.min(d_spacings)
       del d_spacings
       if d_star_sq_step is None:
         d_star_sq_step = 0.004
     assert (d_star_sq_step>0.0)
+    d_min, d_max = sorted((d_min, d_max))
     return self.use_binning(binning=binning(self.unit_cell(),
       self.indices(),
-      d_min,
       d_max,
+      d_min,
       d_star_sq_step))
 
   def setup_binner_counting_sorted(self,


### PR DESCRIPTION
The current code means that anyone calling `miller.array.setup_binner_d_star_sq_step` and wishing to override the parameters `d_min` and `d_max` must pass `d_min=d_max` and `d_max=d_min`. The `binning` constructor takes arguments in the order `d_max`, `d_min`, i.e. the opposite order to order of the variable names when the constructor is called from the existing Python code.

https://github.com/cctbx/cctbx_project/blob/08b8e83bb3f9ebe47188ecea6eba7db1f8243942/cctbx/miller/bins.h#L44-L49