### PR TITLE
Compatibility with dials cosym clustering changes

### DIFF
--- a/xfel/merging/application/modify/aux_cosym.py
+++ b/xfel/merging/application/modify/aux_cosym.py
@@ -24,6 +24,10 @@ class CosymAnalysis(BaseClass):
     self.output_dir = kwargs.pop('output_dir', None)
     super(CosymAnalysis, self).__init__(*args, **kwargs)
 
+  def run(self):
+    super(CosymAnalysis, self).run()
+    if self.do_plot: self.plot_after_cluster_analysis()
+
   def plot_after_optimize(self):
           print ("optimized coordinates", self.coords.shape)
           xx = []
@@ -43,22 +47,13 @@ class CosymAnalysis(BaseClass):
           plt.show()
 
   def plot_after_cluster_analysis(self):
-          # do another coords plot, but color by cluster
-          # but the problem with this is I don't know to which cluster id==0['h,k,l'] belongs
           xx = flex.double()
           yy = flex.double()
           for item in range(self.coords.shape[0]):
             xx.append(self.coords[(item,0)])
             yy.append(self.coords[(item,1)])
           from matplotlib import pyplot as plt
-          for cl_id in [0.0,1.0]:
-            xs = []
-            ys = []
-            for k in range(len(xx)):
-              if self.cluster_labels[k]==cl_id:
-                xs.append(xx[k])
-                ys.append(yy[k])
-            plt.plot(xs,ys,{0.0:"b.",1.0:"r."}[cl_id])
+          plt.plot(xx, yy, 'r.')
           ax = plt.gca()
           ax.set_aspect("equal")
           circle = plt.Circle((0,0),1,fill=False,edgecolor="b")

--- a/xfel/merging/application/modify/aux_cosym.py
+++ b/xfel/merging/application/modify/aux_cosym.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import, division, print_function
-import copy
 import os
 from scitbx.array_family import flex
-from dials.util.observer import Subject
 from cctbx import sgtbx, miller
 from libtbx import easy_mp
 from scipy import sparse

--- a/xfel/merging/application/modify/aux_cosym.py
+++ b/xfel/merging/application/modify/aux_cosym.py
@@ -71,90 +71,6 @@ class CosymAnalysis(BaseClass):
                 plot_path, self.i_plot, self.plot_format)
             plt.savefig(plot_fname)
 
-  def _space_group_for_dataset(self, dataset_id, sym_ops):
-      """
-      Code from @rjgildea originally in DIALS commit 60986de. This was refactored
-      out of DIALS so for now we are reproducing it here.
-      """
-      if self.input_space_group is not None:
-          sg = copy.deepcopy(self.input_space_group)
-      else:
-          sg = sgtbx.space_group()
-      ref_sym_op_id = None
-      ref_cluster_id = None
-      for sym_op_id in range(len(sym_ops)):
-          i_cluster = self.cluster_labels[
-              len(self.input_intensities) * sym_op_id + dataset_id
-          ]
-          if i_cluster < 0:
-              continue
-          if ref_sym_op_id is None:
-              ref_sym_op_id = sym_op_id
-              ref_cluster_id = i_cluster
-              continue
-          op = sym_ops[ref_sym_op_id].inverse().multiply(sym_ops[sym_op_id])
-          if i_cluster == ref_cluster_id:
-              sg.expand_smx(op.new_denominators(1, 12))
-      return sg.make_tidy()
-
-
-  def run(self): # specializes dials.algorithms.symmetry.cosym.CosymAnalysis
-        #from libtbx.development.timers import Profiler
-        #P = Profiler("initialize target W")
-        self._intialise_target()
-
-        #P = Profiler("optimize W")
-        max_calls = self.params.minimization.max_calls
-        self._optimise(
-            self.params.minimization.engine,
-            max_iterations=self.params.minimization.max_iterations,
-            max_calls=min(20, max_calls) if max_calls else max_calls,
-        )
-        #self.plot_after_optimize()
-
-        #P = Profiler("analyze symmetry W")
-        self._analyse_symmetry()
-        #print(str(self._symmetry_analysis))
-
-        #P = Profiler("cluster analysis W")
-        self._cluster_analysis()
-        if self.do_plot: self.plot_after_cluster_analysis()
-
-  @Subject.notify_event(event="analysed_clusters")
-  def _cluster_analysis(self):
-
-        if self.params.cluster.n_clusters == 1:
-            self.cluster_labels = flex.double(self.coords.all()[0])
-        else:
-            self.cluster_labels = self._do_clustering(self.params.cluster.method)
-
-        sym_ops = [
-            sgtbx.rt_mx(s).new_denominators(1, 12) for s in self.target.get_sym_ops()
-        ]
-
-        reindexing_ops = {}
-        space_groups = {}
-        self.cosets = {}
-
-        for dataset_id in range(len(self.input_intensities)):
-            space_groups[dataset_id] = self._space_group_for_dataset(
-                dataset_id, sym_ops
-            )
-
-            cosets = sgtbx.cosets.left_decomposition(
-                self.target._lattice_group, space_groups[dataset_id]
-            )
-            self.cosets[dataset_id] = cosets
-
-            reindexing_ops[dataset_id] = self._reindexing_ops_for_dataset(
-                dataset_id, sym_ops, cosets
-            )
-
-        self.space_groups = space_groups
-        self.reindexing_ops = reindexing_ops
-
-
-
 
 from dials.command_line.cosym import logger
 from dials.command_line.cosym import cosym as dials_cl_cosym_wrapper
