### PR TITLE
Generalize tst_exafel_api to both cuda and kokkos

### DIFF
--- a/simtbx/gpu/detector.cu
+++ b/simtbx/gpu/detector.cu
@@ -219,10 +219,10 @@ namespace gpu {
   }
 
   void
-  gpu_detector::set_active_pixels_on_GPU(af::shared<int> active_pixel_list_value){
+  gpu_detector::set_active_pixels_on_GPU(af::shared<std::size_t> active_pixel_list_value){
     active_pixel_list = active_pixel_list_value;
     cudaSafeCall(cudaSetDevice(h_deviceID));
-    int * ptr_active_pixel_list = active_pixel_list.begin();
+    std::size_t * ptr_active_pixel_list = active_pixel_list.begin();
     cudaSafeCall(cudaMalloc((void ** )&cu_active_pixel_list, sizeof(*cu_active_pixel_list) * active_pixel_list.size() ));
     cudaSafeCall(cudaMemcpy(cu_active_pixel_list,
                             ptr_active_pixel_list,

--- a/simtbx/gpu/detector.cu
+++ b/simtbx/gpu/detector.cu
@@ -234,16 +234,16 @@ namespace gpu {
   gpu_detector::get_whitelist_raw_pixels(af::shared<std::size_t> selection
   ){
     //return the data array for the multipanel detector case, but only for whitelist pixels
-    af::shared<double> z(active_pixel_list.size(), af::init_functor_null<double>());
+    af::shared<double> z(selection.size(), af::init_functor_null<double>());
     double* begin = z.begin();
     cudaSafeCall(cudaSetDevice(h_deviceID));
     CUDAREAL * cu_active_pixel_results;
     std::size_t * cu_active_pixel_selection;
 
-    cudaSafeCall(cudaMalloc((void ** )&cu_active_pixel_results, sizeof(*cu_active_pixel_results) * active_pixel_list.size() ));
-    cudaSafeCall(cudaMalloc((void ** )&cu_active_pixel_selection, sizeof(*cu_active_pixel_selection) * selection.size() ));
+    cudaSafeCall(cudaMalloc((void ** )&cu_active_pixel_results, sizeof(*cu_active_pixel_results) * z.size() ));
+    cudaSafeCall(cudaMalloc((void ** )&cu_active_pixel_selection, sizeof(*cu_active_pixel_selection) * z.size() ));
     cudaSafeCall(cudaMemcpy(cu_active_pixel_selection,
-                 selection.begin(), sizeof(*cu_active_pixel_selection) * selection.size(),
+                 selection.begin(), sizeof(*cu_active_pixel_selection) * z.size(),
                  cudaMemcpyHostToDevice));
 
     cudaDeviceProp deviceProps = { 0 };
@@ -251,14 +251,14 @@ namespace gpu {
     int smCount = deviceProps.multiProcessorCount;
     dim3 threadsPerBlock(THREADS_PER_BLOCK_X, THREADS_PER_BLOCK_Y);
     dim3 numBlocks(smCount * 8, 1);
-    int total_pixels = active_pixel_list.size();
+    int total_pixels = z.size();
     get_active_pixel_selection_CUDAKernel<<<numBlocks, threadsPerBlock>>>(
-      cu_active_pixel_results, cu_active_pixel_selection, cu_accumulate_floatimage, total_pixels);
+      cu_active_pixel_results, cu_active_pixel_selection, cu_accumulate_floatimage, z.size());
 
     cudaSafeCall(cudaMemcpy(
       begin,
       cu_active_pixel_results,
-      sizeof(*cu_active_pixel_results) * active_pixel_list.size(),
+      sizeof(*cu_active_pixel_results) * z.size(),
       cudaMemcpyDeviceToHost));
     cudaSafeCall(cudaFree(cu_active_pixel_selection));
     cudaSafeCall(cudaFree(cu_active_pixel_results));

--- a/simtbx/gpu/detector.h
+++ b/simtbx/gpu/detector.h
@@ -51,7 +51,7 @@ struct gpu_detector{
   void scale_in_place(const double&);
   void write_raw_pixels(simtbx::nanoBragg::nanoBragg&);
   af::flex_double get_raw_pixels();
-  void set_active_pixels_on_GPU(af::shared<int>);
+  void set_active_pixels_on_GPU(af::shared<std::size_t>);
   af::shared<double> get_whitelist_raw_pixels(af::shared<std::size_t>);
   void each_image_free();
 
@@ -78,8 +78,8 @@ struct gpu_detector{
   CUDAREAL * cu_distance, * cu_Xbeam, * cu_Ybeam;
 
   /* all-panel whitelist of active pixels on GPU */
-  af::shared<int> active_pixel_list;
-  int * cu_active_pixel_list;
+  af::shared<std::size_t> active_pixel_list;
+  std::size_t * cu_active_pixel_list;
 
   packed_metrology const metrology;
   private:

--- a/simtbx/gpu/gpu_ext.cpp
+++ b/simtbx/gpu/gpu_ext.cpp
@@ -97,7 +97,7 @@ namespace simtbx { namespace gpu {
              (arg_("channel_number"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("weight")=1.0),
              "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spot contributions to the detector's accumulator array")
         .def("add_energy_channel_mask_allpanel",
-             static_cast<void (exascale_api::*)(int const&, gpu_energy_channels&, gpu_detector&, af::shared<int> const) >
+             static_cast<void (exascale_api::*)(int const&, gpu_energy_channels&, gpu_detector&, af::shared<std::size_t> const) >
              (&exascale_api::add_energy_channel_mask_allpanel),
              (arg_("channel_number"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("pixel_active_list_ints")),
              "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels\n"

--- a/simtbx/gpu/gpu_ext.cpp
+++ b/simtbx/gpu/gpu_ext.cpp
@@ -94,6 +94,7 @@ namespace simtbx { namespace gpu {
              "Allocate and transfer input data on the GPU")
         .def("add_energy_channel_from_gpu_amplitudes",
              &simtbx::gpu::exascale_api::add_energy_channel_from_gpu_amplitudes,
+             (arg_("channel_number"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("weight")=1.0),
              "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spot contributions to the detector's accumulator array")
         .def("add_energy_channel_mask_allpanel",
              static_cast<void (exascale_api::*)(int const&, gpu_energy_channels&, gpu_detector&, af::shared<int> const) >

--- a/simtbx/gpu/simulation.cu
+++ b/simtbx/gpu/simulation.cu
@@ -167,7 +167,7 @@ namespace af = scitbx::af;
   ){
         // here or there, need to convert the all_panel_mask (3D map) into a 1D list of accepted pixels
         // coordinates for the active pixel list are absolute offsets into the detector array
-        af::shared<int> active_pixel_list;
+        af::shared<std::size_t> active_pixel_list;
         const bool* jptr = all_panel_mask.begin();
         for (int j=0; j < all_panel_mask.size(); ++j){
           if (jptr[j]) {
@@ -183,7 +183,7 @@ namespace af = scitbx::af;
     int const& ichannel,
     simtbx::gpu::gpu_energy_channels & gec,
     simtbx::gpu::gpu_detector & gdt,
-    af::shared<int> const active_pixel_list
+    af::shared<std::size_t> const active_pixel_list
   ){
         cudaSafeCall(cudaSetDevice(SIM.device_Id));
 

--- a/simtbx/gpu/simulation.cuh
+++ b/simtbx/gpu/simulation.cuh
@@ -59,7 +59,7 @@ __global__ void debranch_maskall_CUDAKernel(int npanels, int spixels, int fpixel
     const CUDAREAL * __restrict__ Fhkl, const hklParams * __restrict__ FhklParams,
     int nopolar, const CUDAREAL * __restrict__ polar_vector,
     CUDAREAL polarization, CUDAREAL fudge,
-    const int * __restrict__ pixel_lookup,
+    const std::size_t * __restrict__ pixel_lookup,
     float * floatimage /*out*/, float * omega_reduction/*out*/,
     float * max_I_x_reduction/*out*/, float * max_I_y_reduction /*out*/, bool * rangemap) {
         __shared__ int s_vec_len;

--- a/simtbx/gpu/simulation.cuh
+++ b/simtbx/gpu/simulation.cuh
@@ -339,6 +339,7 @@ __global__ void add_array_CUDAKernel(double * lhs, float * rhs, int array_size){
       pixIdx < total_pixels; pixIdx += stride) {
     const int j = pixIdx; /* position in pixel array */
     lhs[j] = lhs[j] + (double)rhs[j]; // specifically add low precision to high precision array
+    rhs[j] = 0; // reset deepest array for next calculation
     }
   }
 

--- a/simtbx/gpu/simulation.h
+++ b/simtbx/gpu/simulation.h
@@ -20,7 +20,8 @@ struct exascale_api {
   void show();
   void add_energy_channel_from_gpu_amplitudes(int const&,
     simtbx::gpu::gpu_energy_channels &,
-    simtbx::gpu::gpu_detector &
+    simtbx::gpu::gpu_detector &,
+    double const&
   );
   void add_energy_channel_mask_allpanel(int const&,
     simtbx::gpu::gpu_energy_channels &,

--- a/simtbx/gpu/simulation.h
+++ b/simtbx/gpu/simulation.h
@@ -31,7 +31,7 @@ struct exascale_api {
   void add_energy_channel_mask_allpanel(int const&,
     simtbx::gpu::gpu_energy_channels &,
     simtbx::gpu::gpu_detector &,
-    af::shared<int> const
+    af::shared<std::size_t> const
   );
   void add_background(simtbx::gpu::gpu_detector &, int const&);
   void allocate();

--- a/simtbx/gpu/tst_shoeboxes.py
+++ b/simtbx/gpu/tst_shoeboxes.py
@@ -115,7 +115,7 @@ class whitelist_case(several_wavelength_case):
         print("USE_WHITELIST(pixel_address)_API+++++++++++++ Wavelength %d=%.6f, Flux %.6e, Fluence %.6e"%(
             x, SIM.wavelength_A, SIM.flux, SIM.fluence))
         gpu_simulation.add_energy_channel_mask_allpanel(
-            x, gpu_channels_singleton, gpu_detector, positive_mask.iselection().as_int())
+            x, gpu_channels_singleton, gpu_detector, positive_mask.iselection())
         per_image_scale_factor = self.domains_per_crystal # 1.0
         gpu_detector.scale_in_place(per_image_scale_factor) # apply scale directly on GPU
         positive_mask_int_pixels = gpu_detector.get_raw_pixels()
@@ -125,7 +125,7 @@ class whitelist_case(several_wavelength_case):
         print("USE_WHITELIST(pixel_address)_API+++++++++++++ Wavelength %d=%.6f, Flux %.6e, Fluence %.6e"%(
             x, SIM.wavelength_A, SIM.flux, SIM.fluence))
         gpu_simulation.add_energy_channel_mask_allpanel(
-            x, gpu_channels_singleton, gpu_detector, negative_mask.iselection().as_int())
+            x, gpu_channels_singleton, gpu_detector, negative_mask.iselection())
       gpu_detector.scale_in_place(per_image_scale_factor) # apply scale directly on GPU
       negative_mask_int_pixels = gpu_detector.get_raw_pixels()
       gpu_detector.scale_in_place(0) # reset

--- a/simtbx/gpu/tst_shoeboxes.py
+++ b/simtbx/gpu/tst_shoeboxes.py
@@ -1,0 +1,219 @@
+"""
+Extend the previous tests
+Implemented unit tests for the whitelist mechanism:
+     7) implement shoebox masks and resulting mask
+     8) 3-wavelength, use add_energy_channel_mask_allpanel, use all-pixel int mask (equate 3,8)
+     9) 3-wavelength, use add_energy_channel_mask_allpanel, use all-pixel bool mask (equate 3,9)
+Unit test strategy:
+Do a reference simulation with monochromatic beam.  Use dials to find strong spots.
+Then construct two masks:  the positive mask just on the strong spot shoeboxes,
+                       and the negative mask on all other pixels, including weak tails, weak spots, and background.
+Then do two Bragg spot whitelist calls: one on tne positve mask, one on the negative mask.
+A test image consisting of the sum of background + positive mask values + negative mask values should equal the reference image.
+Furthermore, the result should be the same for either type of whitelist: bool array or integer addresses.
+The GPU classes required modification for this to work, specifically the deepest array had to
+be reinitialized after each Bragg calculation.
+"""
+from __future__ import absolute_import, division, print_function
+import numpy as np
+from dials.array_family import flex
+from scitbx.matrix import sqr
+from simtbx.gpu.tst_unified import several_wavelength_case
+from simtbx.nanoBragg.tst_gauss_argchk import water, basic_crystal, basic_beam, basic_detector, amplitudes
+from simtbx import get_exascale
+from simtbx.nanoBragg import nanoBragg, shapetype
+
+def _dials_phil_str():
+    return """
+  include scope dials.algorithms.spot_finding.factory.phil_scope
+"""
+def spots_params():
+  from iotbx.phil import parse
+  dials_phil_str = _dials_phil_str()
+  master_phil="""
+    context = kokkos_gpu *cuda
+      .type = choice
+      .optional = False
+      .help = backend for parallel execution
+  output {
+    shoeboxes = True
+      .type = bool
+      .help = Save the raw pixel values inside the reflection shoeboxes during spotfinding.
+  }
+  """
+  phil_scope = parse(master_phil + dials_phil_str, process_includes=True)
+  # The script usage
+  import libtbx.load_env # implicit import
+  from dials.util.options import ArgumentParser
+  # Create the parser
+  parser = ArgumentParser(usage="",phil=phil_scope, epilog="")
+  # Parse the command line. quick_parse is required for MPI compatibility
+  params, options = parser.parse_args(show_diff_phil=True,quick_parse=True)
+  return params, options
+
+class whitelist_case(several_wavelength_case):
+  def extensions_for_shoebox_usage(self, params, argchk=False, gpu_background=True, sources=False):
+    gpu_channels_type = get_exascale("gpu_energy_channels",params.context)
+    gpu_channels_singleton = gpu_channels_type (deviceId = 0)
+
+    SIM = nanoBragg(self.DETECTOR, self.BEAM, panel_id=0)
+    SIM.adc_offset_adu=0
+    SIM.device_Id = 0
+
+    assert gpu_channels_singleton.get_deviceID()==SIM.device_Id # API test
+    assert gpu_channels_singleton.get_nchannels() == 0 # uninitialized
+    for x in range(len(self.flux)):
+          gpu_channels_singleton.structure_factors_to_GPU_direct(
+           x, self.sfall_channels[x].indices(), self.sfall_channels[x].data())
+    assert gpu_channels_singleton.get_nchannels() == len(self.flux) #API test
+    SIM.Ncells_abc = (20,20,20)
+    SIM.Amatrix = sqr(self.CRYSTAL.get_A()).transpose()
+    SIM.oversample = 2
+    SIM.xtal_shape = shapetype.Gauss
+    SIM.interpolate = 0
+    # allocate GPU arrays
+    gpu_simulation = get_exascale("exascale_api",params.context)(nanoBragg = SIM)
+    gpu_simulation.allocate()
+    gpu_detector = get_exascale("gpu_detector",params.context)(
+                 deviceId=SIM.device_Id, detector=self.DETECTOR, beam=self.BEAM)
+    gpu_detector.each_image_allocate()
+    assert sources is False # original exascale API, explicit energy loop in Python
+
+    for x in range(len(self.flux)):
+        SIM.wavelength_A = self.wavlen[x]
+        print("USE_WHITELIST(bool)_API+++++++++++++ Wavelength %d=%.6f, Flux %.6e, Fluence %.6e"%(
+            x, SIM.wavelength_A, SIM.flux, SIM.fluence))
+        gpu_simulation.add_energy_channel_mask_allpanel(
+            x, gpu_channels_singleton, gpu_detector, positive_mask.as_1d())
+            #weight = self.frac[x])
+    per_image_scale_factor = self.domains_per_crystal # 1.0
+    gpu_detector.scale_in_place(per_image_scale_factor) # apply scale directly on GPU
+    positive_mask_bool_pixels = gpu_detector.get_raw_pixels()
+    gpu_detector.scale_in_place(0) # reset
+    """ explanation:  There are two arrays on device
+    m_floatimage is the deepest one, that adds up bragg spots for each simulation call
+    m_accumulate_floatimage is incremented by m_floatimage in the add_array(), only at the end of each simulation call
+    the scale_in_place(0) only resets the shallow array (m_accumulate_floatimage)
+    the deeper array (m_floatimage) could only be zeroed previously by the deallocate/allocate cycle
+    instead, propose changing the add_array() kernel so that it does two jobs:
+      1) add the deep array (m_floatimage) to the shallow (which is the current behavior)
+      2) zero out the deep array (new behavior, should fix problem)
+    """
+    for x in range(len(self.flux)):
+        SIM.wavelength_A = self.wavlen[x]
+        print("USE_WHITELIST(bool)_API+++++++++++++ Wavelength %d=%.6f, Flux %.6e, Fluence %.6e"%(
+            x, SIM.wavelength_A, SIM.flux, SIM.fluence))
+        gpu_simulation.add_energy_channel_mask_allpanel(
+            x, gpu_channels_singleton, gpu_detector, negative_mask.as_1d())
+    gpu_detector.scale_in_place(per_image_scale_factor) # apply scale directly on GPU
+    negative_mask_bool_pixels = gpu_detector.get_raw_pixels()
+    gpu_detector.scale_in_place(0) # reset
+
+    if True: # insert tests here, for the integer-address whitelist interface
+      for x in range(len(self.flux)):
+        SIM.wavelength_A = self.wavlen[x]
+        print("USE_WHITELIST(pixel_address)_API+++++++++++++ Wavelength %d=%.6f, Flux %.6e, Fluence %.6e"%(
+            x, SIM.wavelength_A, SIM.flux, SIM.fluence))
+        gpu_simulation.add_energy_channel_mask_allpanel(
+            x, gpu_channels_singleton, gpu_detector, positive_mask.iselection().as_int())
+        per_image_scale_factor = self.domains_per_crystal # 1.0
+        gpu_detector.scale_in_place(per_image_scale_factor) # apply scale directly on GPU
+        positive_mask_int_pixels = gpu_detector.get_raw_pixels()
+      gpu_detector.scale_in_place(0) # reset
+      for x in range(len(self.flux)):
+        SIM.wavelength_A = self.wavlen[x]
+        print("USE_WHITELIST(pixel_address)_API+++++++++++++ Wavelength %d=%.6f, Flux %.6e, Fluence %.6e"%(
+            x, SIM.wavelength_A, SIM.flux, SIM.fluence))
+        gpu_simulation.add_energy_channel_mask_allpanel(
+            x, gpu_channels_singleton, gpu_detector, negative_mask.iselection().as_int())
+      gpu_detector.scale_in_place(per_image_scale_factor) # apply scale directly on GPU
+      negative_mask_int_pixels = gpu_detector.get_raw_pixels()
+      gpu_detector.scale_in_place(0) # reset
+      assert np.allclose(positive_mask_int_pixels, positive_mask_bool_pixels) # either API gives same answer (int vs. bool)
+      assert np.allclose(negative_mask_int_pixels, negative_mask_bool_pixels)
+
+    SIM.wavelength_A = self.BEAM.get_wavelength() # return to canonical energy for subsequent background
+    SIM.Fbg_vs_stol = water
+    SIM.amorphous_sample_thick_mm = 0.02
+    SIM.amorphous_density_gcm3 = 1
+    SIM.amorphous_molecular_weight_Da = 18
+    SIM.flux=1e12
+    SIM.beamsize_mm=0.003 # square (not user specified)
+    SIM.exposure_s=1.0 # multiplies flux x exposure
+    gpu_simulation.add_background(gpu_detector)
+    """Problem statement (before the GPU code was modified)
+with pos first
+pos -> back + pos
+neg -> back + neg + pos
+both-> back + neg + 2*pos
+
+with neg first
+pos -> back + neg + pos
+neg -> back + neg
+both-> back + 2*neg + pos
+
+"""
+    gpu_detector.write_raw_pixels(SIM)  # updates SIM.raw_pixels from GPU
+    gpu_detector.each_image_free()
+    SIM.raw_pixels += positive_mask_bool_pixels
+    SIM.raw_pixels += negative_mask_bool_pixels
+    return SIM
+
+if __name__=="__main__":
+  params,options = spots_params()
+  # make the dxtbx objects
+  BEAM = basic_beam()
+  DETECTOR = basic_detector()
+  CRYSTAL = basic_crystal()
+  SF_model = amplitudes(CRYSTAL)
+  # Famp = SF_model.Famp # simple uniform amplitudes
+  SF_model.random_structure(CRYSTAL)
+  SF_model.ersatz_correct_to_P1()
+
+  # Initialize based on GPU context
+  gpu_instance_type = get_exascale("gpu_instance", params.context)
+  gpu_instance = gpu_instance_type(deviceId = 0)
+
+  print("\n# Use case 1 (%s). Monochromatic source"%params.context)
+  SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=flex.double([1.]))
+  SIM1 = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True)
+  scale = SIM1.get_intfile_scale() # case 1 is the overall scale factor to write all result files
+  SIM1.to_cbf("test_shoebox_%s_001.cbf"%(params.context), intfile_scale=scale)
+  SIM1.raw_pixels *= scale # temporarily set to intfile_scale for spotfinder
+  from dxtbx.model.experiment_list import (
+    Experiment,
+    ExperimentList,
+    ExperimentListFactory,
+  )
+  experiments = ExperimentListFactory.from_imageset_and_crystal(SIM1.imageset, CRYSTAL)
+
+  # Find the strong spots
+  observed = flex.reflection_table.from_observations(experiments, params, is_stills=True)
+  observed.as_file("test_shoebox_%s_001.refl"%(params.context))
+  SIM1.raw_pixels /= scale # reset from intfile_scale after spotfinder
+  # Find the positive mask
+  image_grid = flex.grid(SIM1.raw_pixels.focus())
+  positive_mask = flex.bool(image_grid, False)
+
+  imask = SIM1.imageset.get_mask(0)
+  for x in range(len(observed)):
+    fast1, fast2, slow1, slow2, z1, z2 = observed["bbox"][x]
+    for slow in range(slow1,slow2):
+      for fast in range(fast1,fast2):
+        positive_mask[(slow,fast)]=True
+  negative_mask=~positive_mask
+  import pickle
+  with open("test_shoebox_%s_001.mask"%(params.context),"wb") as M:
+    pickle.dump([positive_mask], M)
+  with open("test_shoebox_%s_002.mask"%(params.context),"wb") as M:
+    pickle.dump([negative_mask], M)
+
+  print("\n# Use case 2 (%s). Pixel masks."%params.context)
+  print(positive_mask.count(True), negative_mask.count(True), len(positive_mask))
+  WC = whitelist_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=flex.double([1.]))
+  SIM3 = WC.extensions_for_shoebox_usage(params=params, argchk=False, gpu_background=True)
+  SIM3.to_cbf("test_shoebox_%s_003.cbf"%(params.context), intfile_scale=scale)
+
+  assert np.allclose(SIM1.raw_pixels, SIM3.raw_pixels) # reassembly equates with original image
+
+print("OK")

--- a/simtbx/gpu/tst_unified.py
+++ b/simtbx/gpu/tst_unified.py
@@ -147,7 +147,7 @@ class several_wavelength_case:
             ichannels = flex.int(range(len(self.flux))),
             gpu_amplitudes = gpu_channels_singleton,
             gpu_detector = gpu_detector,
-            pixel_active_list_ints = flex.int(range(NN)),
+            pixel_active_list_ints = flex.size_t(range(NN)),
             weights = self.frac/len(self.frac)
       )
     per_image_scale_factor = self.domains_per_crystal # 1.0

--- a/simtbx/gpu/tst_unified.py
+++ b/simtbx/gpu/tst_unified.py
@@ -8,11 +8,12 @@ Test 0) use monochromatic interface to generate a background-only pattern as ref
      3) exafel api interface, GPU background,  3-wavelength, use add_energy_channel_from_gpu_amplitudes
      4) exafel api interface, GPU background,  3-wavelength, use add_energy_multichannel_mask_allpanel (equate 3,4)
      5-6) verify the get_whitelist_raw_pixels API
-Not implemented yet:
+Moved to tst_shoeboxes:
      7) implement shoebox masks and resulting mask
      8) 3-wavelength, use add_energy_channel_mask_allpanel, use all-pixel int mask (equate 3,8)
      9) 3-wavelength, use add_energy_channel_mask_allpanel, use all-pixel bool mask (equate 3,9)
 Not implemented yet: multipanel detector, write to .h5 file
+                     also implement with 3-color, not just mono, thus forcing weights
      10) 3-wavelength, use add_energy_multichannel_mask_allpanel, use all-pixel int mask (equate 3,10)
      11) 3-wavelength, use add_energy_multichannel_mask_allpanel, use whitelist
 """

--- a/simtbx/gpu/tst_unified.py
+++ b/simtbx/gpu/tst_unified.py
@@ -1,0 +1,290 @@
+"""
+Extend the previous tests in tst_gauss_argchk, tst_exafel_api, tst_kokkos_lib
+New tests provide a context flag to exercise either cuda or kokkos_gpu
+New tests implement a multipanel detector, not monolithic
+Test 0) use monochromatic interface to generate a background-only pattern as reference
+     1) exafel api interface, GPU background, monochromatic, use add_energy_channel_from_gpu_amplitudes
+     2) exafel api interface, GPU background, monochromatic, use add_energy_multichannel_mask_allpanel (equate 1,2)
+     3) exafel api interface, GPU background,  3-wavelength, use add_energy_channel_from_gpu_amplitudes
+     4) exafel api interface, GPU background,  3-wavelength, use add_energy_multichannel_mask_allpanel (equate 3,4)
+Not implemented yet:
+     5) implement shoebox masks and verify the get_whitelist_raw_pixels API
+     6) 3-wavelength, use add_energy_channel_mask_allpanel, use all-pixel int mask (equate 3,6)
+     7) 3-wavelength, use add_energy_channel_mask_allpanel, use all-pixel bool mask (equate 3,7)
+Not implemented yet: multipanel detector, write to .h5 file
+     8) 3-wavelength, use add_energy_multichannel_mask_allpanel, use all-pixel int mask (equate 3,8)
+     9) 3-wavelength, use add_energy_multichannel_mask_allpanel, use whitelist
+"""
+from __future__ import absolute_import, division, print_function
+import numpy as np
+import dxtbx
+from scitbx.array_family import flex
+from dxtbx_model_ext import flex_Beam
+from scitbx.matrix import sqr
+from simtbx.nanoBragg import nanoBragg, shapetype
+from simtbx.nanoBragg.tst_gauss_argchk import water, basic_crystal, basic_beam, basic_detector, amplitudes
+from simtbx import get_exascale
+from dxtbx.model.beam import BeamFactory
+import math
+from scitbx.math import five_number_summary
+
+def parse_input():
+  from iotbx.phil import parse
+  master_phil="""
+    context = kokkos_gpu *cuda
+      .type = choice
+      .optional = False
+      .help = backend for parallel execution
+  """
+  phil_scope = parse(master_phil)
+  # The script usage
+  import libtbx.load_env # implicit import
+  from dials.util.options import ArgumentParser
+  # Create the parser
+  parser = ArgumentParser(
+        usage="\n libtbx.python tst_unified_api context=[kokkos_gpu|cuda]",
+        phil=phil_scope,
+        epilog="test monolithic detector, three-energy beam, cuda vs. kokkos")
+  # Parse the command line. quick_parse is required for MPI compatibility
+  params, options = parser.parse_args(show_diff_phil=True,quick_parse=True)
+  return params,options
+
+class several_wavelength_case:
+  def __init__(self, BEAM, DETECTOR, CRYSTAL, SF_model, weights):
+    SIM = nanoBragg(DETECTOR, BEAM, panel_id=0)
+    nchannels = len(weights)
+    assert nchannels in [1,3]
+    if nchannels==1:
+      print("\nassume monochromatic")
+      self.wavlen = flex.double([BEAM.get_wavelength()])
+    else:
+      print("\nassume three energy channels")
+      self.wavlen = flex.double([BEAM.get_wavelength()-0.02, BEAM.get_wavelength(), BEAM.get_wavelength()+0.02])
+    self.frac = weights
+    self.flux = self.frac*SIM.flux
+
+    self.sfall_channels = {}
+    for x in range(len(self.wavlen)):
+      self.sfall_channels[x] = SF_model.get_amplitudes(at_angstrom = self.wavlen[x])
+    self.DETECTOR = DETECTOR
+    self.BEAM = BEAM
+    self.CRYSTAL = CRYSTAL
+    self.domains_per_crystal = 5.E10 # put Bragg spots on larger scale relative to background
+
+  def set_pythony_beams(self,SIM): # for the multiwavelength case with use of multiple nanoBragg sources
+    pythony_beams = flex_Beam()
+    for x in range(len(self.flux)):
+      beam_descr = {'direction': (0.0, 0.0, 1.0),
+             'divergence': 0.0,
+             'flux': 1e11,
+             'polarization_fraction': 1.,
+             'polarization_normal': (0.0, 1.0, 0.0),
+             'sigma_divergence': 0.0,
+             'transmission': 1.0,
+             'wavelength': self.wavlen[x]/1.e10} # not sure why this has to be in meters
+      pythony_beams.append(BeamFactory.from_dict(beam_descr))
+    SIM.xray_beams = pythony_beams
+
+  def reset_pythony_beams(self,SIM): # for mono-wavelength addition of background
+    pythony_beams = flex_Beam()
+    beam_descr = {'direction': (0.0, 0.0, 1.0),
+             'divergence': 0.0,
+             'flux': 1e12,
+             'polarization_fraction': 1.,
+             'polarization_normal': (0.0, 1.0, 0.0),
+             'sigma_divergence': 0.0,
+             'transmission': 1.0,
+             'wavelength': BEAM.get_wavelength()/1.e10} # not sure why this has to be in meters
+    pythony_beams.append(BeamFactory.from_dict(beam_descr))
+    SIM.xray_beams = pythony_beams
+
+  def modularized_exafel_api_for_GPU(self, params, argchk=False, gpu_background=True, sources=False):
+    gpu_channels_type = get_exascale("gpu_energy_channels",params.context)
+    gpu_channels_singleton = gpu_channels_type (deviceId = 0)
+
+    SIM = nanoBragg(self.DETECTOR, self.BEAM, panel_id=0)
+    SIM.adc_offset_adu=0
+    SIM.device_Id = 0
+
+    assert gpu_channels_singleton.get_deviceID()==SIM.device_Id # API test
+    assert gpu_channels_singleton.get_nchannels() == 0 # uninitialized
+    for x in range(len(self.flux)):
+          gpu_channels_singleton.structure_factors_to_GPU_direct(
+           x, self.sfall_channels[x].indices(), self.sfall_channels[x].data())
+    assert gpu_channels_singleton.get_nchannels() == len(self.flux) #API test
+    SIM.Ncells_abc = (20,20,20)
+    SIM.Amatrix = sqr(self.CRYSTAL.get_A()).transpose()
+    SIM.oversample = 2
+    SIM.xtal_shape = shapetype.Gauss
+    SIM.interpolate = 0
+    # allocate GPU arrays
+    gpu_simulation = get_exascale("exascale_api",params.context)(nanoBragg = SIM)
+    gpu_simulation.allocate()
+    gpu_detector = get_exascale("gpu_detector",params.context)(
+                 deviceId=SIM.device_Id, detector=self.DETECTOR, beam=self.BEAM)
+    gpu_detector.each_image_allocate()
+    # gpu_detector.show_summary()
+
+    # two completely independent interfaces to loop over energies
+    if sources is False: # original exascale API, explicit energy loop in Python
+      for x in range(len(self.flux)):
+        SIM.wavelength_A = self.wavlen[x]
+        print("USE_EXASCALE_API+++++++++++++ Wavelength %d=%.6f, Flux %.6e, Fluence %.6e"%(
+            x, SIM.wavelength_A, SIM.flux, SIM.fluence))
+        gpu_simulation.add_energy_channel_from_gpu_amplitudes(
+            x, gpu_channels_singleton, gpu_detector,
+            weight = self.frac[x])
+    else: # loop in C++; precludes using sources for divergence; uses sources from nanoBragg table
+      self.set_pythony_beams(SIM)
+      NN = 0 # compute the number of pixels
+      for panel in self.DETECTOR:
+          sz = panel.get_image_size()
+          NN += sz[0]*sz[1]
+      gpu_simulation.add_energy_multichannel_mask_allpanel(
+            ichannels = flex.int(range(len(self.flux))),
+            gpu_amplitudes = gpu_channels_singleton,
+            gpu_detector = gpu_detector,
+            pixel_active_list_ints = flex.int(range(NN)),
+            weights = self.frac/len(self.frac)
+      )
+    per_image_scale_factor = self.domains_per_crystal # 1.0
+    gpu_detector.scale_in_place(per_image_scale_factor) # apply scale directly on GPU
+    if sources is False:
+      SIM.wavelength_A = self.BEAM.get_wavelength() # return to canonical energy for subsequent background
+    else:
+      self.reset_pythony_beams(SIM)
+    SIM.Fbg_vs_stol = water
+    SIM.amorphous_sample_thick_mm = 0.02
+    SIM.amorphous_density_gcm3 = 1
+    SIM.amorphous_molecular_weight_Da = 18
+    SIM.flux=1e12
+    SIM.beamsize_mm=0.003 # square (not user specified)
+    SIM.exposure_s=1.0 # multiplies flux x exposure
+    gpu_simulation.add_background(gpu_detector)
+
+    # deallocate GPU arrays afterward
+    gpu_detector.write_raw_pixels(SIM)  # updates SIM.raw_pixels from GPU
+    self.data_array = gpu_detector.get_raw_pixels()
+    assert self.data_array.focus()[0] == len(self.DETECTOR) # number of panels
+    if len(self.DETECTOR) == 1: # if one panel, we can assert data are the same both ways
+      single_size = self.data_array.focus()[1:3]
+      self.data_array.reshape(flex.grid((single_size[0],single_size[1])))
+      assert np.allclose(SIM.raw_pixels, self.data_array)
+    gpu_detector.each_image_free()
+    return SIM
+
+if __name__=="__main__":
+  params,options = parse_input()
+  # make the dxtbx objects
+  BEAM = basic_beam()
+  DETECTOR = basic_detector()
+  CRYSTAL = basic_crystal()
+  SF_model = amplitudes(CRYSTAL)
+  # Famp = SF_model.Famp # simple uniform amplitudes
+  SF_model.random_structure(CRYSTAL)
+  SF_model.ersatz_correct_to_P1()
+
+  # Initialize based on GPU context
+  gpu_instance_type = get_exascale("gpu_instance", params.context)
+  gpu_instance = gpu_instance_type(deviceId = 0)
+
+  print("\n# Use case 0 (%s). Background only"%params.context)
+  SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=flex.double([0.]))
+  SIM0 = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True)
+
+  print("\n# Use case 1 (%s). Monochromatic source"%params.context)
+  SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=flex.double([1.]))
+  SIM1 = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True)
+  scale = SIM1.get_intfile_scale() # case 1 is the overall scale factor to write all result files
+  SIM1.to_cbf("test_unified_%s_001.cbf"%(params.context), intfile_scale=scale)
+  SIM0.to_cbf("test_unified_%s_000.cbf"%(params.context), intfile_scale=scale)
+
+  background_pixels = scale * SIM0.raw_pixels.as_1d()
+  mean_background_pixel = flex.mean(background_pixels)
+  print("mean",mean_background_pixel,"on",len(background_pixels))
+  print("five number summary",five_number_summary(background_pixels))
+
+  bragg_pixels_whole_image = (scale * (SIM1.raw_pixels - SIM0.raw_pixels).as_1d())
+  bragg_pixels_only = bragg_pixels_whole_image.select(bragg_pixels_whole_image > 1.)
+  print("mean",flex.mean(bragg_pixels_only),"on",len(bragg_pixels_only))
+  print("five number summary",five_number_summary(bragg_pixels_only))
+  # require the max Bragg peak to be 100x greater than the mean background
+  assert flex.max(bragg_pixels_only) > 100. * mean_background_pixel
+
+  multiple = 8.
+  SWC_mult = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=flex.double([multiple]))
+  SIM1_mult = SWC_mult.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True)
+  # Bragg spot intensity should scale exactly with weight, using add_energy_channel_from_gpu_amplitudes
+  assert np.allclose( (SIM1_mult.raw_pixels - SIM0.raw_pixels), multiple*(SIM1.raw_pixels - SIM0.raw_pixels) )
+
+  if "kokkos" in params.context:
+    print("\n# Use case 2 (%s). Monochromatic source"%params.context)#"sources=True": use multichannel API
+    SIM2 = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True, sources=True)
+    SIM2.to_cbf("test_unified_%s_002.cbf"%(params.context), intfile_scale=scale)
+  # Bragg spot intensity should scale exactly with weight, using multichannel API
+    assert np.allclose(SIM1.raw_pixels, SIM2.raw_pixels) # equate monochromatic, two Bragg interfaces
+
+  # Use explicitly 3-color code and equate with explicitly 1-color:
+  print ("\n Equate background")
+  weights = flex.double([(0./6.), (0./6.), (0./6.)]) # background only shot
+  SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=weights)
+  SIM_ctrl_py = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True)
+  assert np.allclose(SIM_ctrl_py.raw_pixels, SIM0.raw_pixels) # equate background
+  if "kokkos" in params.context:
+    SIM_ctrl_nb = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True, sources=True)
+    assert np.allclose(SIM_ctrl_nb.raw_pixels, SIM0.raw_pixels) # equate background
+
+  print ("\n Equate 1-color")
+  weights = flex.double([(0./6.), (6./6.), (0./6.)]) # implicitly one color
+  SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=weights)
+  SIM_ctrl_py = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True)
+  assert np.allclose(SIM_ctrl_py.raw_pixels, SIM1.raw_pixels) # equate one color
+  if "kokkos" in params.context:
+    SIM_ctrl_nb = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True, sources=True)
+    assert np.allclose(SIM_ctrl_nb.raw_pixels, SIM1.raw_pixels) # equate one color
+
+  print ("\n Equate 2-color")
+  weights = flex.double([(3./6.), (0./6.), (3./6.)]) # two color simulation with 3 explicit channels
+  SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=weights)
+  SIM_ctrl_py = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True)
+  SIM_ctrl_py.to_cbf("test_unified_%s_ctrl2_002.cbf"%(params.context), intfile_scale=scale)
+  if "kokkos" in params.context:
+    SIM_ctrl_nb = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True, sources=True)
+    assert np.allclose(SIM_ctrl_nb.raw_pixels, SIM_ctrl_py.raw_pixels) # equate two color with 2 different APIs
+
+  # Controls
+  # flux in 1:3:2 ratio
+  # flux in 2:3:1 ratio
+  print("\n# Use case 3 (%s). 3-Color"%params.context)
+  weights = flex.double([(1./6.), (3./6.), (2./6.)]) # three color simulation slightly biased toward lower energy
+  SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=weights)
+  SIM3 = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True)
+  SIM3.to_cbf("test_unified_%s_003.cbf"%(params.context), intfile_scale=scale)
+  if "kokkos" in params.context:
+    print("\n# Use case 4 (%s). 3-Color"%params.context)
+    SIM4 = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True, sources=True)
+    SIM4.to_cbf("test_unified_%s_004.cbf"%(params.context), intfile_scale=scale)
+    assert np.allclose(SIM3.raw_pixels, SIM4.raw_pixels) # equate three color with 2 different APIs
+
+  print("\n# Use case 3a (%s). 3-Color with bias toward high energy"%params.context)
+  weights = flex.double([(2./6.), (3./6.), (1./6.)]) # three color simulation slightly biased toward higher energy
+  SWC = several_wavelength_case(BEAM, DETECTOR, CRYSTAL, SF_model, weights=weights)
+  SIM3a = SWC.modularized_exafel_api_for_GPU(params=params, argchk=False, gpu_background=True)
+  SIM3a.to_cbf("test_unified_%s_103.cbf"%(params.context), intfile_scale=scale)
+
+  # Now evaluate Bragg spots' radius of gyration (lower energy should be higher radius)
+  low_energy_px = (scale*(SIM3.raw_pixels-SIM0.raw_pixels)).as_numpy_array()
+  hi_energy_px = (scale*(SIM3a.raw_pixels-SIM0.raw_pixels)).as_numpy_array()
+  xpts = np.array(range(low_energy_px.shape[0]))
+  ypts = np.array(range(low_energy_px.shape[1]))
+  X2D, Y2D = np.meshgrid(xpts,ypts)
+  # center of mass = sum(mass * position) / sum(mass)
+  center_of_mass_xy = (low_energy_px.shape[0]/2., low_energy_px.shape[1]/2.)
+  # radius of gyration sq = sum(mass * (r_sq from com)) / sum(mass)
+  lo_rg_sq = ( np.sum(low_energy_px * ((X2D-center_of_mass_xy[0])**2 + (Y2D-center_of_mass_xy[1])**2))/np.sum(low_energy_px)  )
+  hi_rg_sq = ( np.sum(hi_energy_px * ((X2D-center_of_mass_xy[0])**2 + (Y2D-center_of_mass_xy[1])**2))/np.sum(hi_energy_px)  )
+  print("low energy radius of gyration",math.sqrt(lo_rg_sq))
+  print("hi energy radius of gyration",math.sqrt(hi_rg_sq))
+  assert lo_rg_sq > hi_rg_sq
+
+print("OK")

--- a/simtbx/kokkos/detector.cpp
+++ b/simtbx/kokkos/detector.cpp
@@ -198,22 +198,9 @@ namespace simtbx { namespace Kokkos {
     //return the data array for the multipanel detector case, but only for whitelist pixels
     vector_size_t active_pixel_selection = vector_size_t("active_pixel_selection", selection.size());
     transfer_shared2kokkos(active_pixel_selection, selection);
-    // vector_size_t::HostMirror host_selection = create_mirror_view(active_pixel_selection);
-    // for (int i=0; i<selection.size(); ++i) {
-    //   host_selection( i ) = selection[ i ];
-    // }
-    // deep_copy(active_pixel_selection, host_selection);
 
     size_t output_pixel_size = selection.size();
     vector_cudareal_t active_pixel_results = vector_cudareal_t("active_pixel_results", output_pixel_size);
-    // CUDAREAL * cu_active_pixel_results;
-    // std::size_t * cu_active_pixel_selection;
-
-    // cudaSafeCall(cudaMalloc((void ** )&cu_active_pixel_results, sizeof(*cu_active_pixel_results) * active_pixel_list.size() ));
-    // cudaSafeCall(cudaMalloc((void ** )&cu_active_pixel_selection, sizeof(*cu_active_pixel_selection) * selection.size() ));
-    // cudaSafeCall(cudaMemcpy(cu_active_pixel_selection,
-    //              selection.begin(), sizeof(*cu_active_pixel_selection) * selection.size(),
-    //              cudaMemcpyHostToDevice));
 
     auto temp = m_accumulate_floatimage;
 
@@ -223,31 +210,10 @@ namespace simtbx { namespace Kokkos {
       size_t index = active_pixel_selection( i );
       active_pixel_results( i ) = temp( index );
     });
-    // int smCount = 84; //deviceProps.multiProcessorCount;
-    // dim3 threadsPerBlock(THREADS_PER_BLOCK_X, THREADS_PER_BLOCK_Y);
-    // dim3 numBlocks(smCount * 8, 1);
-    // int total_pixels = active_pixel_list.size();
-    // get_active_pixel_selection_CUDAKernel<<<numBlocks, threadsPerBlock>>>(
-    //   cu_active_pixel_results, cu_active_pixel_selection, cu_accumulate_floatimage, total_pixels);
-
-    // vector_cudareal_t::HostMirror host_results = create_mirror_view(active_pixel_results);
-    // deep_copy(host_results, active_pixel_results);
 
     af::shared<double> output_array(output_pixel_size, af::init_functor_null<double>());
     transfer_kokkos2shared(output_array, active_pixel_results);
 
-    // double* output_array_ptr = output_array.begin();
-    // for (int i=0; i<m_active_pixel_size; ++i) {
-    //   output_array_ptr[ i ] = host_results( i );
-    // }
-
-    // cudaSafeCall(cudaMemcpy(
-    //   begin,
-    //   cu_active_pixel_results,
-    //   sizeof(*cu_active_pixel_results) * active_pixel_list.size(),
-    //   cudaMemcpyDeviceToHost));
-    // cudaSafeCall(cudaFree(cu_active_pixel_selection));
-    // cudaSafeCall(cudaFree(cu_active_pixel_results));
     SCITBX_ASSERT(output_array.size() == output_pixel_size);
     return output_array;
   }

--- a/simtbx/kokkos/detector.cpp
+++ b/simtbx/kokkos/detector.cpp
@@ -187,7 +187,7 @@ namespace simtbx { namespace Kokkos {
   }
 
   void
-  kokkos_detector::set_active_pixels_on_GPU(af::shared<int> active_pixel_list_value) {
+  kokkos_detector::set_active_pixels_on_GPU(af::shared<std::size_t> active_pixel_list_value) {
     m_active_pixel_size = active_pixel_list_value.size();
     transfer_shared2kokkos(m_active_pixel_list, active_pixel_list_value);
     active_pixel_list = active_pixel_list_value;

--- a/simtbx/kokkos/detector.h
+++ b/simtbx/kokkos/detector.h
@@ -50,7 +50,7 @@ struct kokkos_detector{
   void scale_in_place(const double&);
   void write_raw_pixels(simtbx::nanoBragg::nanoBragg&);
   af::flex_double get_raw_pixels();
-  void set_active_pixels_on_GPU(af::shared<int>);
+  void set_active_pixels_on_GPU(af::shared<std::size_t>);
   af::shared<double> get_whitelist_raw_pixels(af::shared<std::size_t>);
   inline void each_image_free(){} //no op in Kokkos
   int h_deviceID;
@@ -92,9 +92,9 @@ struct kokkos_detector{
   vector_cudareal_t m_Ybeam = vector_cudareal_t("m_Ybeam", 0);
 
   // all-panel whitelist of active pixels on GPU
-  af::shared<int> active_pixel_list;
-  int m_active_pixel_size;
-  vector_int_t m_active_pixel_list = vector_int_t("m_active_pixel_list", 0);
+  af::shared<std::size_t> active_pixel_list;
+  std::size_t m_active_pixel_size;
+  vector_size_t m_active_pixel_list = vector_size_t("m_active_pixel_list", 0);
 };
 } // Kokkos
 } // simtbx

--- a/simtbx/kokkos/kokkos_ext.cpp
+++ b/simtbx/kokkos/kokkos_ext.cpp
@@ -104,13 +104,13 @@ namespace simtbx { namespace Kokkos {
              "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels\n"
              "The pixel_active_mask_bools is a large array with one bool per detector pixel")
         .def("add_energy_channel_mask_allpanel",
-             static_cast<void (exascale_api::*)(int const&,kokkos_energy_channels&,kokkos_detector&, af::shared<int> const) >
+             static_cast<void (exascale_api::*)(int const&,kokkos_energy_channels&,kokkos_detector&, af::shared<std::size_t> const) >
              (&exascale_api::add_energy_channel_mask_allpanel),
              (arg_("channel_number"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("pixel_active_list_ints")),
              "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels\n"
              "The pixel_active_list_ints is a small array with integer-offset addresses for each pixel-of-interest")
         .def("add_energy_multichannel_mask_allpanel",
-             static_cast<void (exascale_api::*)(af::shared<int> const,kokkos_energy_channels&,kokkos_detector&, af::shared<int> const,
+             static_cast<void (exascale_api::*)(af::shared<int> const,kokkos_energy_channels&,kokkos_detector&, af::shared<std::size_t> const,
              af::shared<double> const) >
              (&exascale_api::add_energy_multichannel_mask_allpanel),
              (arg_("ichannels"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("pixel_active_list_ints"), arg_("weights")),

--- a/simtbx/kokkos/kokkos_ext.cpp
+++ b/simtbx/kokkos/kokkos_ext.cpp
@@ -95,6 +95,7 @@ namespace simtbx { namespace Kokkos {
              "Allocate and transfer input data on the GPU")
         .def("add_energy_channel_from_gpu_amplitudes",
              &simtbx::Kokkos::exascale_api::add_energy_channel_from_gpu_amplitudes,
+             (arg_("channel_number"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("weight")=1.0),
              "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spot contributions to the detector's accumulator array")
         .def("add_energy_channel_mask_allpanel",
              static_cast<void (exascale_api::*)(int const&,kokkos_energy_channels&,kokkos_detector&, af::shared<bool>) >
@@ -109,9 +110,10 @@ namespace simtbx { namespace Kokkos {
              "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels\n"
              "The pixel_active_list_ints is a small array with integer-offset addresses for each pixel-of-interest")
         .def("add_energy_multichannel_mask_allpanel",
-             static_cast<void (exascale_api::*)(af::shared<int> const,kokkos_energy_channels&,kokkos_detector&, af::shared<int> const) >
+             static_cast<void (exascale_api::*)(af::shared<int> const,kokkos_energy_channels&,kokkos_detector&, af::shared<int> const,
+             af::shared<double> const) >
              (&exascale_api::add_energy_multichannel_mask_allpanel),
-             (arg_("ichannels"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("pixel_active_list_ints")),
+             (arg_("ichannels"), arg_("gpu_amplitudes"), arg_("gpu_detector"), arg_("pixel_active_list_ints"), arg_("weights")),
              "Point to Fhkl at a new energy channel on the GPU, and accumulate Bragg spots on mask==True pixels\n"
              "The pixel_active_list_ints is a small array with integer-offset addresses for each pixel-of-interest"
              "ichannels: for each nanoBragg source, the value instructs the simulation which channel in gpu_structure_factors"

--- a/simtbx/kokkos/kokkos_utils.h
+++ b/simtbx/kokkos/kokkos_utils.h
@@ -52,6 +52,7 @@ void
 add_array( view_1d_t<T> lhs, const view_1d_t<U> rhs ) {
   Kokkos::parallel_for("add_arrays", lhs.span(), KOKKOS_LAMBDA(const int& i) {
     lhs( i ) = lhs( i ) + (T)rhs( i );
+    rhs( i ) = 0;
   });
 }
 

--- a/simtbx/kokkos/simulation.cpp
+++ b/simtbx/kokkos/simulation.cpp
@@ -175,7 +175,7 @@ namespace Kokkos {
   ){
     // here or there, need to convert the all_panel_mask (3D map) into a 1D list of accepted pixels
     // coordinates for the active pixel list are absolute offsets into the detector array
-    af::shared<int> active_pixel_list;
+    af::shared<std::size_t> active_pixel_list;
     const bool* jptr = all_panel_mask.begin();
     for (int j=0; j < all_panel_mask.size(); ++j){
       if (jptr[j]) {
@@ -190,7 +190,7 @@ namespace Kokkos {
     int const& ichannel,
     simtbx::Kokkos::kokkos_energy_channels & kec,
     simtbx::Kokkos::kokkos_detector & kdt,
-    af::shared<int> const active_pixel_list
+    af::shared<std::size_t> const active_pixel_list
   ){
     kdt.set_active_pixels_on_GPU(active_pixel_list);
 
@@ -257,7 +257,7 @@ namespace Kokkos {
     af::shared<int> const ichannels,
     simtbx::Kokkos::kokkos_energy_channels & kec,
     simtbx::Kokkos::kokkos_detector & kdt,
-    af::shared<int> const active_pixel_list,
+    af::shared<std::size_t> const active_pixel_list,
     af::shared<double> const weight
   ){
     kdt.set_active_pixels_on_GPU(active_pixel_list);

--- a/simtbx/kokkos/simulation.h
+++ b/simtbx/kokkos/simulation.h
@@ -18,7 +18,8 @@ struct exascale_api {
   void show();
   void add_energy_channel_from_gpu_amplitudes(int const&,
     simtbx::Kokkos::kokkos_energy_channels &,
-    simtbx::Kokkos::kokkos_detector &
+    simtbx::Kokkos::kokkos_detector &,
+    double const&
   );
   void add_energy_channel_mask_allpanel(int const&,
     simtbx::Kokkos::kokkos_energy_channels &,
@@ -33,7 +34,8 @@ struct exascale_api {
   void add_energy_multichannel_mask_allpanel(af::shared<int> const,
     simtbx::Kokkos::kokkos_energy_channels &,
     simtbx::Kokkos::kokkos_detector &,
-    af::shared<int> const
+    af::shared<int> const,
+    af::shared<double> const
   );
 
   void add_background(simtbx::Kokkos::kokkos_detector &);

--- a/simtbx/kokkos/simulation.h
+++ b/simtbx/kokkos/simulation.h
@@ -29,12 +29,12 @@ struct exascale_api {
   void add_energy_channel_mask_allpanel(int const&,
     simtbx::Kokkos::kokkos_energy_channels &,
     simtbx::Kokkos::kokkos_detector &,
-    af::shared<int> const
+    af::shared<std::size_t> const
   );
   void add_energy_multichannel_mask_allpanel(af::shared<int> const,
     simtbx::Kokkos::kokkos_energy_channels &,
     simtbx::Kokkos::kokkos_detector &,
-    af::shared<int> const,
+    af::shared<std::size_t> const,
     af::shared<double> const
   );
 

--- a/simtbx/kokkos/simulation_kernels.h
+++ b/simtbx/kokkos/simulation_kernels.h
@@ -373,7 +373,7 @@ void debranch_maskall_Kernel(int npanels, int spixels, int fpixels, int total_pi
     const vector_cudareal_t Fhkl, const hklParams FhklParams,
     int nopolar, const vector_cudareal_t polar_vector,
     CUDAREAL polarization, CUDAREAL fudge,
-    const vector_int_t pixel_lookup,
+    const vector_size_t pixel_lookup,
     vector_float_t floatimage /*out*/, vector_float_t omega_reduction/*out*/,
     vector_float_t max_I_x_reduction/*out*/, vector_float_t max_I_y_reduction /*out*/, vector_bool_t rangemap) {
 

--- a/simtbx/run_tests.py
+++ b/simtbx/run_tests.py
@@ -77,6 +77,7 @@ if OPT.enable_cuda:
     "$D/gpu/tst_gpu_multisource_background.py", # CPU / GPU background comparison
     ["$D/gpu/tst_exafel_api.py","context=cuda"],# CPU / GPU, polychromatic beam, monolithic detector
     ["$D/gpu/tst_unified.py","context=cuda"],   # GPU, exaFEL full API
+    ["$D/gpu/tst_shoeboxes.py","context=cuda"],   # GPU, test whitelist API
   ]
 else:
   tst_list.append(
@@ -86,6 +87,7 @@ if OPT.enable_kokkos and sys.platform.startswith('linux'):
    tst_list_parallel += [
      ["$D/gpu/tst_exafel_api.py","context=kokkos_gpu"],# GPU in kokkos
      ["$D/gpu/tst_unified.py","context=kokkos_gpu"],# GPU, exaFEL full API
+     ["$D/gpu/tst_shoeboxes.py","context=kokkos_gpu"],# GPU, test whitelist API
    ]
 if OPT.enable_cuda:
   if OPT.enable_cxx11 and sys.platform != 'win32':

--- a/simtbx/run_tests.py
+++ b/simtbx/run_tests.py
@@ -76,6 +76,7 @@ if OPT.enable_cuda:
     ["$D/nanoBragg/tst_gauss_argchk.py","GPU"], # tests CPU+GPU, argchk optimization
     "$D/gpu/tst_gpu_multisource_background.py", # CPU / GPU background comparison
     ["$D/gpu/tst_exafel_api.py","context=cuda"],# CPU / GPU, polychromatic beam, monolithic detector
+    ["$D/gpu/tst_unified.py","context=cuda"],   # GPU, exaFEL full API
   ]
 else:
   tst_list.append(
@@ -84,6 +85,7 @@ else:
 if OPT.enable_kokkos and sys.platform.startswith('linux'):
    tst_list_parallel += [
      ["$D/gpu/tst_exafel_api.py","context=kokkos_gpu"],# GPU in kokkos
+     ["$D/gpu/tst_unified.py","context=kokkos_gpu"],# GPU, exaFEL full API
    ]
 if OPT.enable_cuda:
   if OPT.enable_cxx11 and sys.platform != 'win32':


### PR DESCRIPTION
Accordingly, retire tst_kokkos_lib in run_tests.py. Switch contexts with a command-line flag.