### PR TITLE
Merge bookkeeping

### DIFF
--- a/xfel/merging/application/group/group_reflections.py
+++ b/xfel/merging/application/group/group_reflections.py
@@ -27,7 +27,8 @@ class hkl_group(worker):
 
     reflections = reflection_table_utils.prune_reflection_table_keys(reflections=reflections,
                         keys_to_keep=['intensity.sum.value', 'intensity.sum.variance', 'miller_index_asymmetric', \
-                                      'exp_id', 'intensity.sum.value.unmodified', 'intensity.sum.variance.unmodified'])
+                                      'exp_id', 'intensity.sum.value.unmodified', 'intensity.sum.variance.unmodified'],
+                        keys_to_ignore=self.params.input.persistent_refl_cols)
 
     # set up hkl chunks to be used for all-to-all; every avialable rank participates in all-to-all, even a rank that doesn't load any data
     self.logger.log_step_time("SETUP_CHUNKS")

--- a/xfel/merging/application/input/file_loader.py
+++ b/xfel/merging/application/input/file_loader.py
@@ -128,6 +128,7 @@ class simple_file_loader(worker):
         self.logger.log("Reading %s %s"%(experiments_filename, reflections_filename))
         experiments = ExperimentListFactory.from_json_file(experiments_filename, check_format = False)
         reflections = flex.reflection_table.from_file(reflections_filename)
+        reflections["xfel.merge.input_refl_index"] = flex.int(list(range(len(reflections))))
         self.logger.log("Data read, prepping")
 
         if 'intensity.sum.value' in reflections:
@@ -185,7 +186,8 @@ class simple_file_loader(worker):
     reflections = reflection_table_utils.prune_reflection_table_keys(reflections=reflections,
                     keys_to_keep=['intensity.sum.value', 'intensity.sum.variance', 'miller_index', 'miller_index_asymmetric', \
                                   'exp_id', 's1', 'intensity.sum.value.unmodified', 'intensity.sum.variance.unmodified',
-                                  'kapton_absorption_correction', 'flags'])
+                                  'kapton_absorption_correction', 'flags'],
+                    keys_to_ignore=self.params.input.persistent_refl_cols)
     self.logger.log("Pruned reflection table")
     self.logger.log("Memory usage: %d MB"%get_memory_usage())
     return reflections

--- a/xfel/merging/application/input/file_loader.py
+++ b/xfel/merging/application/input/file_loader.py
@@ -3,6 +3,7 @@ import os
 from dxtbx.model.experiment_list import ExperimentListFactory
 from dials.array_family import flex
 from six.moves import range
+import json
 from xfel.merging.application.input.file_lister import file_lister
 from xfel.merging.application.input.file_load_calculator import file_load_calculator
 from xfel.merging.application.utils.memory_usage import get_memory_usage
