### PR TITLE
optionally skip making a default crystal when instantiating NBcrystal

### DIFF
--- a/simtbx/nanoBragg/nanoBragg_crystal.py
+++ b/simtbx/nanoBragg/nanoBragg_crystal.py
@@ -9,17 +9,20 @@ from cctbx import sgtbx
 
 class NBcrystal(object):
 
-  def __init__(self):
-    ucell = (79.1, 79.1, 38.4, 90, 90, 90)
-    self.xtal_shape = "gauss"  # shapetype.Gauss
-    self.Ncells_abc = (10, 10, 10)
-    self.mos_spread_deg = 0
-    self.n_mos_domains = 1
-    self.thick_mm = 0.1
-    self.symbol = 'P43212'
-    self.miller_array = NBcrystal.dummie_Fhkl(ucell, self.symbol)
-    self.dxtbx_crystal = NBcrystal.dxtbx_crystal_from_ucell_and_symbol(ucell_tuple_Adeg=ucell,
-                                                                       symbol=(self.symbol))
+  def __init__(self, default=True):
+    if default:
+      ucell = (79.1, 79.1, 38.4, 90, 90, 90)
+      self.xtal_shape = "gauss"  # shapetype.Gauss
+      self.Ncells_abc = (10, 10, 10)
+      self.mos_spread_deg = 0
+      self.n_mos_domains = 1
+      self.thick_mm = 0.1
+      self.symbol = 'P43212'
+      self.miller_array = NBcrystal.dummie_Fhkl(ucell, self.symbol)
+      self.dxtbx_crystal = NBcrystal.dxtbx_crystal_from_ucell_and_symbol(ucell_tuple_Adeg=ucell,
+                                                                         symbol=(self.symbol))
+    else:
+      self._miller_array = None
 
   @property
   def space_group_info(self):

--- a/simtbx/nanoBragg/sim_data.py
+++ b/simtbx/nanoBragg/sim_data.py
@@ -37,10 +37,10 @@ def determine_spot_scale(beam_size_mm, crystal_thick_mm, mosaic_vol_mm3):
 
 class SimData:
 
-  def __init__(self):
+  def __init__(self, default_crystal=True):
     self.detector = SimData.simple_detector(180, 0.1, (512, 512))
     self.seed = 1
-    self.crystal = NBcrystal()
+    self.crystal = NBcrystal(default=default_crystal)
     self.add_air = False
     self.add_water = True
     self.water_path_mm = 0.005


### PR DESCRIPTION
The NBcrystal constructor takes about ~~0.5 s~~ 50 ms to make a dummy crystal. We want to instantiate thousands of these, so we need the option to skip the dummy crystal.

Edit: accidentally timed this on a debug build. The real time is 50 ms, but that is still a big fraction of our total runtime so this PR is still needed.

