### PR TITLE
xfel SCons: Don't overwrite dials helper vars if already set

### DIFF
--- a/xfel/SConscript
+++ b/xfel/SConscript
@@ -4,8 +4,13 @@ Import("env_base", "env_etc")
 
 env_etc.xfel_dist = libtbx.env.dist_path("xfel")
 env_etc.xfel_include = os.path.dirname(env_etc.xfel_dist)
-env_etc.dials_dist = libtbx.env.dist_path("dials")
-env_etc.dials_include = os.path.dirname(env_etc.dials_dist)
+
+# If the DIALS paths aren't already set up, do that now
+if not hasattr(env_etc, "dials_dist"):
+  env_etc.dials_dist = libtbx.env.dist_path("dials")
+if not hasattr(env_etc, "dials_include"):
+  env_etc.dials_include = os.path.dirname(env_etc.dials_dist)
+
 env_etc.xfel_common_includes = [
   env_etc.dials_include,
   env_etc.xfel_include,


### PR DESCRIPTION
At the moment, these variables are defined in both XFEL and DIALS, because dials might be configured after XFEL in the module load order. This change continues the current behaviour, but in cases where DIALS has already set the variables, they will not be overwritten.