### PR TITLE
Sort jobs correctly in cctbx.xfel jobs tab

### DIFF
--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -8,7 +8,6 @@ Last Changed: 06/03/2016
 Description : XFEL UI Custom Widgets and Controls
 '''
 
-import math
 import os
 import wx
 import wx.lib.agw.floatspin as fs
@@ -649,7 +648,7 @@ import wx.lib.mixins.listctrl as listmix
 
 class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
   def __init__(self, parent, style=wx.LC_ICON):
-    self.numeric_columns = set()
+    self.integer_columns = set()
     self.parent = parent
     self.sortable_mixin = listmix
     wx.ListCtrl.__init__(self, parent, style=style)
@@ -679,25 +678,23 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
     return self
 
   def get_appropriate_sorter(self):
-    return self.numerical_column_sorter if self._col in self.numeric_columns \
+    return self.integer_column_sorter if self._col in self.integer_columns \
       else self.GetColumnSorter()
 
-  def numerical_column_sorter(self, key1, key2):
+  def integer_column_sorter(self, key1, key2):
     col = self._col
     ascending = self._colSortFlag[col]
-    item1 = self.itemDataMap[key1][col]
-    item2 = self.itemDataMap[key2][col]
-    value1 = -2147483647 if item1 == '-' else int(item1)
-    value2 = -2147483647 if item2 == '-' else int(item2)
-    print(key1, type(key1))
-    print(key2, type(key2))
-    print(value1, type(value1))
-    print(value2, type(value2))
-    difference = value1 - value2
-    print(difference, type(difference))
-    if difference == 0 or math.isnan(difference):
+    try:
+      item1 = int(self.itemDataMap[key1][col])
+    except (ValueError, SystemError):
+      item1 = -1073741824
+    try:
+      item2 = int(self.itemDataMap[key2][col])
+    except (ValueError, SystemError):
+      item2 = -1073741824
+    difference = item1 - item2
+    if difference == 0:
       difference = 1 if key1 > key2 else -1
-    print(difference, type(difference))
     return difference if ascending else -difference
 
 

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -593,7 +593,7 @@ class TableCtrl(CtrlBase):
     # add column labels (xlabels)
     if len(clabels) > 0:
       self.sizer.Add(wx.StaticText(self, label=''))
-      for item in column_labels:
+      for i in clabels:
         clabel = wx.StaticText(self, label=i.decode('utf-8'), size=clabel_size)
         clabel.SetFont(self.font)
         self.sizer.Add(clabel)

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -648,7 +648,7 @@ import wx.lib.mixins.listctrl as listmix
 
 class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
   def __init__(self, parent, style=wx.LC_ICON):
-    self.numeric_columns = []
+    self.numeric_columns = set()
     self.parent = parent
     self.sortable_mixin = listmix
     wx.ListCtrl.__init__(self, parent, style=style)

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -370,7 +370,7 @@ class OptionCtrl(CtrlBase):
                label='',
                label_size=(100, -1),
                label_style='normal',
-               sub_labels=[],
+               sub_labels=(),
                ctrl_size=(300, -1),
                **kwargs):
 
@@ -385,7 +385,7 @@ class OptionCtrl(CtrlBase):
       opt_box = wx.FlexGridSizer(1, len(items) * 2, 0, 10)
 
     for key, value in items:
-      if sub_labels != []:
+      if sub_labels:
         sub_label = sub_labels[items.index((key, value))]
       else:
         sub_label = key
@@ -408,7 +408,7 @@ class VerticalOptionCtrl(CtrlBase):
                label='',
                label_size=(100, -1),
                label_style='normal',
-               sub_labels=[],
+               sub_labels=(),
                ctrl_size=(300, -1)):
 
     CtrlBase.__init__(self, parent=parent, label_style=label_style)
@@ -423,7 +423,7 @@ class VerticalOptionCtrl(CtrlBase):
       opt_box = wx.FlexGridSizer(len(items) * 2, 2, 10, 10)
 
     for key, value in items:
-      if sub_labels != []:
+      if sub_labels:
         sub_label = sub_labels[items.index((key, value))]
       else:
         sub_label = key
@@ -572,11 +572,11 @@ class TableCtrl(CtrlBase):
       Data must be a list of lists for multi-column tables '''
 
   def __init__(self, parent,
-               clabels=[],
+               clabels=(),
                clabel_size=(200, -1),
-               rlabels=[],
+               rlabels=(),
                rlabel_size=(200, -1),
-               contents=[],
+               contents=(),
                label_style='normal',
                content_style='normal'):
 
