### PR TITLE
Xfelgui batch logging

### DIFF
--- a/xfel/ui/__init__.py
+++ b/xfel/ui/__init__.py
@@ -116,6 +116,9 @@ db {
   port = 3306
     .type = int
     .help = Port number to be used for connection
+  logging_batch_size = 3
+    .type = int
+    .help = Number of images to log at once. Increase if using many (thousands) of processors.
 }
 """
 master_phil_scope = parse(master_phil_str + db_phil_str, process_includes=True)

--- a/xfel/ui/db/frame_logging.py
+++ b/xfel/ui/db/frame_logging.py
@@ -10,16 +10,39 @@ class DialsProcessorWithLogging(Processor):
     super(DialsProcessorWithLogging, self).__init__(params, composite_tag, rank)
     self.tt_low = None
     self.tt_high = None
-    self.db_app = dxtbx_xfel_db_application(params, cache_connection=True)
+    if params.db.logging_batch_size:
+      self.queries = []
+    else:
+      self.db_app = dxtbx_xfel_db_application(params, cache_connection=True)
+
+  def finalize(self):
+    super(DialsProcessorWithLogging, self).finalize()
+    if self.params.db.logging_batch_size: self.log_batched_frames()
+    
+  def log_batched_frames(self):
+    db_app = dxtbx_xfel_db_application(self.params, cache_connection=True)
+    for q in self.queries:
+      experiments, reflections, run, n_strong, timestamp, two_theta_low, two_theta_high, db_event = q
+      log_frame(experiments, reflections, self.params, run, n_strong, timestamp = timestamp,
+                           two_theta_low = two_theta_low, two_theta_high = two_theta_high,
+                           db_event = db_event, app = db_app)
+    self.queries = []
 
   def log_frame(self, experiments, reflections, run, n_strong, timestamp = None,
                 two_theta_low = None, two_theta_high = None, db_event = None):
     # update an existing db_event if db_event is not None
     if self.params.experiment_tag is None:
       return
-    db_event = log_frame(experiments, reflections, self.params, run, n_strong, timestamp = timestamp,
-                         two_theta_low = two_theta_low, two_theta_high = two_theta_high,
-                         db_event = db_event, app = self.db_app)
+    if self.params.db.logging_batch_size:
+      self.queries.append((experiments, reflections, run, n_strong, timestamp,
+                           two_theta_low, two_theta_high,
+                           db_event))
+      if len(self.queries) >= self.params.db.logging_batch_size:
+        self.log_batched_frames()
+    else:
+      db_event = log_frame(experiments, reflections, self.params, run, n_strong, timestamp = timestamp,
+                           two_theta_low = two_theta_low, two_theta_high = two_theta_high,
+                           db_event = db_event, app = self.db_app)
     return db_event
 
   def get_run_and_timestamp(self, obj):
@@ -66,19 +89,28 @@ class DialsProcessorWithLogging(Processor):
 
   def find_spots(self, experiments):
     observed = super(DialsProcessorWithLogging, self).find_spots(experiments)
-    run, timestamp = self.get_run_and_timestamp(experiments)
-    self.db_event = self.log_frame(None, None, run, len(observed), timestamp = timestamp,
-                                   two_theta_low = self.tt_low, two_theta_high = self.tt_high)
+    if (
+        not self.params.dispatch.index or
+        len(observed) < self.params.dispatch.hit_finder.minimum_number_of_reflections
+    ):
+      run, timestamp = self.get_run_and_timestamp(experiments)
+      self.log_frame(None, None, run, len(observed), timestamp = timestamp,
+                     two_theta_low = self.tt_low, two_theta_high = self.tt_high)
     return observed
 
   def index(self, experiments, reflections):
-    experiments, indexed = super(DialsProcessorWithLogging, self).index(experiments, reflections)
-
-    if not(self.params.dispatch.integrate):
+    try:
+      experiments, indexed = super(DialsProcessorWithLogging, self).index(experiments, reflections)
+    except Exception as e:
       run, timestamp = self.get_run_and_timestamp(experiments)
-      self.log_frame(experiments, indexed, run, len(indexed), timestamp = timestamp,
-                     two_theta_low = self.tt_low, two_theta_high = self.tt_high,
-                     db_event = self.db_event)
+      self.log_frame(None, None, run, len(reflections), timestamp = timestamp,
+                     two_theta_low = self.tt_low, two_theta_high = self.tt_high)
+      raise e
+    else:
+      if not self.params.dispatch.integrate:
+        run, timestamp = self.get_run_and_timestamp(experiments)
+        self.log_frame(experiments, indexed, run, len(indexed), timestamp = timestamp,
+                       two_theta_low = self.tt_low, two_theta_high = self.tt_high)
     return experiments, indexed
 
   def integrate(self, experiments, indexed):
@@ -87,11 +119,12 @@ class DialsProcessorWithLogging(Processor):
     try:
       integrated = super(DialsProcessorWithLogging, self).integrate(experiments, indexed)
       self.log_frame(experiments, integrated, run, len(integrated), timestamp = timestamp,
-                     two_theta_low = self.tt_low, two_theta_high = self.tt_high,
-                     db_event = self.db_event)
+                     two_theta_low = self.tt_low, two_theta_high = self.tt_high)
       return integrated
     except Exception as e:
       self.log_frame(experiments, indexed, run, len(indexed), timestamp = timestamp,
-                     two_theta_low = self.tt_low, two_theta_high = self.tt_high,
-                     db_event = self.db_event)
+                     two_theta_low = self.tt_low, two_theta_high = self.tt_high)
       raise e
+    else:
+      self.log_frame(experiments, indexed, run, len(indexed), timestamp = timestamp,
+                     two_theta_low = self.tt_low, two_theta_high = self.tt_high)

--- a/xfel/ui/db/frame_logging.py
+++ b/xfel/ui/db/frame_logging.py
@@ -19,7 +19,7 @@ class DialsProcessorWithLogging(Processor):
   def finalize(self):
     super(DialsProcessorWithLogging, self).finalize()
     if self.params.db.logging_batch_size: self.log_batched_frames()
-    
+
   def log_batched_frames(self):
     db_app = dxtbx_xfel_db_application(self.params, cache_connection=True)
     for q in self.queries:
@@ -98,7 +98,6 @@ class DialsProcessorWithLogging(Processor):
       run, timestamp = self.get_run_and_timestamp(experiments)
       self.log_frame(None, None, run, self.n_strong, timestamp = timestamp,
                      two_theta_low = self.tt_low, two_theta_high = self.tt_high)
-    
     return observed
 
   def index(self, experiments, reflections):


### PR DESCRIPTION
* Refactor `DialsProcessorWithLogging` so that each event (shot) only logs one `db_event`. This makes all db queries independent so they can be batched.
* Add method `DialsProcessorWithLogging.log_batched_frames` and optionally call it from `log_frame`
* Add ui phil param `db.logging_batch_size`