### PR TITLE
Implement kokkos_gpu version of gpu test.

### DIFF
--- a/simtbx/kokkos/kokkos_ext.cpp
+++ b/simtbx/kokkos/kokkos_ext.cpp
@@ -120,6 +120,7 @@ namespace simtbx { namespace Kokkos {
              "to use for structure factor lookup.  If -1, skip this source wavelength."
              )
         .def("add_background", &simtbx::Kokkos::exascale_api::add_background,
+             (arg_("detector"), arg_("override_source")=-1),
              "Add a background field directly on the GPU")
         .def("show",&simtbx::Kokkos::exascale_api::show)
         ;

--- a/simtbx/kokkos/simulation.cpp
+++ b/simtbx/kokkos/simulation.cpp
@@ -325,7 +325,7 @@ namespace Kokkos {
   }
 
   void
-  exascale_api::add_background(simtbx::Kokkos::kokkos_detector & kdt) {
+  exascale_api::add_background(simtbx::Kokkos::kokkos_detector & kdt, int const& override_source) {
         // cudaSafeCall(cudaSetDevice(SIM.device_Id));
 
         // transfer source_I, source_lambda
@@ -376,7 +376,7 @@ namespace Kokkos {
         // the for loop around panels.  Offsets given.
         for (std::size_t panel_id = 0; panel_id < kdt.m_panel_count; panel_id++) {
           add_background_kokkos_kernel(SIM.sources,
-          SIM.oversample,
+          SIM.oversample, override_source,
           SIM.pixel_size, kdt.m_slow_dim_size, kdt.m_fast_dim_size, SIM.detector_thicksteps,
           SIM.detector_thickstep, SIM.detector_attnlen,
           extract_subview(kdt.m_sdet_vector, panel_id, m_vector_length),

--- a/simtbx/kokkos/simulation.h
+++ b/simtbx/kokkos/simulation.h
@@ -38,7 +38,7 @@ struct exascale_api {
     af::shared<double> const
   );
 
-  void add_background(simtbx::Kokkos::kokkos_detector &);
+  void add_background(simtbx::Kokkos::kokkos_detector &, int const&);
   void allocate();
   //~exascale_api();
 

--- a/simtbx/kokkos/simulation_kernels.h
+++ b/simtbx/kokkos/simulation_kernels.h
@@ -629,7 +629,7 @@ void debranch_maskall_Kernel(int npanels, int spixels, int fpixels, int total_pi
 //                 float * max_I_y_reduction, bool * rangemap);
 
 
-void add_background_kokkos_kernel(int sources, int nanoBragg_oversample,
+void add_background_kokkos_kernel(int sources, int nanoBragg_oversample, int override_source,
     CUDAREAL pixel_size, int spixels, int fpixels, int detector_thicksteps,
     CUDAREAL detector_thickstep, CUDAREAL detector_attnlen,
     const vector_cudareal_t  sdet_vector, const vector_cudareal_t  fdet_vector,
@@ -644,7 +644,7 @@ void add_background_kokkos_kernel(int sources, int nanoBragg_oversample,
     vector_float_t floatimage)
 {
 
-    int oversample=-1, override_source=-1; //override features that usually slow things down,
+    int oversample=-1;                     //override features that usually slow things down,
                                            //like oversampling pixels & multiple sources
     int source_start = 0;
     // allow user to override automated oversampling decision at call time with arguments

--- a/simtbx/kokkos/simulation_kernels.h
+++ b/simtbx/kokkos/simulation_kernels.h
@@ -712,7 +712,6 @@ void add_background_kokkos_kernel(int sources, int nanoBragg_oversample, int ove
 
                     // loop over sources now
                     for(int source=source_start; source<sources; ++source) {
-                        double n_source_scale = (have_single_source) ? orig_sources : source_I[source];
 
                         // retrieve stuff from cache
                         CUDAREAL incident[4];

--- a/simtbx/kokkos/simulation_kernels.h
+++ b/simtbx/kokkos/simulation_kernels.h
@@ -647,13 +647,16 @@ void add_background_kokkos_kernel(int sources, int nanoBragg_oversample, int ove
     int oversample=-1;                     //override features that usually slow things down,
                                            //like oversampling pixels & multiple sources
     int source_start = 0;
+    int orig_sources = sources;
     // allow user to override automated oversampling decision at call time with arguments
     if(oversample<=0) oversample = nanoBragg_oversample;
     if(oversample<=0) oversample = 1;
+    bool have_single_source = false;
     if(override_source>=0) {
         // user-specified source in the argument
         source_start = override_source;
         sources = source_start +1;
+        have_single_source = true;
     }
     // make sure we are normalizing with the right number of sub-steps
     int steps = oversample*oversample;
@@ -709,6 +712,7 @@ void add_background_kokkos_kernel(int sources, int nanoBragg_oversample, int ove
 
                     // loop over sources now
                     for(int source=source_start; source<sources; ++source) {
+                        double n_source_scale = (have_single_source) ? orig_sources : source_I[source];
 
                         // retrieve stuff from cache
                         CUDAREAL incident[4];
@@ -762,7 +766,7 @@ void add_background_kokkos_kernel(int sources, int nanoBragg_oversample, int ove
                         }
 
                         // accumulate unscaled pixel intensity from this
-                        Ibg += sign*Fbg*Fbg*polar*omega_pixel*source_fraction*capture_fraction;
+                        Ibg += sign*Fbg*Fbg*polar*omega_pixel*capture_fraction*n_source_scale;
                     } // end of source loop
                 } // end of detector thickness loop
             } // end of sub-pixel y loop

--- a/simtbx/kokkos/simulation_kernels.h
+++ b/simtbx/kokkos/simulation_kernels.h
@@ -658,6 +658,7 @@ void add_background_kokkos_kernel(int sources, int nanoBragg_oversample, int ove
         sources = source_start +1;
         full_spectrum = false;
     }
+    n_source_scale *= !full_spectrum;
     // make sure we are normalizing with the right number of sub-steps
     int steps = oversample*oversample;
     CUDAREAL subpixel_size = pixel_size/oversample;
@@ -719,8 +720,7 @@ void add_background_kokkos_kernel(int sources, int nanoBragg_oversample, int ove
                         incident[2] = -source_Y(source);
                         incident[3] = -source_Z(source);
                         CUDAREAL lambda = source_lambda(source);
-                        CUDAREAL source_fraction = full_spectrum * source_I(source);
-                        source_fraction += !full_spectrum * n_source_scale;
+                        CUDAREAL source_fraction = full_spectrum * source_I(source) + n_source_scale;
                         // construct the incident beam unit vector while recovering source distance
                         unitize(incident, incident);
 

--- a/simtbx/run_tests.py
+++ b/simtbx/run_tests.py
@@ -85,6 +85,7 @@ else:
   )
 if OPT.enable_kokkos and sys.platform.startswith('linux'):
    tst_list_parallel += [
+     ["$D/gpu/tst_gpu_multisource_background.py","context=kokkos_gpu"],# CPU / GPU background comparison
      ["$D/gpu/tst_exafel_api.py","context=kokkos_gpu"],# GPU in kokkos
      ["$D/tests/tst_unified.py","context=kokkos_gpu"],# GPU, exaFEL full API
      ["$D/gpu/tst_shoeboxes.py","context=kokkos_gpu"],# GPU, test whitelist API


### PR DESCRIPTION
Within the exascale_api, most API functions are now subject to identical tests in both the cuda and kokkos_gpu contexts.  This commit adds a test for the add_background() function, tested with a multi-source beam model.