### PR TITLE
Remove exp_id from cctbx.xfel.merge

### DIFF
--- a/.azure-pipelines/xfel/download-source.yml
+++ b/.azure-pipelines/xfel/download-source.yml
@@ -56,6 +56,7 @@ jobs:
       git lfs install --local
       git pull --rebase
       git lfs pull
+      git checkout xfel_exp_id
     displayName: Update xfel_regression
 
   # preserve permissions and delete extra files

--- a/.azure-pipelines/xfel/download-source.yml
+++ b/.azure-pipelines/xfel/download-source.yml
@@ -57,6 +57,8 @@ jobs:
       git pull --rebase
       git lfs pull
       git checkout xfel_exp_id
+      cd ../dials
+      git checkout empty_tables
     displayName: Update xfel_regression
 
   # preserve permissions and delete extra files

--- a/.azure-pipelines/xfel/download-source.yml
+++ b/.azure-pipelines/xfel/download-source.yml
@@ -56,9 +56,6 @@ jobs:
       git lfs install --local
       git pull --rebase
       git lfs pull
-      git checkout xfel_exp_id
-      cd ../dials
-      git checkout empty_tables
     displayName: Update xfel_regression
 
   # preserve permissions and delete extra files

--- a/xfel/merging/application/balance/load_balancer.py
+++ b/xfel/merging/application/balance/load_balancer.py
@@ -168,7 +168,6 @@ class load_balancer(worker):
       for expt_id, experiment in enumerate(self.split_experiments[i]):
         sel |= reflections['id'] == expt_id
       self.split_reflections.append(reflections.select(sel))
-      #self.split_reflections[i].reset_ids()
 
   def distribute_reflections_over_experiment_chunks_cpp(self, reflections):
     '''Distribute reflections over experiment chunks according to experiment identifiers, '''
@@ -197,9 +196,6 @@ class load_balancer(worker):
 
         for expt_id in set(ref_table['id']):
           ref_table.experiment_identifiers()[expt_id] = reflections.experiment_identifiers()[expt_id]
-        #ref_table.reset_ids()
-
-        #print(self.mpi_helper.rank, set(ref_table['id']), list(ref_table.experiment_identifiers().keys()))
 
     self.logger.log("Distributed %d out of %d reflections"%(distributed_reflection_count, reflection_count))
 

--- a/xfel/merging/application/balance/load_balancer.py
+++ b/xfel/merging/application/balance/load_balancer.py
@@ -45,19 +45,6 @@ class load_balancer(worker):
       mpi_split_comm = self.mpi_helper.comm.Split(mpi_color, mpi_new_rank)
       new_experiments, new_reflections = self.distribute_over_ranks(experiments, reflections, mpi_split_comm, self.params.input.parallel_file_load.ranks_per_node)
 
-    if self.params.input.parallel_file_load.reset_experiment_id_column:
-      self.logger.log('Starting id column reset')
-      id_map = new_reflections.experiment_identifiers()
-      reverse_map = {}
-      for expt_id, experiment in enumerate(new_experiments):
-        id_map[expt_id] = experiment.identifier
-        reverse_map[experiment.identifier] = expt_id
-      id_col = new_reflections['id']
-      ident_col = new_reflections['exp_id']
-      for i in range(len(new_reflections)):
-        id_col[i] = reverse_map[ident_col[i]]
-      self.logger.log('Column reset done')
-
     if self.params.input.parallel_file_load.balance == "global2":
       # get status again AFTER balancing and report back number of experiments on EACH RANK in the main_log if balance_verbose is set
       if self.params.input.parallel_file_load.balance_verbose and self.mpi_helper.rank == 0:
@@ -134,9 +121,7 @@ class load_balancer(worker):
 
     self.logger.log_step_time("LB_REFLS_CONSOLIDATE")
     self.logger.log("Consolidating reflections after all-to-all...")
-    new_reflections = flex.reflection_table()
-    for entry in new_split_reflections:
-      new_reflections.extend(entry)
+    new_reflections = flex.reflection_table.concat(new_split_reflections)
     del new_split_reflections
     self.logger.log_step_time("LB_REFLS_CONSOLIDATE", True)
 
@@ -144,7 +129,6 @@ class load_balancer(worker):
 
   def exchange_reflections_by_alltoall_sliced(self, mpi_communicator, number_of_slices):
     '''Split each hkl chunk into N slices. This is needed to address the MPI alltoall memory problem'''
-    result_reflections = flex.reflection_table() # the total reflection table, which this rank will receive after running all slices of alltoall
     list_of_sliced_reflection_chunks = [] # if the self.split_reflections list contains chunks: [A,B,C...], it will be sliced like: [[A1,A2,...,An], [B1,B2,...,Bn], [C1,C2,...,Cn], ...], where n is the number of chunk slices
     for i in range(len(self.split_reflections)):
       reflection_chunk_slices = []
@@ -164,22 +148,27 @@ class load_balancer(worker):
 
       self.logger.log_step_time("CONSOLIDATE")
       self.logger.log("Consolidating reflection tables...")
-      for chunk in received_reflection_chunks:
-        result_reflections.extend(chunk)
+      if j == 0:
+        all_received = received_reflection_chunks
+      else:
+        for i in range(len(self.split_reflections)):
+          # extend here because we are working within a chunk, and the ids are consistent within that chunk
+          all_received[i].extend(received_reflection_chunks[i])
       self.logger.log_step_time("CONSOLIDATE", True)
