### PR TITLE
Fix kokkos makefile parser 

### DIFF
--- a/simtbx/kokkos/SConscript
+++ b/simtbx/kokkos/SConscript
@@ -69,6 +69,9 @@ kokkos_cxxflags = subprocess.check_output(
   ['make', '-f', 'Makefile.kokkos', 'print-cxx-flags'],
   cwd=os.environ['KOKKOS_PATH'])
 kokkos_cxxflags = kokkos_cxxflags.split(b'\n')
+# remove empty lines (this will also remove trailing \n in stdout)
+kokkos_cxxflags = list(filter(lambda x: x!=b'', kokkos_cxxflags))
+# last line returned by print-cxx-flags contains flags
 kokkos_cxxflags = kokkos_cxxflags[-1].decode('utf8').split()
 print('KOKKOS_CXXFLAGS:', kokkos_cxxflags)
 print('='*79)


### PR DESCRIPTION
For unknown reasons `Makefile.kokkos print-cxx-flags` will print an error. This doesn't affect the final output, but means that now the cxx flags are on the second line.

We observe the the relevant output is always on the last non-empty line. Hence this fix will always look there (rather than a fixed line number).

Tagging @Trzs @bkpoon 