### PR TITLE
SwissFEL updates from P20231

### DIFF
--- a/xfel/swissfel/jf16m_cxigeom2nexus.py
+++ b/xfel/swissfel/jf16m_cxigeom2nexus.py
@@ -275,7 +275,6 @@ class jf16m_cxigeom2nexus(object):
         data_pulse_ids = h5py.File(self.params.unassembled_file, 'r')[unassembled_data_key+'/pulse_id'][()]
       else:
         data_pulse_ids = h5py.File(self.params.unassembled_file, 'r')[unassembled_data_key+'/pulse_id'][()]
-      #data_pulse_ids += self.params.pulse_offset
       beam_h5 = h5py.File(self.params.beam_file, 'r')
       if self.params.spectral_data_key:
         spectral_data_key = self.params.spectral_data_key

--- a/xfel/swissfel/jf16m_cxigeom2nexus.py
+++ b/xfel/swissfel/jf16m_cxigeom2nexus.py
@@ -301,19 +301,22 @@ class jf16m_cxigeom2nexus(object):
         try:
           where = np.where(beam_pulse_ids==pulse_id)[0][0]
         except IndexError:
+          # No spectrum in file. Add bogus energy to fail in indexing
           energies[i] = .00001
           if self.params.recalculate_wavelength:
             orig_energies[i] = .00001
           if self.params.include_spectra:
             spectra_x[i] = np.zeros(beam_spectra_x[0].size)+0.00001
             spectra_y[i] = np.zeros(beam_spectra_y[0].size)+0.00001
-          print("filling zero spectrum for missing pulse id")
+          print("filling zero spectrum for missing pulse id ", pulse_id)
         else:
           if self.params.recalculate_wavelength:
             assert self.params.beam_file is not None, "Must provide beam file to recalculate wavelength"
             x = beam_spectra_x[where]
             y = beam_spectra_y[where].astype(float)
+            # super basic baseline subtraction
             ycorr = y - np.percentile(y, 10)
+            # weighted mean
             e = sum(x*ycorr) / sum(ycorr)
             energies[i] = e
             orig_energies[i] = beam_energies[where]


### PR DESCRIPTION
- Handle images without a corresponding spectrum by filling in energy=0.0001 eV
- Add phil param for pulse ID offset between spectra and images

Co-authored-by: Iris Young <idyoung@lbl.gov>
Co-authored-by: Aaron Brewster <asbrewster@lbl.gov>