### PR TITLE
Decouple cuda and kokkos build for Spock

### DIFF
--- a/libtbx/SConscript
+++ b/libtbx/SConscript
@@ -1447,7 +1447,13 @@ def enable_cuda_if_possible():
     env_base['BUILDERS']['cudaSharedLibrary'] = shared_library_builder
     env_base['BUILDERS']['cudaSharedLibrary'].add_src_builder(shared_object_builder)
 
+def enable_kokkos_if_possible():
+  env_etc.enable_kokkos = False
+  if (libtbx.env.build_options.enable_kokkos):
+    env_etc.enable_kokkos = True
+
 enable_openmp_if_possible()
 enable_cuda_if_possible()
+enable_kokkos_if_possible()
 
 Export("env_base", "env_etc")

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -35,6 +35,7 @@ default_build_boost_python_extensions = True
 default_enable_openmp_if_possible = False
 default_enable_boost_threads = True
 default_enable_cuda = False
+default_enable_kokkos = False
 default_opt_resources = False
 default_enable_cxx11 = False
 default_use_conda = False
@@ -977,6 +978,7 @@ Wait for the command to finish, then try again.""" % vars())
         enable_boost_threads
           =command_line.options.enable_boost_threads,
         enable_cuda=command_line.options.enable_cuda,
+        enable_kokkos=command_line.options.enable_kokkos,
         use_conda=command_line.options.use_conda,
         opt_resources=command_line.options.opt_resources,
         use_environment_flags=command_line.options.use_environment_flags,
@@ -2606,6 +2608,7 @@ class build_options:
         enable_openmp_if_possible=default_enable_openmp_if_possible,
         enable_boost_threads=True,
         enable_cuda=default_enable_cuda,
+        enable_kokkos=default_enable_kokkos,
         use_conda=default_use_conda,
         opt_resources=default_opt_resources,
         precompile_headers=False,
@@ -2669,6 +2672,7 @@ class build_options:
     print("Enable OpenMP if possible:", self.enable_openmp_if_possible, file=f)
     print("Boost threads enabled:", self.enable_boost_threads, file=f)
     print("Enable CUDA:", self.enable_cuda, file=f)
+    print("Enable KOKKOS:", self.enable_kokkos, file=f)
     print("Use conda:", self.use_conda, file=f)
     print("Use opt_resources if available:", self.opt_resources, file=f)
     print("Use environment flags:", self.use_environment_flags, file=f)
@@ -2853,6 +2857,11 @@ class pre_process_args:
       default=default_enable_cuda,
       help="Use optimized CUDA routines for certain calculations.  Requires at least one NVIDIA GPU with compute capability of 2.0 or higher, and CUDA Toolkit 4.0 or higher (default: %s)"
         % default_enable_cuda)
+    parser.option(None, "--enable_kokkos",
+      action="store_true",
+      default=default_enable_kokkos,
+      help="Use optimized KOKKOS routines for certain calculations. Which backend (CUDA/HIP/OpenMP) is used, depends on the system (default: %s)"
+        % default_enable_kokkos)
     parser.option(None, "--use_conda",
       action="store_true",
       default=default_use_conda,

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -3065,6 +3065,9 @@ def unpickle(build_path=None, env_name="libtbx_env"):
     env.installed_modules = []
   if not hasattr(env, "installed_order"):
     env.installed_order = []
+  # XXX backward compatibility 2022-01-19
+  if not hasattr(env.build_options, "enable_kokkos"):
+    env.build_options.enable_kokkos = False
   # update installed location
   if env.installed:
     sys_prefix = get_conda_prefix()

--- a/simtbx/SConscript
+++ b/simtbx/SConscript
@@ -34,6 +34,6 @@ if not env_etc.no_boost_python:
   env_simtbx.SConscript("gpu/SConscript",exports={ 'env' : env_simtbx })
   env_simtbx.SConscript("pixel/SConscript",exports={ 'env' : env_simtbx })
 
-  # only build kokkos on linux and if CUDA is enabled
-  if sys.platform.startswith('linux') and env_etc.enable_cuda:
+  # only build kokkos on linux and if kokkos is enabled
+  if sys.platform.startswith('linux') and env_etc.enable_kokkos:
     env_simtbx.SConscript("kokkos/SConscript",exports={ 'env' : env_simtbx })

--- a/simtbx/kokkos/SConscript
+++ b/simtbx/kokkos/SConscript
@@ -165,33 +165,20 @@ if not env_etc.no_boost_python:
   kokkos_ext_env.Prepend(CXXFLAGS=['-DCUDAREAL=double'] + kokkos_cxxflags)
   kokkos_ext_env.Prepend(CPPFLAGS=['-DCUDAREAL=double'] + kokkos_cxxflags)
   kokkos_ext_env.Prepend(CPPPATH=[os.environ['KOKKOS_PATH']])
+  default_libs = [
+    "simtbx_kokkos",
+    "scitbx_boost_python",
+    env_etc.boost_python_lib,
+    "cctbx",
+    "kokkos"]
   if 'Cuda' in os.getenv('KOKKOS_DEVICES'):
     kokkos_ext_env.Append(LIBPATH=[os.path.join(os.environ['CUDA_HOME'], 'lib64')])
-    kokkos_ext_env.Append(LIBS=env_etc.libm +
-      ["simtbx_kokkos",
-      "scitbx_boost_python",
-      env_etc.boost_python_lib,
-      "cctbx",
-      "kokkos",
-      "cudart",
-      "cuda"])
+    kokkos_ext_env.Append(LIBS=env_etc.libm + default_libs + ["cudart", "cuda"])
   elif 'HIP' in os.getenv('KOKKOS_DEVICES'):
     kokkos_ext_env.Append(LIBPATH=[os.path.join(os.environ['ROCM_PATH'], 'lib')])
-    kokkos_ext_env.Append(LIBS=env_etc.libm +
-      ["simtbx_kokkos",
-      "scitbx_boost_python",
-      env_etc.boost_python_lib,
-      "cctbx",
-      "kokkos",
-      "amdhip64",
-      "hsa-runtime64"])
+    kokkos_ext_env.Append(LIBS=env_etc.libm + default_libs + ["amdhip64", "hsa-runtime64"])
   else:
-    kokkos_ext_env.Append(LIBS=env_etc.libm +
-      ["simtbx_kokkos",
-      "scitbx_boost_python",
-      env_etc.boost_python_lib,
-      "cctbx",
-      "kokkos"])
+    kokkos_ext_env.Append(LIBS=env_etc.libm + default_libs)
 
   simtbx_kokkos_ext = kokkos_ext_env.SharedLibrary(
     target="#lib/simtbx_kokkos_ext.so",

--- a/simtbx/kokkos/SConscript
+++ b/simtbx/kokkos/SConscript
@@ -170,7 +170,7 @@ if not env_etc.no_boost_python:
     kokkos_ext_env.Append(LIBS=env_etc.libm +
       ["simtbx_kokkos",
       "scitbx_boost_python",
-      get_boost_library_with_python_version("boost_python", kokkos_ext_env['LIBPATH']),
+      env_etc.boost_python_lib,
       "cctbx",
       "kokkos",
       "cudart",
@@ -180,7 +180,7 @@ if not env_etc.no_boost_python:
     kokkos_ext_env.Append(LIBS=env_etc.libm +
       ["simtbx_kokkos",
       "scitbx_boost_python",
-      get_boost_library_with_python_version("boost_python", kokkos_ext_env['LIBPATH']),
+      env_etc.boost_python_lib,
       "cctbx",
       "kokkos",
       "amdhip64",
@@ -189,7 +189,7 @@ if not env_etc.no_boost_python:
     kokkos_ext_env.Append(LIBS=env_etc.libm +
       ["simtbx_kokkos",
       "scitbx_boost_python",
-      get_boost_library_with_python_version("boost_python", kokkos_ext_env['LIBPATH']),
+      env_etc.boost_python_lib,
       "cctbx",
       "kokkos"])
 

--- a/simtbx/kokkos/SConscript
+++ b/simtbx/kokkos/SConscript
@@ -21,20 +21,74 @@ def detect_architecture(verbose=True):
     architecture = "HSW"
   return architecture
 
+class system_config(object):
+  def __init__(self, host_variable, host_name):
+    self.host_variable = host_variable
+    self.host_name = host_name
+    self.env = {}
+
+  def is_host(self):
+    return (self.host_name==os.getenv(self.host_variable))
+
+  def get_copy(self):
+    clone = system_config(self.host_variable, self.host_name)
+    clone.env = dict(self.env)
+    return clone
+
+cfg_default = system_config(host_variable = 'NO_WHERE', host_name='N/A')
+cfg_default.env['KOKKOS_DEVICES'] = "OpenMP"
+cfg_default.env['KOKKOS_ARCH'] = "HSW"
+cfg_default.env['KOKKOS_CUDA_OPTIONS'] = ""
+cfg_default.env['LDFLAGS'] = "-Llib"
+cfg_default.env['LDLIBS'] = "-lkokkos -ldl"
+cfg_default.env['CXX'] = 'g++'
+
+list_cfg = []
+
+cfg_corigpu = cfg_default.get_copy()
+cfg_corigpu.host_variable = 'NERSC_HOST'
+cfg_corigpu.host_name = 'cori' 
+cfg_corigpu.env['KOKKOS_DEVICES'] = "Cuda"
+cfg_corigpu.env['KOKKOS_ARCH'] = "Volta70"
+cfg_corigpu.env['KOKKOS_CUDA_OPTIONS'] = "enable_lambda,force_uvm"
+cfg_corigpu.env['LDFLAGS'] += " -L$(CUDA_HOME)/lib64"
+cfg_corigpu.env['LDLIBS'] += " -lcudart -lcuda"
+cfg_corigpu.env['CXX'] = ''
+list_cfg.append(cfg_corigpu)
+
+cfg_perlmutter = cfg_corigpu.get_copy()
+cfg_perlmutter.host_name = 'perlmutter'
+cfg_perlmutter.env['KOKKOS_ARCH'] = 'Ampere80'
+list_cfg.append(cfg_perlmutter)
+
+cfg_spock = cfg_default.get_copy()
+cfg_spock.host_variable = 'LMOD_SYSTEM_NAME'
+cfg_spock.host_name = 'spock'
+cfg_spock.env['KOKKOS_DEVICES'] = "HIP"
+cfg_spock.env['KOKKOS_ARCH'] = "Vega908"
+cfg_spock.env['CXX'] = 'hipcc'
+list_cfg.append(cfg_spock)
+
+system_settings = cfg_default.env
+for cfg in list_cfg:
+  if cfg.is_host():
+    system_settings = cfg.env
+    break
+
 # libkokkos.a
 # call kokkos build system directly
 # set environment variable defaults if necessary
 if os.getenv('KOKKOS_DEVICES') is None:
-  os.environ['KOKKOS_DEVICES'] = "Cuda"
+  os.environ['KOKKOS_DEVICES'] = system_settings['KOKKOS_DEVICES']
 if os.getenv('KOKKOS_PATH') is None:
   os.environ['KOKKOS_PATH'] = libtbx.env.under_dist('simtbx', '../../kokkos')
 if os.getenv('KOKKOS_ARCH') is None:
-  os.environ['KOKKOS_ARCH'] = detect_architecture(verbose = True)
+  os.environ['KOKKOS_ARCH'] = system_settings['KOKKOS_ARCH']
 if os.getenv('KOKKOS_CUDA_OPTIONS') is None:
-  os.environ['KOKKOS_CUDA_OPTIONS'] = "enable_lambda,force_uvm"
+  os.environ['KOKKOS_CUDA_OPTIONS'] = system_settings['KOKKOS_CUDA_OPTIONS']
 os.environ['CXXFLAGS'] = '-O3 -fPIC -DCUDAREAL=double'
-os.environ['LDFLAGS'] = '-Llib -L$(CUDA_HOME)/lib64'
-os.environ['LDLIBS'] = '-lkokkos -ldl -lcudart -lcuda'
+os.environ['LDFLAGS'] = system_settings['LDFLAGS']
+os.environ['LDLIBS'] = system_settings['LDLIBS']
 
 original_cxx = None
 kokkos_lib = 'libkokkos.a'
@@ -42,7 +96,10 @@ kokkos_cxxflags = None
 
 if os.getenv('CXX') is not None:
   original_cxx = os.environ['CXX']
-os.environ['CXX'] = os.path.join(os.environ['KOKKOS_PATH'], 'bin', 'nvcc_wrapper')
+if 'Cuda' in os.getenv('KOKKOS_DEVICES'):
+  os.environ['CXX'] = os.path.join(os.environ['KOKKOS_PATH'], 'bin', 'nvcc_wrapper')
+else:
+  os.environ['CXX'] = system_settings['CXX']
 print('='*79)
 print('Building Kokkos')
 print('-'*79)
@@ -108,15 +165,33 @@ if not env_etc.no_boost_python:
   kokkos_ext_env.Prepend(CXXFLAGS=['-DCUDAREAL=double'] + kokkos_cxxflags)
   kokkos_ext_env.Prepend(CPPFLAGS=['-DCUDAREAL=double'] + kokkos_cxxflags)
   kokkos_ext_env.Prepend(CPPPATH=[os.environ['KOKKOS_PATH']])
-  kokkos_ext_env.Append(LIBPATH=[os.path.join(os.environ['CUDA_HOME'], 'lib64')])
-  kokkos_ext_env.Append(LIBS=env_etc.libm +
-    ["simtbx_kokkos",
-     "scitbx_boost_python",
-     env_etc.boost_python_lib,
-     "cctbx",
-     "kokkos",
-     "cudart",
-     "cuda"])
+  if 'Cuda' in os.getenv('KOKKOS_DEVICES'):
+    kokkos_ext_env.Append(LIBPATH=[os.path.join(os.environ['CUDA_HOME'], 'lib64')])
+    kokkos_ext_env.Append(LIBS=env_etc.libm +
+      ["simtbx_kokkos",
+      "scitbx_boost_python",
+      get_boost_library_with_python_version("boost_python", kokkos_ext_env['LIBPATH']),
+      "cctbx",
+      "kokkos",
+      "cudart",
+      "cuda"])
+  elif 'HIP' in os.getenv('KOKKOS_DEVICES'):
+    kokkos_ext_env.Append(LIBPATH=[os.path.join(os.environ['ROCM_PATH'], 'lib')])
+    kokkos_ext_env.Append(LIBS=env_etc.libm +
+      ["simtbx_kokkos",
+      "scitbx_boost_python",
+      get_boost_library_with_python_version("boost_python", kokkos_ext_env['LIBPATH']),
+      "cctbx",
+      "kokkos",
+      "amdhip64",
+      "hsa-runtime64"])
+  else:
+    kokkos_ext_env.Append(LIBS=env_etc.libm +
+      ["simtbx_kokkos",
+      "scitbx_boost_python",
+      get_boost_library_with_python_version("boost_python", kokkos_ext_env['LIBPATH']),
+      "cctbx",
+      "kokkos"])
 
   simtbx_kokkos_ext = kokkos_ext_env.SharedLibrary(
     target="#lib/simtbx_kokkos_ext.so",

--- a/simtbx/kokkos/SConscript
+++ b/simtbx/kokkos/SConscript
@@ -69,6 +69,11 @@ cfg_spock.env['KOKKOS_ARCH'] = "Vega908"
 cfg_spock.env['CXX'] = 'hipcc'
 list_cfg.append(cfg_spock)
 
+cfg_crusher = cfg_spock.get_copy()
+cfg_crusher.host_name = 'crusher'
+cfg_crusher.env['KOKKOS_ARCH'] = "Vega90A"
+list_cfg.append(cfg_crusher)
+
 system_settings = cfg_default.env
 for cfg in list_cfg:
   if cfg.is_host():

--- a/simtbx/kokkos/detector.cpp
+++ b/simtbx/kokkos/detector.cpp
@@ -174,9 +174,8 @@ namespace simtbx { namespace Kokkos {
   kokkos_detector::get_raw_pixels(){
     //return the data array for the multipanel detector case
     af::flex_double output_array(af::flex_grid<>(m_panel_count,m_slow_dim_size,m_fast_dim_size), af::init_functor_null<double>());
-    double* output_array_ptr = output_array.begin();
-
     transfer_kokkos2flex(output_array, m_accumulate_floatimage);
+
     // vector_double_t::HostMirror host_floatimage = create_mirror_view(m_accumulate_floatimage);
     // deep_copy(host_floatimage, m_accumulate_floatimage);
 
@@ -215,11 +214,13 @@ namespace simtbx { namespace Kokkos {
     //              selection.begin(), sizeof(*cu_active_pixel_selection) * selection.size(),
     //              cudaMemcpyHostToDevice));
 
+    auto temp = m_accumulate_floatimage;
+
     parallel_for("get_active_pixel_selection",
                   range_policy(0, m_active_pixel_size),
                   KOKKOS_LAMBDA (const int i) {
       size_t index = active_pixel_selection( i );
-      active_pixel_results( i ) = m_accumulate_floatimage( index );
+      active_pixel_results( i ) = temp( index );
     });
     // int smCount = 84; //deviceProps.multiProcessorCount;
     // dim3 threadsPerBlock(THREADS_PER_BLOCK_X, THREADS_PER_BLOCK_Y);

--- a/simtbx/kokkos/kernel_math.h
+++ b/simtbx/kokkos/kernel_math.h
@@ -213,6 +213,10 @@ KOKKOS_FUNCTION CUDAREAL sincg(CUDAREAL x, CUDAREAL N) {
 
 }
 
+#ifndef
+  sinpi(x) sin(x * M_PI)
+#endif
+
 KOKKOS_INLINE_FUNCTION CUDAREAL sincgrad(CUDAREAL x, CUDAREAL N) {
         if (x != 0.0) {
                 return sinpi(x * N) / sinpi(x);

--- a/simtbx/kokkos/kernel_math.h
+++ b/simtbx/kokkos/kernel_math.h
@@ -213,8 +213,8 @@ KOKKOS_FUNCTION CUDAREAL sincg(CUDAREAL x, CUDAREAL N) {
 
 }
 
-#ifndef
-  sinpi(x) sin(x * M_PI)
+#ifndef sinpi
+#define  sinpi(x) sin(x * M_PI)
 #endif
 
 KOKKOS_INLINE_FUNCTION CUDAREAL sincgrad(CUDAREAL x, CUDAREAL N) {

--- a/simtbx/run_tests.py
+++ b/simtbx/run_tests.py
@@ -71,8 +71,10 @@ if OPT.enable_cuda:
     ["$D/nanoBragg/tst_gauss_argchk.py","GPU"], # tests CPU+GPU, argchk optimization
     "$D/gpu/tst_exafel_api.py",                 # CPU / GPU, polychromatic beam, monolithic detector
     "$D/gpu/tst_gpu_multisource_background.py", # CPU / GPU background comparison
-    "$D/kokkos/tst_kokkos_lib.py",                  # GPU in kokkos
+    "$D/kokkos/tst_kokkos_lib.py",              # GPU in kokkos
   ]
+  if not OPT.enable_kokkos:
+    tst_list_parallel.pop(-1)    # remove kokkos test if kokkos is not available
   if OPT.enable_cxx11 and sys.platform != 'win32':
       for tst in db_tst_list:
           if isinstance(tst, str):
@@ -82,6 +84,11 @@ if OPT.enable_cuda:
           tst_list_parallel.append(par_tst)
 
       tst_list_parallel += db_tst_list_onlyCuda
+elif OPT.enable_kokkos:
+   tst_list_parallel = [
+     ["$D/nanoBragg/tst_gauss_argchk.py","CPU"], # tests CPU argchk optimization
+     "$D/kokkos/tst_kokkos_lib.py",              # GPU in kokkos
+   ]  
 else:
   tst_list.append(
     ["$D/nanoBragg/tst_gauss_argchk.py","CPU"]

--- a/simtbx/run_tests.py
+++ b/simtbx/run_tests.py
@@ -88,7 +88,7 @@ elif OPT.enable_kokkos:
    tst_list_parallel = [
      ["$D/nanoBragg/tst_gauss_argchk.py","CPU"], # tests CPU argchk optimization
      "$D/kokkos/tst_kokkos_lib.py",              # GPU in kokkos
-   ]  
+   ]
 else:
   tst_list.append(
     ["$D/nanoBragg/tst_gauss_argchk.py","CPU"]


### PR DESCRIPTION
Spock uses AMD MI100 cards, which require HIP. This PR changes the build script so kokkos can be build with the HIP backend independent of cuda.