### PR TITLE
Unpin everything

### DIFF
--- a/.azure-pipelines/xfel/conda-linux.yml
+++ b/.azure-pipelines/xfel/conda-linux.yml
@@ -109,43 +109,43 @@ jobs:
   # download daily cached build directory for builds
   # always do builds from scratch for "Update build cache" on Saturday night (Pacific)
   # always do builds from scratch for "Weekly" pipeline
-  #  - task: DownloadPipelineArtifact@2
-  #    inputs:
-  #      source: 'specific'
-  #      project: '$(resources.pipeline.build_cache.projectID)'
-  #      pipeline: '$(resources.pipeline.build_cache.pipelineID)'
-  #      allowPartiallySucceededBuilds: true
-  #      allowFailedBuilds: true
-  #      artifact: '$(artifact_name)'
-  #      path: $(Pipeline.Workspace)
-  #    displayName: Download cached build
-  #    condition: >
-  #      and(or(and(eq(variables['Build.DefinitionName'], 'Update build cache'),
-  #                 ne(variables['day'], 'Sunday')),
-  #             eq(variables['Build.DefinitionName'], 'CI'),
-  #             eq(variables['Build.DefinitionName'], 'CI branch'),
-  #             eq(variables['Build.DefinitionName'], 'XFEL CI'),
-  #             eq(variables['Build.DefinitionName'], 'XFEL CI branch'),
-  #             eq(variables['Build.DefinitionName'], 'Full')),
-  #          ne(variables['SKIP_CACHED_BUILD'], 'true'))
-  #    continueOnError: true
-  #
-  #  - script: |
-  #      cd $(Pipeline.Workspace)
-  #      tar -xf build.tar
-  #      rm build.tar
-  #    displayName: Extract build tarball
-  #    condition: >
-  #      and(or(and(eq(variables['Build.DefinitionName'], 'Update build cache'),
-  #                 ne(variables['day'], 'Sunday')),
-  #             eq(variables['Build.DefinitionName'], 'CI'),
-  #             eq(variables['Build.DefinitionName'], 'CI branch'),
-  #             eq(variables['Build.DefinitionName'], 'XFEL CI'),
-  #             eq(variables['Build.DefinitionName'], 'XFEL CI branch'),
-  #             eq(variables['Build.DefinitionName'], 'Full')),
-  #          ne(variables['SKIP_CACHED_BUILD'], 'true'))
-  #    continueOnError: true
-  #    failOnStderr: false
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: 'specific'
+      project: '$(resources.pipeline.build_cache.projectID)'
+      pipeline: '$(resources.pipeline.build_cache.pipelineID)'
+      allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
+      artifact: '$(artifact_name)'
+      path: $(Pipeline.Workspace)
+    displayName: Download cached build
+    condition: >
+      and(or(and(eq(variables['Build.DefinitionName'], 'Update build cache'),
+                 ne(variables['day'], 'Sunday')),
+             eq(variables['Build.DefinitionName'], 'CI'),
+             eq(variables['Build.DefinitionName'], 'CI branch'),
+             eq(variables['Build.DefinitionName'], 'XFEL CI'),
+             eq(variables['Build.DefinitionName'], 'XFEL CI branch'),
+             eq(variables['Build.DefinitionName'], 'Full')),
+          ne(variables['SKIP_CACHED_BUILD'], 'true'))
+    continueOnError: true
+
+  - script: |
+      cd $(Pipeline.Workspace)
+      tar -xf build.tar
+      rm build.tar
+    displayName: Extract build tarball
+    condition: >
+      and(or(and(eq(variables['Build.DefinitionName'], 'Update build cache'),
+                 ne(variables['day'], 'Sunday')),
+             eq(variables['Build.DefinitionName'], 'CI'),
+             eq(variables['Build.DefinitionName'], 'CI branch'),
+             eq(variables['Build.DefinitionName'], 'XFEL CI'),
+             eq(variables['Build.DefinitionName'], 'XFEL CI branch'),
+             eq(variables['Build.DefinitionName'], 'Full')),
+          ne(variables['SKIP_CACHED_BUILD'], 'true'))
+    continueOnError: true
+    failOnStderr: false
 
   # build
   - template: ${{ parameters.template }}

