### PR TITLE
Add new constraint scalar_scaled_adp

### DIFF
--- a/smtbx/refinement/constraints/boost_python/constraints_ext.cpp
+++ b/smtbx/refinement/constraints/boost_python/constraints_ext.cpp
@@ -19,6 +19,7 @@ namespace boost_python {
   void wrap_rigid();
   void wrap_direction();
   void wrap_same_group();
+  void wrap_scaled_adp();
 
   namespace {
     void init_module() {
@@ -36,6 +37,7 @@ namespace boost_python {
       wrap_rigid();
       wrap_direction();
       wrap_same_group();
+      wrap_scaled_adp();
     }
   }
 

--- a/smtbx/refinement/constraints/boost_python/scaled_adp.cpp
+++ b/smtbx/refinement/constraints/boost_python/scaled_adp.cpp
@@ -1,0 +1,55 @@
+#include <boost/python/class.hpp>
+#include <boost/python/implicit.hpp>
+#include <boost/python/return_internal_reference.hpp>
+
+#include <smtbx/refinement/constraints/scaled_adp.h>
+
+namespace smtbx { namespace refinement { namespace constraints {
+  namespace boost_python {
+
+    struct scalar_scaled_u_star_parameter_wrapper {
+      typedef scalar_scaled_u_star_parameter wt;
+
+      static void wrap() {
+        using namespace boost::python;
+        return_internal_reference<> rir;
+        class_<wt,
+               bases<asu_u_star_parameter>,
+               std::auto_ptr<wt> >("scalar_scaled_u_star", no_init)
+          .def(init<independent_scalar_parameter *,
+                    wt::scatterer_type *>
+               ((arg("scalar"),
+                 arg("scatterer"))))
+          .add_property("reference", make_function(&wt::reference, rir))
+          ;
+        implicitly_convertible<std::auto_ptr<wt>, std::auto_ptr<parameter> >();
+      }
+    };
+
+    struct scalar_scaled_u_iso_parameter_wrapper {
+      typedef scalar_scaled_u_iso_parameter wt;
+
+      static void wrap() {
+        using namespace boost::python;
+        return_internal_reference<> rir;
+        class_<wt,
+               bases<asu_u_iso_parameter>,
+               std::auto_ptr<wt> >("scalar_scaled_u_iso", no_init)
+          .def(init<independent_scalar_parameter *,
+                    wt::scatterer_type *>
+               ((arg("scalar"),
+                 arg("scatterer"))))
+          .add_property("reference", &wt::reference)
+          ;
+        implicitly_convertible<std::auto_ptr<wt>, std::auto_ptr<parameter> >();
+      }
+    };
+
+    void wrap_scaled_adp() {
+      scalar_scaled_u_star_parameter_wrapper::wrap();
+      scalar_scaled_u_iso_parameter_wrapper::wrap();
+    }
+
+
+}}}}
+

--- a/smtbx/refinement/constraints/boost_python/shared.cpp
+++ b/smtbx/refinement/constraints/boost_python/shared.cpp
@@ -3,6 +3,7 @@
 #include <boost/python/return_internal_reference.hpp>
 
 #include <smtbx/refinement/constraints/shared.h>
+#include <smtbx/refinement/constraints/scaled_adp.h>
 
 namespace smtbx { namespace refinement { namespace constraints {
   namespace boost_python {

--- a/smtbx/refinement/constraints/scaled_adp.cpp
+++ b/smtbx/refinement/constraints/scaled_adp.cpp
@@ -1,0 +1,36 @@
+#include <smtbx/refinement/constraints/scaled_adp.h>
+
+namespace smtbx { namespace refinement { namespace constraints {
+
+void
+scalar_scaled_u_star_parameter
+::linearise(uctbx::unit_cell const &unit_cell,
+            sparse_matrix_type *jacobian_transpose)
+{
+  const scitbx::sym_mat3<double> *ref = reference();
+  independent_scalar_parameter *scalar_ = scalar();
+  value = *ref * scalar_->value;
+
+  if (!jacobian_transpose) return;
+  sparse_matrix_type &jt = *jacobian_transpose;
+  std::size_t i = scalar_->index();
+  for (int k=0; k<6; ++k) {
+    jt(i, index() + k) = (*ref)[k];
+  }
+}
+
+void
+scalar_scaled_u_iso_parameter
+::linearise(uctbx::unit_cell const &unit_cell,
+            sparse_matrix_type *jacobian_transpose)
+{
+  const double ref = reference();
+  independent_scalar_parameter *scalar_ = scalar();
+  value = ref * scalar_->value;
+
+  if (!jacobian_transpose) return;
+  sparse_matrix_type &jt = *jacobian_transpose;
+  std::size_t i = scalar_->index();
+  jt(i, index()) = ref;
+}
+}}}

--- a/smtbx/refinement/constraints/scaled_adp.h
+++ b/smtbx/refinement/constraints/scaled_adp.h
@@ -1,0 +1,61 @@
+#include <smtbx/refinement/constraints/reparametrisation.h>
+namespace smtbx { namespace refinement { namespace constraints {
+
+class scalar_scaled_u_star_parameter : public asu_u_star_parameter
+{
+  const scitbx::sym_mat3<double> u_star_ref_;
+public:
+  scalar_scaled_u_star_parameter(
+    independent_scalar_parameter *scalar,
+    scatterer_type *scatterer)
+  : parameter(1),
+    single_asu_scatterer_parameter(scatterer),
+    u_star_ref_(scatterer->u_star)
+  {
+    set_arguments(scalar);
+  }
+
+  scitbx::sym_mat3<double> const *reference() {
+    return &u_star_ref_;
+  }
+
+  independent_scalar_parameter *scalar() const {
+    return dynamic_cast<independent_scalar_parameter *>(this->argument(0));
+  }
+
+  virtual void linearise(uctbx::unit_cell const &unit_cell,
+                         sparse_matrix_type *jacobian_transpose);
+
+};
+
+class scalar_scaled_u_iso_parameter : public asu_u_iso_parameter
+{
+  const double u_iso_ref_;
+public:
+  scalar_scaled_u_iso_parameter(
+    independent_scalar_parameter *scalar,
+    scatterer_type *scatterer)
+  : parameter(1),
+    single_asu_scatterer_parameter(scatterer),
+    u_iso_ref_(scatterer->u_iso)
+  {
+    set_arguments(scalar);
+  }
+
+  double const reference() {
+    //this returns by value (unlike other reference() member functions) so we
+    //can expose it in python, which wouldn't work if it returned double*
+    return u_iso_ref_;
+  }
+
+  independent_scalar_parameter *scalar() const {
+    return dynamic_cast<independent_scalar_parameter *>(this->argument(0));
+  }
+
+  virtual void linearise(uctbx::unit_cell const &unit_cell,
+                         sparse_matrix_type *jacobian_transpose);
+
+};
+
+
+}}}


### PR DESCRIPTION
This takes a group of atoms and allows all their ADP components to
scale by a consistent factor. When applied to the whole structure,
the result is a single-parameter ADP scale for all atoms. This was
used to model radiation damage in:

https://doi.org/10.1002/anie.201806426