### PR TITLE
Fix bug in merging_statistics.as_cif_block function

### DIFF
--- a/iotbx/merging_statistics.py
+++ b/iotbx/merging_statistics.py
@@ -823,7 +823,7 @@ class dataset_statistics(object):
 
     for k, v in six.iteritems(mmcif_to_name_reflns):
       value = self.overall.__getattribute__(v)
-      if 'percent' in v:
+      if 'percent' in k:
         value *= 100
       cif_block['_reflns.' + k] = value
 

--- a/iotbx/regression/tst_merging_statistics.py
+++ b/iotbx/regression/tst_merging_statistics.py
@@ -38,6 +38,7 @@ def exercise(debug=False):
   assert "_reflns_shell" in cif_block
   assert approx_equal(float(cif_block["_reflns.pdbx_Rpim_I_all"]), result.overall.r_pim)
   assert approx_equal(float(cif_block["_reflns.pdbx_CC_half"]), result.overall.cc_one_half)
+  assert approx_equal(float(cif_block["_reflns.percent_possible_obs"]), result.overall.completeness * 100.0)
   assert approx_equal(
     flex.int(cif_block["_reflns_shell.number_measured_obs"]),
     [15737, 15728, 15668, 15371, 14996, 14771, 13899, 13549, 13206, 12528])


### PR DESCRIPTION
Upon iterating through the name dict, the test for finding the string 'percent' should be on the keys, not the values.

Added a line to a test to verify. This issue means that when the merging stats were converted to a cif block, the `_reflns.percent_possible_obs` item has been in the range 0 -> 1 rather than 0 -> 100 as intended.