### PR TITLE
Modifications for Kapton Plugin: Part 2

### DIFF
--- a/xfel/util/kapton_2019_correction_frame_frame_plugin.py
+++ b/xfel/util/kapton_2019_correction_frame_frame_plugin.py
@@ -535,8 +535,8 @@ class KaptonSettingsPanel(wx.Panel):
       """Takes in  x1,y1,x2,y2 and returns the panel where these points lie. If outside any panel then returns None"""
       x1,y1,x2,y2=elem
       # FIXME tolerance levels, a bit hacky
-      d1=1.03
-      d2=-0.03
+      d1=3.09
+      d2=-0.09
       int_panels=[None, None]
       for panel in detector:
         # Convert x,y to f,s for that panel


### PR DESCRIPTION
Adjust tolerance values in Kapton plugin These tolerances are associated with logic used to determine whether or not lines demarcating max/edge Kapton absorption intersect with detector panel(s). Tolerance values were increased by a factor of 3. This increase was chosen based on desired performance and ad hoc testing.

NOTE: This change will not work without pulling dials branch 'fix_max_edge_pt2'.