### PR TITLE
update rayonix trusted values to match convention in cctbx/dxtbx#536

### DIFF
--- a/xfel/cxi/cspad_ana/rayonix_tbx.py
+++ b/xfel/cxi/cspad_ana/rayonix_tbx.py
@@ -5,8 +5,9 @@ from scitbx.array_family import flex
 # given value of rayonix detector saturation xppi6115
 rayonix_saturated_value = 2**16 -1
 
-# minimum value for rayonix data (actually this number is not trusted, numbers above it are)
-rayonix_min_trusted_value = -1
+# minimum value for rayonix data
+rayonix_min_trusted_value = 0
+rayonix_max_trusted_value = rayonix_saturated_value - 1
 
 def get_rayonix_pixel_size(bin_size):
   ''' Given a bin size determine a pixel size.


### PR DESCRIPTION
After merging this, the min_trusted_value set here:

https://github.com/cctbx/dxtbx/blob/450277d94596c980762ae30f58fa357a37a1d642/src/dxtbx/format/FormatXTCRayonix.py#L71-L74

will be correct and the saturated_value can be corrected to the new `rayonix_max_trusted_value`.