### PR TITLE
Make regex patterns raw strings

### DIFF
--- a/boost_adaptbx/boost/python.py
+++ b/boost_adaptbx/boost/python.py
@@ -165,7 +165,7 @@ class gcc_version(object):
 
   def __init__(self):
     pat = r" \s* = \s* (\d+) \s+"
-    m = re.search("__GNUC__ %s __GNUC_MINOR__ %s __GNUC_PATCHLEVEL__ %s"
+    m = re.search(r"__GNUC__ %s __GNUC_MINOR__ %s __GNUC_PATCHLEVEL__ %s"
                   % ((pat,)*3),
                   platform_info, re.X|re.M|re.S)
     if not m:

--- a/cctbx/eltbx/attenuation_coefficient.py
+++ b/cctbx/eltbx/attenuation_coefficient.py
@@ -80,16 +80,16 @@ def chemlex(formula):
   import re
 
   # Check that the formula is valid
-  if re.match('^([A-Z][a-z]{0,2}[1-9]?)*$', formula):
+  if re.match(r'^([A-Z][a-z]{0,2}[1-9]?)*$', formula):
 
     # Split the components by capital letter
-    comp = re.findall('[A-Z][^A-Z]*', formula)
+    comp = re.findall(r'[A-Z][^A-Z]*', formula)
 
     # For each component split into element and number
     el_num = []
     for c in comp:
 
-      r = re.compile('([A-Z][a-z]{0,2})([1-9]+)')
+      r = re.compile(r'([A-Z][a-z]{0,2})([1-9]+)')
       m = r.match(c)
       if m:
         el = m.group(1)

--- a/dox.sphinx/conf.py
+++ b/dox.sphinx/conf.py
@@ -81,7 +81,7 @@ def boostFuncSignature(name,obj,removeSelf=False):
         if len(docc)<2: return None,docc
         doc1=docc[1]
         # functions with weird docstring, likely not documented by boost
-        if not re.match('^'+nname+r'(.*)->.*$',doc1):
+        if not re.match(r'^'+nname+r'(.*)->.*$',doc1):
                 return None,docc
         if doc1.endswith(':'): doc1=doc1[:-1]
         strippedDoc=doc.split('\n')[2:]

--- a/gltbx/util.py
+++ b/gltbx/util.py
@@ -45,7 +45,7 @@ def show_versions():
 def check_glx_availability():
   glxerr = easy_run.fully_buffered("glxinfo -b").stderr_lines
   for line in glxerr :
-    if re.search('extension "GLX" missing', line):
+    if re.search(r'extension "GLX" missing', line):
       return False
   return True
 
@@ -58,7 +58,7 @@ class version(object):
     import re
     self.__dict__ = self._shared_state
     if not self._shared_state:
-      vers_pat = re.compile("^((\d+)\.(\d+))(?:\.(\d+))?(?: (.*))?$")
+      vers_pat = re.compile(r"^((\d+)\.(\d+))(?:\.(\d+))?(?: (.*))?$")
       m = vers_pat.search(gl.glGetString(gl.GL_VERSION))
       self.__dict__.update(dict(zip(
         ["principal", "major_number", "minor_number", "release_number",

--- a/iotbx/cif/builders.py
+++ b/iotbx/cif/builders.py
@@ -770,7 +770,7 @@ class miller_array_builder(crystal_symmetry_builder):
     or like 'HLanomA', 'HLanomB', 'HLanomC', 'HLanomD'
     Use a regular expression to group them accordingly
     """
-    allmatches = re.findall("(\S*(HL(\S*)[abcdABCD](\S*)))", alllabels )
+    allmatches = re.findall(r"(\S*(HL(\S*)[abcdABCD](\S*)))", alllabels )
     HLtagslst = list(set([ (e[2], e[3]) for e in allmatches ]))
     usedkeys = []
     for m in HLtagslst:
@@ -794,7 +794,7 @@ class miller_array_builder(crystal_symmetry_builder):
     remainingkeys = lstkeys[:] # deep copy the list
     alllabels = " ".join(lstkeys) #  _refln.FC _refln.PHIC _refln.FC_ALL _refln.PHIC_ALL _refln.FWT _refln.PHWT _refln.DELFWT _refln.PHDELWT
     mapcoefflabels = []
-    PHmatches = re.findall("((\S*PH)([^I]\S*))", alllabels ) # [('_refln.PHWT', '_refln.PH', 'WT'), ('_refln.PHDELWT', '_refln.PH', 'DELWT')]
+    PHmatches = re.findall(r"((\S*PH)([^I]\S*))", alllabels ) # [('_refln.PHWT', '_refln.PH', 'WT'), ('_refln.PHDELWT', '_refln.PH', 'DELWT')]
     for label in lstkeys:
       for m in PHmatches:
         Flabel = m[1].replace("PH","F") + m[2]
@@ -803,7 +803,7 @@ class miller_array_builder(crystal_symmetry_builder):
           remainingkeys.remove(label)
           remainingkeys.remove(m[0])
     alllabels = " ".join(remainingkeys)
-    PHImatches = re.findall("((\S*PHI)(\S*))", alllabels ) # [('_refln.PHIC', '_refln.PHI', 'C'), ('_refln.PHIC_ALL', '_refln.PHI', 'C_ALL')]
+    PHImatches = re.findall(r"((\S*PHI)(\S*))", alllabels ) # [('_refln.PHIC', '_refln.PHI', 'C'), ('_refln.PHIC_ALL', '_refln.PHI', 'C_ALL')]
     for label in lstkeys:
       for m in PHImatches:
         Flabel = m[1].replace("PHI","F") + m[2]
@@ -812,7 +812,7 @@ class miller_array_builder(crystal_symmetry_builder):
           remainingkeys.remove(label)
           remainingkeys.remove(m[0])
     alllabels = " ".join(remainingkeys)
-    PHDELmatches = re.findall("(((\S*)PH)([^I]\S*(WT)))", alllabels ) # [('_refln.PHDELWT', '_refln.PH', '_refln.', 'DELWT', 'WT')]
+    PHDELmatches = re.findall(r"(((\S*)PH)([^I]\S*(WT)))", alllabels ) # [('_refln.PHDELWT', '_refln.PH', '_refln.', 'DELWT', 'WT')]
     for label in lstkeys:
       for m in PHDELmatches:
         Flabel = m[2] + m[3].replace("WT","FWT")
@@ -821,7 +821,7 @@ class miller_array_builder(crystal_symmetry_builder):
           remainingkeys.remove(label)
           remainingkeys.remove(m[0])
     alllabels = " ".join(remainingkeys)
-    phase_matches = re.findall("((\S*\.)phase(_\S*))", alllabels ) # [('_refln.phase_calc', '_refln.', '')]
+    phase_matches = re.findall(r"((\S*\.)phase(_\S*))", alllabels ) # [('_refln.phase_calc', '_refln.', '')]
     for label in lstkeys:
       for m in phase_matches:
         phaselabel = m[0]
@@ -843,7 +843,7 @@ class miller_array_builder(crystal_symmetry_builder):
         if labl.startswith(okey):
           return self.observation_types[okey]
       return None
-    sigma_matches = re.findall("((\S*\.)SIG(\S*))", alllabels ) # catch label pairs like F(+),SIGF(+)
+    sigma_matches = re.findall(r"((\S*\.)SIG(\S*))", alllabels ) # catch label pairs like F(+),SIGF(+)
     for label in lstkeys:
       for m in sigma_matches:
         FIlabel = m[1] + m[2]
@@ -852,7 +852,7 @@ class miller_array_builder(crystal_symmetry_builder):
           remainingkeys.remove(label)
           remainingkeys.remove(m[0])
     alllabels = " ".join(remainingkeys)
-    sigma_matches = re.findall("((\S*)_sigma(_*\S*))", alllabels ) # [('_refln.F_meas_sigma_au', '_refln.F_meas', '_au'), ('_refln.intensity_sigma', '_refln.intensity', ''), ('_refln.pdbx_I_plus_sigma', '_refln.pdbx_I_plus', '')]
+    sigma_matches = re.findall(r"((\S*)_sigma(_*\S*))", alllabels ) # [('_refln.F_meas_sigma_au', '_refln.F_meas', '_au'), ('_refln.intensity_sigma', '_refln.intensity', ''), ('_refln.pdbx_I_plus_sigma', '_refln.pdbx_I_plus', '')]
     for label in lstkeys:
       for m in sigma_matches:
         FIlabel = m[1] + m[2]
@@ -862,8 +862,8 @@ class miller_array_builder(crystal_symmetry_builder):
           remainingkeys.remove(m[0])
     alllabels = " ".join(remainingkeys)
     # catch generic meas and sigma labels, https://www.iucr.org/__data/iucr/cifdic_html/2/cif_mm.dic/index.html
-    anymeas_matches = re.findall("((\S*)_meas(\S*))", alllabels ) + re.findall("((\S*)_calc(\S*))", alllabels )
-    anysigma_matches = re.findall("((\S*)_sigma(\S*))", alllabels )
+    anymeas_matches = re.findall(r"((\S*)_meas(\S*))", alllabels ) + re.findall(r"((\S*)_calc(\S*))", alllabels )
+    anysigma_matches = re.findall(r"((\S*)_sigma(\S*))", alllabels )
     for mmatch in anymeas_matches:
       for smatch in anysigma_matches:
         if mmatch[1]==smatch[1] and mmatch[2]==smatch[2]:

--- a/iotbx/command_line/file_reader.py
+++ b/iotbx/command_line/file_reader.py
@@ -24,7 +24,7 @@ file_reader
     .caption = Any_format %s
 }
 """ % (" ".join(file_reader.standard_file_types),
-       " ".join([ re.sub(" ", "_", file_reader.standard_file_descriptions[ft])
+       " ".join([ re.sub(r" ", "_", file_reader.standard_file_descriptions[ft])
                   for ft in file_reader.standard_file_types ])))
 
 def run(args=(), params=None, out=sys.stdout):

--- a/iotbx/command_line/pdb_as_fasta.py
+++ b/iotbx/command_line/pdb_as_fasta.py
@@ -34,7 +34,7 @@ def run(args=(), params=None, out=sys.stdout):
           else :
             seq = "".join(chain.as_sequence())
           if (params.ignore_missing_residues_at_start):
-            seq = re.sub("^X*", "", seq)
+            seq = re.sub(r"^X*", "", seq)
           seq_lines = []
           k = 0
           while (k < len(seq)):

--- a/iotbx/data_manager/__init__.py
+++ b/iotbx/data_manager/__init__.py
@@ -39,7 +39,7 @@ data_manager_type['hkl'] = 'miller_array'   # map hkl to parent, miller_array
 # datatypes have corresponding modules in iotbx/data_manager
 # e.g. iotbx/data_manager/model.py
 supported_datatypes = os.listdir(os.path.dirname(__file__))
-re_search = re.compile('.py$')
+re_search = re.compile(r'\.py$')
 supported_datatypes = list(filter(re_search.search, supported_datatypes))
 supported_datatypes.remove('__init__.py')
 supported_datatypes.sort()

--- a/iotbx/data_plots.py
+++ b/iotbx/data_plots.py
@@ -188,11 +188,11 @@ class table_data(object):
     assert remainder == '', 'loggraph table has %d bytes following the table end' % len(remainder)
 
     if '$TABLE' in header:
-      title = re.search('\\$TABLE\\s*:(.*?)(:|\n|$)', header, re.MULTILINE)
+      title = re.search(r'\\$TABLE\\s*:(.*?)(:|\n|$)', header, re.MULTILINE)
       if title:
         self.title = title.group(1).strip()
 
-    graphs = re.search('\\$(GRAPHS|SCATTER)[\\s\n]*((:[^:\n]*:[^:\n]*:[^:\n]*(:|$)[\\s\n]*)*)($|\\$)', header, re.MULTILINE)
+    graphs = re.search(r'\\$(GRAPHS|SCATTER)[\\s\n]*((:[^:\n]*:[^:\n]*:[^:\n]*(:|$)[\\s\n]*)*)($|\\$)', header, re.MULTILINE)
     if graphs:
       if graphs.group(1) == 'GRAPHS':
         self.plot_type = "GRAPH"
@@ -201,7 +201,7 @@ class table_data(object):
       else:
         raise TypeError('Unknown graph type %s' % graphs.group(1))
       graphs = graphs.group(2)
-      for graph in re.finditer(':([^:\n]*):([^:\n]*):([^:\n]*)(:|$)', graphs, re.MULTILINE):
+      for graph in re.finditer(r':([^:\n]*):([^:\n]*):([^:\n]*)(:|$)', graphs, re.MULTILINE):
         self.add_graph(name=graph.group(1),
                        type=graph.group(2),
                        columns=[ int(col)-1 for col in graph.group(3).split(',') ])

--- a/iotbx/detectors/__init__.py
+++ b/iotbx/detectors/__init__.py
@@ -165,5 +165,5 @@ class dataset_info(object):
   def get_frame_path(self, frame):
     assert isinstance(frame, int) and (frame > 0)
     serial_format = "%%0%dd" % (self.base_name.count("#"))
-    format_str = re.sub("[#]{1,}", serial_format, self.base_name)
+    format_str = re.sub(r"[#]{1,}", serial_format, self.base_name)
     return format_str % frame

--- a/iotbx/file_reader.py
+++ b/iotbx/file_reader.py
@@ -416,7 +416,7 @@ class any_file_input(object):
 #    assert len(self._file_object) != 0
 #    for _line in self._file_object.splitlines():
 #      assert not _line.startswith(" ")
-#      line = re.sub(" ", "", _line)
+#      line = re.sub(r" ", "", _line)
 #      assert ((len(line) == 0) or
 #              (line[0] == ">") or
 #              (line == "*") or

--- a/iotbx/fullprof/write_pcr.py
+++ b/iotbx/fullprof/write_pcr.py
@@ -190,19 +190,19 @@ def _set_ref_flags(inputstring, freeparams=[]):
     for param in freeparams:
       if param == "scale":
         # free all scale factors
-        for m in re.finditer('##_scf_##', ret):
+        for m in re.finditer(r'##_scf_##', ret):
           ret = __replace_match(ret, m , varcount)
           varcount += 1
       elif param == "lattice":
         # free all lattice parameters
-        for m in re.finditer('##_lp.*?_##', ret):
+        for m in re.finditer(r'##_lp.*?_##', ret):
           if m.group(0) not in param_to_var:
             param_to_var[m.group(0)] = varcount
             varcount += 1
           ret = __replace_match(ret, m , param_to_var[m.group(0)])
       elif param == "profile":
         # free all profile parameters
-        for m in re.finditer('##_prf*?_##', ret):
+        for m in re.finditer(r'##_prf*?_##', ret):
           if m.group(0) not in param_to_var:
             param_to_var[m.group(0)] = varcount
             varcount += 1
@@ -210,7 +210,7 @@ def _set_ref_flags(inputstring, freeparams=[]):
       else:
         raise ValueError("unknown parameter type: '{0}'".format(param))
   # fix all still unhandled flags
-  for m in re.finditer('##_.*?_##', ret):
+  for m in re.finditer(r'##_.*?_##', ret):
     ret = ret[:m.start()] + "0.00".rjust(len(m.group(0))) + ret[m.end():]
   ret = ret.replace('#__npar__#', str(varcount-1))
   return ret

--- a/iotbx/logfiles.py
+++ b/iotbx/logfiles.py
@@ -16,7 +16,7 @@ def float_or_none(n):
 
 def percent_to_float(value):
   assert value.endswith("%")
-  return float(re.sub("\%$", "", value))
+  return float(re.sub(r"\%$", "", value))
 
 class experiment_info(object):
   def extract_all_stats(self):
@@ -471,7 +471,7 @@ def parse_xscale(lines):
         elif (fields[0] == "total"):
           overall = fields
           break
-        elif re.match("^\d", line):
+        elif re.match(r"^\d", line):
           bins.append(fields)
         j += 1
       assert (len(bins) > 0) and (len(overall) == len(bins[0]))

--- a/iotbx/mtz/__init__.py
+++ b/iotbx/mtz/__init__.py
@@ -231,7 +231,7 @@ class label_decorator(__builtins__["object"]):
 class ccp4_label_decorator(label_decorator):
   def phases(self, root_label, anomalous_sign=None):
     assert (root_label in ["FWT", "DELFWT"])
-    root_label = re.sub("F", "", root_label)
+    root_label = re.sub(r"F", "", root_label)
     return self.anomalous(
       "PH" + root_label + self.phases_suffix,
       anomalous_sign)

--- a/iotbx/pdb/fetch.py
+++ b/iotbx/pdb/fetch.py
@@ -34,7 +34,7 @@ import re
 import os
 
 def looks_like_pdb_id(id):
-  return (len(id) == 4) and (re.match("[1-9]{1}[a-zA-Z0-9]{3}", id))
+  return (len(id) == 4) and (re.match(r"[1-9]{1}[a-zA-Z0-9]{3}", id))
 
 def validate_pdb_id(id):
   if (not looks_like_pdb_id(id)):
@@ -77,7 +77,7 @@ def fetch(id, data_type="pdb", format="pdb", mirror="rcsb", log=None,
       cache_files = os.listdir(local_cache)
       for file_name in cache_files :
         if (len(file_name) > 4):
-          file_id = re.sub("^pdb", "", file_name)[0:4]
+          file_id = re.sub(r"^pdb", "", file_name)[0:4]
           if (file_id.lower() == id):
             if (guess_file_type(file_name) == "pdb"):
               file_name = os.path.join(local_cache, file_name)

--- a/iotbx/pdb/remediation/remediator.py
+++ b/iotbx/pdb/remediation/remediator.py
@@ -350,7 +350,7 @@ def remediate(filename, remediated_out, f=None):
         elif re.match(r'REMARK...\D',line):
           print_line += line + "\n"
           continue
-        elif re.match('REMARK   4 REMEDIATOR',line):
+        elif re.match(r'REMARK   4 REMEDIATOR',line):
           continue
         elif int(line[6:10]) > 4:
           print_line += remark4 + "\n"
@@ -390,8 +390,8 @@ def remediate(filename, remediated_out, f=None):
         m = aa_re.search(print_line)
         if m:
           res = m.group(1)
-          if re.search('1H   '+res,print_line) or re.search('2H   '+res,print_line):
-            print_line = re.sub(' HN2 '+res,'2H   '+res,print_line)
+          if re.search(r'1H   '+res,print_line) or re.search(r'2H   '+res,print_line):
+            print_line = re.sub(r' HN2 '+res,'2H   '+res,print_line)
       print_line=print_line.rstrip("\n")
 
       if not (print_line == ""):

--- a/iotbx/reflection_file_editor.py
+++ b/iotbx/reflection_file_editor.py
@@ -552,9 +552,9 @@ class process_arrays(object):
       default_types = iotbx.mtz.default_column_types(output_array)
       if (array_types[i] is not None):
         if output_array.is_xray_amplitude_array():
-          array_types[i] = re.sub("J", "F", array_types[i])
+          array_types[i] = re.sub(r"J", "F", array_types[i])
         elif output_array.is_xray_intensity_array():
-          array_types[i] = re.sub("F", "J", array_types[i])
+          array_types[i] = re.sub(r"F", "J", array_types[i])
         if len(default_types) == len(array_types[i]):
           print("Recovering original column types %s" % array_types[i], file=log)
           column_types = array_types[i]
@@ -956,7 +956,7 @@ def modify_array(
     raise Sorry("Missing output labels for %s!" % array_name)
   if (array_params.column_root_label is not None):
     output_labels = None
-  labels_base = re.sub(",merged$", "", array_params.labels)
+  labels_base = re.sub(r",merged$", "", array_params.labels)
   input_labels = labels_base.split(",")
   if not None in [array_params.scale_factor, array_params.scale_max] :
     raise Sorry("The parameters scale_factor and scale_max are " +

--- a/iotbx/reflection_file_reader.py
+++ b/iotbx/reflection_file_reader.py
@@ -301,7 +301,7 @@ class any_reflection_file(object):
         shelx_file.close()
         m = re.search(r"^HKLF\s*(\d)", remaining, re.X|re.M|re.S)
         if m is None:
-          raise Sorry("%s does not contain the mandatory HKLF instruction"
+          raise Sorry(r"%s does not contain the mandatory HKLF instruction"
                       % shelx_file.name)
         if m.group(1) == "4":
           self._observation_type = "intensities"

--- a/iotbx/table_one.py
+++ b/iotbx/table_one.py
@@ -271,7 +271,7 @@ def format_d_max_min(d_max_min):
   else :
     (d_max, d_min) = d_max_min
     d_max_str = "%.4g " % d_max
-    d_min_str = re.sub("\.$", ".0", re.sub("0*$", "", "%.3f" % d_min))
+    d_min_str = re.sub(r"\.$", ".0", re.sub(r"0*$", "", "%.3f" % d_min))
     return "%s - %s" % (d_max_str, d_min_str)
 
 def resize_column(cell_values, alignment="right"):

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -448,9 +448,9 @@ class Toolbox(object):
         else:
           branch = False
         remote, rebase = False, False
-      if re.match('remote\s*=', line.strip()):
+      if re.match(r'remote\s*=', line.strip()):
         remote = True
-      if re.match('rebase\s*=', line.strip()):
+      if re.match(r'rebase\s*=', line.strip()):
         rebase = True
     if branch and remote and not rebase:
       insertions.insert(0, (n + 1, branch))

--- a/libtbx/auto_build/create_mac_app.py
+++ b/libtbx/auto_build/create_mac_app.py
@@ -84,7 +84,7 @@ os.spawnv(os.P_NOWAIT, "%s", ["%s"])
 [py2app]
 argv-emulation=0""")
   f.close()
-  script_name = re.sub(".pyc$", ".py", py2app.script_py2applet.__file__)
+  script_name = re.sub(r"\.pyc$", ".py", py2app.script_py2applet.__file__)
   import subprocess
   executable = sys.executable
   if (options.python_interpreter is not None):

--- a/libtbx/auto_build/setup_installer.py
+++ b/libtbx/auto_build/setup_installer.py
@@ -230,7 +230,7 @@ $PYTHON_EXE ./bin/install.py $@
       print("")
       print("********** FETCHING MODULES **********")
       print("")
-      module_list = re.sub(",", " ", module_list)
+      module_list = re.sub(r",", " ", module_list)
       for module_name in module_list.split():
         get_module(module_name)
 
@@ -241,7 +241,7 @@ $PYTHON_EXE ./bin/install.py $@
     base_module_dir = op.join(options.dest, installer_dir, "base")
     os.makedirs(base_module_dir)
     os.chdir(base_module_dir)
-    base_module_list = re.sub(",", " ", base_module_list)
+    base_module_list = re.sub(r",", " ", base_module_list)
     for module_name in base_module_list.split():
       get_module(module_name)
 

--- a/libtbx/development/xcode_build_phase.py
+++ b/libtbx/development/xcode_build_phase.py
@@ -11,7 +11,7 @@ def run_scons():
   m = re.search(r"^(\d+ \. \d+ \. \d+) .*? \[\s*GCC\s* (\d+ \. \d+ \. \d+)",
                 sys.version,
                 re.X|re.M|re.S)
-  print('Python %s (compiled with gcc %s)' % m.groups())
+  print(r'Python %s (compiled with gcc %s)' % m.groups())
   print()
 
   print("** %s **" % libtbx.env.build_path.basename())

--- a/libtbx/fastentrypoints.py
+++ b/libtbx/fastentrypoints.py
@@ -89,7 +89,7 @@ def main():
     import shutil
     import sys
     dests = sys.argv[1:] or ['.']
-    filename = re.sub('\.pyc$', '.py', __file__)
+    filename = re.sub(r'\.pyc$', '.py', __file__)
 
     for dst in dests:
         shutil.copy(filename, dst)

--- a/libtbx/phil/interface.py
+++ b/libtbx/phil/interface.py
@@ -825,7 +825,7 @@ def reindex_phil_objects(phil_object, path_index, only_scope=None):
     for object in phil_object.objects :
       reindex_phil_objects(object, path_index)
 
-non_alnum = re.compile("[^A-Za-z0-9_]")
+non_alnum = re.compile(r"[^A-Za-z0-9_]")
 def substitute_directory_name(phil_object, path_name, sub_name,
     treat_name_as_var_name=True):
   assert (not non_alnum.search(sub_name))

--- a/libtbx/str_utils.py
+++ b/libtbx/str_utils.py
@@ -532,7 +532,7 @@ class find_matching_closing_symbol(object):
     """
     import re
     self.opening, self.closing = opening, closing
-    self._regex = re.compile("(%s)|(%s)" % (re.escape(opening), re.escape(closing)))
+    self._regex = re.compile(r"(%s)|(%s)" % (re.escape(opening), re.escape(closing)))
 
   def __call__(self, string, pos):
     """ An opening symbol shall start at position `pos` of the given `string`.

--- a/libtbx/test_utils/parallel.py
+++ b/libtbx/test_utils/parallel.py
@@ -131,7 +131,7 @@ def reconstruct_test_name(command):
     return command.test_class, command.test_name
 
   if "-m pytest" in command:
-    m = re.search('-m pytest ([^:]*)::(.*)$', command)
+    m = re.search(r'-m pytest ([^:]*)::(.*)$', command)
     command = 'libtbx.python "%s" %s' % (m.group(1), m.group(2))
   pattern = '^[^"]*"([^"]*)"([^"]*)$'
   m = re.search(pattern, command)
@@ -183,9 +183,9 @@ def write_JUnit_XML(results, output_filename="output.xml"):
     if result.return_code == 0:
       # Identify skipped tests
       output = '\n'.join(result.stdout_lines + result.stderr_lines)
-      if re.search('skip', output, re.IGNORECASE):
+      if re.search(r'skip', output, re.IGNORECASE):
         # find first line including word 'skip' and use it as message
-        skipline = re.search('^((.*)skip(.*))$', output, re.IGNORECASE | re.MULTILINE).group(1)
+        skipline = re.search(r'^((.*)skip(.*))$', output, re.IGNORECASE | re.MULTILINE).group(1)
         tc.add_skipped_info(skipline)
     elif result.alert_status == Status.EXPECTED_FAIL:
       tc.add_skipped_info("Expected test failure")

--- a/mmtbx/command_line/cif_as_mtz.py
+++ b/mmtbx/command_line/cif_as_mtz.py
@@ -113,7 +113,7 @@ def run(args, command_name = "phenix.cif_as_mtz", out=sys.stdout,
     raise Sorry("File is not found: %s"%file_name)
   output_r_free_label = command_line.options.output_r_free_label
   if ((not output_r_free_label[0] in string.ascii_uppercase) or
-      (re.search("[^a-zA-Z0-9_\-]", output_r_free_label))):
+      (re.search(r"[^a-zA-Z0-9_\-]", output_r_free_label))):
     raise Sorry(("%s is not a suitable column label.  MTZ format requires "+
       "an uppercase letter as the first character, and only alphanumeric "+
       "characters or hyphens in the rest of the string.")% output_r_free_label)

--- a/mmtbx/command_line/show_r_factors_by_shell.py
+++ b/mmtbx/command_line/show_r_factors_by_shell.py
@@ -103,7 +103,7 @@ Full parameters:
   f_calc = f_obs = r_free_flags = None
   for array in mtz_in.file_server.miller_arrays :
     labels = array.info().labels
-    first_label_non_anom = re.sub("\(.*", "", labels[0])
+    first_label_non_anom = re.sub(r"\(.*", "", labels[0])
     if ((labels[0] == params.f_obs_label) or
         (first_label_non_anom == params.f_obs_label)):
       f_obs = array

--- a/mmtbx/model/model.py
+++ b/mmtbx/model/model.py
@@ -2319,7 +2319,7 @@ class manager(object):
     xrs = self.get_xray_structure()
     scatterers = xrs.scatterers()
     for scatterer in scatterers:
-      neutralized_scatterer = re.sub('[^a-zA-Z]', '', scatterer.scattering_type)
+      neutralized_scatterer = re.sub(r'[^a-zA-Z]', '', scatterer.scattering_type)
       if (neutralized_scatterer != scatterer.scattering_type):
         neutralized = True
         scatterer.scattering_type = neutralized_scatterer

--- a/mmtbx/pdb_distances.py
+++ b/mmtbx/pdb_distances.py
@@ -774,9 +774,9 @@ def CONVERT(list):
 #                   print "resid", resid, "list", list
                    while count <= len(resid):
                        if list[resid_count] != []:
-                           m=re.search('\d+', list[resid_count])
+                           m=re.search(r'\d+', list[resid_count])
                            resid[resid_count] = m.group()
-                           n=re.search('\w', list[resid_count + 1])
+                           n=re.search(r'\w', list[resid_count + 1])
                            resid[resid_count + 1] = n.group()
                            count = count + 2
                            resid_count = resid_count + 2
@@ -813,14 +813,14 @@ def PYMOL_OUTPUT(list, h, pdb_file_main, From, file):
               if file[k] != []:
                  for a in range (1, 3):
                      if From == 'basepairs':
-                         m=re.search('\d+', list[2 * a])
+                         m=re.search(r'\d+', list[2 * a])
                          resid = m.group()
                          RESID = str(resid)
                          line = [["color " + color + ", /" + pdb_file_main + "/*/*/" + RESID + '\n',"hide sticks, /" + pdb_file_main + "/*/*/" + RESID + '\n'],["color " + color + ", /" + pdb_file_main + "/*/*/" + RESID + '\n', "show sticks, /" + pdb_file_main + "/*/*/" + RESID + '\n']]
                          for l in range (len(line[k])):
                              file[k].write(line[k][l])
                      else:
-                         m=re.search('\d+', list[2 * a])
+                         m=re.search(r'\d+', list[2 * a])
                          resid = m.group()
                          RESID = str(resid)
                          line = "color " + color + ", /" + pdb_file_main + "/*/*/" + RESID + '\n'
@@ -1188,10 +1188,10 @@ def loop(MASTER_Basepairs_summary, control, loop_control, CUTOFF, positions):
                     MH_yes = 'n' #Three-bond-basepairs for which only two bonds have been identified are prevented from entering the rest of the loop lines until MAX_CUTOFF_str[0:3]  == CUTOFF_str[0:3]
                 if len(MASTER_Basepairs_summary[i]) > 0:
                     if ('no' in MASTER_Basepairs_summary[i][j]) and ('yes' not in MASTER_Basepairs_summary[i][j]) and MH_yes == 'y':
-                        m=re.search('\d+', MASTER_Basepairs_summary[i][j][2])
+                        m=re.search(r'\d+', MASTER_Basepairs_summary[i][j][2])
                         search1 = m.group()
                         SEARCH1 = to_int(search1) #convert string to integers
-                        m=re.search('\d+', MASTER_Basepairs_summary[i][j][4])
+                        m=re.search(r'\d+', MASTER_Basepairs_summary[i][j][4])
                         search2 = m.group()
                         SEARCH2 = to_int(search2) #convert string to integers
                         list = [MASTER_Basepairs_summary[i][j][2], MASTER_Basepairs_summary[i][j][3], MASTER_Basepairs_summary[i][j][4], MASTER_Basepairs_summary[i][j][5]]
@@ -1496,13 +1496,13 @@ def program(First_List, MASTER_Basepairs_summary, CUTOFF, pdb_file_main, control
 #Detection of lines carrying consecutive bases. These should be not allowed to enter the assignment section, as they can give rise to FALSE basepairs
                 resid = [[],[]]
                 atom = [[],[],[]]
-                m=re.search('\d+', MASTER_Basepairs[i][j][0])
+                m=re.search(r'\d+', MASTER_Basepairs[i][j][0])
                 resid[0] = int(m.group())
-                m=re.search('\d+', MASTER_Basepairs[i][j][3])
+                m=re.search(r'\d+', MASTER_Basepairs[i][j][3])
                 resid[1] = int(m.group())
-                m=re.search('\S+', MASTER_Basepairs[i][j][2])
+                m=re.search(r'\S+', MASTER_Basepairs[i][j][2])
                 atom[0] = str(m.group())
-                m=re.search('\S+', MASTER_Basepairs[i][j][5])
+                m=re.search(r'\S+', MASTER_Basepairs[i][j][5])
                 atom[1] = str(m.group())
                 atom[2] = MASTER_Basepairs[i][j][6]
                 if (resid[1] - resid[0] > 1) or (resid[1] - resid[0] < -1):
@@ -1820,9 +1820,9 @@ def HELICITY(LIST, a0, a1, a2, a3, where_from):
                         match_position = []
                         for r in range (len(LIST)):
                             for s in range (len(LIST[r])):
-                                m=re.search('\d+', LIST[r][s][2])
+                                m=re.search(r'\d+', LIST[r][s][2])
                                 match1 = m.group()
-                                m=re.search('\d+', LIST[r][s][4])
+                                m=re.search(r'\d+', LIST[r][s][4])
                                 match2 = m.group()
 #                                print "LIST[r][s]", LIST[r][s], "\n    match1", match1, "match2", match2, "a0", a0, "a1", a1, "a2", a2, "a3", a3
                                 if (('Loop' in where_from) and ('REMOVED' not in LIST[r][s]) and ('yes' in LIST[r][s]) and ((match1 in a0) and (match2 in a1) or (match2 in a0) and (match1 in a1))):
@@ -1876,7 +1876,7 @@ First_List[0] = []
 import os
 dir =  os.getcwd()
 import re
-ma=re.compile('\/+')
+ma=re.compile(r'\/+')
 iterator = ma.finditer(dir)
 aaa=[]
 for match in iterator:
@@ -1985,10 +1985,10 @@ while CUTOFF < MAX_CUTOFF:
 #Called below
 
 def CONTINUITY_HELICITY_CRITERION(MASTER_Basepairs_summary_line, MASTER_Basepairs_summary, CUTOFF):
-                        m=re.search('\d+', MASTER_Basepairs_summary_line[2])
+                        m=re.search(r'\d+', MASTER_Basepairs_summary_line[2])
                         search1 = m.group()
                         SEARCH1 = to_int(search1) #convert string to integers
-                        m=re.search('\d+', MASTER_Basepairs_summary_line[4])
+                        m=re.search(r'\d+', MASTER_Basepairs_summary_line[4])
                         search2 = m.group()
                         SEARCH2 = to_int(search2) #convert string to integers
                         list = [MASTER_Basepairs_summary_line[2], MASTER_Basepairs_summary_line[3], MASTER_Basepairs_summary_line[4], MASTER_Basepairs_summary_line[5]]
@@ -2315,13 +2315,13 @@ while (yes_count > 0):
                    if 'yes' in MASTER_Basepairs_summary[i][j]:
                       if yes_count == 0: #Initializing 'min' and 'max'
                           count = 1
-                          m=re.search('\d+', MASTER_Basepairs_summary[i][j][2])
+                          m=re.search(r'\d+', MASTER_Basepairs_summary[i][j][2])
                           search1 = m.group()
                           compare_to = to_int(search1)
                           max = [compare_to, i, j]
                           yes_count = 1
                       else:
-                          m=re.search('\d+', MASTER_Basepairs_summary[i][j][2])
+                          m=re.search(r'\d+', MASTER_Basepairs_summary[i][j][2])
                           search1 = m.group()
                           transient = to_int(search1)
                           if transient >= max[0]:
@@ -2889,7 +2889,7 @@ for c in range (len(MASTER_Basepairs_schemes)):
     geometry_counter_real = 0 #Will count only non-FALSE, non-UNDETERMINED basepairs within 'new_list_end[b]' with 'MASTER_Basepairs_schemes[c]' geometry
 #TRUE BASEPAIRS
     for b in range (len(new_list_end)):
-        m=re.search('\S+', new_list_end[b][0])
+        m=re.search(r'\S+', new_list_end[b][0])
         scheme = str(m.group())
         if MASTER_Basepairs_schemes[c] == scheme:
            geometry_counter = geometry_counter + 1

--- a/mmtbx/polygon/__init__.py
+++ b/mmtbx/polygon/__init__.py
@@ -54,7 +54,7 @@ for key_name in keys_to_show :
   else :
     _selected.append(key_name)
 key_params_str = " ".join(_selected)
-captions_str = " ".join([ re.sub(" ", "_", txt) for txt in key_captions ])
+captions_str = " ".join([ re.sub(r" ", "_", txt) for txt in key_captions ])
 
 polygon_params_str = """\
   database_file_name = None

--- a/mmtbx/refinement/ensemble_refinement/scripts/ens_pdb.py
+++ b/mmtbx/refinement/ensemble_refinement/scripts/ens_pdb.py
@@ -11,14 +11,14 @@ def remove_HOH(start_pdb, noHOH_pdb):
 
   openpdb = open(start_pdb,"r")
   noHOHpdb = open(noHOH_pdb, 'w')
-  find_HOH = re.compile('HOH')
+  find_HOH = re.compile(r'HOH')
 
   for line in openpdb:
     if not find_HOH.search(line):
       noHOHpdb.write(line)
 
 def find_number_model(open_pdb):
-  find_MODEL = re.compile('MODEL')
+  find_MODEL = re.compile(r'MODEL')
   max_model_number = 0
   for line in open_pdb:
     if find_MODEL.match(line):
@@ -31,8 +31,8 @@ def find_number_model(open_pdb):
 
 def find_header(open_pdb, num_pdb):
   print("Getting header info...................")
-  find_CRYST1 = re.compile('CRYST')
-  find_SCALE = re.compile('SCALE')
+  find_CRYST1 = re.compile(r'CRYST')
+  find_SCALE = re.compile(r'SCALE')
   for line in open_pdb:
     if find_CRYST1.search(line):
       num_pdb.write(line)
@@ -41,8 +41,8 @@ def find_header(open_pdb, num_pdb):
 
 def model_parse(open_pdb, num_pdb, model_num, new_model_num, start_pdb):
   model_num = str(model_num)
-  find_MODEL = re.compile('MODEL')
-  find_ENDMDL = re.compile('ENDMDL')
+  find_MODEL = re.compile(r'MODEL')
+  find_ENDMDL = re.compile(r'ENDMDL')
   open_pdb = open(start_pdb,"r")
   for line in open_pdb:
     if find_MODEL.search(line):
@@ -69,7 +69,7 @@ def remove_specific_HOH(open_pdb,open_water_list,wat_pdb):
     x = wat_num.split()
     water_list.append(x[0])
 
-  find_HOH = re.compile('HOH')
+  find_HOH = re.compile(r'HOH')
 
   for line in open_pdb:
     if not find_HOH.search(line):
@@ -83,8 +83,8 @@ def remove_specific_HOH(open_pdb,open_water_list,wat_pdb):
 
 def parse_bfactor_occ_infomation(open_pdb, start_pdb):
   print("Parsing B and Occ information")
-  find_MODEL = re.compile('MODEL')
-  find_ENDMDL = re.compile('ENDMDL')
+  find_MODEL = re.compile(r'MODEL')
+  find_ENDMDL = re.compile(r'ENDMDL')
   #
   b_total_array = []
   b_model_array = []
@@ -114,8 +114,8 @@ def parse_bfactor_occ_infomation(open_pdb, start_pdb):
 
 def parse_specific_pdb(open_pdb, start_pdb, num_pdb, last_model, new_model_num=1):
   model_num = str(last_model)
-  find_MODEL = re.compile('MODEL')
-  find_ENDMDL = re.compile('ENDMDL')
+  find_MODEL = re.compile(r'MODEL')
+  find_ENDMDL = re.compile(r'ENDMDL')
   open_pdb = open(start_pdb,"r")
   for line in open_pdb:
     if find_MODEL.search(line):
@@ -167,7 +167,7 @@ def remove_anisou(start_pdb, fin_pdb):
   print("Removing ANISOU...")
   openpdb = open(start_pdb,"r")
   finpdb = open(fin_pdb, 'w')
-  find_ANISOU = re.compile('ANISOU')
+  find_ANISOU = re.compile(r'ANISOU')
 
   for line in openpdb:
     if not find_ANISOU.search(line):
@@ -221,7 +221,7 @@ def extra_conformation(start_pdb, fin_pdb):
   open_pdb = open(start_pdb,"r")
   fin_pdb = open(fin_pdb, 'w')
 
-  find_ATOM = re.compile('ATOM')
+  find_ATOM = re.compile(r'ATOM')
 
   for line in open_pdb:
     if len(line) > 66 and find_ATOM.search(line):

--- a/mmtbx/validation/clashscore.py
+++ b/mmtbx/validation/clashscore.py
@@ -748,7 +748,7 @@ class nqh_flips(validation):
   gui_formats = ["%s", "%s"]
   wx_column_widths = [75,220]
   def __init__(self, pdb_hierarchy):
-    re_flip = re.compile(":FLIP")
+    re_flip = re.compile(r":FLIP")
     validation.__init__(self)
     in_lines = pdb_hierarchy.as_pdb_string()
     reduce_out = run_reduce_with_timeout(

--- a/scitbx/lbfgs/tst_lbfgs_fem.py
+++ b/scitbx/lbfgs/tst_lbfgs_fem.py
@@ -79,7 +79,7 @@ def truncate_floats(out):
   return "".join(fragments)
 
 def replace_e0dd_with_edd(out):
-  match_objects = re.finditer("E[-+]0[0-9][0-9]", out)
+  match_objects = re.finditer(r"E[-+]0[0-9][0-9]", out)
   fragments = []
   k = 0
   for match_obj in match_objects:

--- a/wxtbx/info_panels.py
+++ b/wxtbx/info_panels.py
@@ -205,7 +205,7 @@ class PDBFileInfo(InfoPanelBase):
       str_value = to_str(value)
       alert = False
       if (str_value.endswith("***")):
-        str_value = re.sub("\s*\*\*\*", "", str_value)
+        str_value = re.sub(r"\s*\*\*\*", "", str_value)
         alert = True
       txt2 = wx.StaticText(self.info_panel, -1, str_value)
       font2 = txt2.GetFont()
@@ -415,7 +415,7 @@ class MapCoeffsInfo(InfoPanelBase):
       str_value = to_str(value)
       alert = False
       if (str_value.endswith("***")):
-        str_value = re.sub("\s*\*\*\*", "", str_value)
+        str_value = re.sub(r"\s*\*\*\*", "", str_value)
         alert = True
       txt2 = wx.StaticText(self.info_panel, -1, str_value)
       font2 = txt2.GetFont()

--- a/wxtbx/phil_controls/choice.py
+++ b/wxtbx/phil_controls/choice.py
@@ -15,7 +15,7 @@ class ChoiceCtrl(wx.Choice, phil_controls.PhilCtrl):
     is_selected = [ ("*" in choice) for choice in choices ]
     if (True in is_selected):
       selection = is_selected.index(True)
-    choices = [ re.sub("\*", "", choice) for choice in choices ]
+    choices = [ re.sub(r"\*", "", choice) for choice in choices ]
     if (captions is None):
       captions = list(choices) # XXX force copy
     if (len(captions) != len(choices)):

--- a/wxtbx/phil_controls/numbers.py
+++ b/wxtbx/phil_controls/numbers.py
@@ -63,7 +63,7 @@ class NumbersValidator(TextCtrlValidator):
     elif (value in ["Auto", "auto"]):
       return Auto
     if ("," in value) or (";" in value):
-      value = re.sub(",", " ", re.sub(";", " ", value))
+      value = re.sub(r",", " ", re.sub(r";", " ", value))
     numbers_list = []
     for field in value.split():
       if (field == "None"):

--- a/wxtbx/phil_controls/tree.py
+++ b/wxtbx/phil_controls/tree.py
@@ -139,8 +139,8 @@ class PhilTreeCtrl(customtreectrl.CustomTreeCtrl):
       phil_object = item.GetData()
       phil_object.show()
 
-valid_text = re.compile("^[a-zA-Z]{1,}[a-zA-z0-9_]*$")
-valid_text_partial = re.compile("^[a-zA-Z0-9_]*$")
+valid_text = re.compile(r"^[a-zA-Z]{1,}[a-zA-z0-9_]*$")
+valid_text_partial = re.compile(r"^[a-zA-Z0-9_]*$")
 
 class PhilTreeFrame(wx.Frame):
   def __init__(self, *args, **kwds):

--- a/xfel/command_line/cxi_stream_to_pickle.py
+++ b/xfel/command_line/cxi_stream_to_pickle.py
@@ -20,8 +20,8 @@ logging.basicConfig(level=logging.DEBUG, format=FORMAT)
 
 EV_PER_A = 12398.4187
 # Regular expressions, set up so one can use groups to extract the data
-re_energy = re.compile("photon_energy_eV\s=\s([0-9]+\.[0-9]+)")
-re_uc = re.compile("""Cell\sparameters\s
+re_energy = re.compile(r"photon_energy_eV\s=\s([0-9]+\.[0-9]+)")
+re_uc = re.compile(r"""Cell\sparameters\s
                    ([0-9]+\.[0-9]+)\s # a
                    ([0-9]+\.[0-9]+)\s # b
                    ([0-9]+\.[0-9]+)\snm,\s # c
@@ -30,7 +30,7 @@ re_uc = re.compile("""Cell\sparameters\s
                    ([0-9]+\.[0-9]+) # gamma""", re.X)
 
 # groups 1-7: h,k,l,I,sig(i),peak, background,fs,ss
-re_miller = re.compile("""\s*(-?[0-9]{1,3})
+re_miller = re.compile(r"""\s*(-?[0-9]{1,3})
                           \s*(-?[0-9]{1,3})
                           \s*(-?[0-9]{1,3}) #h,k,l
                           \s*(-?[0-9]+\.[0-9]+)
@@ -38,17 +38,17 @@ re_miller = re.compile("""\s*(-?[0-9]{1,3})
                           ([\s*-?[0-9]+\.[0-9]+){2}  #Peak, background
                           \s*([0-9]+\.[0-9]+)
                           \s*([0-9]+\.[0-9]+) #fs, ssi""", re.X)
-re_lattice_type = re.compile("lattice_type\s=\s([a-zA-Z]+)")
-re_centering = re.compile("centering\s=\s([A-Z])")
+re_lattice_type = re.compile(r"lattice_type\s=\s([a-zA-Z]+)")
+re_centering = re.compile(r"centering\s=\s([A-Z])")
 
 # note the setting lattice is in nm^-1
-re_Astar = re.compile("""astar\s=\s*(-?\+?[0-9]+\.[0-9]+)
+re_Astar = re.compile(r"""astar\s=\s*(-?\+?[0-9]+\.[0-9]+)
                          \s*(-?\+?[0-9]+\.[0-9]+)
                          \s*(-?\+?[0-9]+\.[0-9]+)""", re.X)
-re_Bstar = re.compile("""bstar\s=\s*(-?\+?[0-9]+\.[0-9]+)
+re_Bstar = re.compile(r"""bstar\s=\s*(-?\+?[0-9]+\.[0-9]+)
                          \s*(-?\+?[0-9]+\.[0-9]+)
                          \s*(-?\+?[0-9]+\.[0-9]+)""", re.X)
-re_Cstar = re.compile("""cstar\s=\s*(-?\+?[0-9]+\.[0-9]+)
+re_Cstar = re.compile(r"""cstar\s=\s*(-?\+?[0-9]+\.[0-9]+)
                          \s*(-?\+?[0-9]+\.[0-9]+)
                          \s*(-?\+?[0-9]+\.[0-9]+)""", re.X)
 

--- a/xfel/command_line/jungfrau_metrics.py
+++ b/xfel/command_line/jungfrau_metrics.py
@@ -93,8 +93,8 @@ include scope xfel.command_line.cspad_detector_congruence.phil_scope
 ''', process_includes=True)
 
 import re
-RUN = re.compile(".*run_000([0-9][0-9][0-9])")
-EVENT = re.compile(".*master_([0-9][0-9][0-9][0-9][0-9])")
+RUN = re.compile(r".*run_000([0-9][0-9][0-9])")
+EVENT = re.compile(r".*master_([0-9][0-9][0-9][0-9][0-9])")
 
 # Next steps
 

--- a/xfel/cxi/cspad_ana/mod_filter.py
+++ b/xfel/cxi/cspad_ana/mod_filter.py
@@ -49,8 +49,8 @@ class mod_filter(object):
     self.negate = cspad_tbx.getOptBool(negate)
 
     if (timestamps_path is not None):
-      p_old = re.compile("\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z\d{2}\.\d{3}")
-      p_new = re.compile("\d{17}")
+      p_old = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z\d{2}\.\d{3}")
+      p_new = re.compile(r"\d{17}")
       f = open(timestamps_path, "r")
       self.timestamps_list = []
       for line in f.readlines():

--- a/xfel/metrology/flatfile.py
+++ b/xfel/metrology/flatfile.py
@@ -1019,13 +1019,13 @@ def parse_metrology(path, detector = 'CxiDs1', plot = True, do_diffs = True, old
   # Continuation lines (i.e. backslash preceding a newline) are not
   # permitted.
   pattern_blank = \
-      re.compile('^\s*(#.*)?$')
+      re.compile(r'^\s*(#.*)?$')
   pattern_quadrant = \
-      re.compile('^\s*[Qq][Uu][Aa][Dd]\s+\d+\s*(#.*)?$')
+      re.compile(r'^\s*[Qq][Uu][Aa][Dd]\s+\d+\s*(#.*)?$')
   pattern_sensor = \
-      re.compile('^\s*[Ss][Ee][Nn][Ss][Oo][Rr]\s+[Xx]\s+[Yy]\s+[Zz]\s*(#.*)?$')
+      re.compile(r'^\s*[Ss][Ee][Nn][Ss][Oo][Rr]\s+[Xx]\s+[Yy]\s+[Zz]\s*(#.*)?$')
   pattern_sxyz = \
-      re.compile('^\s*\d+\s+[+-]?\d+\s+[+-]?\d+\s+[+-]?\d+\s*(#.*)?$')
+      re.compile(r'^\s*\d+\s+[+-]?\d+\s+[+-]?\d+\s+[+-]?\d+\s*(#.*)?$')
 
   # Parse the file into dict of dict of four-tuples, indexed by
   # quadrant indices and sensor indices, respectively.


### PR DESCRIPTION
Python 3 interprets string literals as unicode strings, so we need to explicitly define regex patterns as raw strings.

Silences warnings like `DeprecationWarning: invalid escape sequence \S`.

Search pattern used here: `[\W]re\.[^\.(]+\(['"]`