### PR TITLE
Fix a bug introduced in #5ae04d2955fa

### DIFF
--- a/iotbx/reflection_file_reader.py
+++ b/iotbx/reflection_file_reader.py
@@ -306,7 +306,7 @@ class any_reflection_file(object):
           raise Sorry("Can't open files %s.ins or %s.res"
                       "required by the option hklf+ins/res" % ((name,)*2))
         crystal_symmetry = crystal_symmetry_from_ins.extract_from(
-          file=shelx_file)
+          file=shelx_file, close_file=False)
         shelx_file.seek(0)
         remaining = shelx_file.read()
         shelx_file.close()

--- a/iotbx/shelx/crystal_symmetry_from_ins.py
+++ b/iotbx/shelx/crystal_symmetry_from_ins.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, division, print_function
 from iotbx import shelx, builders
 
-def extract_from(file_name=None, file=None, max_characters=100000):
+def extract_from(file_name=None, file=None, max_characters=100000,
+                 close_file=True):
   # XXX backward compatibility 2009-09-17 - keep max_characters keyword
   assert [file_name, file].count(None) == 1
-  stream = shelx.command_stream(file=file, filename=file_name)
+  stream = shelx.command_stream(file=file, filename=file_name,
+                                close_when_deleted=close_file)
   parser = shelx.crystal_symmetry_parser(
     stream, builder=builders.crystal_symmetry_builder())
   parser.parse()

--- a/iotbx/shelx/lexer.py
+++ b/iotbx/shelx/lexer.py
@@ -26,14 +26,16 @@ class command_stream(object):
   shelx_commands.update(commands_allowing_atom_names)
 
 
-  def __init__(self, file=None, filename=None):
+  def __init__(self, file=None, filename=None, close_when_deleted=True):
     assert [file, filename].count(None) == 1
     if file is None: file = open(filename)
     self.file = file
+    self.close_when_deleted = close_when_deleted
 
   def __del__(self):
-    if hasattr(self,'file') and hasattr(self.file,'close'):
-      self.file.close()
+    if self.close_when_deleted:
+      if hasattr(self,'file') and hasattr(self.file,'close'):
+        self.file.close()
 
   _cmd_pat = re.compile(r"""
     ^


### PR DESCRIPTION
It broke the use of

reflection_file_reader.any_reflection_file(hklfn+'=hklf+ins/res')

This feature had no test and it did therefore went unnoticed.