### PR TITLE
Scipy scaling

### DIFF
--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -398,8 +398,14 @@ scaling {
     .help = "mark0: original per-image scaling by reference to isomorphous PDB model"
     .help = "mark1: no scaling, just averaging (i.e. Monte Carlo
              algorithm).  Individual image scale factors are set to 1."
-  weights = *unit icalc
+  weights = *unit icalc icalc_sigma
     .type = choice
+    .help = "Sigmas applied in the linear fit of Iobs vs Icalc. unit: sigmas"
+            "equal to 1. icalc: Sigmas are proportional to the square root of"
+            "Icalc (this relation is totally empirical). icalc_sigma: Error"
+            "due to partiality is proportional to Icalc; this term is added to"
+            "the sigma(Iobs) determined in integration so that sigma ="
+            "sqrt(Icalc**2 + sigma(Iobs)**2)."
 }
 """
 

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -398,6 +398,8 @@ scaling {
     .help = "mark0: original per-image scaling by reference to isomorphous PDB model"
     .help = "mark1: no scaling, just averaging (i.e. Monte Carlo
              algorithm).  Individual image scale factors are set to 1."
+  weights = *unit icalc
+    .type = choice
 }
 """
 

--- a/xfel/merging/application/scale/experiment_scaler.py
+++ b/xfel/merging/application/scale/experiment_scaler.py
@@ -177,6 +177,8 @@ class experiment_scaler(worker):
     result.correlation = correlation
 
     def linfunc(x, m): return x*m
+    # For weighting, we need to put the Icalc values on the scale of Iobs, so
+    # we do a first-pass scale with unit weights and apply it to model_subset.
     slope_unwt = curve_fit(linfunc, exp_subset, model_subset)[0][0]
     model_subset_scaled = model_subset / slope_unwt
     if weights == 'unit':

--- a/xfel/merging/application/scale/experiment_scaler.py
+++ b/xfel/merging/application/scale/experiment_scaler.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, division, print_function
 from xfel.merging.application.worker import worker
-import math
 from dials.array_family import flex
 from dxtbx.model.experiment_list import ExperimentList
 from cctbx import miller
 from cctbx.crystal import symmetry
-import sys
 from scipy.optimize import curve_fit
 from scipy.stats import pearsonr
 import numpy as np
@@ -153,12 +151,11 @@ class experiment_scaler(worker):
       weights='unit'
   ):
     'Scale the observed intensities to the reference, or model, using a linear least squares fit.'
-    assert weights in ['unit', 'icalc']
      # Y = offset + slope * X, where Y is I_r and X is I_o
 
+    assert weights in ['unit', 'icalc']
     result = scaling_result()
     result.data_count = matching_indices.pairs().size()
-
     if result.data_count < 3:
       result.error = scaling_result.err_low_signal
       return result
@@ -173,12 +170,13 @@ class experiment_scaler(worker):
     model_subset = np.array(model_subset)
     exp_subset = np.array(exp_subset)
 
-    def linfunc(x, m): return x*m
     correlation = pearsonr(exp_subset, model_subset)[0]
     if correlation < self.params.filter.outlier.min_corr:
       result.error = scaling_result.err_low_correlation
       return result
     result.correlation = correlation
+
+    def linfunc(x, m): return x*m
     slope_unwt = curve_fit(linfunc, exp_subset, model_subset)[0][0]
     if weights == 'unit':
       slope = slope_unwt


### PR DESCRIPTION
This refactors the xfel.merge experiment_scaler to use `scipy.stats.pearsonr` and `scipy.optimize.curve_fit` to compute the correlation coefficient and scale factor. This facilitates further improvements like new weighting schemes for fitting scale factors. The "icalc" weighting here gave a big improvement in a smSFX dataset, from R1 12.8% to 9.6%.
