### PR TITLE
wx.Timer.Start expects an integer value for milliseconds.

### DIFF
--- a/gltbx/wx_viewer.py
+++ b/gltbx/wx_viewer.py
@@ -132,7 +132,7 @@ class wxGLWindow(wx.glcanvas.GLCanvas):
     self.spintimer_id = 100 # any number
     self.spintimer_maxfps = 30
     self.spintimer = wx.Timer(self, self.spintimer_id)
-    self.spintimer.Start(1000 / self.spintimer_maxfps)
+    self.spintimer.Start(1000 // self.spintimer_maxfps)
 
     self.w, self.h = self.GetClientSize()
 


### PR DESCRIPTION
This fixes:

```
TypeError: Timer.Start(): argument 1 has unexpected type 'float'
```

observed with wx 4.2.0 when trying to run `cctbx.multiplicity_viewer`