### PR TITLE
Ensure anomalous_probability_plot is picklable

### DIFF
--- a/cctbx/miller/__init__.py
+++ b/cctbx/miller/__init__.py
@@ -292,6 +292,11 @@ class binner(ext.binner):
       column_headers=labels,
       table_rows=table_rows)
 
+
+AnomalousProbabilityPlotResult = namedtuple("AnomalousProbabilityPlotResult", [
+  "slope", "intercept", "n_pairs", "expected_delta"])
+
+
 class binned_data(object):
 
   def __init__(self, binner, data, data_fmt=None):
@@ -3126,12 +3131,9 @@ class array(set):
     assert self.is_unique_set_under_symmetry()
     assert self.anomalous_flag()
 
-    result = namedtuple("anomalous_probability_plot", [
-      "slope", "intercept", "n_pairs", "expected_delta"])
-
     dI = self.anomalous_differences()
     if not dI.size():
-      return result(None, None, None, expected_delta)
+      return AnomalousProbabilityPlotResult(None, None, None, expected_delta)
 
     y = dI.data() / dI.sigmas()
     perm = flex.sort_permutation(y)
@@ -3146,8 +3148,8 @@ class array(set):
 
     fit = flex.linear_regression(x, y)
     if fit.is_well_defined():
-      return result(fit.slope(), fit.y_intercept(), x.size(), expected_delta)
-    return result(None, None, None, expected_delta)
+      return AnomalousProbabilityPlotResult(fit.slope(), fit.y_intercept(), x.size(), expected_delta)
+    return AnomalousProbabilityPlotResult(None, None, None, expected_delta)
 
   def phase_entropy(self, exponentiate=False, return_binned_data=False,
                           return_mean=False):

--- a/cctbx/regression/tst_miller.py
+++ b/cctbx/regression/tst_miller.py
@@ -739,9 +739,10 @@ def exercise_array():
     assert approx_equal(tuple(hm.sigmas()), (0.2,0.4))
   assert approx_equal(ma.anomalous_signal(), 0.5063697)
   app = ma.anomalous_probability_plot()
-  assert approx_equal(app.slope, 6.280403781181725)
-  assert approx_equal(app.intercept, -0.23606797749978936)
-  assert app.n_pairs ==  2
+  for app in (app, pickle.loads(pickle.dumps(app))):
+    assert approx_equal(app.slope, 6.280403781181725)
+    assert approx_equal(app.intercept, -0.23606797749978936)
+    assert app.n_pairs ==  2
   assert ma.measurability() == 1.0
   assert approx_equal(ma.anomalous_completeness(), 0.018018)
   assert approx_equal(ma.anomalous_completeness(


### PR DESCRIPTION
The previously locally-defined namedtuple result meant that the result of `iotbx.merging_statistics.dataset_statistics(..., anomalous=True, ...)` was not picklable.

Fixes xia2/xia2#611