### PR TITLE
Kokkos/CUDA equivalent interfaces for exascale_api

### DIFF
--- a/simtbx/gpu/gpu_ext.cpp
+++ b/simtbx/gpu/gpu_ext.cpp
@@ -99,12 +99,14 @@ namespace simtbx { namespace gpu {
              static_cast<void (exascale_api::*)(int const&, gpu_energy_channels&, gpu_detector&, af::shared<int> const) >
              (&exascale_api::add_energy_channel_mask_allpanel),
              (arg_("channel_number"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("pixel_active_list_ints")),
-             "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels")
+             "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels\n"
+             "The pixel_active_list_ints is a small array with integer-offset addresses for each pixel-of-interest")
         .def("add_energy_channel_mask_allpanel",
              static_cast<void (exascale_api::*)(int const&, gpu_energy_channels&, gpu_detector&, af::shared<bool>) >
              (&exascale_api::add_energy_channel_mask_allpanel),
              (arg_("channel_number"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("pixel_active_mask_bools")),
-             "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels")
+             "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels\n"
+             "The pixel_active_mask_bools is a large array with one bool per detector pixel")
         .def("add_background", &simtbx::gpu::exascale_api::add_background,
              (arg_("detector"), arg_("override_source")=-1),
              "Add a background field directly on the GPU")

--- a/simtbx/kokkos/kokkos_ext.cpp
+++ b/simtbx/kokkos/kokkos_ext.cpp
@@ -87,6 +87,7 @@ namespace simtbx { namespace Kokkos {
     wrap()
     {
       using namespace boost::python;
+      using namespace simtbx::Kokkos;
       class_<simtbx::Kokkos::exascale_api>("exascale_api",no_init )
         .def(init<const simtbx::nanoBragg::nanoBragg&>(
             ( arg("nanoBragg"))))
@@ -96,8 +97,17 @@ namespace simtbx { namespace Kokkos {
              &simtbx::Kokkos::exascale_api::add_energy_channel_from_gpu_amplitudes,
              "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spot contributions to the detector's accumulator array")
         .def("add_energy_channel_mask_allpanel",
-             &simtbx::Kokkos::exascale_api::add_energy_channel_mask_allpanel,
-             "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels")
+             static_cast<void (exascale_api::*)(int const&,kokkos_energy_channels&,kokkos_detector&, af::shared<int> const) >
+             (&exascale_api::add_energy_channel_mask_allpanel),
+             (arg_("channel_number"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("pixel_active_list_ints")),
+             "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels\n"
+             "The pixel_active_list_ints is a small array with integer-offset addresses for each pixel-of-interest")
+        .def("add_energy_channel_mask_allpanel",
+             static_cast<void (exascale_api::*)(int const&,kokkos_energy_channels&,kokkos_detector&, af::shared<bool>) >
+             (&exascale_api::add_energy_channel_mask_allpanel),
+             (arg_("channel_number"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("pixel_active_mask_bools")),
+             "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels\n"
+             "The pixel_active_mask_bools is a large array with one bool per detector pixel")
         .def("add_background", &simtbx::Kokkos::exascale_api::add_background,
              "Add a background field directly on the GPU")
         .def("show",&simtbx::Kokkos::exascale_api::show)

--- a/simtbx/kokkos/simulation.cpp
+++ b/simtbx/kokkos/simulation.cpp
@@ -169,8 +169,6 @@ namespace Kokkos {
     simtbx::Kokkos::kokkos_detector & kdt,
     af::shared<bool> all_panel_mask
   ){
-    // cudaSafeCall(cudaSetDevice(SIM.device_Id));
-
     // here or there, need to convert the all_panel_mask (3D map) into a 1D list of accepted pixels
     // coordinates for the active pixel list are absolute offsets into the detector array
     af::shared<int> active_pixel_list;
@@ -180,6 +178,16 @@ namespace Kokkos {
         active_pixel_list.push_back(j);
       }
     }
+    add_energy_channel_mask_allpanel(ichannel, kec, kdt, active_pixel_list);
+  }
+
+  void
+  exascale_api::add_energy_channel_mask_allpanel(
+    int const& ichannel,
+    simtbx::Kokkos::kokkos_energy_channels & kec,
+    simtbx::Kokkos::kokkos_detector & kdt,
+    af::shared<int> const active_pixel_list
+  ){
     kdt.set_active_pixels_on_GPU(active_pixel_list);
 
     // transfer source_I, source_lambda

--- a/simtbx/kokkos/simulation.h
+++ b/simtbx/kokkos/simulation.h
@@ -25,6 +25,12 @@ struct exascale_api {
     simtbx::Kokkos::kokkos_detector &,
     af::shared<bool>
   );
+  void add_energy_channel_mask_allpanel(int const&,
+    simtbx::Kokkos::kokkos_energy_channels &,
+    simtbx::Kokkos::kokkos_detector &,
+    af::shared<int> const
+  );
+
   void add_background(simtbx::Kokkos::kokkos_detector &);
   void allocate();
   //~exascale_api();


### PR DESCRIPTION
Each execution context now has two overloaded versions of exascale_api::add_energy_channel_mask_allpanel