### PR TITLE
Reconcile SMV and CBF writers in nanoBragg.

### DIFF
--- a/simtbx/gpu/tst_exafel_api.py
+++ b/simtbx/gpu/tst_exafel_api.py
@@ -159,11 +159,10 @@ if __name__=="__main__":
   print("\n# Use case 2.  Three-wavelength polychromatic source")
   SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model)
   SIM = SWC.several_wavelength_case_for_CPU()
-  SIM.to_smv_format(fileout="test_full_e_002.img")
+  SIM.to_smv_format(fileout="test_full_e_002.img") # scales by default
   scale = SIM.get_intfile_scale()
   print ("Scale",scale)
-  SIM.raw_pixels *= scale
-  SIM.to_cbf("test_full_e_002.cbf")
+  SIM.to_cbf("test_full_e_002.cbf", intfile_scale=scale)
   # verify cbf (double) and smv (int) produce the same image to within an ADU
   loader_smv = dxtbx.load("test_full_e_002.img")
   loader_cbf = dxtbx.load("test_full_e_002.cbf")
@@ -171,20 +170,17 @@ if __name__=="__main__":
 
   print("\n# Use case 3: modularized api argchk=False, cuda_background=False")
   SIM3 = SWC.modularized_exafel_api_for_GPU(argchk=False, cuda_background=False)
-  SIM3.raw_pixels *= scale
-  SIM3.to_cbf("test_full_e_003.cbf")
+  SIM3.to_cbf("test_full_e_003.cbf", intfile_scale=scale)
   diffs("CPU",SIM.raw_pixels, "GPU",SIM3.raw_pixels)
 
   print("\n# Use case 4: modularized api argchk=False, cuda_background=True")
   SIM4 = SWC.modularized_exafel_api_for_GPU(argchk=False, cuda_background=True)
-  SIM4.raw_pixels *= scale
-  SIM4.to_cbf("test_full_e_004.cbf")
+  SIM4.to_cbf("test_full_e_004.cbf", intfile_scale=scale)
   diffs("CPU",SIM.raw_pixels, "GPU",SIM4.raw_pixels)
 
   print("\n# Use case 5: modularized api argchk=True, cuda_background=True")
   SIM5 = SWC.modularized_exafel_api_for_GPU(argchk=True, cuda_background=True)
-  SIM5.raw_pixels *= scale
-  SIM5.to_cbf("test_full_e_005.cbf")
+  SIM5.to_cbf("test_full_e_005.cbf", intfile_scale=scale)
   diffs("CPU",SIM.raw_pixels, "GPU",SIM5.raw_pixels)
 
 print("OK")

--- a/simtbx/nanoBragg/__init__.py
+++ b/simtbx/nanoBragg/__init__.py
@@ -214,7 +214,19 @@ class _():
 
     return explist
 
-  def to_cbf(self, cbf_filename, toggle_conventions=False):
+  def to_cbf(self, cbf_filename, toggle_conventions=False, intfile_scale=1.0):
+    """write a CBF-format image file to disk from the raw pixel array
+    intfile_scale: multiplicative factor applied to raw pixels before output
+         intfile_scale > 0 : value of the multiplicative factor
+         intfile_scale = 1 (default): do not apply a factor
+         intfile_scale = 0 : compute a reasonable scale factor to set max pixel to 55000; given by get_intfile_scale()"""
+
+    if intfile_scale != 1.0:
+      cache_pixels = self.raw_pixels
+      if intfile_scale > 0: self.raw_pixels = self.raw_pixels * intfile_scale
+      else: self.raw_pixels = self.raw_pixels * self.get_intfile_scale()
+      # print("switch to scaled")
+
     if toggle_conventions:
       # switch to DIALS convention before writing CBF
       CURRENT_CONV = self.beamcenter_convention
@@ -225,6 +237,10 @@ class _():
 
     if toggle_conventions:
       self.beamcenter_convention=CURRENT_CONV
+
+    if intfile_scale != 1.0:
+      self.raw_pixels = cache_pixels
+      # print("switch back to cached")
 
 def make_imageset(data, beam, detector):
   format_class = FormatBraggInMemoryMultiPanel(data)

