### PR TITLE
Nasty workaround for DYLD_FALLBACK_LIBRARY_PATH

### DIFF
--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -1186,6 +1186,8 @@ Wait for the command to finish, then try again.""" % vars())
       p = op.join(sys.prefix, d)
       if (op.isdir(p)):
         result.append(self.as_relocatable_path(p))
+    if (sys.platform.startswith("darwin")):
+      result.append(absolute_path("/usr/lib"))
     return result
 
   def write_conda_dispatcher(self, source_file, target_file,


### PR DESCRIPTION
Since thanks to SIP this is clobbered in any fork / exec scenario the SHELL
default value of this is lost in the dispatcher script which is usually
harmless but in some cases - as I found - harmful.

This restores /usr/lib to the cctbx default value of that path so ensures
libraries which are depended on are found. This is not a problem in the usual
Python / conda ecosystem so this nasty workaround is probably valid and
justified.

Fixes #701