@@ -622,8 +622,9 @@ class RadioCtrl(CtrlBase):
                label_style='normal',
                ctrl_size=(100, -1),
                direction='horizontal',
-               items={}, **kwargs):
+               items=None, **kwargs):
     CtrlBase.__init__(self, parent=parent, label_style=label_style, **kwargs)
+    items = {} if items is None else items
 
     if direction == 'horizontal':
       radio_group = wx.FlexGridSizer(1, len(items) + 1, 0, 10)
@@ -651,8 +652,8 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
     self.sortable_mixin = listmix
     wx.ListCtrl.__init__(self, parent, style=style)
 
-  def initialize_sortable_columns(self, n_col=0, itemDataMap={}):
-    self.itemDataMap = itemDataMap
+  def initialize_sortable_columns(self, n_col=0, itemDataMap=None):
+    self.itemDataMap = {} if itemDataMap is None else itemDataMap
     self.sortable_mixin.ColumnSorterMixin.__init__(self, n_col)
     sortable_list = self.GetListCtrl()
     if sortable_list:
@@ -782,7 +783,7 @@ class GaugeBar(CtrlBase):
                choice_label_size=(120, -1),
                choice_size=(100, -1),
                choice_style='normal',
-               choices=[],
+               choices=(),
                gauge_max=100):
     CtrlBase.__init__(self, parent=parent, label_style=label_style,
                       content_style=content_style)

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -693,9 +693,13 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
       item2 = float(self.itemDataMap[key2][col])
     except (ValueError, SystemError):
       item2 = float('-Inf')
+    print(item1)
+    print(item2)
     difference = item1 - item2
+    print(difference)
     if difference == 0 or math.isnan(difference):
       difference = 1 if key1 > key2 else -1
+    print(difference)
     return difference if ascending else -difference
 
 

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -685,21 +685,16 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
   def numerical_column_sorter(self, key1, key2):
     col = self._col
     ascending = self._colSortFlag[col]
-    try:
-      item1 = float(self.itemDataMap[key1][col])
-    except (ValueError, SystemError):
-      item1 = -1e99
-    try:
-      item2 = float(self.itemDataMap[key2][col])
-    except (ValueError, SystemError):
-      item2 = -1e99
+    item1 = self.itemDataMap[key1][col]
+    item2 = self.itemDataMap[key2][col]
+    value1 = -2147483647 if item1 == '-' else int(item1)
+    value2 = -2147483647 if item2 == '-' else int(item2)
     print(key1, type(key1))
     print(key2, type(key2))
-    print(item1, type(item1))
-    print(item2, type(item2))
-    difference = item1 - item2
+    print(value1, type(value1))
+    print(value2, type(value2))
+    difference = value1 - value2
     print(difference, type(difference))
-    difference = 1 if item1 > item2 else -1 if item1 < item2 else 0
     if difference == 0 or math.isnan(difference):
       difference = 1 if key1 > key2 else -1
     print(difference, type(difference))

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -648,6 +648,7 @@ import wx.lib.mixins.listctrl as listmix
 
 class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
   def __init__(self, parent, style=wx.LC_ICON):
+    self.numeric_columns = []
     self.parent = parent
     self.sortable_mixin = listmix
     wx.ListCtrl.__init__(self, parent, style=style)