--- a/simtbx/nanoBragg/nanoBragg.cpp
+++ b/simtbx/nanoBragg/nanoBragg.cpp
@@ -3951,7 +3951,7 @@ nanoBragg::add_noise()
 }
 // end of add_noise()
 
-double nanoBragg::get_intfile_scale( double intfile_scale) const {
+double nanoBragg::get_intfile_scale(double intfile_scale) const {
     const double* floatimage = raw_pixels.begin();
     double max_value = (double)std::numeric_limits<unsigned short int>::max();
     double saturation = floor(max_value - 1 );

--- a/simtbx/nanoBragg/nanoBragg.cpp
+++ b/simtbx/nanoBragg/nanoBragg.cpp
@@ -3951,6 +3951,39 @@ nanoBragg::add_noise()
 }
 // end of add_noise()
 
+double nanoBragg::get_intfile_scale( double intfile_scale) const {
+    const double* floatimage = raw_pixels.begin();
+    double max_value = (double)std::numeric_limits<unsigned short int>::max();
+    double saturation = floor(max_value - 1 );
+    /* output as ints */
+
+    unsigned short int intimage;
+    double max_I = this-> max_I;
+    double max_I_x = this-> max_I_x;
+    double max_I_y = this-> max_I_y;
+    if(intfile_scale <= 0.0){
+        /* need to auto-scale */
+        int i=0;
+        for(int spixel=0;spixel<spixels;++spixel)
+        {
+            for(int fpixel=0;fpixel<fpixels;++fpixel)
+            {
+                if(i==0 || max_I < floatimage[i])
+                {
+                    max_I = floatimage[i];
+                    max_I_x = fpixel;
+                    max_I_y = spixel;
+                }
+                ++i;
+            }
+        }
+        if(verbose) printf("providing default scaling: max_I = %g @ (%g %g)\n",max_I,max_I_x,max_I_y);
+        intfile_scale = 1.0;
+        if(max_I>0.0) intfile_scale = 55000.0/(max_I);
+    }
+    return intfile_scale;
+}
+
 void
 nanoBragg::to_smv_format_streambuf(boost_adaptbx::python::streambuf & output,
     double intfile_scale, int const&debug_x, int const& debug_y) const {

--- a/simtbx/nanoBragg/nanoBragg.h
+++ b/simtbx/nanoBragg/nanoBragg.h
@@ -582,6 +582,7 @@ class nanoBragg {
 
     /* utility function for outputting an image to examine */
     void to_smv_format(std::string const& fileout, double intfile_scale, int debug_x, int debug_y);
+    double get_intfile_scale(double intfile_scale) const;
     void to_smv_format_streambuf(boost_adaptbx::python::streambuf &, double, int const&, int const&) const;
 };
 

--- a/simtbx/nanoBragg/nanoBragg_ext.cpp
+++ b/simtbx/nanoBragg/nanoBragg_ext.cpp
@@ -1972,6 +1972,9 @@ printf("DEBUG: pythony_stolFbg[1]=(%g,%g)\n",nanoBragg.pythony_stolFbg[1][0],nan
       .def("to_smv_format",&nanoBragg::to_smv_format,
         (arg_("fileout"),arg_("intfile_scale")=0,arg_("debug_x")=-1,arg("debug_y")=-1),
         "interally produce an SMV-format image file on disk from the raw pixel array\nintfile_scale is applied before rounding off to integral pixel values")
+      .def("get_intfile_scale",&nanoBragg::get_intfile_scale,
+        (arg_("intfile_scale")=0),
+        "expose the intfile_scale multiplier to raw pixels that is normally hidden within the to_smv_format interface.\nintfile_scale is applied before rounding off to integral pixel values")
       .def("raw_pixels_unsigned_short_as_python_bytes",&raw_pixels_unsigned_short_as_python_bytes,
         (arg_("intfile_scale")=0,arg_("debug_x")=-1,arg("debug_y")=-1),
         "get the unsigned short raw pixels as a Python bytes object.  Intfile_scale is applied before rounding off to integral pixel values")

--- a/simtbx/nanoBragg/nanoBragg_ext.cpp
+++ b/simtbx/nanoBragg/nanoBragg_ext.cpp
@@ -1970,11 +1970,19 @@ printf("DEBUG: pythony_stolFbg[1]=(%g,%g)\n",nanoBragg.pythony_stolFbg[1][0],nan
        "apply specified Poisson, calibration, flicker and read-out noise to the pixels")
 
       .def("to_smv_format",&nanoBragg::to_smv_format,
-        (arg_("fileout"),arg_("intfile_scale")=0,arg_("debug_x")=-1,arg("debug_y")=-1),
-        "interally produce an SMV-format image file on disk from the raw pixel array\nintfile_scale is applied before rounding off to integral pixel values")
+        (arg_("fileout"),arg_("intfile_scale")=0,arg_("debug_x")=-1,arg_("debug_y")=-1),
+        "write an SMV-format image file to disk from the raw pixel array\n"
+        "intfile_scale: multiplicative factor applied to raw pixels before rounding off to integral pixel values\n"
+        "     intfile_scale > 0 : specify a value for the multiplicative factor\n"
+        "     intfile_scale = 1 : do not apply a factor\n"
+        "     intfile_scale = 0 (default): compute a reasonable scale factor to set max pixel to 55000; same value given by get_intfile_scale()"
+        )
       .def("get_intfile_scale",&nanoBragg::get_intfile_scale,
         (arg_("intfile_scale")=0),
-        "expose the intfile_scale multiplier to raw pixels that is normally hidden within the to_smv_format interface.\nintfile_scale is applied before rounding off to integral pixel values")
+        "expose the intfile_scale multiplier to raw pixels that is normally hidden within the to_smv_format interface.\n"
+        "user can apply the return value to the output pixels using to_smv_format(<value>) or to_cbf(<value>)\n"
+        "     intfile_scale = 0 (default): compute a reasonable scale factor to set max pixel to 55000"
+        )
       .def("raw_pixels_unsigned_short_as_python_bytes",&raw_pixels_unsigned_short_as_python_bytes,
         (arg_("intfile_scale")=0,arg_("debug_x")=-1,arg("debug_y")=-1),
         "get the unsigned short raw pixels as a Python bytes object.  Intfile_scale is applied before rounding off to integral pixel values")

--- a/simtbx/nanoBragg/tst_gauss_argchk.py
+++ b/simtbx/nanoBragg/tst_gauss_argchk.py
@@ -204,6 +204,7 @@ def simple_monochromatic_case(bragg_engine, BEAM, DETECTOR, CRYSTAL, SF_model, a
   SIM.progress_meter=False
   SIM.add_background()
   ref_mean_with_background = flex.mean(SIM.raw_pixels)
+  print ("Ratio",ref_max_bragg/ref_mean_with_background)
   assert ref_max_bragg > 10. * ref_mean_with_background # data must be sensible, Bragg >> solvent
   return SIM
 

--- a/simtbx/nanoBragg/tst_gauss_argchk.py
+++ b/simtbx/nanoBragg/tst_gauss_argchk.py
@@ -230,16 +230,13 @@ if __name__=="__main__":
   SIM.adc_offset_adu=0
   SIM.to_smv_format(fileout="test_full_001.img", intfile_scale=output_scale)
   assert approx_equal(SIM.raw_pixels, SIM2.raw_pixels)
-  SIM.raw_pixels*=output_scale
-  SIM.to_cbf("test_full_001.cbf")
+  SIM.to_cbf("test_full_001.cbf", intfile_scale=output_scale)
 
   if runmode=="GPU":
     bragg_engine = nanoBragg.add_nanoBragg_spots_cuda
     SIM3 = simple_monochromatic_case(bragg_engine, BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False)
-    SIM3.raw_pixels*=output_scale
-    SIM3.to_cbf("test_full_003.cbf")
+    SIM3.to_cbf("test_full_003.cbf", intfile_scale=output_scale)
     SIM4 = simple_monochromatic_case(bragg_engine, BEAM, DETECTOR, CRYSTAL, SF_model, argchk=True)
-    SIM4.raw_pixels*=output_scale
     assert approx_equal(SIM.raw_pixels, SIM3.raw_pixels)
     assert approx_equal(SIM.raw_pixels, SIM4.raw_pixels)
 

--- a/simtbx/nanoBragg/tst_gauss_argchk.py
+++ b/simtbx/nanoBragg/tst_gauss_argchk.py
@@ -172,7 +172,9 @@ class amplitudes:
     #f_model.show_summary()
     return f_model
 
-def simple_monochromatic_case(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False):
+CPU_GPU_Lookup = dict(add_nanoBragg_spots="CPU", add_nanoBragg_spots_cuda="GPU")
+
+def simple_monochromatic_case(bragg_engine, BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False):
   Famp = SF_model.get_amplitudes(at_angstrom=BEAM.get_wavelength())
 
   # do the simulation
@@ -182,12 +184,15 @@ def simple_monochromatic_case(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False):
   SIM.Amatrix = sqr(CRYSTAL.get_A()).transpose()
   SIM.oversample = 2
   if argchk:
-    print("\nmonochromatic case, CPU argchk")
+    print("\nmonochromatic case,",CPU_GPU_Lookup[bragg_engine.__name__],"argchk")
     SIM.xtal_shape = shapetype.Gauss_argchk
   else:
-    print("\nmonochromatic case, CPU no argchk")
+    print("\nmonochromatic case,",CPU_GPU_Lookup[bragg_engine.__name__],"no argchk")
     SIM.xtal_shape = shapetype.Gauss
-  SIM.add_nanoBragg_spots()
+  bragg_engine(SIM) # appropriate add_nanoBragg_spots, either CPU or GPU
+  domains_per_crystal = 5.E10 # put Bragg spots on larger scale relative to background
+  SIM.raw_pixels*=domains_per_crystal
+  ref_max_bragg = flex.max(SIM.raw_pixels) # get the maximum pixel value for a Bragg spot
 
   SIM.Fbg_vs_stol = water
   SIM.amorphous_sample_thick_mm = 0.02
@@ -198,34 +203,8 @@ def simple_monochromatic_case(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False):
   SIM.exposure_s=1.0 # multiplies flux x exposure
   SIM.progress_meter=False
   SIM.add_background()
-  return SIM
-
-def simple_monochromatic_case_GPU(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False):
-  Famp = SF_model.get_amplitudes(at_angstrom=BEAM.get_wavelength())
-
-  # do the simulation
-  SIM = nanoBragg(DETECTOR, BEAM, panel_id=0)
-  SIM.Ncells_abc = (20,20,20)
-  SIM.Fhkl = Famp
-  SIM.Amatrix = sqr(CRYSTAL.get_A()).transpose()
-  SIM.oversample = 2
-  if argchk:
-    print("\nmonochromatic case, GPU argchk")
-    SIM.xtal_shape = shapetype.Gauss_argchk
-  else:
-    print("\nmonochromatic case, GPU no argchk")
-    SIM.xtal_shape = shapetype.Gauss
-  SIM.add_nanoBragg_spots_cuda()
-
-  SIM.Fbg_vs_stol = water
-  SIM.amorphous_sample_thick_mm = 0.02
-  SIM.amorphous_density_gcm3 = 1
-  SIM.amorphous_molecular_weight_Da = 18
-  SIM.flux=1e12
-  SIM.beamsize_mm=0.003 # square (not user specified)
-  SIM.exposure_s=1.0 # multiplies flux x exposure
-  SIM.progress_meter=False
-  SIM.add_background()
+  ref_mean_with_background = flex.mean(SIM.raw_pixels)
+  assert ref_max_bragg > 10. * ref_mean_with_background # data must be sensible, Bragg >> solvent
   return SIM
 
 if __name__=="__main__":
@@ -242,16 +221,24 @@ if __name__=="__main__":
   assert runmode in ["CPU","GPU"]
 
   # Use case 1.  Simple monochromatic X-rays
-  SIM = simple_monochromatic_case(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False)
-  SIM2 = simple_monochromatic_case(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=True)
-  SIM.to_smv_format(fileout="test_full_001.img")
-  SIM.to_cbf("test_full_001.cbf")
+  bragg_engine = nanoBragg.add_nanoBragg_spots
+  SIM = simple_monochromatic_case(bragg_engine, BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False)
+  SIM2 = simple_monochromatic_case(bragg_engine, BEAM, DETECTOR, CRYSTAL, SF_model, argchk=True)
+  output_scale = SIM.get_intfile_scale(intfile_scale=0)
+  #print("The output scale is",output_scale)
+  SIM.adc_offset_adu=0
+  SIM.to_smv_format(fileout="test_full_001.img", intfile_scale=output_scale)
   assert approx_equal(SIM.raw_pixels, SIM2.raw_pixels)
+  SIM.raw_pixels*=output_scale
+  SIM.to_cbf("test_full_001.cbf")
 
   if runmode=="GPU":
-    SIM3 = simple_monochromatic_case_GPU(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False)
+    bragg_engine = nanoBragg.add_nanoBragg_spots_cuda
+    SIM3 = simple_monochromatic_case(bragg_engine, BEAM, DETECTOR, CRYSTAL, SF_model, argchk=False)
+    SIM3.raw_pixels*=output_scale
     SIM3.to_cbf("test_full_003.cbf")
-    SIM4 = simple_monochromatic_case_GPU(BEAM, DETECTOR, CRYSTAL, SF_model, argchk=True)
+    SIM4 = simple_monochromatic_case(bragg_engine, BEAM, DETECTOR, CRYSTAL, SF_model, argchk=True)
+    SIM4.raw_pixels*=output_scale
     assert approx_equal(SIM.raw_pixels, SIM3.raw_pixels)
     assert approx_equal(SIM.raw_pixels, SIM4.raw_pixels)
 

--- a/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
+++ b/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
@@ -113,8 +113,14 @@ SIM.oversample = oversmaple
 SIM.xtal_shape = shapetype.Gauss
 SIM.add_nanoBragg_spots()
 
+# Take note that the CBF writer and SMV writer handle spot scale differently
+output_scale=1.E9
+SIM.adc_offset_adu=0
+smv_filename = "test_full_100.img"
+SIM.to_smv_format(fileout=smv_filename, intfile_scale=output_scale)
 # write the simulation to disk using cbf writer
-cbf_filename = "test_full.cbf"
+SIM.raw_pixels*=output_scale
+cbf_filename = "test_full_100.cbf"
 print("write simulation to disk (%s)" % cbf_filename)
 SIM.to_cbf(cbf_filename)
 
@@ -133,8 +139,14 @@ test_cbf.Amatrix = sqr(CRYSTAL.get_A()).transpose()
 test_cbf.oversample = oversmaple
 test_cbf.xtal_shape = shapetype.Gauss
 test_cbf.add_nanoBragg_spots()
+test_cbf.raw_pixels*=output_scale
 
 # verify test_cbf and SIM produce the same Bragg spot image
 print("Check the intensities haven't changed, and that  cbf writing preserved geometry")
 assert np.allclose(SIM.raw_pixels.as_numpy_array(), test_cbf.raw_pixels.as_numpy_array())
+
+# verify cbf (double) and smv (int) produce the same image to within an ADU
+loader_smv = dxtbx.load(smv_filename)
+assert np.allclose(loader.get_raw_data().as_numpy_array(), loader_smv.get_raw_data().as_numpy_array(), atol=1.1)
+
 print("OK!")

--- a/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
+++ b/simtbx/nanoBragg/tst_nanoBragg_cbf_write.py
@@ -118,11 +118,11 @@ output_scale=1.E9
 SIM.adc_offset_adu=0
 smv_filename = "test_full_100.img"
 SIM.to_smv_format(fileout=smv_filename, intfile_scale=output_scale)
+
 # write the simulation to disk using cbf writer
-SIM.raw_pixels*=output_scale
 cbf_filename = "test_full_100.cbf"
 print("write simulation to disk (%s)" % cbf_filename)
-SIM.to_cbf(cbf_filename)
+SIM.to_cbf(cbf_filename, intfile_scale=output_scale)
 
 # load the CBF from disk
 print("Open file %s using dxtbx" % cbf_filename)


### PR DESCRIPTION
Use an output scale producing visible Bragg spots. Output scale is applied as a function argument to SMV writer But with CBF it is a multiplier to the actual pixels Verify both files (CBF, double) and (SMV, int) have same pixel values to within rounding error.

Run the test with libtbx.python tst_nanoBragg_cbf_write.py
View the two result images with dials.image_viewer test_full_100.*