+    # now concatenate all the chunks, resetting the ids to be contiguous
+    result_reflections = flex.reflection_table.concat(all_received)
 
     return result_reflections
 
   def distribute_reflections_over_experiment_chunks_python(self, reflections):
     self.split_reflections = []
-    for i in range(len(self.split_experiments)):
-      self.split_reflections.append(self.reflection_table_stub(reflections))
 
     for i in range(len(self.split_experiments)):
-      for expt_idx, experiment in enumerate(self.split_experiments[i]):
-        refls = reflections.select(reflections['exp_id'] == experiment.identifier)
-        refls['id'] = flex.int(len(refls), expt_idx)
-        self.split_reflections[i].extend(refls)
+      sel = flex.bool(len(reflections), False)
+      for expt_id, experiment in enumerate(self.split_experiments[i]):
+        sel |= reflections['id'] == expt_id
+      self.split_reflections.append(reflections.select(sel))
+      #self.split_reflections[i].reset_ids()
 
   def distribute_reflections_over_experiment_chunks_cpp(self, reflections):
     '''Distribute reflections over experiment chunks according to experiment identifiers, '''
@@ -205,6 +194,12 @@ class load_balancer(worker):
 
       for ref_table in self.split_reflections:
         distributed_reflection_count += ref_table.size()
+
+        for expt_id in set(ref_table['id']):
+          ref_table.experiment_identifiers()[expt_id] = reflections.experiment_identifiers()[expt_id]
+        #ref_table.reset_ids()
+
+        #print(self.mpi_helper.rank, set(ref_table['id']), list(ref_table.experiment_identifiers().keys()))
 
     self.logger.log("Distributed %d out of %d reflections"%(distributed_reflection_count, reflection_count))
 
@@ -267,15 +262,19 @@ class load_balancer(worker):
     # pare down balanced_experiments and balanced_reflections as we separate off what to send out
     send_data = [(None, None) for j in range(len(send_tuples))]
     recv_data = [(None, None) for j in range(len(send_tuples))]
+    emap = reflections.experiment_identifiers()
     for (j, count) in send_instructions:
       send_expt_j = experiments[-count:]
       experiments = experiments[:-count]
       send_refl_j = self.reflection_table_stub(reflections)
       for k, e in enumerate(send_expt_j):
-        r = reflections.select(reflections['exp_id'] == e.identifier) # select matching reflections to send
-        r['id'] = flex.int(len(r), k)
+        sel = emap.values() == e.identifier
+        assert sel.count(True) == 1
+        e_id = emap.keys().select(sel)[0]
+        r = reflections.select(reflections['id'] == e_id) # select matching reflections to send
         send_refl_j.extend(r)
-        reflections = reflections.select(reflections['exp_id'] != e.identifier) # remove from this rank's reflections
+        reflections = reflections.select(reflections['id'] != e_id) # remove from this rank's reflections
+      send_refl_j.reset_ids()
       send_data[j] = (send_expt_j, send_refl_j)
     recv_data = mpi_communicator.alltoall(send_data)
 
@@ -286,7 +285,7 @@ class load_balancer(worker):
       recv_ids = set([e.identifier for e in received_expt_i])
       assert current_ids.isdisjoint(recv_ids)
       experiments.extend(received_expt_i)
-      reflections.extend(received_refl_i)
+      flex.reflection_table.concat([reflections, received_refl_i])
 
     self.logger.log_step_time("LB_EXPTS_AND_REFLS_ALLTOALL", True)
 

--- a/xfel/merging/application/balance/load_balancer.py
+++ b/xfel/merging/application/balance/load_balancer.py
@@ -270,7 +270,8 @@ class load_balancer(worker):
         r = reflections.select(reflections['id'] == e_id) # select matching reflections to send
         send_refl_j.extend(r)
         reflections = reflections.select(reflections['id'] != e_id) # remove from this rank's reflections
-      send_refl_j.reset_ids()
+      if send_refl_j:
+        send_refl_j.reset_ids()
       send_data[j] = (send_expt_j, send_refl_j)
     recv_data = mpi_communicator.alltoall(send_data)
 

--- a/xfel/merging/application/balance/load_balancer.py
+++ b/xfel/merging/application/balance/load_balancer.py
@@ -270,8 +270,7 @@ class load_balancer(worker):
         r = reflections.select(reflections['id'] == e_id) # select matching reflections to send
         send_refl_j.extend(r)
         reflections = reflections.select(reflections['id'] != e_id) # remove from this rank's reflections
-      if send_refl_j:
-        send_refl_j.reset_ids()
+      send_refl_j.reset_ids()
       send_data[j] = (send_expt_j, send_refl_j)
     recv_data = mpi_communicator.alltoall(send_data)
 

--- a/xfel/merging/application/errors/error_modifier_ha14.py
+++ b/xfel/merging/application/errors/error_modifier_ha14.py
@@ -19,8 +19,8 @@ class error_modifier_ha14(worker):
     self.logger.log_step_time("ERROR_MODIFIER_HA14")
     if len(reflections) > 0:
       self.logger.log("Modifying intensity errors -- ha14 method...")
