### PR TITLE
Expose the "legacy" mask generation before 2243cc9 thru phil params

### DIFF
--- a/mmtbx/masks/__init__.py
+++ b/mmtbx/masks/__init__.py
@@ -341,7 +341,7 @@ class manager(object):
     else:
       asu_mask_obj = asu_mask(
         xray_structure = self.xray_structure,
-        d_min = d_min,
+        d_min          = d_min,
         mask_params    = self.mask_params).asu_mask
       self._f_mask = self._compute_f(mask_obj=asu_mask_obj,
         ma=self.miller_array, sel=self.sel_Fmask_res)


### PR DESCRIPTION
As discussed in https://github.com/cctbx/cctbx_project/issues/712 we've had to disable some xfel tests because the solvent mask generation gives new results since 2243cc9. This PR preserves the current default behavior (to my knowledge) but it makes two changes:
- Add a phil param for the max resolution at which solvent contributions are computed. This was previously hardcoded as 3Å.
- If `grid_step_factor` has been set, then `d_min` of the Miller array is passed to the `asu_mask` constructor. I don't see how `grid_step_factor` can be usable without this change.

When this PR is merged, we can temporarily add the following lines:
```
  params2.mask.Fmask_res_high = 0
  params2.mask.grid_step_factor = 4
  params2.mask.solvent_radius = 1.11
```
to the places in `xfel/merging` and `LS49` where we compute model intensities. Then the tests will be usable again and we can subsequently recompute the reference results and stop modifying the mask params.