@@ -24,21 +25,23 @@ def create_experiment_identifier(experiment, experiment_file_path, experiment_id
   return hash_obj.hexdigest()
 
 
-def generate_experiment_identifiers(experiments):
+def preGen_experiment_identifiers(experiments, exp_filename):
   """
-  Label experiments according to image filename, image number (for multi-image files), lattice number
+  Label experiments according to image number (for multi-image files), lattice number, H
+  where H is a unique per-experiment hash
   This information will be preserved in the reflection files that are optionally output
   if output.save_experiments_and_reflections=True.
   """
   done_expts = {}
-  for expt in experiments:
+  for i_exp, expt in enumerate(experiments):
+    exp_hash = create_experiment_identifier(expt, exp_filename, i_exp)
     iset = expt.imageset
     path = iset.paths()[0]
     single_file_index = iset.indices()[0]
     key = "%s_%s" % (path, single_file_index)
     n_hits = done_expts.setdefault(key, 0)
     done_expts[key] = n_hits + 1
-    ident = "%s_%s_%s" % (path, single_file_index, n_hits)
+    ident = "I%s_L%s_%s" % (single_file_index, n_hits, exp_hash)
     expt.identifier = ident
 
 #for integration pickles:
@@ -108,16 +111,26 @@ class simple_file_loader(worker):
       file_list = self.get_list()
       self.logger.log("Built an input list of %d json/pickle file pairs"%(len(file_list)))
       self.params.input.path = None # Rank 0 has already parsed the input parameters
+
+      # optionally write a file list mapping to disk, useful in post processing if save_experiments_and_reflections=True
+      file_id_from_names = None
+      if self.params.output.expanded_bookkeeping:
+        apath = lambda x: os.path.abspath(x)
+        file_names_from_id = {i_f: tuple(map(apath, exp_ref_pair)) for i_f, exp_ref_pair in enumerate(file_list)}
+        with open(os.path.join(self.params.output.output_dir, "file_list_map.json"), "w") as o:
+          json.dump(file_names_from_id, o)
+        file_id_from_names = {tuple(map(apath, exp_ref_pair)): i_f for i_f, exp_ref_pair in enumerate(file_list)}
+
       per_rank_file_list = file_load_calculator(self.params, file_list, self.logger).\
                               calculate_file_load(available_rank_count = self.mpi_helper.size)
       self.logger.log('Transmitting a list of %d lists of json/pickle file pairs'%(len(per_rank_file_list)))
-      transmitted = per_rank_file_list
+      transmitted = per_rank_file_list, file_id_from_names
     else:
       transmitted = None
 
     self.logger.log_step_time("BROADCAST_FILE_LIST")
-    transmitted = self.mpi_helper.comm.bcast(transmitted, root = 0)
-    new_file_list = transmitted[self.mpi_helper.rank] if self.mpi_helper.rank < len(transmitted) else None
+    new_file_list, file_names_mapping = self.mpi_helper.comm.bcast(transmitted, root = 0)
+    new_file_list = new_file_list[self.mpi_helper.rank] if self.mpi_helper.rank < len(new_file_list) else None
     self.logger.log_step_time("BROADCAST_FILE_LIST", True)
 
     # Load the data
@@ -128,7 +141,15 @@ class simple_file_loader(worker):
         self.logger.log("Reading %s %s"%(experiments_filename, reflections_filename))
         experiments = ExperimentListFactory.from_json_file(experiments_filename, check_format = False)
         reflections = flex.reflection_table.from_file(reflections_filename)
-        reflections["xfel.merge.input_refl_index"] = flex.int(list(range(len(reflections))))
+        if self.params.output.expanded_bookkeeping:
+          # NOTE: these are un-prunable
+          reflections["input_refl_index"] = flex.int(
+            list(range(len(reflections))))
+          reflections["orig_exp_id"] = reflections['id']
+          assert file_names_mapping is not None
+          exp_ref_pair = os.path.abspath(experiments_filename), os.path.abspath(reflections_filename)
+          this_refl_fileMappings = [file_names_mapping[exp_ref_pair]]*len(reflections)
+          reflections["file_list_mapping"] = flex.int(this_refl_fileMappings)
         self.logger.log("Data read, prepping")
 
         if 'intensity.sum.value' in reflections:
@@ -142,8 +163,8 @@ class simple_file_loader(worker):
         for k in eid.keys():
           del eid[k]
 
-        if self.params.input.use_iset_for_expid:
-          generate_experiment_identifiers(experiments)
+        if self.params.output.expanded_bookkeeping:
+          preGen_experiment_identifiers(experiments, experiments_filename)
         for experiment_id, experiment in enumerate(experiments):
           # select reflections of the current experiment
           refls_sel = reflections['id'] == experiment_id

--- a/xfel/merging/application/modify/polarization.py
+++ b/xfel/merging/application/modify/polarization.py
@@ -83,7 +83,8 @@ class polarization(worker):
 
     # Remove 's1' column from the reflection table
     from xfel.merging.application.reflection_table_utils import reflection_table_utils
-    reflections = reflection_table_utils.prune_reflection_table_keys(reflections=result, keys_to_delete=['s1'])
+    reflections = reflection_table_utils.prune_reflection_table_keys(reflections=result, keys_to_delete=['s1'],
+                                                                     keys_to_ignore=self.params.input.persistent_refl_cols)
     self.logger.log("Pruned reflection table")
     self.logger.log("Memory usage: %d MB"%get_memory_usage())
 

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -32,6 +32,10 @@ input {
       .type = choice
       .help = whether we keep or reject experiments according to the alist(s)
   }
+  use_iset_for_expid = False
+    .type = bool
+    .help = Option to tag reflections with their filename, file index, and lattice number.
+    .help = This is useful for post-merge analysis and bookkeeping.
   keep_imagesets = False
     .type = bool
     .help = If True, keep imagesets attached to experiments

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -37,10 +37,6 @@ input {
     .multiple = True
     .help = Names of reflection table columns that will remain after all prune steps
     .help = If output.save_experiments_and_reflections=True, then these columns will be in the saved tables.
-  use_iset_for_expid = False
-    .type = bool
-    .help = Option to tag reflections with their filename, file index, and lattice number.
-    .help = This is useful for post-merge analysis and bookkeeping.
   keep_imagesets = False
     .type = bool
     .help = If True, keep imagesets attached to experiments
@@ -502,6 +498,14 @@ merging {
 
 output_phil = """
 output {
+  expanded_bookkeeping = False
+    .type = bool
+    .help = if True, and if save_experiments_and_reflections=True, then include in the saved refl tabls:
+    .help = 1- modified exp_id column that contains the image number and lattice number
+    .help = 2- index corresponding to the particular reflection in the input file (usually something_integrated.refl)
+    .help = 3- the is_odd flag
+    .help = 4- the original exp id for the reflection
+    .help = 5- a unique number mapping the reflection to its input expFile, refFile pair (see output_dir/file_list_mapping.json)
   prefix = iobs
     .type = str
     .help = Prefix for all output file names

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -32,6 +32,11 @@ input {
       .type = choice
       .help = whether we keep or reject experiments according to the alist(s)
   }
+  persistent_refl_cols = None
+    .type = str
+    .multiple = True
+    .help = Names of reflection table columns that will remain after all prune steps
+    .help = If output.save_experiments_and_reflections=True, then these columns will be in the saved tables.
   use_iset_for_expid = False
     .type = bool
     .help = Option to tag reflections with their filename, file index, and lattice number.

--- a/xfel/merging/application/reflection_table_utils.py
+++ b/xfel/merging/application/reflection_table_utils.py
@@ -27,21 +27,18 @@ class reflection_table_utils(object):
   @staticmethod
   def select_odd_experiment_reflections(reflections):
     'Select reflections from experiments with odd ids. An experiment id must be a string representing a hexadecimal number'
-    # NOTE: exp_id is no longer guaranteed to be what it once was...
     exp_index_map = {exp_uid: i for i, exp_uid in enumerate(set(reflections["exp_id"]))}
     sel = [exp_index_map[exp_id] % 2 == 1 for exp_id in reflections["exp_id"]]
     sel = flex.bool(sel)
-    reflections["xfel.merge.is_odd_experiment"] = sel
+    reflections["is_odd_experiment"] = sel  # store this for later use, NOTE this is un-prunable if expanded_bookkeeping=True
     return reflections.select(sel)
 
   @staticmethod
   def select_even_experiment_reflections(reflections):
     'Select reflections from experiments with even ids. An experiment id must be a string representing a hexadecimal number'
-    # NOTE: exp_id is no longer guaranteed to be what it once was...
     exp_index_map = {exp_uid: i for i, exp_uid in enumerate(set(reflections["exp_id"]))}
     sel = [exp_index_map[exp_id] % 2 == 0 for exp_id in reflections["exp_id"]]
     sel = flex.bool(sel)
-    reflections["xfel.merge.is_even_experiment"] = sel
     return reflections.select(sel)
 
   @staticmethod
@@ -87,14 +84,6 @@ class reflection_table_utils(object):
                                   keys_to_ignore=None):
     '''Remove reflection table keys: either inclusive or exclusive, columns in keys_to_ignore will always remain'''
     # These columns were created by the merging application, and we want to retain them
-    if keys_to_ignore is None:
-      keys_to_ignore = []
-    keysCreatedByMerge = ["xfel.merge.input_refl_index", "xfel.merge.is_odd_experiment",
-                          "xfel.merge.is_even_experiment"]
-    for key in keysCreatedByMerge:
-      if key not in keys_to_ignore:
-        keys_to_ignore.append(key)
-
     if keys_to_delete is not None:
       keys_to_delete = [k for k in keys_to_delete if k not in keys_to_ignore]
     if keys_to_keep is not None:

--- a/xfel/merging/command_line/merge.py
+++ b/xfel/merging/command_line/merge.py
@@ -112,6 +112,8 @@ class Script(object):
     from xfel.merging import application
     import importlib, sys, copy
 
+    self._resolve_persistent_columns()
+
     workers = []
     steps = self.params.dispatch.step_list if self.params.dispatch.step_list else default_steps
     for step in steps:
@@ -203,6 +205,16 @@ class Script(object):
     if self.params.mp.debug.cProfile:
       pr.disable()
       pr.dump_stats(os.path.join(self.params.output.output_dir, "cpu_%s_%d.prof"%(self.params.output.prefix, self.mpi_helper.rank)))
+
+  def _resolve_persistent_columns(self):
+    if self.params.output.expanded_bookkeeping:
+      if self.params.input.persistent_refl_cols is None:
+        self.params.input.persistent_refl_cols = []
+      keysCreatedByMerge = ["input_refl_index", "orig_exp_id", "file_list_mapping", "is_odd_experiment"]
+      for key in keysCreatedByMerge:
+        if key not in self.params.input.persistent_refl_cols:
+          self.params.input.persistent_refl_cols.append(key)
+
 
 if __name__ == '__main__':
   script = Script()


### PR DESCRIPTION
Importantly, introduced in the second commit,  the default now is to create and columns `is_even, is_odd, input_refl_index` in the reflection tables, and never prune them, optionally writing them to disk if save_experiments_and_reflections=True .