### PR TITLE
experiment_filter: add ability to exclude cells matching a cluster

### DIFF
--- a/xfel/merging/application/filter/experiment_filter.py
+++ b/xfel/merging/application/filter/experiment_filter.py
@@ -61,6 +61,11 @@ class experiment_filter(worker):
     features = np.array(features).reshape(1,-1)
     cov=self.cluster_data["populations"].fit_components[self.params.filter.unit_cell.cluster.covariance.component]
     m_distance = sqrt(cov.mahalanobis(features))
+    for other in self.params.filter.unit_cell.cluster.covariance.skip_component:
+      skip_cov = self.cluster_data["populations"].fit_components[other]
+      skip_distance = sqrt(skip_cov.mahalanobis(features))
+      if skip_distance < self.params.filter.unit_cell.cluster.covariance.skip_mahalanobis:
+        return False
     return m_distance < self.params.filter.unit_cell.cluster.covariance.mahalanobis
 
   def run(self, experiments, reflections):

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -197,12 +197,19 @@ filter
           .type = path
         component = 0
           .type = int(value_min=0)
+        skip_component = None
+          .type = int(value_min=0)
+          .multiple = True
+          .help = If a lattice belongs to any of these components, exclude it from processing.
         mahalanobis = 4.0
           .type = float(value_min=0)
           .help = Is essentially the standard deviation cutoff. Given that the unit cells
           .help = are estimated to be distributed by a multivariate Gaussian, this is the
           .help = maximum deviation (in sigmas) from the central value that is allowable for the
           .help = unit cell to be considered part of the cluster.
+        skip_mahalanobis = 4.0
+          .type = float(value_min=0)
+          .help = Cutoff distance for any components specified under skip_component.
         }
       isoform = None
         .type=str


### PR DESCRIPTION
This is motivated by the use case where a pseudomerohedral indexing ambiguity is resolved by unit cell clustering and manual reindexing. For example: for an orthorhombic unit cell 100 x 102 x 150 A, there is a pseudomerohedral indexing ambiguity around the rotation axis a+b. The misindexed lattices will cluster around 102 x 100 x 150 A. If the clusters are separable, then this is resolved by separately isolating the second cluster and reindexing it with modify_reindex_to_reference, then merging both clusters (which are now indexed consistently).

The skip_component parameter is needed because this approach fails if an experiment belongs to both components and thus appears twice in the final merge. Therefore when we isolate component 1, we exclude any experiment that also matches component 0.