--- a/.azure-pipelines/xfel/conda-linux.yml
+++ b/.azure-pipelines/xfel/conda-linux.yml
@@ -109,43 +109,43 @@ jobs:
   # download daily cached build directory for builds
   # always do builds from scratch for "Update build cache" on Saturday night (Pacific)
   # always do builds from scratch for "Weekly" pipeline
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: 'specific'
-      project: '$(resources.pipeline.build_cache.projectID)'
-      pipeline: '$(resources.pipeline.build_cache.pipelineID)'
-      allowPartiallySucceededBuilds: true
-      allowFailedBuilds: true
-      artifact: '$(artifact_name)'
-      path: $(Pipeline.Workspace)
-    displayName: Download cached build
-    condition: >
-      and(or(and(eq(variables['Build.DefinitionName'], 'Update build cache'),
-                 ne(variables['day'], 'Sunday')),
-             eq(variables['Build.DefinitionName'], 'CI'),
-             eq(variables['Build.DefinitionName'], 'CI branch'),
-             eq(variables['Build.DefinitionName'], 'XFEL CI'),
-             eq(variables['Build.DefinitionName'], 'XFEL CI branch'),
-             eq(variables['Build.DefinitionName'], 'Full')),
-          ne(variables['SKIP_CACHED_BUILD'], 'true'))
-    continueOnError: true
-
-  - script: |
-      cd $(Pipeline.Workspace)
-      tar -xf build.tar
-      rm build.tar
-    displayName: Extract build tarball
-    condition: >
-      and(or(and(eq(variables['Build.DefinitionName'], 'Update build cache'),
-                 ne(variables['day'], 'Sunday')),
-             eq(variables['Build.DefinitionName'], 'CI'),
-             eq(variables['Build.DefinitionName'], 'CI branch'),
-             eq(variables['Build.DefinitionName'], 'XFEL CI'),
-             eq(variables['Build.DefinitionName'], 'XFEL CI branch'),
-             eq(variables['Build.DefinitionName'], 'Full')),
-          ne(variables['SKIP_CACHED_BUILD'], 'true'))
-    continueOnError: true
-    failOnStderr: false
+  #  - task: DownloadPipelineArtifact@2
+  #    inputs:
+  #      source: 'specific'
+  #      project: '$(resources.pipeline.build_cache.projectID)'
+  #      pipeline: '$(resources.pipeline.build_cache.pipelineID)'
+  #      allowPartiallySucceededBuilds: true
+  #      allowFailedBuilds: true
+  #      artifact: '$(artifact_name)'
+  #      path: $(Pipeline.Workspace)
+  #    displayName: Download cached build
+  #    condition: >
+  #      and(or(and(eq(variables['Build.DefinitionName'], 'Update build cache'),
+  #                 ne(variables['day'], 'Sunday')),
+  #             eq(variables['Build.DefinitionName'], 'CI'),
+  #             eq(variables['Build.DefinitionName'], 'CI branch'),
+  #             eq(variables['Build.DefinitionName'], 'XFEL CI'),
+  #             eq(variables['Build.DefinitionName'], 'XFEL CI branch'),
+  #             eq(variables['Build.DefinitionName'], 'Full')),
+  #          ne(variables['SKIP_CACHED_BUILD'], 'true'))
+  #    continueOnError: true
+  #
+  #  - script: |
+  #      cd $(Pipeline.Workspace)
+  #      tar -xf build.tar
+  #      rm build.tar
+  #    displayName: Extract build tarball
+  #    condition: >
+  #      and(or(and(eq(variables['Build.DefinitionName'], 'Update build cache'),
+  #                 ne(variables['day'], 'Sunday')),
+  #             eq(variables['Build.DefinitionName'], 'CI'),
+  #             eq(variables['Build.DefinitionName'], 'CI branch'),
+  #             eq(variables['Build.DefinitionName'], 'XFEL CI'),
+  #             eq(variables['Build.DefinitionName'], 'XFEL CI branch'),
+  #             eq(variables['Build.DefinitionName'], 'Full')),
+  #          ne(variables['SKIP_CACHED_BUILD'], 'true'))
+  #    continueOnError: true
+  #    failOnStderr: false
 
   # build
   - template: ${{ parameters.template }}

--- a/.azure-pipelines/xfel/unix-psana-build.yml
+++ b/.azure-pipelines/xfel/unix-psana-build.yml
@@ -60,7 +60,7 @@ steps:
     conda activate psana_env
     cd $(Pipeline.Workspace)
     rm -rf modules/boost
-    python bootstrap.py --builder=xfel --use-conda $CONDA_PREFIX --nproc=4 --config-flags="--compiler=conda" --config-flags="--use_environment_flags" --config-flags="--enable_cxx11" --config-flags="--no_bin_python" --no-boost-src build
+    python bootstrap.py --builder=xfel --use-conda $CONDA_PREFIX --nproc=4 --config-flags="--compiler=conda" --config-flags="--use_environment_flags" --config-flags="--no_bin_python" --no-boost-src build
   displayName: Configure and Build
 
 # test

--- a/xfel/conda_envs/psana_environment.yml
+++ b/xfel/conda_envs/psana_environment.yml
@@ -11,9 +11,7 @@ dependencies:
  - scons
 
  # psana
- # Temporary pin: This is a "new enough" psana but doesn't require boost 1.78.
- # See discussion in dials/dials#2299 and links therein.
- - psana=4.0.47
+ - psana
 
  # python
  - python
@@ -36,8 +34,7 @@ dependencies:
  - pyopengl
 
  # HDF5 (main libraries come with psana)
- # 11/08/22: pin h5py, see h5py/h5py#1880 and conda-forge/h5py-feedstock#92
- - h5py<3.2
+ - h5py
  - hdf5plugin  # [unix]
 
  # other
@@ -79,6 +76,6 @@ dependencies:
  # See https://github.com/cctbx/cctbx_project/issues/627
  - numpy=1.20|>=1.21.5
 
- # Temporarily pin boost due to it now requiring C++14
- - boost<=1.74
- - boost-cpp<=1.74
+ # boost
+ - boost
+ - boost-cpp


### PR DESCRIPTION
The psana=4.0.47 and h5py<3.2 pins are mutually incompatible, apparently related to the packages zlib/libzlib. The h5py issue in h5py/h5py#1880 and conda-forge/h5py-feedstock#92 is no longer reproducible. The problem with C++ compiler standard for boost 1.78 was resolved by 47c364ac, meaning that psana can now be unpinned. Therefore it appears we can unpin everything and monitor for regressions when using h5py.

Co-authored-by: Aaron Brewster <asbrewster@lbl.gov>