### PR TITLE
Add ABI checks for `scitbx.flex`

### DIFF
--- a/scitbx/array_family/boost_python/tst_flex.py
+++ b/scitbx/array_family/boost_python/tst_flex.py
@@ -1498,6 +1498,12 @@ mean:   2.00
   assert approx_equal(flex.double([3,7]).sample_standard_deviation(), 8**0.5)
 
 def exercise_complex_functions():
+  assert (flex.complex_double() == None) is False
+  try:
+    cd_none = flex.complex_double([None])
+  except TypeError as e:
+    assert "converter" in str(e)
+  else: raise Exception_expected
   c = 1+2j
   x = flex.complex_double((c,))
   y = flex.real(x)


### PR DESCRIPTION
We see these tests sometimes fail when the ABI shifts slightly, eg.
dials/dials#1001. Adding the tests here to catch these situations early.

So far, no clear idea what causes this.