### PR TITLE
interactive peak picking in powder_from_spots

### DIFF
--- a/xfel/small_cell/README.md
+++ b/xfel/small_cell/README.md
@@ -182,12 +182,11 @@ $ cd combined; dials.combine_experiments *.expt *.refl reference_from_experiment
 
 Plot the powder pattern:
 ```
-$ cctbx.xfel.powder_from_spots combined.* output.xy_file=powder.xy
+$ cctbx.xfel.powder_from_spots combined.* output.xy_file=powder.xy output.peak_file=peaks.txt
 ```
 
-This should display an interactive matplotlib window. Manually identify about 20 d-spacings. Record them
-with 3 decimal places accuracy in a new file `peaks.txt`. Then run GSASII powder
-indexing through the `candidate_cells` wrapper:
+This should display an interactive matplotlib window. Zoom, drag and click to identify about 20 d-spacings.
+Then run GSASII powder indexing through the `candidate_cells` wrapper:
 ```
 $ cctbx.xfel.candidate_cells nproc=64 input.peak_list=peaks.txt input.powder_pattern=powder.xy search.timeout=300
 ```

--- a/xfel/small_cell/command_line/powder_from_spots.py
+++ b/xfel/small_cell/command_line/powder_from_spots.py
@@ -90,6 +90,12 @@ output {
     .type = str
   xy_file = None
     .type = str
+  peak_file = None
+    .type = str
+    .help = Optionally, specify an output file for interactive peak picking in \
+            the plot window. Clicking and holding on the plot will bring up a \
+            vertical line to help; releasing the mouse button will add the \
+            nearest local maximum to the output file peak_file.
 }
 """
 )

--- a/xfel/small_cell/command_line/powder_from_spots.py
+++ b/xfel/small_cell/command_line/powder_from_spots.py
@@ -94,7 +94,7 @@ output {
     .type = str
     .help = Optionally, specify an output file for interactive peak picking in \
             the plot window. Clicking and holding on the plot will bring up a \
-            vertical line to help; releasing the mouse button will add the \
+            vertical line to help. Releasing the mouse button will add the \
             nearest local maximum to the output file peak_file.
 }
 """

--- a/xfel/small_cell/spotfinder_radial_average.py
+++ b/xfel/small_cell/spotfinder_radial_average.py
@@ -134,13 +134,15 @@ class Spotfinder_radial_average:
         vertical_line = ax.axvline(color='r', lw=0.8, ls='--', x=xvalues[1])
         vertical_line.set_visible(False)
         def onmove(event):
+          if fig.canvas.toolbar.mode: return
           x = event.xdata
           vertical_line.set_xdata(x)
           ax.figure.canvas.draw()
         def onclick(event):
+          if fig.canvas.toolbar.mode: return
           vertical_line.set_visible(True)
-          print()
         def onrelease(event):
+          if fig.canvas.toolbar.mode: return
           vertical_line.set_visible(False)
           peak = self._nearest_peak(event.xdata,xvalues,yvalues)
           if peak is not None:

--- a/xfel/small_cell/spotfinder_radial_average.py
+++ b/xfel/small_cell/spotfinder_radial_average.py
@@ -129,6 +129,7 @@ class Spotfinder_radial_average:
           f.write("{:.6f}\t{}\n".format(1/x, y))
 
     if params.output.peak_file:
+      assert plt.get_backend() == "TkAgg"
       #If a peak list output file is specified, do interactive peak picking:
       with open(params.output.peak_file, 'w') as f:
         vertical_line = ax.axvline(color='r', lw=0.8, ls='--', x=xvalues[1])

--- a/xfel/small_cell/spotfinder_radial_average.py
+++ b/xfel/small_cell/spotfinder_radial_average.py
@@ -153,6 +153,7 @@ Currently supported options: %s""" %backend_list
           peak = self._nearest_peak(event.xdata,xvalues,yvalues)
           if peak is not None:
             print('Selected x=%f, nearest local maximum=%f, writing to %s.' % (1/event.xdata, peak, params.output.peak_file))
+            f.write(str(peak)+"\n")
 
         mmv = fig.canvas.mpl_connect('motion_notify_event', onmove)
         cid = fig.canvas.mpl_connect('button_press_event', onclick)

--- a/xfel/small_cell/spotfinder_radial_average.py
+++ b/xfel/small_cell/spotfinder_radial_average.py
@@ -129,7 +129,10 @@ class Spotfinder_radial_average:
           f.write("{:.6f}\t{}\n".format(1/x, y))
 
     if params.output.peak_file:
-      assert plt.get_backend() == "TkAgg"
+      backend_list = ["TkAgg","QtAgg"]
+      assert (plt.get_backend() in backend_list), """Matplotlib backend not compatible with interactive peak picking.
+You can set the MPLBACKEND environment varibale to change this.
+Currently supported options: %s""" %backend_list
       #If a peak list output file is specified, do interactive peak picking:
       with open(params.output.peak_file, 'w') as f:
         vertical_line = ax.axvline(color='r', lw=0.8, ls='--', x=xvalues[1])
@@ -138,17 +141,18 @@ class Spotfinder_radial_average:
           if fig.canvas.toolbar.mode: return
           x = event.xdata
           vertical_line.set_xdata(x)
-          ax.figure.canvas.draw()
+          if plt.getp(vertical_line, 'visible'):
+            ax.figure.canvas.draw()
         def onclick(event):
           if fig.canvas.toolbar.mode: return
           vertical_line.set_visible(True)
         def onrelease(event):
           if fig.canvas.toolbar.mode: return
           vertical_line.set_visible(False)
+          ax.figure.canvas.draw()
           peak = self._nearest_peak(event.xdata,xvalues,yvalues)
           if peak is not None:
             print('Selected x=%f, nearest local maximum=%f, writing to %s.' % (1/event.xdata, peak, params.output.peak_file))
-            f.write(str(1/event.xdata)+"\n")
 
         mmv = fig.canvas.mpl_connect('motion_notify_event', onmove)
         cid = fig.canvas.mpl_connect('button_press_event', onclick)


### PR DESCRIPTION
Hi,

I have added optional simple interactive peak picking to xfel/small_cell/powder_from_spots, using the matplotlib window which was already generated. If a peak output file is specified, and the user clicks on the plot, the abscissa of the closest local maximum to the location of the click will be added to the peak file. While holding the mouse down a vertical line is shown to help placement.

This is my first time trying to contribute something to CCTBX so please forgive me if I got something wrong. I didn't see any folder with tests in the XFEL module so I wasn't sure how to add a test - but I swear my change doesn't break anything, it's extremely limited in scope.

Cheers,

David