### PR TITLE
Prevent `all_integrated_refls = None` returned by integrate worker

### DIFF
--- a/xfel/merging/application/integrate/integrate.py
+++ b/xfel/merging/application/integrate/integrate.py
@@ -60,8 +60,12 @@ class integrate(worker):
       else:
         all_integrated_refls = integrated
 
-    self.logger.log("Integration done, %d experiments, %d reflections"%(len(all_integrated_expts), len(all_integrated_refls)))
+    if all_integrated_refls is None:
+      all_integrated_refls = flex.reflection_table()
+    self.logger.log("Integration done, %d experiments, %d reflections" %
+                    (len(all_integrated_expts), len(all_integrated_refls)))
     return all_integrated_expts, all_integrated_refls
+
 
 if __name__ == '__main__':
   from xfel.merging.application.worker import exercise_worker


### PR DESCRIPTION
Tiny commit, but since it modifies return type/value of Integrate worker, hence PR. 

When merging data after ensemble refinement, I encountered the following error:

    File ".../cctbx/modules/cctbx_project/xfel/merging/application/integrate/integrate.py", line 63, in run
      self.logger.log("Integration done, %d experiments, %d reflections"%(len(all_integrated_expts), len(all_integrated_refls)))
    TypeError: object of type 'NoneType' has no len()

The default behavior for Integrate worker is: define `all_integrated_refls` as None (line 34) and replace it with integrated reflections as soon as you find any (line 61). However, if no reflections are found `all_integrated_refls` will remain `None` which will raise said `TypeError` when prompted for len().

In this PR I assumed that an expected behavior of the worker would be to return empty `flex.reflection_table()` if no reflections have been integrated. To this end I added a `= flex.reflection_table() if is None` check at the end of the worker.