### PR TITLE
skip unneeded memory operations in detector::each_image_allocate_cuda

### DIFF
--- a/simtbx/gpu/detector.cu
+++ b/simtbx/gpu/detector.cu
@@ -269,7 +269,7 @@ namespace gpu {
   gpu_detector::each_image_allocate_cuda(){
     cudaSetDevice(h_deviceID);
     /*allocate and zero reductions */
-    bool * rangemap = (bool*) calloc(_image_size, sizeof(bool));
+
     float * omega_reduction = (float*) calloc(_image_size, sizeof(float));
     float * max_I_x_reduction = (float*) calloc(_image_size, sizeof(float));
     float * max_I_y_reduction = (float*) calloc(_image_size, sizeof(float));
@@ -277,30 +277,18 @@ namespace gpu {
 
     cu_omega_reduction = NULL;
     cudaSafeCall(cudaMalloc((void ** )&cu_omega_reduction, sizeof(*cu_omega_reduction) * _image_size));
-    cudaSafeCall(cudaMemcpy(cu_omega_reduction,
-                 omega_reduction, sizeof(*cu_omega_reduction) * _image_size,
-                 cudaMemcpyHostToDevice));
 
     cu_max_I_x_reduction = NULL;
     cudaSafeCall(cudaMalloc((void ** )&cu_max_I_x_reduction, sizeof(*cu_max_I_x_reduction) * _image_size));
-    cudaSafeCall(cudaMemcpy(cu_max_I_x_reduction,
-                 max_I_x_reduction, sizeof(*cu_max_I_x_reduction) * _image_size,
-                 cudaMemcpyHostToDevice));
 
     cu_max_I_y_reduction = NULL;
     cudaSafeCall(cudaMalloc((void ** )&cu_max_I_y_reduction, sizeof(*cu_max_I_y_reduction) * _image_size));
-    cudaSafeCall(cudaMemcpy(cu_max_I_y_reduction, max_I_y_reduction, sizeof(*cu_max_I_y_reduction) * _image_size,
-                 cudaMemcpyHostToDevice));
 
     cu_rangemap = NULL;
     cudaSafeCall(cudaMalloc((void ** )&cu_rangemap, sizeof(*cu_rangemap) * _image_size));
-    cudaSafeCall(cudaMemcpy(cu_rangemap,
-                 rangemap, sizeof(*cu_rangemap) * _image_size,
-                 cudaMemcpyHostToDevice));
 
     // deallocate host arrays
     // potential memory leaks
-    free(rangemap);
     free(omega_reduction);
     free(max_I_x_reduction);
     free(max_I_y_reduction);


### PR DESCRIPTION
Are these cudaMemcpy (and one calloc) necessary? I don't think the arrays they copy over contain any data. These operations are very expensive, they make up 2/3 of the total runtime for the simulation profiled below. With this commit, the runtime for `each_image_allocate_cuda()` goes from 77ms to 1.6ms. The LS49 and simtbx tests pass.

```
Timer unit: 1e-06 s

Total time: 0.121016 s
File: /global/cscratch1/sd/dwpaley/cb5/alcc-recipes/cctbx/modules/LS49/adse13_187/cyto_batch.py
Function: multipanel_sim at line 92

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    92                                           def multipanel_sim(
    93                                             CRYSTAL, DETECTOR, BEAM, Famp, energies, fluxes,
    94                                             background_wavelengths=None, background_wavelength_weights=None,
    95                                             background_total_flux=None, background_sample_thick_mm=None,
    96                                             density_gcm3=1, molecular_weight=18,
    97                                             cuda=False, oversample=0, Ncells_abc=(50, 50, 50),
    98                                             mos_dom=1, mos_spread=0, mos_aniso=(0,0,0,0,0,0,0,0,0), beamsize_mm=0.001,
    99                                             crystal_size_mm=0.01,
   100                                             verbose=0, default_F=0, interpolate=0, profile="gauss",
   101                                             spot_scale_override=None, show_params=False, time_panels=False,
   102                                             add_water = False, add_air=False, water_path_mm=0.005, air_path_mm=0,
   103                                             adc_offset=0, readout_noise=3, psf_fwhm=0, gain=1, mosaicity_random_seeds=None,
   104                                             include_background=True, mask_file="",skip_numpy=False,relevant_whitelist_order=None):
   105
   106         1          3.0      3.0      0.0    import cProfile
   107         1          4.0      4.0      0.0    pr = cProfile.Profile()
   108                                             #pr.enable()
   109         1          6.0      6.0      0.0    from simtbx.nanoBragg.nanoBragg_beam import NBbeam
   110         1          4.0      4.0      0.0    from simtbx.nanoBragg.nanoBragg_crystal import NBcrystal
   111         1          4.0      4.0      0.0    from simtbx.nanoBragg.sim_data import SimData
   112         1          5.0      5.0      0.0    from simtbx.nanoBragg.utils import get_xray_beams
   113         1          7.0      7.0      0.0    from scitbx.array_family import flex
   114         1          6.0      6.0      0.0    from scipy import constants
   115         1          3.0      3.0      0.0    import numpy as np
   116         1          3.0      3.0      0.0    ENERGY_CONV = 10000000000.0 * constants.c * constants.h / constants.electron_volt
   117         1          2.0      2.0      0.0    assert cuda # disallow the default
   118
   119         1         10.0     10.0      0.0    nbBeam = NBbeam()
   120         1          2.0      2.0      0.0    nbBeam.size_mm = beamsize_mm
   121         1          7.0      7.0      0.0    nbBeam.unit_s0 = BEAM.get_unit_s0()
   122         1         14.0     14.0      0.0    wavelengths = ENERGY_CONV / np.array(energies)
   123         1         10.0     10.0      0.0    nbBeam.spectrum = list(zip(wavelengths, fluxes))
   124
   125         1         20.0     20.0      0.0    class Nodefault_NBcrystal(NBcrystal):
   126                                               def __init__(self): self._miller_array = None
   127         1          3.0      3.0      0.0    nbCrystal = Nodefault_NBcrystal()
   128         1          4.0      4.0      0.0    nbCrystal.dxtbx_crystal = CRYSTAL
   129                                             #nbCrystal.miller_array = None # use the gpu_channels_singleton mechanism instead
   130         1          3.0      3.0      0.0    nbCrystal.Ncells_abc = Ncells_abc
   131         1        222.0    222.0      0.2    nbCrystal.symbol = CRYSTAL.get_space_group().info().type().lookup_symbol()
   132         1          4.0      4.0      0.0    nbCrystal.thick_mm = crystal_size_mm
   133         1          3.0      3.0      0.0    nbCrystal.xtal_shape = profile
   134         1          3.0      3.0      0.0    nbCrystal.n_mos_domains = mos_dom
   135         1          3.0      3.0      0.0    nbCrystal.mos_spread_deg = mos_spread
   136         1          2.0      2.0      0.0    nbCrystal.mos_aniso = mos_aniso
   137
   138         1          2.0      2.0      0.0    pid = 0 # remove the loop, use C++ iteration over detector panels
   139         1          2.0      2.0      0.0    use_exascale_api = True
   140         1          2.0      2.0      0.0    if use_exascale_api:
   141
   142         1        259.0    259.0      0.2      S = SimData(default_crystal=False)
   143         1          4.0      4.0      0.0      S.detector = DETECTOR
   144         1          3.0      3.0      0.0      S.beam = nbBeam
   145         1          3.0      3.0      0.0      S.crystal = nbCrystal
   146         1          6.0      6.0      0.0      S.panel_id = pid
   147         1          2.0      2.0      0.0      S.add_air = add_air
   148         1          2.0      2.0      0.0      S.air_path_mm = air_path_mm
   149         1          2.0      2.0      0.0      S.add_water = add_water
   150         1          2.0      2.0      0.0      S.water_path_mm = water_path_mm
   151         1          2.0      2.0      0.0      S.readout_noise = readout_noise
   152         1          3.0      3.0      0.0      S.gain = gain
   153         1          3.0      3.0      0.0      S.psf_fwhm = psf_fwhm
   154         1          3.0      3.0      0.0      S.include_noise = False
   155
   156         1          2.0      2.0      0.0      if mosaicity_random_seeds is not None:
   157                                                 S.mosaic_seeds = mosaicity_random_seeds
   158
   159         1          3.0      3.0      0.0      S.instantiate_nanoBragg(verbose=verbose, oversample=oversample, interpolate=interpolate,
   160         1      14733.0  14733.0     12.2        device_Id=Famp.get_deviceID(),default_F=default_F, adc_offset=adc_offset)
   161
   162         1          3.0      3.0      0.0      SIM = S.D # the nanoBragg instance
   163         1          4.0      4.0      0.0      assert Famp.get_deviceID()==SIM.device_Id
   164         1          3.0      3.0      0.0      if spot_scale_override is not None:
   165         1          4.0      4.0      0.0        SIM.spot_scale = spot_scale_override
   166         1          2.0      2.0      0.0      assert Famp.get_nchannels() == 1 # non-anomalous scenario
   167
   168         1          7.0      7.0      0.0      from simtbx.gpu import exascale_api
   169         1          5.0      5.0      0.0      gpu_simulation = exascale_api(nanoBragg = SIM)
   170         1        131.0    131.0      0.1      gpu_simulation.allocate_cuda() # presumably done once for each image
   171
   172         1          6.0      6.0      0.0      from simtbx.gpu import gpu_detector as gpud
   173         1          2.0      2.0      0.0      gpu_detector = gpud(deviceId=SIM.device_Id, detector=DETECTOR,
   174         1        947.0    947.0      0.8                          beam=BEAM)
   175         1      79297.0  79297.0     65.5      gpu_detector.each_image_allocate_cuda()
   176
   177                                               # revisit the allocate cuda for overlap with detector, sync up please
   178         1          3.0      3.0      0.0      x = 0 # only one energy channel
   179         1          2.0      2.0      0.0      if mask_file is "": # all-pixel kernel
   180                                                 P = Profiler("%40s"%"from gpu amplitudes cuda")
   181                                                 gpu_simulation.add_energy_channel_from_gpu_amplitudes_cuda(
   182                                                 x, Famp, gpu_detector)
   183         1          3.0      3.0      0.0      elif type(mask_file) is flex.bool: # 1D bool array, flattened from ipanel, islow, ifast
   184         1         10.0     10.0      0.0        P = Profiler("%40s"%"from gpu amplitudes cuda with bool mask")
   185         1          3.0      3.0      0.0        gpu_simulation.add_energy_channel_mask_allpanel_cuda(
   186         1      21660.0  21660.0     17.9        x, Famp, gpu_detector, mask_file )
   187                                               else:
   188                                                 assert type(mask_file) is str
   189                                                 from LS49.adse13_187.adse13_221.mask_utils import mask_from_file
   190                                                 boolean_mask = mask_from_file(mask_file)
   191                                                 P = Profiler("%40s"%"from gpu amplitudes cuda with file mask")
   192                                                 gpu_simulation.add_energy_channel_mask_allpanel_cuda(
   193                                                 x, Famp, gpu_detector, boolean_mask )
   194         1          4.0      4.0      0.0      TIME_BRAGG = time()-P.start_el
   195
   196         1          3.0      3.0      0.0      per_image_scale_factor = 1./len(energies)
   197         1        755.0    755.0      0.6      gpu_detector.scale_in_place_cuda(per_image_scale_factor) # apply scale directly on GPU
   198
   199         1          3.0      3.0      0.0      if include_background:
   200                                                 t_bkgrd_start = time()
   201                                                 SIM.beamsize_mm = beamsize_mm
   202
   203                                                 wavelength_weights = np.array(background_wavelength_weights)
   204                                                 weights = wavelength_weights / wavelength_weights.sum() * background_total_flux
   205                                                 spectrum = list(zip(background_wavelengths, weights))
   206                                                 xray_beams = get_xray_beams(spectrum, BEAM)
   207                                                 SIM.xray_beams = xray_beams
   208                                                 SIM.Fbg_vs_stol = water
   209                                                 SIM.flux=sum(weights)
   210                                                 SIM.amorphous_sample_thick_mm = background_sample_thick_mm
   211                                                 SIM.amorphous_density_gcm3 = density_gcm3
   212                                                 SIM.amorphous_molecular_weight_Da = molecular_weight
   213                                                 gpu_simulation.add_background_cuda(gpu_detector)
   214                                                 TIME_BG = time()-t_bkgrd_start
   215         1          2.0      2.0      0.0      else: TIME_BG=0.
   216
   217         1          2.0      2.0      0.0      if skip_numpy:
   218         1         57.0     57.0      0.0        P = Profiler("%40s"%"get short whitelist values")
   219         1       1119.0   1119.0      0.9        whitelist_only = gpu_detector.get_whitelist_raw_pixels_cuda(relevant_whitelist_order)
   220         1         63.0     63.0      0.1        P = Profiler("%40s"%"each image free cuda")
   221         1       1507.0   1507.0      1.2        gpu_detector.each_image_free_cuda()
   222                                                 #pr.disable()
   223         1         12.0     12.0      0.0        from pstats import SortKey
   224                                                 #pr.print_stats(sort=SortKey.CUMULATIVE)
   225         1          2.0      2.0      0.0        return whitelist_only, TIME_BG, TIME_BRAGG
   226
   227                                               packed_numpy = gpu_detector.get_raw_pixels_cuda()
   228                                               gpu_detector.each_image_free_cuda()
   229
   230                                               #pr.disable()
   231                                               from pstats import SortKey
   232                                               #pr.print_stats(sort=SortKey.CUMULATIVE)
   233                                               return packed_numpy.as_numpy_array(), TIME_BG, TIME_BRAGG
```