### PR TITLE
Add button to start mysql server

### DIFF
--- a/xfel/command_line/cxi_mpi_submit.py
+++ b/xfel/command_line/cxi_mpi_submit.py
@@ -283,8 +283,15 @@ def get_submission_id(result, method):
     print('Submission', 'ID', 'is', submission_id)
     return submission_id
 
-def do_submit(command, submit_path, stdoutdir, mp_params, job_name, dry_run=False):
-  submit_command = get_submit_command_chooser(command, submit_path, stdoutdir, mp_params, job_name=job_name)
+def do_submit(command, submit_path, stdoutdir, mp_params, log_name="log.out", err_name="log.err", job_name=None, dry_run=False):
+  submit_command = get_submit_command_chooser(command,
+                                              submit_path,
+                                              stdoutdir,
+                                              mp_params,
+                                              log_name=log_name,
+                                              err_name=err_name,
+                                              job_name=job_name,
+                                              )
   if mp_params.method in ['lsf', 'sge', 'pbs']:
     parts = submit_command.split(" ")
     script = open(parts.pop(-1), "rb")
@@ -292,7 +299,6 @@ def do_submit(command, submit_path, stdoutdir, mp_params, job_name, dry_run=Fals
     command = " ".join(parts + [run_command.decode()])
   else:
     command = submit_command
-  print(command)
   submit_command = str(submit_command) # unicode workaround
 
   if dry_run:
@@ -304,8 +310,8 @@ def do_submit(command, submit_path, stdoutdir, mp_params, job_name, dry_run=Fals
     if submission_id > 0:
       return submission_id
     else:
-      stdout = os.open(os.path.join(stdoutdir, 'log.out'), os.O_WRONLY|os.O_CREAT|os.O_TRUNC); os.dup2(stdout, 1)
-      stderr = os.open(os.path.join(stdoutdir, 'log.err'), os.O_WRONLY|os.O_CREAT|os.O_TRUNC); os.dup2(stderr, 2)
+      stdout = os.open(os.path.join(stdoutdir, 'submit.log'), os.O_WRONLY|os.O_CREAT|os.O_TRUNC); os.dup2(stdout, 1)
+      stderr = os.open(os.path.join(stdoutdir, 'submit.err'), os.O_WRONLY|os.O_CREAT|os.O_TRUNC); os.dup2(stderr, 2)
       os.execv(command.split()[0], command.split())
   else:
     try:
@@ -468,7 +474,7 @@ class Script(object):
 
     job_name = "r%s"%params.input.run_num
 
-    submission_id = do_submit(command, submit_path, stdoutdir, params.mp, job_name=job_name, dry_run=params.dry_run)
+    submission_id = do_submit(command, submit_path, stdoutdir, params.mp, log_name="log.out", err_name="err.out", job_name=job_name, dry_run=params.dry_run)
     print("Job submitted.  Output in", trialdir)
     return submission_id
 

--- a/xfel/ui/__init__.py
+++ b/xfel/ui/__init__.py
@@ -123,6 +123,26 @@ db {
   logging_batch_size = 3
     .type = int
     .help = Number of images to log at once. Increase if using many (thousands) of processors.
+  server {
+    basedir = None
+      .type = path
+      .help = Root folder for mysql database
+
+    prompt_for_root_password = False
+      .type = bool
+      .help = Whether to always ask for the root password. Note, root password is always \
+              needed when the database is initialized.
+    
+    root_user = 'root'
+      .type = str
+      .help = username for root
+      .expert_level = 2
+
+    root_password = None
+      .type = str
+      .help = Password for root user
+      .expert_level = 2
+  }
 }
 """
 master_phil_scope = parse(master_phil_str + db_phil_str, process_includes=True)

--- a/xfel/ui/__init__.py
+++ b/xfel/ui/__init__.py
@@ -132,7 +132,7 @@ db {
       .type = bool
       .help = Whether to always ask for the root password. Note, root password is always \
               needed when the database is initialized.
-    
+
     root_user = 'root'
       .type = str
       .help = username for root

--- a/xfel/ui/command_line/ui_server.py
+++ b/xfel/ui/command_line/ui_server.py
@@ -94,7 +94,6 @@ def run(args):
       rootpw3 = getpass.getpass()
 
   print("Starting server")
-  print(f'cnf_path {cnf_path}')
   assert os.path.exists(cnf_path)
   server_process = easy_run.subprocess.Popen(["mysqld", "--defaults-file=%s"%(cnf_path)])
 
@@ -151,6 +150,6 @@ def run(args):
 
 
 if __name__ == '__main__':
-  print(sys.argv)      
+  print(sys.argv)
   run(sys.argv[1:])
 

--- a/xfel/ui/command_line/ui_server.py
+++ b/xfel/ui/command_line/ui_server.py
@@ -94,6 +94,7 @@ def run(args):
       rootpw3 = getpass.getpass()
 
   print("Starting server")
+  print(f'cnf_path {cnf_path}')
   assert os.path.exists(cnf_path)
   server_process = easy_run.subprocess.Popen(["mysqld", "--defaults-file=%s"%(cnf_path)])
 
@@ -150,4 +151,6 @@ def run(args):
 
 
 if __name__ == '__main__':
+  print(sys.argv)      
   run(sys.argv[1:])
+

--- a/xfel/ui/command_line/ui_server.py
+++ b/xfel/ui/command_line/ui_server.py
@@ -23,21 +23,7 @@ While the server is running, the user can connect to with with the xfel gui by p
 
 """
 
-phil_str = """
-db {
-  server {
-    basedir = None
-      .type = path
-      .help = Root folder for mysql database
-
-    prompt_for_root_password = False
-      .type = bool
-      .help = Whether to always ask for the root password. Note, root password is always \
-              needed when the database is initialized.
-  }
-}
-"""
-phil_scope = parse(phil_str + db_phil_str)
+phil_scope = parse(phil_str)
 
 default_cnf = \
 """
@@ -115,16 +101,8 @@ def run(args):
 
   params.db.host = '127.0.0.1'
   if initialize:
-    #new_user = params.db.user
-    #new_password = params.db.password
-    #new_db = params.db.name
-    #params.db.user = 'root'
-    #params.db.password = ''
-    #params.db.name = ''
-    #print ("Changing password")
     app = db_application(params)
     app.execute_query("ALTER USER 'root'@'localhost' IDENTIFIED BY '%s'"%(params.db.server.root_password))
-    #params.db.password = rootpw
     print ("Creating empty database %s"%params.db.name)
     app.execute_query("CREATE DATABASE %s"%params.db.name)
     print ("Creating new user %s"%params.db.user)
@@ -138,10 +116,6 @@ def run(args):
     print ("Initialized")
   else:
     app = db_application(params)
-
-  #if params.db.server.prompt_for_root_password:
-    #params.db.user = 'root'
-   # params.db.server.root_password = rootpw3
 
   print ("Raising max connections")
   app.execute_query("SET GLOBAL max_connections=50000")

--- a/xfel/ui/components/submission_tracker.py
+++ b/xfel/ui/components/submission_tracker.py
@@ -145,11 +145,11 @@ class QueueInterrogator(object):
       pass
     elif self.queueing_system == 'slurm' or self.queueing_system == "shifter":
       hostname_command = "sacct --job %s -o NODELIST --noheader | tail -n 1"
-      result = easy_run.fully_buffered(command=hostname_command%submission_id)
-      if result.show_stdout():
-        return result.show_stdout().strip()
-      elif result.show_stderr():
-        print(result.show_stderr())
+      result = easy_run.fully_buffered(command=hostname_command%submission_id).raise_if_errors()
+      if result.stdout_lines:
+        return result.stdout_lines[0].strip()
+      else:
+        return ""
     elif self.queueing_system == 'htcondor':
       print("method to obtain hostname running MySQL server not implemented for ", self.queueing_system)
       pass

--- a/xfel/ui/components/submission_tracker.py
+++ b/xfel/ui/components/submission_tracker.py
@@ -133,6 +133,27 @@ class QueueInterrogator(object):
     else:
       return status
 
+  def get_mysql_server_hostname(self, submission_id):
+    if self.queueing_system in ["mpi", "lsf"]:
+      print(f"method to obtain hostname running MySQL server not implemented for {self.queueing_system}")
+      pass
+    elif self.queueing_system == 'pbs':
+      print(f"method to obtain hostname running MySQL server not implemented for {self.queueing_system}")
+      pass
+    elif self.queueing_system == 'sge':
+      print(f"method to obtain hostname running MySQL server not implemented for {self.queueing_system}")
+      pass
+    elif self.queueing_system == 'slurm' or self.queueing_system == "shifter":
+      hostname_command = "sacct --job %s -o NODELIST --noheader | tail -n 1"
+      result = easy_run.fully_buffered(command=hostname_command%submission_id)
+      if result.show_stdout():
+        return result.show_stdout().strip()
+      elif result.show_stderr():
+        print(result.show_stderr())
+    elif self.queueing_system == 'htcondor':
+      print(f"method to obtain hostname running MySQL server not implemented for {self.queueing_system}")
+      pass
+
 class LogReader(object):
   """A log reader that distinguishes between expected results of successful and unsuccessful
   log file termination, and returns an error message if the log file cannot be found or read."""

--- a/xfel/ui/components/submission_tracker.py
+++ b/xfel/ui/components/submission_tracker.py
@@ -135,13 +135,13 @@ class QueueInterrogator(object):
 
   def get_mysql_server_hostname(self, submission_id):
     if self.queueing_system in ["mpi", "lsf"]:
-      print(f"method to obtain hostname running MySQL server not implemented for {self.queueing_system}")
+      print("method to obtain hostname running MySQL server not implemented for ", self.queueing_system)
       pass
     elif self.queueing_system == 'pbs':
-      print(f"method to obtain hostname running MySQL server not implemented for {self.queueing_system}")
+      print("method to obtain hostname running MySQL server not implemented for ", self.queueing_system)
       pass
     elif self.queueing_system == 'sge':
-      print(f"method to obtain hostname running MySQL server not implemented for {self.queueing_system}")
+      print("method to obtain hostname running MySQL server not implemented for ", self.queueing_system)
       pass
     elif self.queueing_system == 'slurm' or self.queueing_system == "shifter":
       hostname_command = "sacct --job %s -o NODELIST --noheader | tail -n 1"
@@ -151,7 +151,7 @@ class QueueInterrogator(object):
       elif result.show_stderr():
         print(result.show_stderr())
     elif self.queueing_system == 'htcondor':
-      print(f"method to obtain hostname running MySQL server not implemented for {self.queueing_system}")
+      print("method to obtain hostname running MySQL server not implemented for ", self.queueing_system)
       pass
 
 class LogReader(object):

--- a/xfel/ui/components/xfel_gui_dialogs.py
+++ b/xfel/ui/components/xfel_gui_dialogs.py
@@ -382,10 +382,9 @@ class DBCredentialsDialog(BaseDialog):
     e.Skip()
 
   def onStartDB(self, e):
-    print("starting db")
-    start_db_dialog = StartDBDialog(self, self.params)
-    if (start_db_dialog.ShowModal() == wx.ID_OK):
-      self.params.db.root_psswd = start_db_dialog.get_db_root_psswd.ctr.GetValue()
+    self.start_db_dialog = StartDBDialog(self, self.params)
+    if (self.start_db_dialog.ShowModal() == wx.ID_OK):
+      print("Preparing to initialize DB")
 
 class StartDBDialog(BaseDialog):
   ''' Dialog to start DB '''
@@ -405,16 +404,25 @@ class StartDBDialog(BaseDialog):
                         content_style=content_style,
                         style=wx.NO_BORDER,
                         *args, **kwargs)
-
-    font = wx.Font(14, wx.FONTFAMILY_DEFAULT, wx.NORMAL, wx.FONTWEIGHT_BOLD, False)
-    warning_label1 = wx.StaticText(self, wx.ID_STATIC, 'Aaron is worried about your health')
+    warn_icon = wx.ArtProvider.GetBitmap(wx.ART_WARNING, wx.ART_OTHER, (50,50))
+    self.staticbmp = wx.StaticBitmap(self, -1, warn_icon, pos=(1,1))
+    self.start_db_sizer.Add(self.staticbmp, flag=wx.ALL)
+    self.vsiz.Add(self.start_db_sizer, 0)
+    font = wx.Font(10, wx.FONTFAMILY_DEFAULT, wx.NORMAL, wx.FONTWEIGHT_NORMAL, False)
+    warning_label1 = wx.StaticText(self, wx.ID_STATIC, 'This will initialize the server! Make sure the server is not already running!')
     warning_label1.SetFont(font)
-    self.start_db_sizer.Add(warning_label1, 0, wx.ALL|wx.LEFT)
-    self.vsiz.Add(self.start_db_sizer,0, wx.ALL, 0)
-    warning_label2 = wx.StaticText(self, wx.ID_STATIC, 'Have you seen the doctor lately?')
-    warning_label2.SetFont(font)
-    self.start_db_sizer2.Add(warning_label2, 0, wx.ALL|wx.RIGHT)
-    self.vsiz.Add(self.start_db_sizer2,0, wx.ALL, 5)
+    self.start_db_sizer.Add(warning_label1, 0, wx.ALL|wx.RIGHT)
+    self.vsiz.Add(self.start_db_sizer,0, wx.ALL, 20)
+    self.get_db_basedir = gctr.TextButtonCtrl(self,
+                                              name='basedir',
+                                              label='DB Base Directory',
+                                              label_style='bold',
+                                              label_size=(150,-1),
+                                              big_button_size=(130,-1),
+                                              value=os.path.join(self.params.output_folder, 'MySql')
+                                              )
+    self.start_db_sizer2.Add(self.get_db_basedir)
+    self.vsiz.Add(self.start_db_sizer2,0, wx.ALL, 40)
     self.get_db_root_psswd = gctr.TextButtonCtrl(self,
                                            name='db_root_password',
                                            label='DB Root Password',
@@ -429,7 +437,7 @@ class StartDBDialog(BaseDialog):
     self.start_db_sizer3.Add(-1,-1,proportion=1)
     self.start_db_cancel_btn = wx.Button(self, label="Cancel", id=wx.ID_CANCEL)
     self.start_db_sizer3.Add(self.start_db_cancel_btn)
-    self.vsiz.Add(self.start_db_sizer3,0, wx.ALL, 20)
+    self.vsiz.Add(self.start_db_sizer3,0, wx.ALL, 60)
     self.main_sizer.Add(self.start_db_sizer,flag=wx.EXPAND | wx.ALL, border=10)
     self.main_sizer.Add(self.start_db_sizer2,flag=wx.EXPAND | wx.ALL, border=10)
     self.main_sizer.Add(self.start_db_sizer3,flag=wx.EXPAND | wx.ALL, border=10)
@@ -445,6 +453,11 @@ class StartDBDialog(BaseDialog):
 
   def onLaunchDB(self, e):
     print("launching db")
+    print('params',dir(self.params.db))
+
+    self.params.db.server.root_password = self.get_db_root_psswd.ctr.GetValue()
+    self.params.db.server.basedir = self.get_db_basedir.ctr.GetValue()
+    print('basedir', self.params.db.server.basedir)
     launch_db_dialog = LaunchDBDialog(self, self.params)
 
 class LaunchDBDialog(BaseDialog):
@@ -462,17 +475,33 @@ class LaunchDBDialog(BaseDialog):
                         style=wx.NO_BORDER,
                         *args, **kwargs)
 
-    # verify that all db credentials exist
-    def submit_start_server_job(params):
-      from xfel.command_line.cxi_mpi_submit import do_submit      
-    # call a function that:
-      # writes a sh script to submit job
-      # returns the location where the db files will live
-      # function to determine path of db if doesn't exist
-    db_file_location = "path/to/db"
+    def _submit_start_server_job(params):
+      from xfel.command_line.cxi_mpi_submit import do_submit
+      assert self.params.db.user is not None, f"DB User not defined!"
+      assert self.params.db.password is not None, f"Password for DB User not defined!"
+      assert self.params.db.server.root_password is not None, f"Root password for DB not defined!" 
+      assert self.params.db.server.basedir is not None, f"Base directory for DB not defined!"
+      
+      try:
+         print('basedir',params.db.server.basedir, os.path.exists(params.db.server.basedir)) 
+         if not os.path.exists(params.db.server.basedir):
+           import copy
+           new_params = copy.deepcopy(params)
+           new_params.mp.log_name = "mysql.log"
+           new_params.mp.err_name = "mysql.err"
+           params.mp.extra_args = "db.port=%d db.server.basedir=%s db.user=%s db.name=%s" %(params.db.port, params.db.server.basedir, params.db.user, params.experiment_tag)
+           print("submitting job")
+           do_submit('cctbx.xfel.ui_server', new_params.output_folder, new_params.output_folder, new_params.mp, 'cctbxmysql')
+      except: 
+         raise RuntimeError(f"Couldn\'t submit job to start MySql DB.\n Could MySql already be running?\n Check if {params.db.server.basedir} exists.")      
+
+      
+    _submit_start_server_job(self.params)  
+    db_file_location = self.params.db.server.basedir
     self.launch_db_sizer = wx.BoxSizer(wx.HORIZONTAL)
-    msg_text = "DB will be located in " + str(db_file_location)
+    msg_text = "DB will be located in\n" + str(db_file_location)
     self.db_start_box = wx.MessageBox(msg_text,"DB Info", wx.OK | wx.ICON_INFORMATION)
+
 
 class LCLSFacilityOptions(BaseDialog):
   ''' Options settings specific to LCLS'''

--- a/xfel/ui/components/xfel_gui_dialogs.py
+++ b/xfel/ui/components/xfel_gui_dialogs.py
@@ -365,7 +365,7 @@ class DBCredentialsDialog(BaseDialog):
 
 
     self.Bind(wx.EVT_CHECKBOX, self.onDropTables, self.chk_drop_tables)
-    self.Bind(wx.EVT_CHECKBOX, self.onStartDB, self.btn_db_start)
+    self.Bind(wx.EVT_BUTTON, self.onStartDB, self.btn_db_start)
 
     self.Fit()
     self.SetTitle('Database Credentials')
@@ -382,12 +382,10 @@ class DBCredentialsDialog(BaseDialog):
     e.Skip()
 
   def onStartDB(self, e):
-    # render new dialog box with texctrl
+    print("starting db")
     start_db_dialog = StartDBDialog(self, self.params)
-    start_db_dialog.Center()
-    #if (start_db_dialog.ShowModal() == wx.ID_OK):
-    self.params.db.root_psswd = start_db_dialog.get_db_root_psswd.ctr.GetValue()
-    # Call new OnStartDB
+    if (start_db_dialog.ShowModal() == wx.ID_OK):
+      self.params.db.root_psswd = start_db_dialog.get_db_root_psswd.ctr.GetValue()
 
 class StartDBDialog(BaseDialog):
   ''' Dialog to start DB '''
@@ -398,25 +396,83 @@ class StartDBDialog(BaseDialog):
                *args, **kwargs):
 
     self.params = params
-    self.start_db_sizer = wx.BoxSizer(wx.VERTICAL)
+    self.start_db_sizer = wx.BoxSizer(wx.HORIZONTAL)
+    self.start_db_sizer2 = wx.BoxSizer(wx.HORIZONTAL)
+    self.start_db_sizer3 = wx.BoxSizer(wx.HORIZONTAL)
+    self.vsiz = wx.BoxSizer(wx.VERTICAL)
     BaseDialog.__init__(self, parent,
                         label_style=label_style,
                         content_style=content_style,
                         style=wx.NO_BORDER,
                         *args, **kwargs)
 
+    font = wx.Font(14, wx.FONTFAMILY_DEFAULT, wx.NORMAL, wx.FONTWEIGHT_BOLD, False)
+    warning_label1 = wx.StaticText(self, wx.ID_STATIC, 'Aaron is worried about your health')
+    warning_label1.SetFont(font)
+    self.start_db_sizer.Add(warning_label1, 0, wx.ALL|wx.LEFT)
+    self.vsiz.Add(self.start_db_sizer,0, wx.ALL, 0)
+    warning_label2 = wx.StaticText(self, wx.ID_STATIC, 'Have you seen the doctor lately?')
+    warning_label2.SetFont(font)
+    self.start_db_sizer2.Add(warning_label2, 0, wx.ALL|wx.RIGHT)
+    self.vsiz.Add(self.start_db_sizer2,0, wx.ALL, 5)
     self.get_db_root_psswd = gctr.TextButtonCtrl(self,
-                                       name='db_root',
-                                       label='DB Server Root Password',
-                                       label_style='bold',
-                                       label_size=(150, -1),
-                                       big_button=True,
-                                       big_button_label='Launch Server',
-                                       big_button_size=(130, -1))
-    self.start_db_sizer.Add(self.get_db_root_psswd, flag=wx.EXPAND | wx.ALL, border=10)
+                                           name='db_root_password',
+                                           label='DB Root Password',
+                                           label_style='bold',
+                                           label_size=(150, -1),
+                                           text_style=wx.TE_PASSWORD,
+                                           big_button=True,
+                                           big_button_label='Launch Server',
+                                           big_button_size=(130, -1))
+    
+    self.start_db_sizer3.Add(self.get_db_root_psswd)
+    self.start_db_sizer3.Add(-1,-1,proportion=1)
+    self.start_db_cancel_btn = wx.Button(self, label="Cancel", id=wx.ID_CANCEL)
+    self.start_db_sizer3.Add(self.start_db_cancel_btn)
+    self.vsiz.Add(self.start_db_sizer3,0, wx.ALL, 20)
+    self.main_sizer.Add(self.start_db_sizer,flag=wx.EXPAND | wx.ALL, border=10)
+    self.main_sizer.Add(self.start_db_sizer2,flag=wx.EXPAND | wx.ALL, border=10)
+    self.main_sizer.Add(self.start_db_sizer3,flag=wx.EXPAND | wx.ALL, border=10)
+
+
+    self.get_db_root_psswd.Bind(wx.EVT_BUTTON, self.onLaunchDB)
+
+
 
     self.Fit()
-    self.SetTitle('Database Credentials')
+    self.Center()
+    self.SetTitle('Start Database')
+
+  def onLaunchDB(self, e):
+    print("launching db")
+    launch_db_dialog = LaunchDBDialog(self, self.params)
+
+class LaunchDBDialog(BaseDialog):
+  ''' Dialog to start DB '''
+
+  def __init__(self, parent, params,
+               label_style='bold',
+               content_style='normal',
+               *args, **kwargs):
+
+    self.params = params
+    BaseDialog.__init__(self, parent,
+                        label_style=label_style,
+                        content_style=content_style,
+                        style=wx.NO_BORDER,
+                        *args, **kwargs)
+
+    # verify that all db credentials exist
+    def submit_start_server_job(params):
+      from xfel.command_line.cxi_mpi_submit import do_submit      
+    # call a function that:
+      # writes a sh script to submit job
+      # returns the location where the db files will live
+      # function to determine path of db if doesn't exist
+    db_file_location = "path/to/db"
+    self.launch_db_sizer = wx.BoxSizer(wx.HORIZONTAL)
+    msg_text = "DB will be located in " + str(db_file_location)
+    self.db_start_box = wx.MessageBox(msg_text,"DB Info", wx.OK | wx.ICON_INFORMATION)
 
 class LCLSFacilityOptions(BaseDialog):
   ''' Options settings specific to LCLS'''

--- a/xfel/ui/components/xfel_gui_dialogs.py
+++ b/xfel/ui/components/xfel_gui_dialogs.py
@@ -175,7 +175,6 @@ class SettingsDialog(BaseDialog):
                         flag=wx.EXPAND | wx.ALL,
                         border=10)
 
-    #self.btn_mp = wx.Button(self, label='Multiprocessing...')
     self.btn_op = gctr.Button(self, name='advanced', label='Advanced Settings...')
     self.btn_OK = wx.Button(self, label="OK", id=wx.ID_OK)
     self.btn_OK.SetDefault()
@@ -239,6 +238,9 @@ class SettingsDialog(BaseDialog):
     adv.Center()
 
     adv.ShowModal()
+
+
+## check for configure multiprocessinig parameters statement
 
   def onDBCredentialsButton(self, e):
     creds = DBCredentialsDialog(self, self.params)
@@ -329,6 +331,8 @@ class DBCredentialsDialog(BaseDialog):
                                            value=params.db.password)
     self.main_sizer.Add(self.db_password, flag=wx.EXPAND | wx.ALL, border=10)
 
+
+
     # Drop tables button
     self.chk_drop_tables = wx.CheckBox(self,
                                        label='Delete and regenerate all tables')
@@ -347,12 +351,21 @@ class DBCredentialsDialog(BaseDialog):
       self.main_sizer.Add(self.web_location, flag=wx.EXPAND | wx.ALL, border=10)
 
     # Dialog control
-    dialog_box = self.CreateSeparatedButtonSizer(wx.OK | wx.CANCEL)
-    self.main_sizer.Add(dialog_box,
-                        flag=wx.EXPAND | wx.ALL,
-                        border=10)
+    
+    self.btn_db_start = gctr.Button(self, name='start_db', label='Start DB Server')
+    self.db_btn_OK = wx.Button(self, name='db_OK', label="OK", id=wx.ID_OK)
+    self.db_btn_OK.SetDefault()
+    self.db_btn_cancel = wx.Button(self, label="Cancel", id=wx.ID_CANCEL)
+    self.button_sizer = wx.BoxSizer(wx.HORIZONTAL)
+    self.button_sizer.Add(self.btn_db_start)
+    self.button_sizer.Add(-1,-1, proportion=1)
+    self.button_sizer.Add(self.db_btn_OK)
+    self.button_sizer.Add(self.db_btn_cancel)
+    self.main_sizer.Add(self.button_sizer,flag=wx.EXPAND | wx.ALL, border=10)
+
 
     self.Bind(wx.EVT_CHECKBOX, self.onDropTables, self.chk_drop_tables)
+    self.Bind(wx.EVT_CHECKBOX, self.onStartDB, self.btn_db_start)
 
     self.Fit()
     self.SetTitle('Database Credentials')
@@ -367,6 +380,43 @@ class DBCredentialsDialog(BaseDialog):
       if (msg.ShowModal() == wx.ID_NO):
         self.chk_drop_tables.SetValue(False)
     e.Skip()
+
+  def onStartDB(self, e):
+    # render new dialog box with texctrl
+    start_db_dialog = StartDBDialog(self, self.params)
+    start_db_dialog.Center()
+    #if (start_db_dialog.ShowModal() == wx.ID_OK):
+    self.params.db.root_psswd = start_db_dialog.get_db_root_psswd.ctr.GetValue()
+    # Call new OnStartDB
+
+class StartDBDialog(BaseDialog):
+  ''' Dialog to start DB '''
+
+  def __init__(self, parent, params,
+               label_style='bold',
+               content_style='normal',
+               *args, **kwargs):
+
+    self.params = params
+    self.start_db_sizer = wx.BoxSizer(wx.VERTICAL)
+    BaseDialog.__init__(self, parent,
+                        label_style=label_style,
+                        content_style=content_style,
+                        style=wx.NO_BORDER,
+                        *args, **kwargs)
+
+    self.get_db_root_psswd = gctr.TextButtonCtrl(self,
+                                       name='db_root',
+                                       label='DB Server Root Password',
+                                       label_style='bold',
+                                       label_size=(150, -1),
+                                       big_button=True,
+                                       big_button_label='Launch Server',
+                                       big_button_size=(130, -1))
+    self.start_db_sizer.Add(self.get_db_root_psswd, flag=wx.EXPAND | wx.ALL, border=10)
+
+    self.Fit()
+    self.SetTitle('Database Credentials')
 
 class LCLSFacilityOptions(BaseDialog):
   ''' Options settings specific to LCLS'''

--- a/xfel/ui/components/xfel_gui_dialogs.py
+++ b/xfel/ui/components/xfel_gui_dialogs.py
@@ -398,15 +398,22 @@ class DBCredentialsDialog(BaseDialog):
           import copy
           new_params = copy.deepcopy(params)
           new_params.mp.use_mpi = False
-          db_exp_name = self.params.experiment_tag if len(self.params.experiment_tag) > 0 else "standalone"
-          new_params.mp.extra_args = ["db.port=%d db.server.basedir=%s db.user=%s db.name=%s db.server.root_password=%s" %(params.db.port, params.db.server.basedir, params.db.user, db_exp_name, params.db.server.root_password)]
+          new_params.mp.extra_args = ["db.port=%d db.server.basedir=%s db.user=%s db.name=%s db.server.root_password=%s" %(params.db.port, params.db.server.basedir, params.db.user, params.db.name, params.db.server.root_password)]
           submit_path = os.path.join(params.output_folder, "launch_server_submit.sh")
           print("submitting job")
           submission_id = do_submit('cctbx.xfel.ui_server', submit_path, new_params.output_folder, new_params.mp, log_name="my_SQL.log", err_name="my_SQL.err", job_name='cctbxmysql')
           #remove root password from params
           if submission_id:
             print('job was submitted')
-            params.db.server.root_password = ''
+            print('resetting params object')
+            self.params.db.host     = params.db.host
+            self.params.db.port     = int(params.db.port)
+            self.params.db.name     = params.db.name
+            self.params.db.user     = params.db.user
+            self.params.db.password = params.db.password
+            self.params.db.server.root_password = ''
+            self.params.db.server.basedir = params.db.server.basedir
+
           else:
             print('couldn\'t submit job')
         except:
@@ -420,7 +427,6 @@ class DBCredentialsDialog(BaseDialog):
       print("Started DB")
       os.remove(os.path.join(self.params.output_folder, "launch_server_submit.sh"))
       self.Close()
-
 
 class StartDBDialog(BaseDialog):
   ''' Dialog to start DB '''

--- a/xfel/ui/components/xfel_gui_dialogs.py
+++ b/xfel/ui/components/xfel_gui_dialogs.py
@@ -387,10 +387,10 @@ class DBCredentialsDialog(BaseDialog):
 
       def _submit_start_server_job(params):
         from xfel.command_line.cxi_mpi_submit import do_submit
-        assert self.params.db.user is not None, f"DB User not defined!"
-        assert self.params.db.password is not None, f"Password for DB User not defined!"
-        assert self.params.db.server.root_password is not None, f"Root password for DB not defined!"
-        assert self.params.db.server.basedir is not None, f"Base directory for DB not defined!"
+        assert self.params.db.user is not None, "DB User not defined!"
+        assert self.params.db.password is not None, "Password for DB User not defined!"
+        assert self.params.db.server.root_password is not None, "Root password for DB not defined!"
+        assert self.params.db.server.basedir is not None, "Base directory for DB not defined!"
 
         try:
           import copy
@@ -406,11 +406,10 @@ class DBCredentialsDialog(BaseDialog):
             print('resetting params object')
             if (self.params.mp.method == 'slurm') or (self.params.mp.method == 'shifter'):
               try:
-                print("getting slurm stuff")  
                 q = QueueInterrogator(self.params.mp.method)
                 hostname = q.get_mysql_server_hostname(submission_id)
                 self.params.db.host = hostname
-              except:
+              except ValueError:
                 print(f"Unable to find hostname running MySQL server from SLURM. Submission ID: {submission_id}")
                 pass
             elif self.params.mp.method == 'local':
@@ -430,8 +429,9 @@ class DBCredentialsDialog(BaseDialog):
             os.remove(os.path.join(self.params.output_folder, "launch_server_submit_submit.sh"))
           else:
             print('couldn\'t submit job')
-        except:
-          raise RuntimeError(f"Couldn\'t submit job to start MySql DB.\n Could MySql already be running?\n Check if {params.db.server.basedir} exists.")
+        except RuntimeError:
+          print("Couldn\'t submit job to start MySql DB.")
+          print("Check if all phil parameters required to launch jobs exists.")
 
       _submit_start_server_job(self.params)
       db_file_location = self.params.db.server.basedir

--- a/xfel/ui/components/xfel_gui_dialogs.py
+++ b/xfel/ui/components/xfel_gui_dialogs.py
@@ -398,25 +398,30 @@ class DBCredentialsDialog(BaseDialog):
           new_params.mp.use_mpi = False
           new_params.mp.extra_args = ["db.port=%d db.server.basedir=%s db.user=%s db.name=%s db.server.root_password=%s" %(params.db.port, params.db.server.basedir, params.db.user, params.db.name, params.db.server.root_password)]
           submit_path = os.path.join(params.output_folder, "launch_server_submit.sh")
-          print("submitting job")
-          submission_id = do_submit('cctbx.xfel.ui_server', submit_path, new_params.output_folder, new_params.mp, log_name="my_SQL.log", err_name="my_SQL.err", job_name='cctbx_start_mysql')
+          submission_id = do_submit('cctbx.xfel.ui_server',
+                                    submit_path,
+                                    new_params.output_folder,
+                                    new_params.mp,
+                                    log_name="my_SQL.log",
+                                    err_name="my_SQL.err",
+                                    job_name='cctbx_start_mysql'
+                                   )
           #remove root password from params
           if submission_id:
-            print('job was submitted')
-            print('resetting params object')
             if (self.params.mp.method == 'slurm') or (self.params.mp.method == 'shifter'):
               try:
                 q = QueueInterrogator(self.params.mp.method)
                 hostname = q.get_mysql_server_hostname(submission_id)
-                self.params.db.host = hostname
+                if hostname:
+                  self.params.db.host = hostname
               except ValueError:
-                print(f"Unable to find hostname running MySQL server from SLURM. Submission ID: {submission_id}")
+                print("Unable to find hostname running MySQL server from SLURM. Submission ID: ", submission_id)
                 pass
             elif self.params.mp.method == 'local':
               self.params.db.host = params.db.host
             else:
-              print(f"Unable to find hostname running MySQL server on {self.params.mp.method}")
-              print(f"Submission ID: {submission_id}")
+              print("Unable to find hostname running MySQL server on ", self.params.mp.method)
+              print("Submission ID: ", submission_id)
 
             self.params.db.port = int(params.db.port)
             self.params.db.name = params.db.name

--- a/xfel/ui/db/job.py
+++ b/xfel/ui/db/job.py
@@ -848,7 +848,7 @@ class MergingJob(Job):
       params = copy.deepcopy(params)
       params.nnodes = params.nnodes_merge
 
-    return do_submit(command, submit_path, output_path, params, identifier_string)
+    return do_submit(command, submit_path, output_path, params, log_name="log.out", err_name="err.out", job_name=identifier_string)
 
 class PhenixJob(Job):
   def get_global_path(self):
@@ -915,7 +915,7 @@ class PhenixJob(Job):
        params.shifter.srun_script_template = os.path.join( \
          libtbx.env.find_in_repositories("xfel/ui/db/cfgs"), "phenix_srun.sh")
 
-    return do_submit(command, submit_path, output_path, params, identifier_string)
+    return do_submit(command, submit_path, output_path, params, log_name="log.out", err_name="err.out", job_name=identifier_string)
 
 # Support classes and functions for job submission
 

--- a/xfel/util/mp.py
+++ b/xfel/util/mp.py
@@ -250,6 +250,11 @@ class get_local_submit_command(get_submit_command):
       elif self.params.nproc > 1:
         self.command += " mp.nproc=%d" % self.params.nproc
 
+  def eval_params(self):
+    # <args> (optional, following the command)
+    for arg in self.params.extra_args:
+      self.args.append(arg)
+
   def generate_submit_command(self):
     return self.submit_path
 


### PR DESCRIPTION
The desired behavior of this PR is to add the required UI features to enable a user to start a database server from the UI. The main changes are:

1.  Logic added to create new dialog boxes to guide user to add required info to start DB server in /ui/components/xfel_gui_dialogs.py
2.  Small changes  in /ui/command_line/ui_server.py to ensure backwards compatibility of ui_server.py
3. Add in more phil parameters in /ui/__init.py__ necessary to support ability to launch server from GUI
4.  Add args in `do_submit` function in command_line/cxi_mpi_submit.py to pass in log and err file names- helpful to diagnose potential db issues
5. Added new method to class QueueInterrogator in /components/submission_tracker.py to retrieve name of host running server on NERSC and write to phil parameters
6. Added args for log and err files to `do_submit` function call in /ui/db/job.py due to 4 
7. Add function to process extra args added to phil parameters that was previously absent in `get_local_submit_command` class in /util/mp.py
  
Desired behavior:
To start the DB server from GUI.

1. Open the xfel GUI. For testing on NERSC, I found that it was necessary to specify the location of environment setup script as well as the give extra arguments that specify job time, account, CPU constraint argument and qos argument

<img width="682" alt="Screen Shot 2022-11-14 at 11 31 10 AM" src="https://user-images.githubusercontent.com/47763698/201749441-3ffd58b1-beac-4562-959c-b5acfbe718ef.png">

2. Access the new dialog boxes via the `DB Credentials` button that pops up in the very first dialog box that appears upon start-up of the GUI.

3. Press the `Start DB` button on the `DB Credentials` dialog box
<img width="522" alt="Screen Shot 2022-11-14 at 9 54 00 AM" src="https://user-images.githubusercontent.com/47763698/201748642-abe810f2-5c75-46fe-add8-74fdcae5d46a.png">

4. Enter  password for MySql server root and location of MySql DB and press OK

<img width="653" alt="Screen Shot 2022-11-14 at 11 39 52 AM" src="https://user-images.githubusercontent.com/47763698/201751047-a8b5fd3d-84d2-4959-884e-436e1b92b336.png">


6. Job to launch the server should be submitted to the queue. The root password will be deleted from phil parameters and the script used to launch the start server job will be removed for password security. 

The `ui_server.py` script should function just as it had previously.