@@ -662,7 +663,7 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
   def __OnColClick(self, e):
     self._col = e.GetColumn()
     self._colSortFlag[self._col] = int(not self._colSortFlag[self._col])
-    self.GetListCtrl().SortItems(self.GetColumnSorter())
+    self.GetListCtrl().SortItems(self.get_appropriate_sorter())
     self.OnSortOrderChanged()
     if hasattr(self.parent, 'onColClick'):
       self.parent.onColClick(e)
@@ -670,11 +671,26 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
   def RestoreSortOrder(self, col, colSortFlag):
     self._col = col
     self._colSortFlag = colSortFlag
-    self.GetListCtrl().SortItems(self.GetColumnSorter())
+    self.GetListCtrl().SortItems(self.get_appropriate_sorter())
     self.OnSortOrderChanged()
 
   def GetListCtrl(self):
     return self
+
+  def get_appropriate_sorter(self):
+    return self.numerical_column_sorter if self._col in self.numeric_columns \
+      else self.GetColumnSorter()
+
+  def numerical_column_sorter(self, key1, key2):
+    col = self._col
+    ascending = self._colSortFlag[col]
+    item1 = float(self.itemDataMap[key1][col])
+    item2 = float(self.itemDataMap[key2][col])
+    difference = item1 - item2
+    if difference == 0:
+      difference = 1 if key1 > key2 else -1
+    return difference if ascending else -difference
+
 
 # ------------------------------- UI Elements -------------------------------- #
 

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -699,6 +699,7 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
     print(item2, type(item2))
     difference = item1 - item2
     print(difference, type(difference))
+    difference = 1 if item1 > item2 else -1 if item1 < item2 else 0
     if difference == 0 or math.isnan(difference):
       difference = 1 if key1 > key2 else -1
     print(difference, type(difference))

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -687,11 +687,11 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
     try:
       item1 = int(self.itemDataMap[key1][col])
     except (ValueError, SystemError):
-      item1 = -1073741824
+      item1 = -1073741820
     try:
       item2 = int(self.itemDataMap[key2][col])
     except (ValueError, SystemError):
-      item2 = -1073741824
+      item2 = -1073741820
     difference = item1 - item2
     if difference == 0:
       difference = 1 if key1 > key2 else -1

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -688,11 +688,11 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
     try:
       item1 = float(self.itemDataMap[key1][col])
     except (ValueError, SystemError):
-      item1 = float('-Inf')
+      item1 = -1e99
     try:
       item2 = float(self.itemDataMap[key2][col])
     except (ValueError, SystemError):
-      item2 = float('-Inf')
+      item2 = -1e99
     print(key1, type(key1))
     print(key2, type(key2))
     print(item1, type(item1))

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -693,13 +693,15 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
       item2 = float(self.itemDataMap[key2][col])
     except (ValueError, SystemError):
       item2 = float('-Inf')
-    print(item1)
-    print(item2)
+    print(key1, type(key1))
+    print(key2, type(key2))
+    print(item1, type(item1))
+    print(item2, type(item2))
     difference = item1 - item2
-    print(difference)
+    print(difference, type(difference))
     if difference == 0 or math.isnan(difference):
       difference = 1 if key1 > key2 else -1
