### PR TITLE
allow_polymer_cross_special_position flag

### DIFF
--- a/mmtbx/hydrogens/reduce_hydrogen.py
+++ b/mmtbx/hydrogens/reduce_hydrogen.py
@@ -123,6 +123,7 @@ class place_hydrogens():
     p.pdb_interpretation.clash_guard.nonbonded_distance_threshold=None
     p.pdb_interpretation.use_neutron_distances = self.use_neutron_distances
     p.pdb_interpretation.proceed_with_excessive_length_bonds=True
+    p.pdb_interpretation.allow_polymer_cross_special_position=True
     #p.pdb_interpretation.automatic_linking.link_metals = True
 
     t0 = time.time()


### PR DESCRIPTION
This pdb_interpretation parameter allows processing of pdb files that otherwise fail.  It is likely inappropriate for refinement, but is useful in validation where we seek to accept as many models as possible.  Allowing structures that cross special positions may cause problems in symmetry-aware modes.

A minimal pdb file for testing the behavior should be attached.

[2byb_min.txt](https://github.com/cctbx/cctbx_project/files/7346571/2byb_min.txt)

