### PR TITLE
bootstrap.py: add XFEL-specific defaults

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -2288,6 +2288,7 @@ class XFELLegacyBuilder(CCIBuilder):
     pass
 
 class XFELBuilder(CCIBuilder):
+  PYDEFAULT = '39'
   CODEBASES_EXTRA = [
     'dials',
     'iota',
@@ -2304,6 +2305,14 @@ class XFELBuilder(CCIBuilder):
     'uc_metrics',
   ]
   HOT_EXTRA = ['msgpack']
+
+  def __init__(self, *args, **kwargs):
+    kwargs['no_boost_src'] = True
+    if kwargs['python'] == '27':
+      print('Warning: Python 2.7 was requested (maybe by default).')
+      print('Py27 is no longer supported. Resetting to Py{}.'.format(self.PYDEFAULT))
+      kwargs['python'] = self.PYDEFAULT
+    super(XFELBuilder, self).__init__(*args, **kwargs)
 
   def add_base(self, extra_opts=[]):
     super(XFELBuilder, self).add_base(

--- a/xfel/conda_envs/README.md
+++ b/xfel/conda_envs/README.md
@@ -24,8 +24,7 @@ $ wget https://raw.githubusercontent.com/cctbx/cctbx_project/master/libtbx/auto_
 $ wget https://raw.githubusercontent.com/cctbx/cctbx_project/master/xfel/conda_envs/psana_environment.yml
 $ mamba env create -f psana_environment.yml -p $PWD/conda_base
 $ conda activate `pwd`/conda_base
-$ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base --nproc=48 \
-    --python=39 --no-boost-src hot update build
+$ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base --nproc=48 hot update build
 $ echo $PWD/build/conda_setpaths.sh
 ```
 To activate the cctbx environment, `source` the script that was printed in the final step.
@@ -43,15 +42,13 @@ $ wget https://raw.githubusercontent.com/cctbx/cctbx_project/master/libtbx/auto_
 $ wget https://raw.githubusercontent.com/cctbx/cctbx_project/master/xfel/conda_envs/psana_environment.yml
 $ mamba env create -f psana_environment.yml -p $PWD/conda_base
 $ conda activate $PWD/conda_base
-$ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base --nproc=48 \
-    --python=39 --no-boost-src hot update
+$ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base --nproc=48 hot update
 $ exit
 $ ssh psana
 [...]
 $ cd /reg/d/psdm/<experiment>/scratch/dwpaley/cctbx
 $ conda activate $PWD/conda_base
-$ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base --nproc=12 \
-    --python=39 --no-boost-src build
+$ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base --nproc=12 build
 $ echo $PWD/build/conda_setpaths.sh
 ```
 
@@ -62,7 +59,7 @@ with standardized compilers from conda instead. Replace the step `python bootstr
 ```
 $ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base \
   --config-flags="--compiler=conda" --config-flags="--use_environment_flags" \
-  --nproc=10 --python=39 --no-boost-src build
+  --nproc=10 build
 ```
 
 # cctbx.xfel tests


### PR DESCRIPTION
This is just something I was playing with. There are two things to consider here:

- Thoughts on modifying bootstrap default options by intercepting the kwargs passed to the Builder constructor?
- If the value in `options.python` is equal to the default (currently `'27'`) I don't know if there is a clean way to decide whether that value was explicitly supplied by the user. We could set `default=None` and catch that value and set it to the real default, but then the parser can't tell the user what the default is. However in this case I think we can reasonably assume that no user is actually requesting 27, so the XFEL builder catches that value and resets it to 39.

I think these changes would be nice, but they're not urgent, so feel free to consider this a conversation starter on builder-specific bootstrap defaults :)