-      for experiment in experiments:
-        refls = reflections.select(reflections['exp_id'] == experiment.identifier)
+      for expt_id in range(len(experiments)):
+        refls = reflections.select(reflections['id'] == expt_id)
         refls = self.modify_errors(refls)
         new_reflections.extend(refls)
     self.logger.log_step_time("ERROR_MODIFIER_HA14", True)

--- a/xfel/merging/application/filter/experiment_filter.py
+++ b/xfel/merging/application/filter/experiment_filter.py
@@ -48,8 +48,7 @@ class experiment_filter(worker):
     '''Remove specified experiments from the experiment list. Remove corresponding reflections from the reflection table'''
     experiments.select_on_experiment_identifiers([i for i in experiments.identifiers() if i not in experiment_ids_to_remove])
     reflections.remove_on_experiment_identifiers(experiment_ids_to_remove)
-    if reflections:
-      reflections.reset_ids()
+    reflections.reset_ids()
 
     return experiments, reflections
 

--- a/xfel/merging/application/filter/experiment_filter.py
+++ b/xfel/merging/application/filter/experiment_filter.py
@@ -48,7 +48,8 @@ class experiment_filter(worker):
     '''Remove specified experiments from the experiment list. Remove corresponding reflections from the reflection table'''
     experiments.select_on_experiment_identifiers([i for i in experiments.identifiers() if i not in experiment_ids_to_remove])
     reflections.remove_on_experiment_identifiers(experiment_ids_to_remove)
-    reflections.reset_ids()
+    if reflections:
+      reflections.reset_ids()
 
     return experiments, reflections
 

--- a/xfel/merging/application/filter/reflection_filter.py
+++ b/xfel/merging/application/filter/reflection_filter.py
@@ -146,7 +146,8 @@ class reflection_filter(worker):
 
     self.logger.log_step_time("SIGNIFICANCE_FILTER", True)
 
-    new_reflections.reset_ids()
+    if new_reflections:
+      new_reflections.reset_ids()
     return new_experiments, new_reflections
 
 if __name__ == '__main__':

--- a/xfel/merging/application/filter/reflection_filter.py
+++ b/xfel/merging/application/filter/reflection_filter.py
@@ -146,8 +146,7 @@ class reflection_filter(worker):
 
     self.logger.log_step_time("SIGNIFICANCE_FILTER", True)
 
-    if new_reflections:
-      new_reflections.reset_ids()
+    new_reflections.reset_ids()
     return new_experiments, new_reflections
 
 if __name__ == '__main__':

--- a/xfel/merging/application/filter/reflection_filter.py
+++ b/xfel/merging/application/filter/reflection_filter.py
@@ -146,6 +146,7 @@ class reflection_filter(worker):
 
     self.logger.log_step_time("SIGNIFICANCE_FILTER", True)
 
+    new_reflections.reset_ids()
     return new_experiments, new_reflections
 
 if __name__ == '__main__':

--- a/xfel/merging/application/filter/reflection_filter.py
+++ b/xfel/merging/application/filter/reflection_filter.py
@@ -48,7 +48,7 @@ class reflection_filter(worker):
     kap = 'kapton_absorption_correction' in reflections
 
     for expt_id, experiment in enumerate(experiments):
-      exp_reflections = reflections.select(reflections['exp_id'] == experiment.identifier)
+      exp_reflections = reflections.select(reflections['id'] == expt_id)
       if not len(exp_reflections): continue
 
       N_obs_pre_filter = exp_reflections.size()

--- a/xfel/merging/application/input/file_loader.py
+++ b/xfel/merging/application/input/file_loader.py
@@ -158,7 +158,6 @@ class simple_file_loader(worker):
           reflections['intensity.sum.variance.unmodified'] = reflections['intensity.sum.variance'] * 1
 
         new_ids = flex.int(len(reflections), -1)
-        new_identifiers = flex.std_string(len(reflections))
         eid = reflections.experiment_identifiers()
         for k in eid.keys():
           del eid[k]
@@ -178,15 +177,12 @@ class simple_file_loader(worker):
             experiment.imageset = None
           all_experiments.append(experiment)
 
-          # Reflection experiment 'id' is unique within this rank; 'exp_id' (i.e. experiment identifier) is unique globally
-          new_identifiers.set_selected(refls_sel, experiment.identifier)
-
+          # Reflection 'id' is unique within this rank; experiment.identifier is unique globally
           new_id = len(all_experiments)-1
           eid[new_id] = experiment.identifier
           new_ids.set_selected(refls_sel, new_id)
         assert (new_ids < 0).count(True) == 0, "Not all reflections accounted for"
         reflections['id'] = new_ids
-        reflections['exp_id'] = new_identifiers
         all_reflections.extend(reflections)
     else:
       self.logger.log("Received a list of 0 json/pickle file pairs")
