### PR TITLE
Fix simtbx flux test

### DIFF
--- a/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
+++ b/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
@@ -53,7 +53,7 @@ WAVELEN = ENERGY_CONV/ENERGY
 # dxtbx beam model description
 beam_descr = {'direction': (0.0, 0.0, 1.0),
              'divergence': 0.0,
-             'flux': 0,
+             'flux': 1e11,
              'polarization_fraction': 1.,
              'polarization_normal': (0.0, 1.0, 0.0),
              'sigma_divergence': 0.0,

--- a/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
+++ b/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
@@ -53,7 +53,7 @@ WAVELEN = ENERGY_CONV/ENERGY
 # dxtbx beam model description
 beam_descr = {'direction': (0.0, 0.0, 1.0),
              'divergence': 0.0,
-             'flux': 1e11,
+             'flux': 0,
              'polarization_fraction': 1.,
              'polarization_normal': (0.0, 1.0, 0.0),
              'sigma_divergence': 0.0,

--- a/xfel/cftbx/detector/cspad_cbf_tbx.py
+++ b/xfel/cftbx/detector/cspad_cbf_tbx.py
@@ -729,7 +729,7 @@ def metro_phil_to_basis_dict(metro):
 
   return bd
 
-def add_frame_specific_cbf_tables(cbf, wavelength, timestamp, trusted_ranges, diffrn_id = "DS1", is_xfel = True, gain = 1.0):
+def add_frame_specific_cbf_tables(cbf, wavelength, timestamp, trusted_ranges, diffrn_id = "DS1", is_xfel = True, gain = 1.0, flux = None):
   """ Adds tables to cbf handle that won't already exsist if the cbf file is just a header
   @ param wavelength Wavelength in angstroms
   @ param timestamp String formatted timestamp for the image
@@ -741,8 +741,12 @@ def add_frame_specific_cbf_tables(cbf, wavelength, timestamp, trusted_ranges, di
 
    Post-sample treatment of the beam is described by data
    items in the DIFFRN_DETECTOR category."""
-  cbf.add_category("diffrn_radiation", ["diffrn_id","wavelength_id","probe"])
-  cbf.add_row([diffrn_id,"WAVELENGTH1","x-ray"])
+  if flux:
+    cbf.add_category("diffrn_radiation", ["diffrn_id","wavelength_id","probe","beam_flux"])
+    cbf.add_row([diffrn_id,"WAVELENGTH1","x-ray","%f"%flux])
+  else:
+    cbf.add_category("diffrn_radiation", ["diffrn_id","wavelength_id","probe"])
+    cbf.add_row([diffrn_id,"WAVELENGTH1","x-ray"])
 
   """ Data items in the DIFFRN_RADIATION_WAVELENGTH category describe
    the wavelength of the radiation used in measuring the diffraction


### PR DESCRIPTION
A recent bugfix (cctbx/dxtbx#488) added better flux support to the dxtbx Beam object.  In order to use it in simtbx's cbf [writing test](https://github.com/cctbx/cctbx_project/blob/master/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py#L56), we have to add better support for reading and writing CBFs to the xfel cbf tool box, which is used by the dxtbx cbf writer.

Should be merged simultaneously with cctbx/dxtbx#493