### PR TITLE
Lower hard-coded unit cell limit from 70 A^3 to 40 A^3

### DIFF
--- a/rstbx/symmetry/constraints/a_g_conversion.h
+++ b/rstbx/symmetry/constraints/a_g_conversion.h
@@ -99,7 +99,7 @@ struct AG { // convert orientation matrix A to metrical matrix g & reverse
     G = uc_sym_mat3(g0,g1,g2,g3,g4,g5);
     cctbx::uctbx::unit_cell ersatz_uc ( cctbx::uctbx::unit_cell(G).reciprocal() );
 
-    if ( ersatz_uc.volume() <= 70.){ throw SCITBX_ERROR(
+    if ( ersatz_uc.volume() <= 40.){ throw SCITBX_ERROR(
       "Metrical matrix g is expected to be in the reciprocal setting;this appears to be direct space");
     }
 

--- a/rstbx/symmetry/constraints/parameter_reduction.py
+++ b/rstbx/symmetry/constraints/parameter_reduction.py
@@ -31,9 +31,9 @@ class symmetrize_reduce_enlarge(object):
       from cctbx.crystal_orientation import crystal_orientation
       which_setting = [crystal_orientation(orientation,True),
                        crystal_orientation(orientation,False)]
-      #kludgy test for space setting: unit cell volume is never < 70 Angstroms^3
+      #kludgy test for space setting: unit cell volume is never < 40 Angstroms^3
       conversion_to_A3 = (length_unit*length_unit*length_unit)/1.E-30
-      select = [a.unit_cell().volume()*conversion_to_A3 > 70.
+      select = [a.unit_cell().volume()*conversion_to_A3 > 40.
                 for a in which_setting]
       self.orientation = which_setting[select.index(True)]
 


### PR DESCRIPTION
Indexing NaCl neutron data with DIALS gives a P1 volume lower than the current hard-coded threshold in rstbx. The highest symmetry solution is an almost perfect fit with the experimental result (5.64, see below), so fairly confident the P1 cell is valid.
![img](https://user-images.githubusercontent.com/60879630/181765811-ade3a3ac-5188-4fe7-a3db-a502ab978cc7.png)

