### PR TITLE
Start allowing new numpy versions >=1.21.5

### DIFF
--- a/xfel/conda_envs/psana_environment.yml
+++ b/xfel/conda_envs/psana_environment.yml
@@ -70,6 +70,6 @@ dependencies:
  - mysql
  - mysqlclient
 
- # temporarily pin numpy version
+ # Avoid numpy 1.21.[01234]
  # See https://github.com/cctbx/cctbx_project/issues/627
- - numpy=1.20
+ - numpy=1.20|>=1.21.5

--- a/xfel/conda_envs/psana_lcls_environment.yml
+++ b/xfel/conda_envs/psana_lcls_environment.yml
@@ -73,6 +73,6 @@ dependencies:
  - mysql
  - mysqlclient
 
- # temporarily pin numpy version
+ # Avoid numpy 1.21.[01234]
  # See https://github.com/cctbx/cctbx_project/issues/627
- - numpy=1.20
+ - numpy=1.20|>=1.21.5


### PR DESCRIPTION
This reflects the resolution of #627 as discussed in several other issues
and PRs:

- https://github.com/boostorg/python/issues/376
- https://github.com/numpy/numpy/pull/20507
- https://github.com/numpy/numpy/pull/20616

Leaving this "bibliography" here because the fix in numpy PR 20616 is
considered temporary; thus someday we may have to revisit this to fix the
underlying bug in boost::python.

Co-authored-by: Billy Poon <bkpoon@lbl.gov>