-    print(difference)
+    print(difference, type(difference))
     return difference if ascending else -difference
 
 

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -8,6 +8,7 @@ Last Changed: 06/03/2016
 Description : XFEL UI Custom Widgets and Controls
 '''
 
+import math
 import os
 import wx
 import wx.lib.agw.floatspin as fs
@@ -684,10 +685,16 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
   def numerical_column_sorter(self, key1, key2):
     col = self._col
     ascending = self._colSortFlag[col]
-    item1 = float(self.itemDataMap[key1][col])
-    item2 = float(self.itemDataMap[key2][col])
+    try:
+      item1 = float(self.itemDataMap[key1][col])
+    except ValueError:
+      item1 = float('-Inf')
+    try:
+      item2 = float(self.itemDataMap[key2][col])
+    except ValueError:
+      item2 = float('-Inf')
     difference = item1 - item2
-    if difference == 0:
+    if difference == 0 or math.isnan(difference):
       difference = 1 if key1 > key2 else -1
     return difference if ascending else -difference
 

--- a/xfel/ui/components/xfel_gui_controls.py
+++ b/xfel/ui/components/xfel_gui_controls.py
@@ -687,11 +687,11 @@ class SortableListCtrl(wx.ListCtrl, listmix.ColumnSorterMixin):
     ascending = self._colSortFlag[col]
     try:
       item1 = float(self.itemDataMap[key1][col])
-    except ValueError:
+    except (ValueError, SystemError):
       item1 = float('-Inf')
     try:
       item2 = float(self.itemDataMap[key2][col])
-    except ValueError:
+    except (ValueError, SystemError):
       item2 = float('-Inf')
     difference = item1 - item2
     if difference == 0 or math.isnan(difference):

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -1681,6 +1681,7 @@ class JobsTab(BaseTab):
     self.job_list.InsertColumn(7, "Subm ID")
     self.job_list.InsertColumn(8, "Status")
 
+    self.job_list.numeric_columns = [0]
     self.job_list_sort_flag = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     self.job_list_col = 0
 

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -1681,7 +1681,7 @@ class JobsTab(BaseTab):
     self.job_list.InsertColumn(7, "Subm ID")
     self.job_list.InsertColumn(8, "Status")
 
-    self.job_list.numeric_columns = {0}
+    self.job_list.numeric_columns = {0, 6}
     self.job_list_sort_flag = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     self.job_list_col = 0
 

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -1681,7 +1681,7 @@ class JobsTab(BaseTab):
     self.job_list.InsertColumn(7, "Subm ID")
     self.job_list.InsertColumn(8, "Status")
 
-    self.job_list.numeric_columns = [0]
+    self.job_list.numeric_columns = {0}
     self.job_list_sort_flag = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     self.job_list_col = 0
 

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -1681,7 +1681,7 @@ class JobsTab(BaseTab):
     self.job_list.InsertColumn(7, "Subm ID")
     self.job_list.InsertColumn(8, "Status")
 
-    self.job_list.integer_columns = {0, 6}
+    self.job_list.integer_columns = {0, 6, 7}
     self.job_list_sort_flag = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     self.job_list_col = 0
 

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -1681,7 +1681,7 @@ class JobsTab(BaseTab):
     self.job_list.InsertColumn(7, "Subm ID")
     self.job_list.InsertColumn(8, "Status")
 
-    self.job_list.numeric_columns = {0, 6}
+    self.job_list.integer_columns = {0, 6}
     self.job_list_sort_flag = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     self.job_list_col = 0
 


### PR DESCRIPTION
The aim of this PR is to introduce a correct numeric sort for columns "Job" and "Task" in cctbx.xfel GUI. These columns display (usually) integers as strings, which according to default sort result in `- < 12 < 123 < 2 < 23`. This is clearly expected, but unintended.

With my limited experience I couldn't find build-in natural column sorter, but I wrote a custom one which handles the issue using try-except statements. This sorter assigns unconvertable strings such as ` ` or `-` value of -1073741820 (slightly shy off half the minimum 32-bit integer, -1e99 caused SegFault). This new sorter acts on columns "Job" and "Task", and does not appear to be slower than the built-in one, although the largest table I could test on had barely 1000 rows.

Additionally, I replaced some mutable default parameters in `cctbx_project/xfel/ui/components/xfel_gui_controls.py` with their immutable and fixed some typos. [Python Mutable Defaults Are The Source of All Evil](https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/) and some very confusing errors. They have their niche use, but I highly doubt anyone wanted the utilize it in the GUI.

A word of warning: when testing this code today on Perlmutter for ~an hour, at some point my GUI crashed with `BusError` and removed my `.cctbx.xfel/settings.phil` in the process. I do not think this was caused by my changes, but if anything like that happens in near future, then the devil might be somewhere here?