### PR TITLE
Work around for ev11 crash

### DIFF
--- a/xfel/merging/application/errors/error_modifier_ev11.py
+++ b/xfel/merging/application/errors/error_modifier_ev11.py
@@ -124,7 +124,7 @@ class error_modifier_ev11(worker):
       global_sum_of_der_wrt_sadd_in_bin     = comm.reduce(flex.sum(sum_of_der_wrt_sadd_in_bin),   MPI.SUM, root=0)
 
       if self.mpi_helper.rank == 0:
-        if global_number_of_reflections_in_bin > 0:
+        if global_number_of_reflections_in_bin > 0 and global_sum_of_delta_squared_in_bin > 0:
 
           global_weight_for_bin = math.sqrt(global_number_of_reflections_in_bin)
 


### PR DESCRIPTION
Work around for when ev11 gets a negative global_sum_of_delta_squared_in_bin for a given bin.

The test case I have shows that the refinement takes a bad step giving a high target function value, even if I throw out a bad bin.  It then recovers the minimization procedure:
```
5669.41
5669.41
2638.52
2571.27
2291.39
1115.96
2253525.53  <-- this is the bad step with the single bin that needs to be thrown out to avoid a math domain error
1115.78
2289.79
943.97
936.21
927.23
918.19
868.21
803.22
799.45
```