@@ -277,40 +193,6 @@ class dials_cl_cosym_subclass (dials_cl_cosym_wrapper):
             experiments, reflections, use_datasets=identifiers
         )
 
-    @Subject.notify_event(event="run_cosym")
-    def run(self):
-        self.cosym_analysis.run()
-
-        space_groups = {}
-        reindexing_ops = {}
-        for dataset_id in self.cosym_analysis.reindexing_ops:
-            if 0 in self.cosym_analysis.reindexing_ops[dataset_id]:
-                cb_op = self.cosym_analysis.reindexing_ops[dataset_id][0]
-                reindexing_ops.setdefault(cb_op, [])
-                reindexing_ops[cb_op].append(dataset_id)
-            if dataset_id in self.cosym_analysis.space_groups:
-                space_groups.setdefault(
-                    self.cosym_analysis.space_groups[dataset_id], []
-                )
-                space_groups[self.cosym_analysis.space_groups[dataset_id]].append(
-                    dataset_id
-                )
-
-        logger.info("Space groups:")
-        for sg, datasets in space_groups.items():
-            logger.info(str(sg.info().reference_setting()))
-            logger.info(datasets)
-
-        logger.info("Reindexing operators:")
-        for cb_op, datasets in reindexing_ops.items():
-            logger.info(cb_op)
-            logger.info(datasets)
-
-        self._apply_reindexing_operators(
-            reindexing_ops, subgroup=None
-        # changed in xfel subclass:  set subgroup=None.
-        # in dials parent class:  subgroup=self.cosym_analysis.best_subgroup
-        )
 
 class TargetWithFastRij(Target):
   def __init__(self, *args, **kwargs):

--- a/xfel/merging/application/modify/cosym.py
+++ b/xfel/merging/application/modify/cosym.py
@@ -175,7 +175,7 @@ class cosym(worker):
       # Keep this block even though not currently used; need for future assertions:
       LG = COSYM.cosym_analysis.target._lattice_group
       LGINP = LG.change_basis(COSYM.cosym_analysis.cb_op_inp_min.inverse()).change_basis(minimum_to_input)
-      SG = COSYM.cosym_analysis.space_groups[sidx_plus]
+      SG = COSYM.cosym_analysis.input_space_group
       SGINP = SG.change_basis(COSYM.cosym_analysis.cb_op_inp_min.inverse()).change_basis(minimum_to_input)
       CO = sgtbx.cosets.left_decomposition(LGINP, SGINP)
       partitions = CO.partitions

--- a/xfel/merging/application/modify/cosym.py
+++ b/xfel/merging/application/modify/cosym.py
@@ -169,7 +169,7 @@ class cosym(worker):
 
       minimum_to_input = COSYM.cb_op_to_minimum[sidx_plus].inverse()
       reindex_op = minimum_to_input * \
-                     sgtbx.change_of_basis_op(COSYM.cosym_analysis.reindexing_ops[sidx_plus][0]) * \
+                     sgtbx.change_of_basis_op(COSYM.cosym_analysis.reindexing_ops[sidx_plus]) * \
                      COSYM.cb_op_to_minimum[sidx_plus]
 
       # Keep this block even though not currently used; need for future assertions:
@@ -218,7 +218,7 @@ class cosym(worker):
           print("Anchor","experiments:",len(sampling_experiments_for_cosym))
 
           anchor_op = ANCHOR.cb_op_to_minimum[0].inverse() * \
-                     sgtbx.change_of_basis_op(ANCHOR.cosym_analysis.reindexing_ops[0][0]) * \
+                     sgtbx.change_of_basis_op(ANCHOR.cosym_analysis.reindexing_ops[0]) * \
                      ANCHOR.cb_op_to_minimum[0]
           anchor_coset = None
           for p_no, partition in enumerate(partitions):
@@ -236,7 +236,7 @@ class cosym(worker):
 
             minimum_to_input = ANCHOR.cb_op_to_minimum[sidx_plus].inverse()
             reindex_op = minimum_to_input * \
-                     sgtbx.change_of_basis_op(ANCHOR.cosym_analysis.reindexing_ops[sidx_plus][0]) * \
+                     sgtbx.change_of_basis_op(ANCHOR.cosym_analysis.reindexing_ops[sidx_plus]) * \
                      ANCHOR.cb_op_to_minimum[sidx_plus]
             this_reindex_op = reindex_op.as_hkl()
             this_coset = None


### PR DESCRIPTION
This removes the overrides of some private methods. It wasn't clear to me what they were doing that was different to the original dials.cosym versions, and after removing them and falling back on the original dials implementations, the tests still pass.

Caveat: the cctbx.xfel cosym test currently fails as a result of https://github.com/cctbx/cctbx_project/issues/606, however after commenting out the `logger.debug` statement in https://github.com/dials/dials/pull/1647 the test passes.

See https://github.com/dials/dials/pull/1647