### PR TITLE
Update cctbx.xfel.merge defaults

### DIFF
--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -37,7 +37,7 @@ input {
     .multiple = True
     .help = Names of reflection table columns that will remain after all prune steps
     .help = If output.save_experiments_and_reflections=True, then these columns will be in the saved tables.
-  keep_imagesets = False
+  keep_imagesets = True
     .type = bool
     .help = If True, keep imagesets attached to experiments
   path = None
@@ -390,7 +390,7 @@ scaling {
 
 postrefinement_phil = """
 postrefinement {
-  enable = False
+  enable = True
     .type = bool
     .help = enable the preliminary postrefinement algorithm (monochromatic)
     .expert_level = 3

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -451,7 +451,7 @@ merging {
     .type = int(value_min=2)
     .help = If defined, merged structure factors not produced for the Miller indices below this threshold.
   error {
-    model = ha14 ev11 errors_from_sample_residuals
+    model = ha14 *ev11 errors_from_sample_residuals
       .type = choice
       .multiple = False
       .help = ha14, formerly sdfac_auto, apply sdfac to each-image data assuming negative

--- a/xfel/merging/command_line/merge.py
+++ b/xfel/merging/command_line/merge.py
@@ -12,7 +12,6 @@ default_steps = [
   'model_scaling', # build full Miller list, model intensities, and resolution binner - for scaling and post-refinement
   'modify', # apply polarization correction, etc.
   'filter', # reject whole experiments or individual reflections
-  'errors_premerge', # correct errors using a per-experiment algorithm, e.g. ha14
   'scale',
   'postrefine',
   'statistics_unitcell', # if required, save the average unit cell to the phil parameters


### PR DESCRIPTION
New defaults based on current usage:
- keep_imagesets is now True (able to do this because cctbx/dxtbx#438 is merged)
- postrefinement.enable now defaults to True.  To remove postrefinement manually, set it to False or remove the postrefinement worker
- Error model is now Ev11.  Because of this, errors_premerge worker is removed from the list of default workers as it is a no-op for Ev11
