### PR TITLE
CBF trusted range updates

### DIFF
--- a/xfel/cftbx/detector/cspad_cbf_tbx.py
+++ b/xfel/cftbx/detector/cspad_cbf_tbx.py
@@ -793,9 +793,13 @@ def add_frame_specific_cbf_tables(cbf, wavelength, timestamp, trusted_ranges, di
   if not isinstance(gain, list):
     gain = [gain] * len(array_names)
 
-  cbf.add_category("array_intensities",["array_id","binary_id","linearity","gain","gain_esd","overload","undefined_value"])
+
+  cbf.add_category("array_intensities",["array_id","binary_id","linearity","gain","gain_esd","overload","underload","undefined_value"])
   for i, array_name in enumerate(array_names):
-    cbf.add_row([array_name,str(i+1),"linear","%f"%gain[i],"0.0",str(trusted_ranges[i][1]),str(trusted_ranges[i][0])])
+    overload = trusted_ranges[i][1] + 1
+    underload = trusted_ranges[i][0]
+    undefined = underload - 1
+    cbf.add_row([array_name,str(i+1),"linear","%f"%gain[i],"0.0",str(overload),str(underload),str(undefined)])
 
 def add_tiles_to_cbf(cbf, tiles, verbose = False):
   """

--- a/xfel/cxi/cspad_ana/rayonix_tbx.py
+++ b/xfel/cxi/cspad_ana/rayonix_tbx.py
@@ -62,8 +62,7 @@ def get_rayonix_cbf_handle(tiles, metro, timestamp, cbf_root, wavelength, distan
                                         # included in the axis_settings table below
       basis.pixel_size = (pixel_size,pixel_size)
       basis.dimension = detector_size
-      from xfel.cxi.cspad_ana.rayonix_tbx import rayonix_saturated_value
-      basis.trusted_range = (rayonix_min_trusted_value, rayonix_saturated_value)
+      basis.trusted_range = (rayonix_min_trusted_value, rayonix_max_trusted_value)
     else:
       assert False # shouldn't be reached as it would indicate a hierarchy for this detector
     basis.axis_name = detector_axes_names[-1]
@@ -290,7 +289,7 @@ def format_object_from_data(base_dxtbx, data, distance, wavelength, timestamp, a
 
   n_asics = data.focus()[0] * data.focus()[1]
   cspad_cbf_tbx.add_frame_specific_cbf_tables(cbf, wavelength,timestamp,
-    [(rayonix_min_trusted_value, rayonix_saturated_value)]*n_asics)
+    [(rayonix_min_trusted_value, rayonix_max_trusted_value)]*n_asics)
 
   # Set the distance, I.E., the length translated along the Z axis
   cbf.find_category(b"diffrn_scan_frame_axis")


### PR DESCRIPTION
- Start adding `underload`, which is the minimum trusted value, to CBFs.
- Set CBF `overload` to the smallest untrusted value
- Use rayonix_max_trusted_value instead of rayonix_saturated_value when setting trusted ranges.

This supersedes #826.

Co-authored-by: Aaron Brewster <asbrewster@lbl.gov>