### PR TITLE
Add experimental support for custom merging workers

### DIFF
--- a/xfel/merging/application/README.md
+++ b/xfel/merging/application/README.md
@@ -30,8 +30,7 @@ class polarization(worker):
 ```
 # Required boilerplate for custom workers
 import sys, inspect, os
-current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.current
-frame())))
+current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 sys.path.insert(0, current_dir)
 # End boilerplate. You may import directly from the directory containing this
 # module. It's not necessary to reset the path.

--- a/xfel/merging/application/README.md
+++ b/xfel/merging/application/README.md
@@ -1,0 +1,47 @@
+## Custom merging workers
+
+`cctbx.xfel.merge` supports custom workers located or linked in
+`~/.cctbx.xfel/merging/application/`.
+
+### Requirements for all merging workers
+
+- Inherit from `xfel.merging.application.worker.worker`
+
+- Implement `__init__` and `__repr__` methods that look like this:
+```
+class polarization(worker):
+  def __init__(self, params, mpi_helper=None, mpi_logger=None):
+    super(polarization, self).__init__(params=params, mpi_helper=mpi_helper, mpi_logger=mpi_logger)
+  def __repr__(self):
+    return 'Apply polarization correction'
+```
+
+- Implement a `run` method that takes `experiments, reflections` and returns
+  the same
+
+- Also include a `factory`, see `xfel/merging/application/modify/factory.py`
+  for an example.
+
+### Special requirement for custom workers
+
+- The factory typically imports the worker in order to construct and return it.
+  A trick is required in the custom factory to temporarily modify the import
+  path:
+```
+# Required boilerplate for custom workers
+import sys, inspect, os
+current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.current
+frame())))
+sys.path.insert(0, current_dir)
+# End boilerplate. You may import directly from the directory containing this
+# module. It's not necessary to reset the path.
+from unit_cell_statistics import unit_cell_statistics
+from beam_statistics import beam_statistics
+```
+
+### Optional custom phil strings
+
+- Any file `phil.py` under `~/.cctbx.xfel/merging/application` will be checked
+  for a module-level variable `phil_str` which will be added to the global
+  `cctbx.xfel.merge` phil string before parsing.
+

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -574,13 +574,14 @@ custom_phil_pathstr = os.path.join(
   "~", ".cctbx.xfel", "merging", "application"
 )
 custom_phil_pathstr = os.path.expanduser(custom_phil_pathstr)
-for dir in os.listdir(custom_phil_pathstr):
-  path = os.path.join(custom_phil_pathstr, dir, 'phil.py')
-  if not os.path.isfile(path): continue
-  spec = importlib.util.spec_from_file_location('_', path)
-  module = importlib.util.module_from_spec(spec)
-  spec.loader.exec_module(module)
-  master_phil += module.phil_str
+if os.path.isdir(custom_phil_pathstr):
+  for dir in os.listdir(custom_phil_pathstr):
+    path = os.path.join(custom_phil_pathstr, dir, 'phil.py')
+    if not os.path.isfile(path): continue
+    spec = importlib.util.spec_from_file_location('_', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    master_phil += module.phil_str
 
 
 phil_scope = parse(master_phil, process_includes = True)

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -568,6 +568,21 @@ modify.cosym.use_curvatures=False
 master_phil = dispatch_phil + input_phil + tdata_phil + filter_phil + modify_phil + \
               select_phil + scaling_phil + postrefinement_phil + merging_phil + \
               output_phil + statistics_phil + group_phil + lunus_phil + publish_phil
+
+import os, importlib
+custom_phil_pathstr = os.path.join(
+  "~", ".cctbx.xfel", "merging", "application"
+)
+custom_phil_pathstr = os.path.expanduser(custom_phil_pathstr)
+for dir in os.listdir(custom_phil_pathstr):
+  path = os.path.join(custom_phil_pathstr, dir, 'phil.py')
+  if not os.path.isfile(path): continue
+  spec = importlib.util.spec_from_file_location('_', path)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  master_phil += module.phil_str
+
+
 phil_scope = parse(master_phil, process_includes = True)
 phil_scope = phil_scope.fetch(parse(program_defaults_phil_str))
 


### PR DESCRIPTION
- User-created workers can be placed in ~/.cctbx.xfel/merging/application
  (or linked there).

- Optional custom phil strings can be included with the worker.

- Documentation of custom workers is added in a new README