### PR TITLE
xfel.merge and cxi.merge: handle the new mosaic solvent model

### DIFF
--- a/xfel/merging/application/model/crystal_model.py
+++ b/xfel/merging/application/model/crystal_model.py
@@ -170,6 +170,14 @@ class crystal_model(worker):
       params2.fmodel.k_sol = self.params.scaling.pdb.k_sol
       params2.fmodel.b_sol = self.params.scaling.pdb.b_sol
 
+    # vvv These params restore the "legacy" solvent mask generation before
+    # vvv cctbx commit 2243cc9a
+    if self.params.scaling.pdb.solvent_algorithm == "flat":
+      params2.mask.Fmask_res_high = 0
+      params2.mask.grid_step_factor = 4
+      params2.mask.solvent_radius = 1.11
+    # ^^^
+
     # Build an array of the model intensities according to the input parameters
     f_model = mmtbx.utils.fmodel_from_xray_structure(xray_structure = xray_structure,
                                                      f_obs          = None,

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -376,6 +376,9 @@ scaling {
       .type = float
       .help = If model is taken from coordinates, use b_sol for bulk solvent B-factor
       .help = default is approximate mean value in PDB (according to Pavel)
+    solvent_algorithm = *mosaic flat
+      .type = choice
+      .help = Mosaic solvent model is as in https://doi.org/10.1101/2021.12.09.471976
   }
   algorithm = *mark0 mark1
     .type = choice

--- a/xfel/merging/general_fcalc.py
+++ b/xfel/merging/general_fcalc.py
@@ -41,6 +41,14 @@ def run (params) :
   if (params.include_bulk_solvent) :
     params2.fmodel.k_sol = params.k_sol
     params2.fmodel.b_sol = params.b_sol
+
+  # vvv These params restore the "legacy" solvent mask generation before
+  # vvv cctbx commit 2243cc9a
+  params2.mask.Fmask_res_high = 0
+  params2.mask.grid_step_factor = 4
+  params2.mask.solvent_radius = 1.11
+  # ^^^
+
   f_model = mmtbx.utils.fmodel_from_xray_structure(
     xray_structure = xray_structure,
     f_obs          = None,


### PR DESCRIPTION
- cctbx.xfel.merge uses the mosaic model by default, but 'flat' is available
- cxi.merge uses the old (flat) model