### PR TITLE
Custom reindexing ops for modify_cosym

### DIFF
--- a/xfel/merging/application/modify/aux_cosym.py
+++ b/xfel/merging/application/modify/aux_cosym.py
@@ -265,7 +265,7 @@ class TargetWithFastRij(Target):
 
     # nproc is an init arg that was removed from class
     # dials.algorithms.symmetry.cosym.target.Target in dials commit 1cd5afe4
-    self._nproc = kwargs.pop('nproc', None)
+    self._nproc = kwargs.pop('nproc', 1)
 
     # if test_data_path is provided, we are constructing this for a unit test
     test_data_path = kwargs.pop('test_data_path', None)
@@ -348,10 +348,10 @@ class TargetWithFastRij(Target):
         indices[cb_op.as_xyz()] = indices_reindexed
         CC.set_indices(cb_op, indices_reindexed)
 
-    results = easy_mp.parallel_map(
+    assert self._nproc==1
+    results = map(
         _compute_one_row,
-        [(CC, i, NN) for i in range(n_lattices)],
-        processes=self._nproc
+        [(CC, i, NN) for i in range(n_lattices)]
     )
 
     rij_matrix = None

--- a/xfel/merging/application/modify/aux_cosym.py
+++ b/xfel/merging/application/modify/aux_cosym.py
@@ -83,8 +83,12 @@ class CosymAnalysis(BaseClass):
               .primitive_setting()
               .group()
           )
-      twin_axis = [tuple(x) for x in self.params.twin_axis]
-      twin_rotation = self.params.twin_rotation
+      if self.params.twin_axis:
+        twin_axis = [tuple(x) for x in self.params.twin_axis]
+        twin_rotation = self.params.twin_rotation
+      else:
+        twin_axis = None
+        twin_rotation = None
       self.target = TargetWithCustomSymops(
           self.intensities,
           self.dataset_ids.as_numpy_array(),

--- a/xfel/merging/application/modify/cosym.py
+++ b/xfel/merging/application/modify/cosym.py
@@ -8,9 +8,6 @@ from dxtbx.model.crystal import MosaicCrystalSauter2014
 from dxtbx.model.experiment_list import ExperimentList
 #from libtbx.development.timers import Profiler, Timer
 
-import dials.algorithms.symmetry.cosym.target
-from xfel.merging.application.modify.aux_cosym import TargetWithFastRij
-dials.algorithms.symmetry.cosym.target.Target = TargetWithFastRij
 
 class cosym(worker):
   """

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -241,6 +241,23 @@ modify
       .help = Size represents a tradeoff,  larger size will take longer to compute but use fewer MPI ranks
       .help = and converge to more accurate coset assignment (higher % consensus).  Ideal value is data
       .help = dependent, default of 600 is good for a 200-Angstrom cell, but value should increase for smaller cell.
+    twin_axis = None
+      .type = ints(size=3)
+      .multiple = True
+      .help = Rotation axis to test as a reindexing operator. Given as a direct \
+          axis, e.g. 1,0,0 is a rotation around the a axis.
+    twin_rotation = None
+      .type = int
+      .multiple = True
+      .help = Rotation corresponding to a value of twin_axis. Given as an \
+          n-fold rotation, e.g. 2 denotes a twofold rotation.
+    single_cb_op_to_minimum = False
+      .type = bool
+      .help = Internally the lattices are transformed to a primitive cell \
+          before cosym analysis. Typically each cb_op_to_minimum is determined \
+          individually, but if the options twin_axis and twin_rotation are \
+          used, the transformation has to be the same for every lattice. \
+          Forcing this is probably harmless but has not been tested extensively.
     plot
       {
       do_plot = True


### PR DESCRIPTION
Let the user specify a reindexing operator (axis and rotation) for modify_cosym. This is useful for e.g. monoclinic PSI (pseudo-hexagonal) where the automatic coset decomposition generates 6 operators (true symmetry 2, lattice pseudosymmetry 622) but we know from separate analysis that only one of those (twofold around a axis) should be tested.