### PR TITLE
libtbx_refresh runs with setuptools in "legacy_editable" mode

### DIFF
--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -2260,8 +2260,21 @@ selfx:
 
       for path in self.pythonpath:
         sys.path.insert(0, abs(path))
+
+      # Some libtbx_refresh scripts do a `pip install --editable`. The default
+      # behavior was changed in setuptools 64 and currently we expect the old
+      # behavior. See: https://github.com/pypa/setuptools/pull/3265
+      sef_previous = os.environ.get('SETUPTOOLS_ENABLE_FEATURES')
+      os.environ['SETUPTOOLS_ENABLE_FEATURES'] = 'legacy_editable'
+
       for module in self.module_list:
         module.process_libtbx_refresh_py()
+
+      if sef_previous is not None:
+          os.environ['SETUPTOOLS_ENABLE_FEATURES'] = sef_previous
+      else:
+          os.environ.pop('SETUPTOOLS_ENABLE_FEATURES')
+
       self.write_python_and_show_path_duplicates()
       self.generate_entry_point_dispatchers()
       self.process_exe()


### PR DESCRIPTION
In https://github.com/pypa/setuptools/pull/3265 (merged in setuptools 64), the default behavior of `pip install --editable` changed. This broke the libtbx.refresh scripts that previously placed an entrypoints file in `modules`, e.g. `modules/dxtbx/src/dxtbx.egg-info/entry_points.txt`.

We restore the legacy behavior by setting an environment variable `SETUPTOOLS_ENABLE_FEATURES=legacy_editable` before running the libtbx_refresh scripts. This allows using the current setuptools, otherwise we would have to pin it again to <=63.