### PR TITLE
Better weather

### DIFF
--- a/xfel/util/weather.py
+++ b/xfel/util/weather.py
@@ -111,13 +111,13 @@ def run(params):
 
   msg = "Five number summary of {} (s): {:7.2f}, {:7.2f}, {:7.2f}, {:7.2f}, {:7.2f}"
   if fail_deltas:
-    process = '{:4d} fail image processing times'.format(fail_total)
+    process = '{:5d} fail image processing times'.format(fail_total)
     print(msg.format(process, *five_number_summary(flex.double(fail_deltas))))
   if good_deltas:
-    process = '{:4d} good image processing times'.format(good_total)
+    process = '{:5d} good image processing times'.format(good_total)
     print(msg.format(process, *five_number_summary(flex.double(good_deltas))))
   if rank_walltimes:
-    process = "{:4d} individual ranks' walltimes".format(len(rank_walltimes))
+    process = "{:5d} individual ranks' walltimes".format(len(rank_walltimes))
     print(msg.format(process, *five_number_summary(flex.double(rank_walltimes))))
 
   if params.wall_time and params.num_nodes and params.num_cores_per_node:

--- a/xfel/util/weather.py
+++ b/xfel/util/weather.py
@@ -101,8 +101,6 @@ def run(params):
         processing_of_most_recent_still_terminated = True
       else:
         processing_of_most_recent_still_terminated = False
-    fail_deltas += [j-i for i, j in zip(fail_timepoints[:-1], fail_timepoints[1:])]
-    good_deltas += [j-i for i, j in zip(good_timepoints[:-1], good_timepoints[1:])]
     rank_walltimes.append(timestamp_to_seconds(ts) - reference)
     plt.plot(fail_timepoints, [rank]*len(fail_timepoints), 'b.')
     plt.plot(good_timepoints, [rank]*len(good_timepoints), 'g.')
@@ -113,13 +111,13 @@ def run(params):
 
   msg = "Five number summary of {}: {:7.3f}, {:7.3f}, {:7.3f}, {:7.3f}, {:7.3f}"
   if fail_deltas:
-    process = '{} fail image processing times'.format(fail_total)
+    process = '{:4d} fail image processing times'.format(fail_total)
     print(msg.format(process, *five_number_summary(flex.double(fail_deltas))))
   if good_deltas:
-    process = '{} good image processing times'.format(fail_total)
+    process = '{:4d} good image processing times'.format(good_total)
     print(msg.format(process, *five_number_summary(flex.double(good_deltas))))
   if rank_walltimes:
-    process = "{} individual ranks' walltimes".format(len(rank_walltimes))
+    process = "{:4d} individual ranks' walltimes".format(len(rank_walltimes))
     print(msg.format(process, *five_number_summary(flex.double(rank_walltimes))))
 
   if params.wall_time and params.num_nodes and params.num_cores_per_node:

--- a/xfel/util/weather.py
+++ b/xfel/util/weather.py
@@ -109,7 +109,7 @@ def run(params):
     if not processing_of_most_recent_still_terminated:
       plt.plot([rank_walltimes[-1]], [rank], 'rx')
 
-  msg = "Five number summary of {}: {:7.3f}, {:7.3f}, {:7.3f}, {:7.3f}, {:7.3f}"
+  msg = "Five number summary of {} (s): {:7.2f}, {:7.2f}, {:7.2f}, {:7.2f}, {:7.2f}"
   if fail_deltas:
     process = '{:4d} fail image processing times'.format(fail_total)
     print(msg.format(process, *five_number_summary(flex.double(fail_deltas))))

--- a/xfel/util/weather.py
+++ b/xfel/util/weather.py
@@ -77,8 +77,8 @@ def run(params):
     reference = None
     fail_timepoints = []
     good_timepoints = []
+    run_timepoints = []
     rank = int(filename.split('_')[1].split('.')[0])
-    print(filename)
     for line in open(os.path.join(root, filename)):
       try:
         hostname, psanats, ts, status, result = line.strip().split(',')
@@ -86,14 +86,18 @@ def run(params):
         continue
       if reference is None:
         reference = timestamp_to_seconds(ts)
+        run_timepoints.append(0)
         assert status not in ['stop', 'done', 'fail']
 
       if status in ['stop', 'done', 'fail']:
         timepoint = timestamp_to_seconds(ts) - reference
+        run_timepoints.append(timepoint)
         if status == 'done':
           good_timepoints.append(timepoint)
+          good_deltas.append(good_timepoints[-1] - run_timepoints[-2])
         else:
           fail_timepoints.append(timepoint)
+          fail_deltas.append(fail_timepoints[-1] - run_timepoints[-2])
         processing_of_most_recent_still_terminated = True
       else:
         processing_of_most_recent_still_terminated = False

--- a/xfel/util/weather.py
+++ b/xfel/util/weather.py
@@ -77,7 +77,6 @@ def run(params):
     good_timepoints = []
     rank = int(filename.split('_')[1].split('.')[0])
     print(filename)
-    run_timepoints = []
     for line in open(os.path.join(root, filename)):
       try:
         hostname, psanats, ts, status, result = line.strip().split(',')
@@ -85,26 +84,24 @@ def run(params):
         continue
       if reference is None:
         reference = timestamp_to_seconds(ts)
-        run_timepoints.append(0)
         assert status not in ['stop', 'done', 'fail']
 
       if status in ['stop', 'done', 'fail']:
         timepoint = timestamp_to_seconds(ts) - reference
-        run_timepoints.append(timepoint)
         if status == 'done':
           good_timepoints.append(timepoint)
-          good_deltas.append(good_timepoints[-1] - run_timepoints[-2])
         else:
           fail_timepoints.append(timepoint)
-          fail_deltas.append(fail_timepoints[-1] - run_timepoints[-2])
-        ok = True
+        processing_of_most_recent_still_terminated = True
       else:
-        ok = False
+        processing_of_most_recent_still_terminated = False
+    fail_deltas += [j-i for i, j in zip(fail_timepoints[:-1], fail_timepoints[1:])]
+    good_deltas += [j-i for i, j in zip(good_timepoints[:-1], good_timepoints[1:])]
     plt.plot(fail_timepoints, [rank]*len(fail_timepoints), 'b.')
     plt.plot(good_timepoints, [rank]*len(good_timepoints), 'g.')
     fail_total += len(fail_timepoints)
     good_total += len(good_timepoints)
-    if not ok:
+    if not processing_of_most_recent_still_terminated:
       plt.plot([timestamp_to_seconds(ts) - reference], [rank], 'rx')
 
   if fail_deltas:


### PR DESCRIPTION
I have removed some repetition and unused variables from the weather plot at `xfel/util/weather.py`. New script additionally outputs the five number summary of individual ranks' wall times. I used that in conjunction with a bash script to quickly find wall times of all individual indexing tasks. Consider rejecting if this functionality is already present in cctbx. The plotting itself should not be affected.

Current output format:

    debug_1.txt
    ...
    debug_127.txt
    Five number summary of 9056 fail image processing times: 1.427, 1.549, 1.616, 2.490, 41.423
    Five number summary of 694 good image processing times: 11.510, 24.707, 29.495, 36.216, 77.082

Suggested output format:

    Five number summary of 9056 fail image processing times:   1.427,   1.549,   1.616,   2.490,  41.423
    Five number summary of  694 good image processing times:  11.510,  24.707,  29.495,  36.216,  77.082
    Five number summary of  127 individual ranks' walltimes: 419.774, 423.190, 445.923, 446.938, 467.427