@@ -205,8 +201,8 @@ class simple_file_loader(worker):
   def prune_reflection_table_keys(self, reflections):
     from xfel.merging.application.reflection_table_utils import reflection_table_utils
     reflections = reflection_table_utils.prune_reflection_table_keys(reflections=reflections,
-                    keys_to_keep=['intensity.sum.value', 'intensity.sum.variance', 'miller_index', 'miller_index_asymmetric', \
-                                  'exp_id', 's1', 'intensity.sum.value.unmodified', 'intensity.sum.variance.unmodified',
+                    keys_to_keep=['id', 'intensity.sum.value', 'intensity.sum.variance', 'miller_index', 'miller_index_asymmetric', \
+                                  's1', 'intensity.sum.value.unmodified', 'intensity.sum.variance.unmodified',
                                   'kapton_absorption_correction', 'flags'],
                     keys_to_ignore=self.params.input.persistent_refl_cols)
     self.logger.log("Pruned reflection table")

--- a/xfel/merging/application/input/file_loader.py
+++ b/xfel/merging/application/input/file_loader.py
@@ -145,7 +145,7 @@ class simple_file_loader(worker):
           # NOTE: these are un-prunable
           reflections["input_refl_index"] = flex.int(
             list(range(len(reflections))))
-          reflections["orig_exp_id"] = reflections['id']
+          reflections["original_id"] = reflections['id']
           assert file_names_mapping is not None
           exp_ref_pair = os.path.abspath(experiments_filename), os.path.abspath(reflections_filename)
           this_refl_fileMappings = [file_names_mapping[exp_ref_pair]]*len(reflections)

--- a/xfel/merging/application/integrate/integrate.py
+++ b/xfel/merging/application/integrate/integrate.py
@@ -31,7 +31,7 @@ class integrate(worker):
     # Re-generate the image sets using their format classes so we can read the raw data
     # Integrate the experiments one at a time to not use up memory
     all_integrated_expts = ExperimentList()
-    all_integrated_refls = flex.reflection_table()
+    all_integrated_refls = None
     current_imageset = None
     current_imageset_path = None
     for expt_id, expt in enumerate(experiments):
@@ -55,7 +55,10 @@ class integrate(worker):
         continue
 
       all_integrated_expts.append(expt)
-      flex.reflection_table.concat([all_integrated, integrated])
+      if all_integrated_refls:
+        flex.reflection_table.concat([all_integrated_refls, integrated])
+      else:
+        all_integrated_refls = integrated
 
     self.logger.log("Integration done, %d experiments, %d reflections"%(len(all_integrated_expts), len(all_integrated_refls)))
     return all_integrated_expts, all_integrated_refls

--- a/xfel/merging/application/integrate/integrate.py
+++ b/xfel/merging/application/integrate/integrate.py
@@ -37,7 +37,7 @@ class integrate(worker):
     for expt_id, expt in enumerate(experiments):
       assert len(expt.imageset.paths()) == 1 and len(expt.imageset) == 1
       self.logger.log("Starting integration experiment %d"%expt_id)
-      refls = reflections.select(reflections['exp_id'] == expt.identifier)
+      refls = reflections.select(reflections['id'] == expt_id)
       if expt.imageset.paths()[0] != current_imageset_path:
         current_imageset_path = expt.imageset.paths()[0]
         current_imageset = ImageSetFactory.make_imageset(expt.imageset.paths())
@@ -55,11 +55,7 @@ class integrate(worker):
         continue
 
       all_integrated_expts.append(expt)
-      idents = integrated.experiment_identifiers()
-      del idents[0]
-      idents[expt_id] = expt.identifier
-      integrated['id'] = flex.int(len(integrated), len(all_integrated_expts)-1)
-      all_integrated_refls.extend(integrated)
+      flex.reflection_table.concat([all_integrated, integrated])
 
     self.logger.log("Integration done, %d experiments, %d reflections"%(len(all_integrated_expts), len(all_integrated_refls)))
     return all_integrated_expts, all_integrated_refls

--- a/xfel/merging/application/lunus/lunus.py
+++ b/xfel/merging/application/lunus/lunus.py
@@ -61,9 +61,11 @@ class lunus(worker):
       index = expt.imageset.indices()[0]
       if image_list[path][index] == n:
         filtered_expts.append(expt)
-        refls_sel |= reflections['exp_id'] == expt.identifier
+        refls_sel |= reflections['id'] == expt_id
+    filtered_refls = reflections.select(refls_sel)
+    filtered_refls.reset_ids()
     self.logger.log("Filtered out %d experiments with more than %d lattices out of %d"%((len(experiments)-len(filtered_expts), n, len(experiments))))
-    return filtered_expts, reflections.select(refls_sel)
+    return filtered_expts, filtered_refls
 
   def run(self, experiments, reflections):
 

--- a/xfel/merging/application/lunus/lunus.py
+++ b/xfel/merging/application/lunus/lunus.py
@@ -63,7 +63,8 @@ class lunus(worker):
         filtered_expts.append(expt)
         refls_sel |= reflections['id'] == expt_id
     filtered_refls = reflections.select(refls_sel)
-    filtered_refls.reset_ids()
+    if filtered_refls:
+      filtered_refls.reset_ids()
     self.logger.log("Filtered out %d experiments with more than %d lattices out of %d"%((len(experiments)-len(filtered_expts), n, len(experiments))))
     return filtered_expts, filtered_refls
 

--- a/xfel/merging/application/lunus/lunus.py
+++ b/xfel/merging/application/lunus/lunus.py
@@ -63,8 +63,7 @@ class lunus(worker):
         filtered_expts.append(expt)
         refls_sel |= reflections['id'] == expt_id
     filtered_refls = reflections.select(refls_sel)
-    if filtered_refls:
-      filtered_refls.reset_ids()
+    filtered_refls.reset_ids()
     self.logger.log("Filtered out %d experiments with more than %d lattices out of %d"%((len(experiments)-len(filtered_expts), n, len(experiments))))
     return filtered_expts, filtered_refls
 

--- a/xfel/merging/application/modify/cosym.py
+++ b/xfel/merging/application/modify/cosym.py
@@ -75,11 +75,11 @@ class cosym(worker):
       uuid_cache = uuid_starting
 
       for tranch_experiments, tranch_reflections in tokens:
-          for experiment in tranch_experiments:
+          for expt_id, experiment in enumerate(tranch_experiments):
             sampling_experiments_for_cosym.append(experiment)
             uuid_cache.append(experiment.identifier)
 
-            exp_reflections = tranch_reflections.select(tranch_reflections['exp_id'] == experiment.identifier)
+            exp_reflections = tranch_reflections.select(tranch_reflections['id'] == expt_id)
             # prepare individual reflection tables for each experiment
 
             cosym.experiment_id_detail(sampling_experiments_for_cosym, sampling_reflections_for_cosym, exp_reflections)
@@ -303,8 +303,9 @@ class cosym(worker):
             accepted_expt.crystal = MosaicCrystalSauter2014( accepted_expt.crystal.change_basis(this_cb_op) )
                                     # need to use wrapper because of cctbx/dxtbx#5
           result_experiments_for_cosym.append(accepted_expt)
-          good_refls |= input_reflections["exp_id"] == iexpt_id
-    selected_reflections = input_reflections.select(good_refls) # XXX is this in place (double check)
+          good_refls |= input_reflections["id"] == iexpt
+    selected_reflections = input_reflections.select(good_refls)
+    selected_reflections.reset_ids()
     self.mpi_helper.comm.barrier()
 
     # still have to reindex the reflection table, but try to do it efficiently

--- a/xfel/merging/application/modify/cosym.py
+++ b/xfel/merging/application/modify/cosym.py
@@ -305,7 +305,8 @@ class cosym(worker):
           result_experiments_for_cosym.append(accepted_expt)
           good_refls |= input_reflections["id"] == iexpt
     selected_reflections = input_reflections.select(good_refls)
-    selected_reflections.reset_ids()
+    if selected_reflections:
+      selected_reflections.reset_ids()
     self.mpi_helper.comm.barrier()
 
     # still have to reindex the reflection table, but try to do it efficiently

--- a/xfel/merging/application/modify/cosym.py
+++ b/xfel/merging/application/modify/cosym.py
@@ -305,8 +305,7 @@ class cosym(worker):
           result_experiments_for_cosym.append(accepted_expt)
           good_refls |= input_reflections["id"] == iexpt
     selected_reflections = input_reflections.select(good_refls)
-    if selected_reflections:
-      selected_reflections.reset_ids()
+    selected_reflections.reset_ids()
     self.mpi_helper.comm.barrier()
 
     # still have to reindex the reflection table, but try to do it efficiently

--- a/xfel/merging/application/modify/polarization.py
+++ b/xfel/merging/application/modify/polarization.py
@@ -21,8 +21,8 @@ class polarization(worker):
 
     result = flex.reflection_table()
 
-    for experiment in experiments:
-      refls = reflections.select(reflections['exp_id'] == experiment.identifier)
+    for expt_id, experiment in enumerate(experiments):
+      refls = reflections.select(reflections['id'] == expt_id)
       if len(refls) == 0: continue
       beam = experiment.beam
       # Remove the need for pixel size within cxi.merge.  Allows multipanel detector with dissimilar panels.

--- a/xfel/merging/application/modify/reindex_cosym.py
+++ b/xfel/merging/application/modify/reindex_cosym.py
@@ -27,7 +27,7 @@ def reindex_refl_by_coset(refl,data,symms,uuids,co,anomalous_flag = False, verbo
         iexpt_id = uuids[iexpt]
         this_coset = all_coset[ all_expt_id.index(iexpt_id) ]
         if this_coset == icoset:
-          good_refls |= refl["exp_id"] == iexpt_id
+          good_refls |= refl["id"] == iexpt
 
     re_millers = mi_new.select(good_refls)
     re_asu = mi_asu_new.select(good_refls)
@@ -35,10 +35,11 @@ def reindex_refl_by_coset(refl,data,symms,uuids,co,anomalous_flag = False, verbo
     refl["miller_index"].set_selected(good_refls, re_millers)
     refl["miller_index_asymmetric"].set_selected(good_refls, re_asu)
   if verbose:
+    id_map = refl.experiment_identifiers()
     for x in range(len(refl)):
-      print ("%3d"%x,refl["exp_id"][x],
-             all_coset[ all_expt_id.index(refl["exp_id"][x]) ],
-             "%10s"%(change_of_basis_op(co.partitions[   all_coset[ all_expt_id.index(refl["exp_id"][x]) ]   ][0]).as_hkl()),
+      print ("%3d"%x,id_map[refl["id"][x]],
+             all_coset[ all_expt_id.index(id_map[refl["id"][x]]) ],
+             "%10s"%(change_of_basis_op(co.partitions[   all_coset[ all_expt_id.index(id_map[refl["id"][x]]) ]   ][0]).as_hkl()),
              "(%4d%4d%4d)"%(cache_miller[x]), "(%4d%4d%4d)"%(cache_asu[x]),
              "(%4d%4d%4d)"%(refl["miller_index"][x]), "(%4d%4d%4d)"%(refl["miller_index_asymmetric"][x]))
 

--- a/xfel/merging/application/modify/reindex_to_reference.py
+++ b/xfel/merging/application/modify/reindex_to_reference.py
@@ -118,7 +118,7 @@ class reindex_to_reference(worker):
 
     # Test each experiment to see if an operator gives a better CC to the reference, and if it does, apply it
     for expt_id, experiment in enumerate(experiments):
-      exp_reflections = reflections.select(reflections['exp_id'] == experiment.identifier)
+      exp_reflections = reflections.select(reflections['id'] == expt_id)
       all_correlations = []
       best_correlation = get_correlation()
       all_correlations.append(best_correlation)

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -523,7 +523,7 @@ output {
   expanded_bookkeeping = False
     .type = bool
     .help = if True, and if save_experiments_and_reflections=True, then include in the saved refl tabls:
-    .help = 1- modified exp_id column that contains the image number and lattice number
+    .help = 1- modified experiment identifier that contains the image number and lattice number
     .help = 2- index corresponding to the particular reflection in the input file (usually something_integrated.refl)
     .help = 3- the is_odd flag
     .help = 4- the original exp id for the reflection

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -97,9 +97,6 @@ input {
       .help = memory reduction factor for MPI alltoall.
       .help = Use mpi_alltoall_slices > 1, when available RAM is insufficient for doing MPI alltoall on all data at once.
       .help = The data will then be split into mpi_alltoall_slices parts and, correspondingly, alltoall will be performed in mpi_alltoall_slices iterations.
-    reset_experiment_id_column = False
-      .type = bool
-      .expert_level = 3
   }
 }
 

--- a/xfel/merging/application/postrefine/postrefinement_rs.py
+++ b/xfel/merging/application/postrefine/postrefinement_rs.py
@@ -48,9 +48,9 @@ class postrefinement_rs(worker):
 
     experiments_rejected_by_reason = {} # reason:how_many_rejected
 
-    for experiment in experiments:
+    for expt_id, experiment in enumerate(experiments):
 
-      exp_reflections = reflections.select(reflections['exp_id'] == experiment.identifier)
+      exp_reflections = reflections.select(reflections['id'] == expt_id)
 
       # Build a miller array with _original_ miller indices of the experiment reflections
       exp_miller_indices_original = miller.set(target_symm, exp_reflections['miller_index'], not self.params.merging.merge_anomalous)
@@ -190,7 +190,8 @@ class postrefinement_rs(worker):
         new_exp_reflections['miller_index_asymmetric']  = result_observations.indices()
         new_exp_reflections['intensity.sum.value']      = result_observations.data()
         new_exp_reflections['intensity.sum.variance']   = flex.pow(result_observations.sigmas(),2)
-        new_exp_reflections['exp_id']                   = flex.std_string(len(new_exp_reflections), experiment.identifier)
+        new_exp_reflections['id']                       = flex.int(len(new_exp_reflections), len(new_experiments)-1)
+        new_exp_reflections.experiment_identifiers()[len(new_experiments)-1] = experiment.identifier
 
         # The original reflection table, i.e. the input to this run() method, has more columns than those used
         # for the postrefinement ("data" and "sigma" in the miller arrays). The problems is: some of the input reflections may have been rejected by now.

--- a/xfel/merging/application/postrefine/postrefinement_rs2.py
+++ b/xfel/merging/application/postrefine/postrefinement_rs2.py
@@ -58,9 +58,9 @@ class postrefinement_rs2(postrefinement_rs):
 
     experiments_rejected_by_reason = {} # reason:how_many_rejected
 
-    for experiment in experiments:
+    for expt_id, experiment in enumerate(experiments):
 
-      exp_reflections = reflections.select(reflections['exp_id'] == experiment.identifier)
+      exp_reflections = reflections.select(reflections['id'] == expt_id)
 
       # Build a miller array with _original_ miller indices of the experiment reflections
       exp_miller_indices_original = miller.set(target_symm, exp_reflections['miller_index'], not self.params.merging.merge_anomalous)
@@ -191,7 +191,8 @@ class postrefinement_rs2(postrefinement_rs):
         new_exp_reflections['miller_index_asymmetric']  = result_observations.indices()
         new_exp_reflections['intensity.sum.value']      = result_observations.data()
         new_exp_reflections['intensity.sum.variance']   = flex.pow(result_observations.sigmas(),2)
-        new_exp_reflections['exp_id']                   = flex.std_string(len(new_exp_reflections), experiment.identifier)
+        new_exp_reflections['id']                       = flex.int(len(new_exp_reflections), len(new_experiments)-1)
+        new_exp_reflections.experiment_identifiers()[len(new_experiments)-1] = experiment.identifier
 
         # The original reflection table, i.e. the input to this run() method, has more columns than those used
         # for the postrefinement ("data" and "sigma" in the miller arrays). The problems is: some of the input reflections may have been rejected by now.

--- a/xfel/merging/application/scale/experiment_scaler.py
+++ b/xfel/merging/application/scale/experiment_scaler.py
@@ -93,7 +93,8 @@ class experiment_scaler(worker):
       new_experiments.append(experiment)
       new_reflections.extend(exp_reflections)
 
-    new_reflections.reset_ids()
+    if new_reflections:
+      new_reflections.reset_ids()
     rejected_experiments = len(experiments) - len(new_experiments)
     assert rejected_experiments == experiments_rejected_because_of_low_signal + \
                                     experiments_rejected_because_of_low_correlation_with_reference

--- a/xfel/merging/application/scale/experiment_scaler.py
+++ b/xfel/merging/application/scale/experiment_scaler.py
@@ -93,8 +93,7 @@ class experiment_scaler(worker):
       new_experiments.append(experiment)
       new_reflections.extend(exp_reflections)
 
-    if new_reflections:
-      new_reflections.reset_ids()
+    new_reflections.reset_ids()
     rejected_experiments = len(experiments) - len(new_experiments)
     assert rejected_experiments == experiments_rejected_because_of_low_signal + \
                                     experiments_rejected_because_of_low_correlation_with_reference

--- a/xfel/merging/application/scale/experiment_scaler.py
+++ b/xfel/merging/application/scale/experiment_scaler.py
@@ -50,8 +50,8 @@ class experiment_scaler(worker):
     experiments_rejected_because_of_low_correlation_with_reference = 0
 
     target_symm = symmetry(unit_cell = self.params.scaling.unit_cell, space_group_info = self.params.scaling.space_group)
-    for experiment in experiments:
-      exp_reflections = reflections.select(reflections['exp_id'] == experiment.identifier)
+    for expt_id, experiment in enumerate(experiments):
+      exp_reflections = reflections.select(reflections['id'] == expt_id)
 
       # Build a miller array for the experiment reflections
       exp_miller_indices = miller.set(target_symm, exp_reflections['miller_index_asymmetric'], True)
@@ -93,6 +93,7 @@ class experiment_scaler(worker):
       new_experiments.append(experiment)
       new_reflections.extend(exp_reflections)
 
+    new_reflections.reset_ids()
     rejected_experiments = len(experiments) - len(new_experiments)
     assert rejected_experiments == experiments_rejected_because_of_low_signal + \
                                     experiments_rejected_because_of_low_correlation_with_reference

--- a/xfel/merging/application/statistics/experiment_resolution_statistics.py
+++ b/xfel/merging/application/statistics/experiment_resolution_statistics.py
@@ -90,7 +90,7 @@ class experiment_resolution_statistics(worker):
       if hkl in self.hkl_resolution_bins:
         i_bin = self.hkl_resolution_bins[hkl]
         for refl in refls.rows():
-          experiments_per_resolution_bins[i_bin].add(refl['exp_id'])
+          experiments_per_resolution_bins[i_bin].add(refls.experiment_identifiers()[refl['id']])
 
     # For each bin, reduce the sets of unique experiment ids to their count
     for i_bin in range(self.resolution_binner.n_bins_all()):

--- a/xfel/merging/application/statistics/intensity_resolution_statistics.py
+++ b/xfel/merging/application/statistics/intensity_resolution_statistics.py
@@ -174,6 +174,7 @@ class intensity_resolution_statistics(worker):
       self.logger.main_log(title)
     reflections_even = reflection_table_utils.select_even_experiment_reflections(reflections)
     self.run_detail(reflections_even)
+    assert len(reflections_even) + len(reflections_odd) == len(reflections)
 
     title = "\n                     Intensity Statistics (all accepted experiments)\n"
     self.logger.log(title, rank_prepend=False)

--- a/xfel/merging/command_line/merge.py
+++ b/xfel/merging/command_line/merge.py
@@ -190,20 +190,7 @@ class Script(object):
         self.mpi_logger.log("Ending step with %d experiments"%len(experiments))
 
     if self.params.output.save_experiments_and_reflections:
-      if len(reflections) and 'id' not in reflections:
-        from dials.array_family import flex
-        id_ = flex.int(len(reflections), -1)
-        if experiments:
-          for expt_number, expt in enumerate(experiments):
-            sel = reflections['exp_id'] == expt.identifier
-            id_.set_selected(sel, expt_number)
-        else:
-          for expt_number, exp_id in enumerate(set(reflections['exp_id'])):
-            sel = reflections['exp_id'] == exp_id
-            id_.set_selected(sel, expt_number)
-        reflections['id'] = id_
-
-        assert (reflections['id'] == -1).count(True) == 0, ((reflections['id'] == -1).count(True), len(reflections))
+      assert 'id' in reflections
 
       if self.mpi_helper.size == 1:
         filename_suffix = ""
@@ -225,7 +212,7 @@ class Script(object):
     if self.params.output.expanded_bookkeeping:
       if self.params.input.persistent_refl_cols is None:
         self.params.input.persistent_refl_cols = []
-      keysCreatedByMerge = ["input_refl_index", "orig_exp_id", "file_list_mapping", "is_odd_experiment"]
+      keysCreatedByMerge = ["file_list_mapping", "is_odd_experiment"]
       for key in keysCreatedByMerge:
         if key not in self.params.input.persistent_refl_cols:
           self.params.input.persistent_refl_cols.append(key)

--- a/xfel/merging/command_line/merge.py
+++ b/xfel/merging/command_line/merge.py
@@ -190,14 +190,13 @@ class Script(object):
         self.mpi_logger.log("Ending step with %d experiments"%len(experiments))
 
     if self.params.output.save_experiments_and_reflections:
-      assert 'id' in reflections
-
       if self.mpi_helper.size == 1:
         filename_suffix = ""
       else:
         filename_suffix = "_%06d"%self.mpi_helper.rank
 
       if len(reflections):
+        assert 'id' in reflections
         reflections.as_file(os.path.join(self.params.output.output_dir, "%s%s.refl"%(self.params.output.prefix, filename_suffix)))
       if experiments:
         experiments.as_file(os.path.join(self.params.output.output_dir, "%s%s.expt"%(self.params.output.prefix, filename_suffix)))

--- a/xfel/merging/command_line/merge.py
+++ b/xfel/merging/command_line/merge.py
@@ -198,7 +198,7 @@ class Script(object):
         filename_suffix = "_%06d"%self.mpi_helper.rank
 
       if len(reflections):
-        reflections.as_pickle(os.path.join(self.params.output.output_dir, "%s%s.refl"%(self.params.output.prefix, filename_suffix)))
+        reflections.as_file(os.path.join(self.params.output.output_dir, "%s%s.refl"%(self.params.output.prefix, filename_suffix)))
       if experiments:
         experiments.as_file(os.path.join(self.params.output.output_dir, "%s%s.expt"%(self.params.output.prefix, filename_suffix)))
 

--- a/xfel/merging/command_line/merge.py
+++ b/xfel/merging/command_line/merge.py
@@ -190,13 +190,14 @@ class Script(object):
         self.mpi_logger.log("Ending step with %d experiments"%len(experiments))
 
     if self.params.output.save_experiments_and_reflections:
+      assert 'id' in reflections
+
       if self.mpi_helper.size == 1:
         filename_suffix = ""
       else:
         filename_suffix = "_%06d"%self.mpi_helper.rank
 
       if len(reflections):
-        assert 'id' in reflections
         reflections.as_file(os.path.join(self.params.output.output_dir, "%s%s.refl"%(self.params.output.prefix, filename_suffix)))
       if experiments:
         experiments.as_file(os.path.join(self.params.output.output_dir, "%s%s.expt"%(self.params.output.prefix, filename_suffix)))

--- a/xfel/merging/command_line/merge.py
+++ b/xfel/merging/command_line/merge.py
@@ -212,7 +212,7 @@ class Script(object):
     if self.params.output.expanded_bookkeeping:
       if self.params.input.persistent_refl_cols is None:
         self.params.input.persistent_refl_cols = []
-      keysCreatedByMerge = ["file_list_mapping", "is_odd_experiment"]
+      keysCreatedByMerge = ["input_refl_index", "original_id", "file_list_mapping", "is_odd_experiment"]
       for key in keysCreatedByMerge:
         if key not in self.params.input.persistent_refl_cols:
           self.params.input.persistent_refl_cols.append(key)

--- a/xfel/merging/command_line/mpi_integrate.py
+++ b/xfel/merging/command_line/mpi_integrate.py
@@ -82,7 +82,6 @@ integrate_phil_str = '''
 
 program_defaults_phil_str = """
 input.keep_imagesets=True
-input.parallel_file_load.reset_experiment_id_column = True
 """
 
 from dials.command_line.stills_process import program_defaults_phil_str as dials_program_defaults_phil_str

--- a/xfel/merging/ext.cpp
+++ b/xfel/merging/ext.cpp
@@ -107,7 +107,8 @@ namespace sx_merging {
     dials::af::reflection_table::key_type key;
     const std::map<std::string, size_t> chunk_lookup;
     const std::vector<dials::af::reflection_table> tables;
-    dials::af::shared<std::string> expt_ids;
+    dials::af::shared<int> expt_ids;
+    boost::shared_ptr<dials::af::reflection_table::experiment_map_type> expt_map;
 
     experiment_id_splitter_visitor(dials::af::reflection_table &src_,
                                    dials::af::reflection_table::key_type key_,
@@ -115,7 +116,8 @@ namespace sx_merging {
                                    const std::vector<dials::af::reflection_table> &tables_)
 
         : src(src_), key(key_), chunk_lookup(chunk_lookup_), tables(tables_) {
-          expt_ids = src.get<std::string>("exp_id");
+          expt_ids = src.get<int>("id");
+          expt_map = src.experiment_identifiers();
         }
 
     template <typename U>
@@ -128,8 +130,11 @@ namespace sx_merging {
         all_columns.push_back(col);
       }
 
+      typedef dials::af::reflection_table::experiment_map_type::const_iterator const_iterator;
       for (size_t i = 0; i < src.size(); ++i) {
-        std::string experiment_id = expt_ids[i];
+        const_iterator found = expt_map->find(expt_ids[i]);
+        DIALS_ASSERT(found != expt_map->end());
+        std::string experiment_id = found->second;
         std::map<std::string, size_t>::const_iterator it = chunk_lookup.find(experiment_id);
         DIALS_ASSERT(it != chunk_lookup.end());
         size_t table_idx = it->second;


### PR DESCRIPTION
Closes dials/dials#1858.

Background: exp_id is a column of experiment identifiers, originally developed in parallel with the experiment_identifier map in DIALS.  Now that the experiment_identifier map is standard in DIALS, exp_id is redundant, so this PR removes it.

Note this PR makes heavy use of two convenience methods in DIALS:

- [concat](https://github.com/dials/dials/blob/main/src/dials/array_family/flex_ext.py#L511-L527): takes two or more reflection tables and concatenates them together, renumbering the `'id'` column and taking care of the experiment_identifer map
- [reset_ids](https://github.com/dials/dials/blob/main/src/dials/array_family/flex_ext.py#L1224-L1236): resets the `'id'` column, accounting for any gaps. Useful after using `select` to remove reflections from a table.