### PR TITLE
Update submodule xfel/euxfel/definitions to point to nexusformat

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "xfel/euxfel/definitions"]
 	path = xfel/euxfel/definitions
-	url = https://github.com/HDRMX/definitions
+	url = https://github.com/nexusformat/definitions


### PR DESCRIPTION
This updates the xfel/euxfel/definitions submodule so that it points to nexusformat/definitions instead of HDRMX/definitions.  The former is up to date and should have anything needed that was put into HDRMX.

We at least need this to work around a [syntax error](https://github.com/HDRMX/definitions/blob/master/manual/source/examples/h5py/TestWriter.py#L68) in HDRMX that isn't in nexusformat.

I had to run these commands to pick up the change (not needed for general cctbx users, just those running NeXus EuXFEL stuff):
```
git submodule sync --recursive
git submodule update --init --recursive --remote
```

@kirienko in your original PR #623, you [commented](https://github.com/cctbx/cctbx_project/pull/623#issuecomment-863398026) you needed to check if nexusformat/definitions has everything you need.  Can you review and verify this change is ok?  Thanks!
