### PR TITLE
Allow subclassing of sharing_handle

### DIFF
--- a/scitbx/array_family/shared_plain.h
+++ b/scitbx/array_family/shared_plain.h
@@ -72,7 +72,7 @@ namespace scitbx { namespace af {
       {}
 
       virtual ~sharing_handle() {
-        if (data != nullptr) {
+        if (data != NULL) {
 #ifdef SCITBX_AF_HAS_ALIGNED_MALLOC
             aligned_free(data);
 #else

--- a/scitbx/array_family/shared_plain.h
+++ b/scitbx/array_family/shared_plain.h
@@ -82,7 +82,7 @@ namespace scitbx { namespace af {
       }
 
       virtual void deallocate() {
-        if (data != nullptr) {
+        if (data != NULL) {
 #ifdef SCITBX_AF_HAS_ALIGNED_MALLOC
             aligned_free(data);
 #else

--- a/scitbx/array_family/shared_plain.h
+++ b/scitbx/array_family/shared_plain.h
@@ -71,25 +71,29 @@ namespace scitbx { namespace af {
 #endif
       {}
 
-      ~sharing_handle() {
+      virtual ~sharing_handle() {
+        if (data != nullptr) {
 #ifdef SCITBX_AF_HAS_ALIGNED_MALLOC
-        aligned_free(data);
+            aligned_free(data);
 #else
-        delete[] data;
+            delete[] data;
 #endif
+        }
       }
 
-      void deallocate() {
+      virtual void deallocate() {
+        if (data != nullptr) {
 #ifdef SCITBX_AF_HAS_ALIGNED_MALLOC
-        aligned_free(data);
+            aligned_free(data);
 #else
-        delete[] data;
+            delete[] data;
 #endif
+        }
         capacity = 0;
         data = 0;
       }
 
-      void swap(sharing_handle& other) {
+      virtual void swap(sharing_handle& other) {
         std::swap(size, other.size);
         std::swap(capacity, other.capacity);
         std::swap(data, other.data);


### PR DESCRIPTION
I want to make scitbx arrays whose memory is managed other than via malloc/delete. This isn't currently possible because  `sharing_handle` isn't polymorphic - it doesn't have a virtual destructor (or anything), so it's impossible to reliably override the implementation.

This patch changes that by:
- Making destructor and functions virtual
- Protect against SEGV or double-freeing of data from subclasses