### PR TITLE
Performance optimizations for cctbx::miller::match_indices

### DIFF
--- a/cctbx/miller/boost_python/match_indices.cpp
+++ b/cctbx/miller/boost_python/match_indices.cpp
@@ -19,8 +19,22 @@ namespace {
         .def(init<af::shared<index<> > const&,
                   af::shared<index<> > const&>())
         .def(init<af::shared<index<> > const&>())
-        .def("match_cached", &w_t::match_cached)
-        .def("match_cached_fast", &w_t::match_cached_fast)
+        .def("match_cached", &w_t::match_cached,
+           "To be used when the match_indices instance was constructed from \n \
+           one Miller array h0. Upon calling match_indices.match_cached(h1),\n \
+           the matches between h0 and h1 are found and stored as tuples\n \
+           (i0, i1) where i0 and i1 are indices into the arrays h0 and h1.\n \
+           Retrieve the array of (i0, i1) tuples by calling\n \
+           match_indices.pairs()."
+            )
+        .def("match_cached_fast", &w_t::match_cached_fast,
+           "See match_indices.match_cached. This is faster when only \n \
+           the pairs (i0, i1) are needed. Other member functions such as \n \
+           match_cached.singles(i) are not available when the matching was \n \
+           done via match_cached_fast. Note that match_cached_fast \n \
+           populates the pairs array in ascending order of indices i1 \n \
+           instead of i0."
+            )
         .def("pairs", &w_t::pairs)
         .def("singles", &w_t::singles)
         .def("have_singles", &w_t::have_singles)

--- a/cctbx/miller/boost_python/match_indices.cpp
+++ b/cctbx/miller/boost_python/match_indices.cpp
@@ -18,6 +18,9 @@ namespace {
       class_<w_t>("match_indices", no_init)
         .def(init<af::shared<index<> > const&,
                   af::shared<index<> > const&>())
+        .def(init<af::shared<index<> > const&>())
+        .def("match_cached", &w_t::match_cached)
+        .def("match_cached_fast", &w_t::match_cached_fast)
         .def("pairs", &w_t::pairs)
         .def("singles", &w_t::singles)
         .def("have_singles", &w_t::have_singles)

--- a/cctbx/miller/boost_python/tst_miller.py
+++ b/cctbx/miller/boost_python/tst_miller.py
@@ -493,6 +493,7 @@ def exercise_match_cached():
   assert mi.have_singles() == 0
   assert list(mi.pairs()) == list(zip(range(5), range(5)))
   mi.match_cached(h1)
+  mi.match_cached(h1) # yes we meant to call it twice
   assert tuple(mi.singles(0)) == (4,)
   assert tuple(mi.singles(1)) == ()
   assert tuple(mi.pairs()) == ((0,2), (1,0), (2,3), (3,1))

--- a/cctbx/miller/boost_python/tst_miller.py
+++ b/cctbx/miller/boost_python/tst_miller.py
@@ -483,6 +483,81 @@ def exercise_match_indices():
   mi = miller.match_indices(h0, h0)
   assert approx_equal(tuple(mi.plus(cd2,cd3)),
     ((2+0j), (4+1j), (4+0j), (4-11j), (2+5.4j)))
+def exercise_match_cached():
+  h0 = flex.miller_index(((1,2,3), (-1,-2,-3), (2,3,4), (-2,-3,-4), (3,4,5)))
+  d0 = flex.double((1,2,3,4,5))
+  h1 = flex.miller_index(((-1,-2,-3), (-2,-3,-4), (1,2,3), (2,3,4)))
+  d1 = flex.double((10,20,30,40))
+  mi = miller.match_indices(h0)
+  mi.match_cached(h0)
+  assert mi.have_singles() == 0
+  assert list(mi.pairs()) == list(zip(range(5), range(5)))
+  mi.match_cached(h1)
+  assert tuple(mi.singles(0)) == (4,)
+  assert tuple(mi.singles(1)) == ()
+  assert tuple(mi.pairs()) == ((0,2), (1,0), (2,3), (3,1))
+  assert tuple(mi.pair_selection(0)) == (1, 1, 1, 1, 0)
+  assert tuple(mi.single_selection(0)) == (0, 0, 0, 0, 1)
+  assert tuple(mi.pair_selection(1)) == (1, 1, 1, 1)
+  assert tuple(mi.single_selection(1)) == (0, 0, 0, 0)
+  assert tuple(mi.paired_miller_indices(0)) \
+      == tuple(h0.select(mi.pair_selection(0)))
+  l1 = list(mi.paired_miller_indices(1))
+  l2 = list(h1.select(mi.pair_selection(1)))
+  l1.sort()
+  l2.sort()
+  assert l1 == l2
+  assert approx_equal(tuple(mi.plus(d0, d1)), (31, 12, 43, 24))
+  assert approx_equal(tuple(mi.minus(d0, d1)), (-29,-8,-37,-16))
+  assert approx_equal(tuple(mi.multiplies(d0, d1)), (30,20,120,80))
+  assert approx_equal(tuple(mi.divides(d0, d1)), (1/30.,2/10.,3/40.,4/20.))
+  assert approx_equal(tuple(mi.additive_sigmas(d0, d1)), [
+    math.sqrt(x*x+y*y) for x,y in ((1,30), (2,10), (3,40), (4,20))])
+  q = flex.size_t((3,2,0,4,1))
+  h1 = h0.select(q)
+  mi = miller.match_indices(h1)
+  mi.match_cached(h0)
+  assert tuple(mi.permutation()) == tuple(q)
+  mi = miller.match_indices(h0)
+  mi.match_cached(h1)
+  p = mi.permutation()
+  assert tuple(p) == (2,4,1,0,3)
+  assert tuple(h1.select(p)) == tuple(h0)
+  cd0 = [ complex(a,b) for (a,b) in ((1,1),(2,0),(3.5,-1.5),(5, -3),(-8,5.4)) ]
+  cd1 = [ complex(a,b) for (a,b) in ((1,-1),(2,1),(0.5,1.5),(-1, -8),(10,0)) ]
+  cd2 = flex.complex_double(cd0)
+  cd3 = flex.complex_double(cd1)
+  mi = miller.match_indices(h0)
+  mi.match_cached(h0)
+  assert approx_equal(tuple(mi.plus(cd2,cd3)),
+    ((2+0j), (4+1j), (4+0j), (4-11j), (2+5.4j)))
+
+def exercise_match_cached_fast():
+  h0 = flex.miller_index(((1,2,3), (-1,-2,-3), (2,3,4), (-2,-3,-4), (3,4,5)))
+  h1 = flex.miller_index(((-1,-2,-3), (-2,-3,-4), (1,2,3), (2,3,4)))
+  mi_ref = miller.match_indices(h0, h1)
+  mi = miller.match_indices(h0)
+  mi.match_cached_fast(h1)
+  assert sorted(mi.pairs()) == sorted(mi_ref.pairs())
+  mi_ref = miller.match_indices(h0, h0)
+  mi.match_cached_fast(h0)
+  assert sorted(mi.pairs()) == sorted(mi_ref.pairs())
+
+  try: mi.singles(0)
+  except RuntimeError: pass
+  else: raise ExceptionExpected
+  try: mi.pair_selection(0)
+  except RuntimeError: pass
+  else: raise ExceptionExpected
+  d0 = flex.double((1,2,3,4,5))
+  try: mi.plus(d0, d0)
+  except RuntimeError: pass
+  else: raise ExceptionExpected
+  try: mi.permutation()
+  except RuntimeError: pass
+  else: raise ExceptionExpected
+
+
 
 def exercise_match_multi_indices():
   h0 = flex.miller_index(((1,2,3), (-1,-2,-3), (2,3,4), (-2,-3,-4), (3,4,5)))
@@ -685,6 +760,8 @@ def run(args):
   exercise_match_bijvoet_mates()
   exercise_merge_equivalents()
   exercise_match_indices()
+  exercise_match_cached()
+  exercise_match_cached_fast()
   exercise_match_multi_indices()
   exercise_phase_integral()
   exercise_phase_transfer()

--- a/cctbx/miller/match_indices.cpp
+++ b/cctbx/miller/match_indices.cpp
@@ -69,6 +69,8 @@ namespace cctbx { namespace miller {
 
     miller_indices_[1] = miller_indices_1;
     pairs_.clear();
+    singles_[0].clear();
+    singles_[1].clear();
     af::shared<long> temp_pairs(lookup_map_.size(), -1);
 
     if (miller_indices_[0].id() == miller_indices_[1].id()) {
@@ -79,6 +81,13 @@ namespace cctbx { namespace miller {
       }
       return;
     }
+
+    singles_[0].reserve(miller_indices_[0].size());
+    singles_[1].reserve(miller_indices_[1].size());
+    if (miller_indices_[0].size() < miller_indices_[1].size())
+      pairs_.reserve(miller_indices_[0].size());
+    else
+      pairs_.reserve(miller_indices_[1].size());
 
     for(std::size_t i=0; i<miller_indices_[1].size(); i++) {
       lookup_map_type::const_iterator
@@ -111,6 +120,10 @@ namespace cctbx { namespace miller {
     pairs_are_valid_ = true;
 
     pairs_.clear();
+    if (miller_indices_[0].size() < miller_indices_[1].size())
+      pairs_.reserve(miller_indices_[0].size());
+    else
+      pairs_.reserve(miller_indices_[1].size());
 
     if (miller_indices_[0].id() == miller_indices_1.id()) {
       // short-cut if same array

--- a/cctbx/miller/match_indices.cpp
+++ b/cctbx/miller/match_indices.cpp
@@ -44,7 +44,6 @@ namespace cctbx { namespace miller {
         l = lookup_map_.find(miller_indices_[0][i]);
       if (l == lookup_map_.end()) {
         singles_[0].push_back(i);
-        ;
       }
       else {
         pairs_.push_back(af::tiny<std::size_t, 2>(i, l->second));

--- a/cctbx/miller/match_indices.cpp
+++ b/cctbx/miller/match_indices.cpp
@@ -5,11 +5,27 @@
 
 namespace cctbx { namespace miller {
 
+
+  match_indices::match_indices(
+    af::shared<index<> > const& miller_indices_0)
+  {
+    singles_are_valid_ = false;
+    pairs_are_valid_ = false;
+
+    miller_indices_[0] = miller_indices_0;
+
+    for(std::size_t i=0;i<miller_indices_[0].size();i++) {
+      lookup_map_[miller_indices_[0][i]] = i;
+    }
+  }
+
   match_indices::match_indices(
     af::shared<index<> > const& miller_indices_0,
     af::shared<index<> > const& miller_indices_1)
   :
-    miller_indices_(miller_indices_0, miller_indices_1)
+    miller_indices_(miller_indices_0, miller_indices_1),
+    singles_are_valid_(true),
+    pairs_are_valid_(true)
   {
     if (miller_indices_[0].id() == miller_indices_[1].id()) {
       // short-cut if same array
@@ -19,17 +35,16 @@ namespace cctbx { namespace miller {
       }
       return;
     }
-    typedef std::map<index<>, std::size_t, fast_less_than<> > lookup_map_type;
-    lookup_map_type lookup_map;
     for(std::size_t i=0;i<miller_indices_[1].size();i++) {
-      lookup_map[miller_indices_[1][i]] = i;
+      lookup_map_[miller_indices_[1][i]] = i;
     }
     std::vector<bool> miller_indices_1_flags(miller_indices_[1].size(), false);
     for(std::size_t i=0;i<miller_indices_[0].size();i++) {
       lookup_map_type::const_iterator
-        l = lookup_map.find(miller_indices_[0][i]);
-      if (l == lookup_map.end()) {
+        l = lookup_map_.find(miller_indices_[0][i]);
+      if (l == lookup_map_.end()) {
         singles_[0].push_back(i);
+        ;
       }
       else {
         pairs_.push_back(af::tiny<std::size_t, 2>(i, l->second));
@@ -42,8 +57,84 @@ namespace cctbx { namespace miller {
   }
 
   void
+  match_indices::match_cached(
+      af::shared<index<> > const& miller_indices_1)
+  {
+    /*
+     * Match against the previously supplied miller_indices_0. This is faster
+     * when calling repeatedly with different miller_indices_1 because the
+     * lookup map is only constructed once.
+     * */
+    singles_are_valid_ = true;
+    pairs_are_valid_ = true;
+
+    miller_indices_[1] = miller_indices_1;
+    pairs_.clear();
+    af::shared<long> temp_pairs(lookup_map_.size(), -1);
+
+    if (miller_indices_[0].id() == miller_indices_[1].id()) {
+      // short-cut if same array
+      pairs_.reserve(miller_indices_[0].size());
+      for(std::size_t i=0;i<miller_indices_[0].size();i++) {
+        pairs_.push_back(af::tiny<std::size_t, 2>(i, i));
+      }
+      return;
+    }
+
+    for(std::size_t i=0; i<miller_indices_[1].size(); i++) {
+      lookup_map_type::const_iterator
+        l = lookup_map_.find(miller_indices_[1][i]);
+      if (l != lookup_map_.end())
+        temp_pairs[l->second] = i;
+      else
+        singles_[1].push_back(i);
+    }
+
+    for (std::size_t i=0; i<temp_pairs.size(); ++i) {
+      if (temp_pairs[i] != -1)
+        pairs_.push_back(af::tiny<std::size_t, 2>(i, temp_pairs[i]));
+      else
+        singles_[0].push_back(i);
+    }
+  }
+
+  void match_indices::match_cached_fast(
+      af::shared<index<> > const& miller_indices_1)
+  {
+    /*
+     * As match_indices::match_cached, but with some extra optimizations.
+     * Only pairs are found, singles are ignored. The order of the results
+     * is different (ordered as found in miller_indices_1, not _0). No member
+     * functions except pairs() can be called if the matching was done this
+     * way.
+     * */
+    singles_are_valid_ = false;
+    pairs_are_valid_ = true;
+
+    pairs_.clear();
+
+    if (miller_indices_[0].id() == miller_indices_1.id()) {
+      // short-cut if same array
+      pairs_.reserve(miller_indices_[0].size());
+      for(std::size_t i=0;i<miller_indices_[0].size();i++) {
+        pairs_.push_back(af::tiny<std::size_t, 2>(i, i));
+      }
+      return;
+    }
+
+    for(std::size_t i=0;i<miller_indices_1.size();i++) {
+      lookup_map_type::const_iterator
+        l = lookup_map_.find(miller_indices_1[i]);
+      if (l != lookup_map_.end())
+        pairs_.push_back(af::tiny<std::size_t, 2>(l->second, i));
+    }
+  }
+
+  void
   match_indices::size_assert_intrinsic() const
   {
+    CCTBX_ASSERT(singles_are_valid_);
+    CCTBX_ASSERT(pairs_are_valid_);
     CCTBX_ASSERT(miller_indices_[0].size() == size_processed(0));
     CCTBX_ASSERT(miller_indices_[1].size() == size_processed(1));
   }

--- a/cctbx/miller/match_indices.h
+++ b/cctbx/miller/match_indices.h
@@ -3,26 +3,40 @@
 
 #include <cctbx/miller/match.h>
 #include <cctbx/miller.h>
+#include <map>
 
 namespace cctbx { namespace miller {
+
+  typedef std::map<index<>, std::size_t, fast_less_than<> > lookup_map_type;
 
   class match_indices
   {
     public:
+
       match_indices() {}
+
+      match_indices(af::shared<index<> > const& indices_0);
 
       match_indices(af::shared<index<> > const& indices_0,
                     af::shared<index<> > const& indices_1);
 
+      void
+      match_cached(af::shared<index<> > const& indices_1);
+
+      void
+      match_cached_fast(af::shared<index<> > const& indices_1);
+
       af::shared<pair_type>
       pairs() const
       {
+        CCTBX_ASSERT(pairs_are_valid_);
         return pairs_;
       }
 
       af::shared<std::size_t>
       singles(std::size_t i) const
       {
+        CCTBX_ASSERT(singles_are_valid_);
         if (i) return singles_[1];
         return singles_[0];
       }
@@ -30,6 +44,7 @@ namespace cctbx { namespace miller {
       bool
       have_singles() const
       {
+        CCTBX_ASSERT(singles_are_valid_);
         return singles_[0].size() || singles_[1].size();
       }
 
@@ -38,6 +53,8 @@ namespace cctbx { namespace miller {
       std::size_t
       size_processed(std::size_t i) const
       {
+        CCTBX_ASSERT(singles_are_valid_);
+        CCTBX_ASSERT(pairs_are_valid_);
         return pairs_.size() + singles_[i].size();
       }
 
@@ -127,6 +144,9 @@ namespace cctbx { namespace miller {
       af::tiny<af::shared<index<> >, 2> miller_indices_;
       af::shared<pair_type> pairs_;
       af::tiny<af::shared<std::size_t>, 2> singles_;
+      lookup_map_type lookup_map_;
+      bool singles_are_valid_;
+      bool pairs_are_valid_;
   };
 
 }} // namespace cctbx::miller


### PR DESCRIPTION
Add a `match_indices` constructor that only takes one miller array.
Then use `mi.match_cached(h1)` as a replacement for `match_indices(h0, h1)`,
but called as follows:

```
mi = match_indices(h0)
mi.match_cached(h1)
```

before using `mi.pairs()`, `mi.singles(i)`, etc. This is faster when a single
array `h0` will be used to match several arrays `h1`, `h2`, ... because a lookup map
is constructed from `h0` and cached.

Another new member function `match_cached_fast` has the same call signature
as `match_cached`, but subsequently only `mi.pairs()` is available. This is
even faster when you only want the pairs.