### PR TITLE
Better detector drift scraping and visualizing

### DIFF
--- a/.azure-pipelines/py2_syntax_exceptions.txt
+++ b/.azure-pipelines/py2_syntax_exceptions.txt
@@ -8,4 +8,4 @@ xfel/ui/db/cfgs/shifter_templates.py
 xfel/small_cell/powder_util.py
 xfel/ui/db/job.py
 xfel/command_line/cxi_mpi_submit.py
-xfel/util/drifter.py
+xfel/util/drift.py

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -688,6 +688,8 @@ class DriftArtist(object):
     axes.set_facecolor('black')
     x_numeric = range(len(self.x))
     x_full_list, y_full_list = zip(*itertools.product(x_numeric, y))
+    print(f"list(x_full_list)=")
+    print(f"list(y_full_list)=")
     bins = (len(self.x), 100)
     axes.hist2d(x_full_list, y_full_list, bins=bins, cmap=plt.cm.viridis)
 

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -4,6 +4,7 @@ from collections import OrderedDict, defaultdict
 from json.decoder import JSONDecodeError
 import glob
 import itertools
+import math
 import os
 import six
 import sys
@@ -685,8 +686,10 @@ class DriftArtist(object):
 
   def _plot_drift_distribution(self, axes, y):
     axes.set_facecolor('black')
-    x_full_list, y_full_list = zip(*itertools.product(self.x, y))
-    axes.hist2d(x_full_list, y_full_list, cmap=plt.cm.viridis)
+    x_numeric = range(len(self.x))
+    x_full_list, y_full_list = zip(*itertools.product(x_numeric, y))
+    bins = (len(self.x), 100)
+    axes.hist2d(x_full_list, y_full_list, bins=bins, cmap=plt.cm.viridis)
 
   def _plot_bars(self):
     y = self.table['expts']

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -195,6 +195,7 @@ def flatten_together(*iterables):
   flattened = [[]] *  len(iterables)
   for iterable_elements in zip(iterables):
     lens = [len(el) for el in iterable_elements if is_iterable(el)]
+    print(f"{lens}")
     if len(unique_elements(lens)) > 1:
       raise ValueError('All iterables elements must be scalars of same-length')
     for iterable_idx, el in enumerate(iterable_elements):

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -708,6 +708,7 @@ class DriftArtist(object):
     b = (len(self.x), 100)
     r = [[-0.5, len(self.x) - 0.5], [min(y_flat), max(y_flat)]]
     axes.hist2d(x_flat, y_flat, bins=b, range=r, cmap=plt.cm.magma_r, cmin=0.5)
+    axes.scatter(self.x, [average(y_iterable) for y_iterable in y], c='w')
 
   def _plot_bars(self):
     y = self.table['expts']

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -190,6 +190,8 @@ class CorrelationMatrix(object):
 
 def flatten_together(*iterables):
   """For each iterable flatten it or repeat its elements, return same-length"""
+  for it in iterables:
+    print(f"{list(it)=}")
   if unique_elements(len(it) for it in iterables if it) != 1:
     raise ValueError('All iterables must have the same non-zero length')
   flattened = [[]] *  len(iterables)

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -161,8 +161,11 @@ class CorrelationMatrix(object):
         elif len(variables[k1]) < 2:
           self.corr[k1][k2] = self.corr[k2][k1] = 0.0
         elif i2 > i1:
-          self.corr[k1][k2] = self.corr[k2][k1] = \
-            correlation(variables[k1], variables[k2], weights=weights)
+          try:
+            corr = correlation(variables[k1], variables[k2], weights=weights)
+          except ZeroDivisionError:
+            corr = 0
+          self.corr[k1][k2] = self.corr[k2][k1] = corr
 
   def __str__(self):
     s = 'Correl. ' + ' '.join('{:>7}'.format(k) for k in self.keys)

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -591,8 +591,6 @@ class DriftArtist(object):
   def __init__(self, table, parameters):
     self.colormap = plt.get_cmap('tab10')
     self.colormap_period = 10
-    self.color_by = 'tag' if len(set(table['tag'])) > 1 else 'task'
-    self.order_by = 'run'
     self.cov_colormap = plt.get_cmap('seismic')
     self.table = table
     self.parameters = parameters
@@ -642,6 +640,14 @@ class DriftArtist(object):
   @property
   def x(self):
     return self.table[self.order_by]
+
+  @property
+  def color_by(self):
+    return 'tag' if len(set(self.table['tag'])) > 1 else 'task'
+
+  @property
+  def order_by(self):
+    return 'run'
 
   def _get_handles_and_labels(self):
     handles, unique_keys = [], []

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -192,7 +192,7 @@ def flatten_together(*iterables):
   """For each iterable flatten it or repeat its elements, return same-length"""
   if len(unique_elements(len(it) for it in iterables if it)) != 1:
     raise ValueError('All iterables must have the same non-zero length')
-  flattened = [[]] *  len(iterables)
+  flattened = [[] for _ in range(len(iterables))]
   for iterable_elements in zip(*iterables):
     print(f"{iterable_elements=}")
     lens = [len(el) for el in iterable_elements if is_iterable(el)]

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -688,8 +688,8 @@ class DriftArtist(object):
     axes.set_facecolor('black')
     x_numeric = range(len(self.x))
     x_full_list, y_full_list = zip(*itertools.product(x_numeric, y))
-    print(f"list(x_full_list)=")
-    print(f"list(y_full_list)=")
+    print(f"{list(x_full_list)=}")
+    print(f"{list(y_full_list)=}")
     bins = (len(self.x), 100)
     axes.hist2d(x_full_list, y_full_list, bins=bins, cmap=plt.cm.viridis)
 

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -124,8 +124,8 @@ DEFAULT_INPUT_SCOPE = parse("""
 
 def average(sequence, weights=None):
   """Calculate weighted arithmetic mean of an iterable"""
-  weights = [1] * len(sequence) if weights is None else weights
-  return sum(s * w for s, w in zip(sequence, weights)) / sum(weights)
+  weights = [1] * len(sequence) if weights is None else list(weights)
+  return sum(s * w for s, w in zip(list(sequence), weights)) / sum(weights)
 
 
 def correlation(xs, ys, weights=None):

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -709,11 +709,10 @@ class DriftArtist(object):
   def _plot_drift_distribution(self, axes, y):
     axes.set_facecolor('black')
     x_numeric = range(len(self.x))
-    x_full_list, y_full_list = flatten_together(x_numeric, y)
-    print(f"{list(x_full_list)=}")
-    print(f"{list(y_full_list)=}")
+    x_flat, y_flat = flatten_together(x_numeric, y)
     bins = (len(self.x), 100)
-    axes.hist2d(x_full_list, y_full_list, bins=bins, cmap=plt.cm.viridis)
+    range_ = [[-0.5, len(self.x) + 0.5], [min(y_flat), max(y_flat)]]
+    axes.hist2d(x_flat, y_flat, bins=bins, range=range_, cmap=plt.cm.viridis, cmin=0.5)
 
   def _plot_bars(self):
     y = self.table['expts']

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -692,9 +692,10 @@ class DriftArtist(object):
     self.axh.bar(self.x, y, width=w, color=self.color_array, alpha=0.5)
 
   def _plot_correlations(self):
-    keys = ['x', 'y', 'z', 'a', 'b', 'c']
-    cm = CorrelationMatrix({k: self.table[k] for k in keys},
-                           weights=self.table['refls'])
+    keys = ['x', 'y', 'z', 'a', 'b', 'c']  # plot correlation between avg only
+    correlated = {k: average(self.table[k]) if is_iterable(self.table[k])
+                  else self.table[k] for k in keys}
+    cm = CorrelationMatrix(correlated, weights=self.table['refls'])
     print(cm)
     self.axw.set_xlim([0, len(keys)])
     self.axw.set_ylim([0, len(keys)])

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -199,6 +199,8 @@ def flatten_together(*iterables):
     if len(unique_elements(lens)) > 1:
       raise ValueError('All iterables elements must be scalars of same-length')
     for iterable_idx, el in enumerate(iterable_elements):
+      print(f"{iterable_idx=}")
+      print(f"{el=}")
       flattened[iterable_idx].extend(el if is_iterable(el) else [el] * max(lens))
   return flattened
 

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -695,8 +695,8 @@ class DriftArtist(object):
 
   def _plot_correlations(self):
     keys = ['x', 'y', 'z', 'a', 'b', 'c']  # plot correlation between avg only
-    correlated = {k: average(self.table[k]) if is_iterable(self.table[k])
-                  else self.table[k] for k in keys}
+    correlated = {k: [average(v) for v in self.table[k]] \
+      if is_iterable(self.table[k][0]) else self.table[k] for k in keys}
     cm = CorrelationMatrix(correlated, weights=self.table['refls'])
     print(cm)
     self.axw.set_xlim([0, len(keys)])

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -30,12 +30,12 @@ Error bars can be derived from the uncertainty of individual reflections'
 position in laboratory reference system.
 
 Example usage 1:
-"libtbx.python `libtbx.find_in_repositories xfel`/util/drifter.py
+"libtbx.python `libtbx.find_in_repositories xfel`/util/drift.py
 input.glob=batch*TDER/ input.kind=merging_directory"
 where `batch*TDER` points to folders with merging results.
 
 Example usage 2:
-"libtbx.python `libtbx.find_in_repositories xfel`/util/drifter.py
+"libtbx.python `libtbx.find_in_repositories xfel`/util/drift.py
 input.glob=r0*/039_rg084/task209 input.kind=tder_task_directory"
 where `r0*/039_rg084/task209` points to folders with TDER results.
 '''

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -124,8 +124,6 @@ DEFAULT_INPUT_SCOPE = parse("""
 
 def average(sequence, weights=None):
   """Calculate weighted arithmetic mean of an iterable"""
-  print(sequence, weights)
-  print(type(sequence), type(weights))
   weights = [1] * len(sequence) if weights is None else weights
   return sum(s * w for s, w in zip(sequence, weights)) / sum(weights)
 
@@ -401,9 +399,6 @@ class MergingDirectoryDriftScraper(BaseDriftScraper):
             print(e)
           else:
             self.table.add(**scrap_dict)
-            print('Updating table with: {}'.format(scrap_dict))
-    for key in self.table.KEYS:
-      print('KEY: {}, LEN: {}'.format(key, len(self.table[key])))
 
 
 class FirstOriginMixin(object):

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -327,7 +327,6 @@ class TderTaskDirectoryDriftScraper(BaseDriftScraper):
       cpp = path_lookup(tder_task_directory, 'combine_experiments_t*',
                         'intermediates', '*chunk*_combine_*.phil')
       combining_phil_paths.extend(cpp)
-    print(f"{combining_phil_paths}=")
     for cpp in unique_elements(combining_phil_paths):  # combine.phil paths
       try:
         scrap_dict = {'tag': "TDER"}

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -707,13 +707,13 @@ class DriftArtist(object):
       axes.errorbar(self.x, y, yerr=y_err, ecolor='black', ls='')
 
   def _plot_drift_distribution(self, axes, y):
-    axes.set_facecolor('gray')
+    # axes.set_facecolor('gray')
     x_numeric = range(len(self.x))
     x_flat, y_flat = flatten_together(x_numeric, y)
     bins = (len(self.x), 100)
     range_ = [[-0.5, len(self.x) - 0.5], [min(y_flat), max(y_flat)]]
     axes.hist2d(x_flat, y_flat, bins=bins, range=range_,
-                cmap=plt.cm.viridis, cmin=0.5)
+                cmap=plt.cm.viridis_r, cmin=0.5)
 
   def _plot_bars(self):
     y = self.table['expts']

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -703,7 +703,8 @@ class DriftArtist(object):
     b = (len(self.x), 100)
     r = [[-0.5, len(self.x) - 0.5], [min(y_flat), max(y_flat)]]
     axes.hist2d(x_flat, y_flat, bins=b, range=r, cmap=plt.cm.magma_r, cmin=0.5)
-    axes.scatter(self.x, [average(y_iterable) for y_iterable in y], c='w')
+    axes.scatter(self.x, [average(y_iterable) for y_iterable in y],
+                 c=self.color_array, edgecolors='white')
 
   def _plot_bars(self):
     y = self.table['expts']

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -716,7 +716,7 @@ class DriftArtist(object):
 
   def _plot_correlations(self):
     keys = ['x', 'y', 'z', 'a', 'b', 'c']
-    flat_cols = flatten_together([self.table[k] for k in keys + ['refls']])
+    flat_cols = flatten_together(*[self.table[k] for k in keys + ['refls']])
     correlated = {k: f for k, f in zip(keys, flat_cols)}
     cm = CorrelationMatrix(correlated, weights=flat_cols[-1])
     print(cm)

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -194,6 +194,7 @@ def flatten_together(*iterables):
     raise ValueError('All iterables must have the same non-zero length')
   flattened = [[]] *  len(iterables)
   for iterable_elements in zip(iterables):
+    print(f"{iterable_elements=}")
     lens = [len(el) for el in iterable_elements if is_iterable(el)]
     if len(unique_elements(lens)) > 1:
       raise ValueError('All iterables elements must be scalars of same-length')

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -124,8 +124,10 @@ DEFAULT_INPUT_SCOPE = parse("""
 
 def average(sequence, weights=None):
   """Calculate weighted arithmetic mean of an iterable"""
-  weights = [1] * len(sequence) if weights is None else list(weights)
-  return sum(s * w for s, w in zip(list(sequence), weights)) / sum(weights)
+  print(sequence, weights)
+  print(type(sequence), type(weights))
+  weights = [1] * len(sequence) if weights is None else weights
+  return sum(s * w for s, w in zip(sequence, weights)) / sum(weights)
 
 
 def correlation(xs, ys, weights=None):

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -572,10 +572,11 @@ class DriftArtist(object):
       ax_top.set_xticklabels(self.table['expts'])
     if self.parameters.uncertainties:
       axes.errorbar(self.x, y, yerr=y_err, ecolor='black', ls='')
-    axes2 = axes.twinx()
     avg_y = average(y, weights=self.table['refls'])
-    axes2.set_ylim([lim / avg_y - 1 for lim in axes.get_ylim()])
-    axes2.yaxis.set_major_formatter(PercentFormatter(xmax=1))
+    if avg_y != 0:
+      axes2 = axes.twinx()
+      axes2.set_ylim([lim / avg_y - 1 for lim in axes.get_ylim()])
+      axes2.yaxis.set_major_formatter(PercentFormatter(xmax=1))
 
   def _plot_bars(self):
     y = self.table['expts']

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -689,7 +689,8 @@ class DriftArtist(object):
       ax_top.tick_params(rotation=90)
       ax_top.set_xticks(self.axx.get_xticks())
       ax_top.set_xticklabels(self.table['expts'])
-    avg_y = average(y, weights=self.table['refls'])
+    flattened_y, flattened_weights = flatten_together(y, self.table['refls'])
+    avg_y = average(flattened_y, weights=flattened_weights)
     if avg_y != 0:
       axes2 = axes.twinx()
       axes2.set_ylim([lim / avg_y - 1 for lim in axes.get_ylim()])

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -465,7 +465,7 @@ class DriftTable(object):
       cells = [self._format_cell(d[k]) for k in self.active_keys]
       for ak in self.auxiliary.keys():
         cells.append(self._format_cell(self[ak][i]))
-      lines.append(' '.join('{!s:9.9}'.format(cell) for cell in cells))
+      lines.append(' '.join(cells))
     return '\n'.join(lines)
 
   def add(self, **kwargs):

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -707,12 +707,13 @@ class DriftArtist(object):
       axes.errorbar(self.x, y, yerr=y_err, ecolor='black', ls='')
 
   def _plot_drift_distribution(self, axes, y):
-    axes.set_facecolor('black')
+    axes.set_facecolor('gray')
     x_numeric = range(len(self.x))
     x_flat, y_flat = flatten_together(x_numeric, y)
     bins = (len(self.x), 100)
-    range_ = [[-0.5, len(self.x) + 0.5], [min(y_flat), max(y_flat)]]
-    axes.hist2d(x_flat, y_flat, bins=bins, range=range_, cmap=plt.cm.viridis, cmin=0.5)
+    range_ = [[-0.5, len(self.x) - 0.5], [min(y_flat), max(y_flat)]]
+    axes.hist2d(x_flat, y_flat, bins=bins, range=range_,
+                cmap=plt.cm.viridis, cmin=0.5)
 
   def _plot_bars(self):
     y = self.table['expts']

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -192,17 +192,21 @@ def flatten_together(*iterables):
   """For each iterable flatten it or repeat its elements, return same-length"""
   if len(unique_elements(len(it) for it in iterables if it)) != 1:
     raise ValueError('All iterables must have the same non-zero length')
-  flattened = [[] for _ in range(len(iterables))]
+  flat = [[] for _ in range(len(iterables))]
   for iterable_elements in zip(*iterables):
     print(f"{iterable_elements=}")
     lens = [len(el) for el in iterable_elements if is_iterable(el)]
     if len(unique_elements(lens)) > 1:
       raise ValueError('All iterables elements must be scalars of same-length')
-    for iterable_idx, el in enumerate(iterable_elements):
-      print(f"{iterable_idx=}")
-      print(f"{el=}")
-      flattened[iterable_idx].extend(el if is_iterable(el) else [el] * max(lens))
-  return flattened
+    elif len(unique_elements(lens)) == 1:
+      for iterable_idx, el in enumerate(iterable_elements):
+        print(f"{iterable_idx=}")
+        print(f"{el=}")
+        flat[iterable_idx].extend(el if is_iterable(el) else [el] * max(lens))
+    else:
+      for iterable_idx, el in enumerate(iterable_elements):
+        flat[iterable_idx].append(el)
+  return flat
 
 
 def is_iterable(value):

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -193,7 +193,7 @@ def flatten_together(*iterables):
   if len(unique_elements(len(it) for it in iterables if it)) != 1:
     raise ValueError('All iterables must have the same non-zero length')
   flattened = [[]] *  len(iterables)
-  for iterable_elements in zip(iterables):
+  for iterable_elements in zip(*iterables):
     print(f"{iterable_elements=}")
     lens = [len(el) for el in iterable_elements if is_iterable(el)]
     if len(unique_elements(lens)) > 1:

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -327,6 +327,7 @@ class TderTaskDirectoryDriftScraper(BaseDriftScraper):
       cpp = path_lookup(tder_task_directory, 'combine_experiments_t*',
                         'intermediates', '*chunk*_combine_*.phil')
       combining_phil_paths.extend(cpp)
+    print(f"{combining_phil_paths}=")
     for cpp in unique_elements(combining_phil_paths):  # combine.phil paths
       try:
         scrap_dict = {'tag': "TDER"}

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -194,14 +194,11 @@ def flatten_together(*iterables):
     raise ValueError('All iterables must have the same non-zero length')
   flat = [[] for _ in range(len(iterables))]
   for iterable_elements in zip(*iterables):
-    print(f"{iterable_elements=}")
     lens = [len(el) for el in iterable_elements if is_iterable(el)]
     if len(unique_elements(lens)) > 1:
       raise ValueError('All iterables elements must be scalars of same-length')
     elif len(unique_elements(lens)) == 1:
       for iterable_idx, el in enumerate(iterable_elements):
-        print(f"{iterable_idx=}")
-        print(f"{el=}")
         flat[iterable_idx].extend(el if is_iterable(el) else [el] * max(lens))
     else:
       for iterable_idx, el in enumerate(iterable_elements):
@@ -707,13 +704,10 @@ class DriftArtist(object):
       axes.errorbar(self.x, y, yerr=y_err, ecolor='black', ls='')
 
   def _plot_drift_distribution(self, axes, y):
-    # axes.set_facecolor('gray')
-    x_numeric = range(len(self.x))
-    x_flat, y_flat = flatten_together(x_numeric, y)
-    bins = (len(self.x), 100)
-    range_ = [[-0.5, len(self.x) - 0.5], [min(y_flat), max(y_flat)]]
-    axes.hist2d(x_flat, y_flat, bins=bins, range=range_,
-                cmap=plt.cm.viridis_r, cmin=0.5)
+    x_flat, y_flat = flatten_together(range(len(self.x)), y)
+    b = (len(self.x), 100)
+    r = [[-0.5, len(self.x) - 0.5], [min(y_flat), max(y_flat)]]
+    axes.hist2d(x_flat, y_flat, bins=b, range=r, cmap=plt.cm.magma_r, cmin=0.5)
 
   def _plot_bars(self):
     y = self.table['expts']
@@ -721,10 +715,10 @@ class DriftArtist(object):
     self.axh.bar(self.x, y, width=w, color=self.color_array, alpha=0.5)
 
   def _plot_correlations(self):
-    keys = ['x', 'y', 'z', 'a', 'b', 'c']  # plot correlation between avg only
-    correlated = {k: [average(v) for v in self.table[k]] \
-      if is_iterable(self.table[k][0]) else self.table[k] for k in keys}
-    cm = CorrelationMatrix(correlated, weights=self.table['refls'])
+    keys = ['x', 'y', 'z', 'a', 'b', 'c']
+    flat_cols = flatten_together([self.table[k] for k in keys + ['refls']])
+    correlated = {k: f for k, f in zip(keys, flat_cols)}
+    cm = CorrelationMatrix(correlated, weights=flat_cols[-1])
     print(cm)
     self.axw.set_xlim([0, len(keys)])
     self.axw.set_ylim([0, len(keys)])

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -190,14 +190,11 @@ class CorrelationMatrix(object):
 
 def flatten_together(*iterables):
   """For each iterable flatten it or repeat its elements, return same-length"""
-  for it in iterables:
-    print(f"{list(it)=}")
-  if unique_elements(len(it) for it in iterables if it) != 1:
+  if len(unique_elements(len(it) for it in iterables if it)) != 1:
     raise ValueError('All iterables must have the same non-zero length')
   flattened = [[]] *  len(iterables)
   for iterable_elements in zip(iterables):
     lens = [len(el) for el in iterable_elements if is_iterable(el)]
-    print(f"{lens}")
     if len(unique_elements(lens)) > 1:
       raise ValueError('All iterables elements must be scalars of same-length')
     for iterable_idx, el in enumerate(iterable_elements):

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -250,8 +250,8 @@ def represent_range_as_str(sorted_iterable):
 
 
 def unique_elements(sequence):
-  """Return unique elements of sequence while preserving its order and type"""
-  return type(sequence)(OrderedDict.fromkeys(sequence))
+  """Return list of unique elements in sequence while preserving its order"""
+  return list(OrderedDict.fromkeys(sequence))
 
 
 ############################### DRIFT SCRAPPING ###############################

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function, division
 import abc
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from json.decoder import JSONDecodeError
 import glob
 import os

--- a/xfel/util/drifter.py
+++ b/xfel/util/drifter.py
@@ -319,13 +319,14 @@ class BaseDriftScraper(object):
     phil = DEFAULT_INPUT_SCOPE.fetch(sources=merging_phils).extract()
     return sorted(set(phil.input.path))
 
-  def locate_refined_expts_refls(self, combine_phil_path):
+  @staticmethod
+  def locate_refined_expts_refls(combine_phil_path):
     """Return all refined expts and refls down-stream from combine_phil_path"""
     path_stem = combine_phil_path.replace('_combine_experiments.phil', '')
     expts_paths = path_lookup(path_stem + '_refined.expt')
     refls_paths = path_lookup(path_stem + '_refined.refl')
-    expts = self.load_experiments(*expts_paths)
-    refls = self.load_reflections(*refls_paths)
+    expts = read_experiments(*expts_paths)
+    refls = read_reflections(*refls_paths)
     return expts, refls
 
   @staticmethod
@@ -387,7 +388,7 @@ class MergingDirectoryDriftScraper(BaseDriftScraper):
       merging_phil_paths.sort(key=os.path.getmtime)
       for scaling_dir in self.locate_scaling_directories(merging_phil_paths):
         scaled_expt_paths = path_lookup(scaling_dir, 'scaling_*.expt')
-        scaled_expts = self.load_experiments(*scaled_expt_paths)
+        scaled_expts = read_experiments(*scaled_expt_paths)
         scaled_identifiers = list(scaled_expts.identifiers())
         scaling_phil_paths = []
         for sep in scaled_expt_paths:

--- a/xfel/util/drifter.py
+++ b/xfel/util/drifter.py
@@ -20,17 +20,24 @@ from matplotlib.patches import Rectangle
 from matplotlib.ticker import PercentFormatter
 
 
-message = ''' This script aims to investigate the spatial drift of a detector
-              as a function of experimental progress. It requires the directory
-              structure to follow that resulting from indexing and ensemble
-              refinement performed by cctbx.xfel. End result is a multiplot
-              with detector origin position (vertical position) as a function
-              of run number (horizontal position), colored according to tag
-              name. Error bars are derived from the uncertainty of individual
-              reflections' position in laboratory reference system.
-              Example usage: `libtbx.python `libtbx.find_in_repositories
-              xfel`/util/drifter.py input.glob=batch*TDER/`, where `batch*TDER`
-              describes folders (and thus dataset names) with merging results.
+message = '''
+This script aims to investigate the spatial drift of a detector as a function
+of experimental progress. It requires the directory structure to follow that
+resulting from indexing and ensemble refinement performed by cctbx.xfel.
+End result is a multiplot with detector origin position (vertical position) as
+a function of run number (horizontal position), colored according to tag name.
+Error bars can be derived from the uncertainty of individual reflections'
+position in laboratory reference system.
+
+Example usage 1:
+"libtbx.python `libtbx.find_in_repositories xfel`/util/drifter.py
+input.glob=batch*TDER/ input.kind=merging_directory"
+where `batch*TDER` points to folders with merging results.
+
+Example usage 2:
+"libtbx.python `libtbx.find_in_repositories xfel`/util/drifter.py
+input.glob=r0*/039_rg084/task209 input.kind=tder_task_directory"
+where `r0*/039_rg084/task209` points to folders with TDER results.
 '''
 
 

--- a/xfel/util/drifter.py
+++ b/xfel/util/drifter.py
@@ -437,7 +437,7 @@ class DriftScraperFactory(object):
   @classmethod
   def get_drift_scraper(cls, table, parameters):
     base = DriftScraperRegistrar.REGISTRY[parameters.input.kind]
-    mixin = DriftUncertaintiesRegistrar.REGISTRY[parameters.uncertainty]
+    mixin = DriftUncertaintiesRegistrar.REGISTRY[parameters.uncertainties]
     class DriftScraper(base, mixin):
       pass
     return DriftScraper(table=table, parameters=parameters)

--- a/xfel/util/drifter.py
+++ b/xfel/util/drifter.py
@@ -250,10 +250,10 @@ class BaseDriftScraper(object):
     trials = sorted(set(index_dir[-13:-10] for index_dir in index_dirs))
     runs = sorted(set(index_dir[-19:-14] for index_dir in index_dirs))
     return {'chunk': path_split(combine_phil_path)[-1][16:19],
-            'run': self.represent_range_as_str(runs),
-            'rungroup': self.represent_range_as_str(rungroups),
+            'run': represent_range_as_str(runs),
+            'rungroup': represent_range_as_str(rungroups),
             'task': path_split(combine_phil_path)[-4],
-            'trial': self.represent_range_as_str(trials)}
+            'trial': represent_range_as_str(trials)}
 
   @staticmethod
   def extract_origin(expts):

--- a/xfel/util/drifter.py
+++ b/xfel/util/drifter.py
@@ -1,12 +1,16 @@
 from __future__ import absolute_import, print_function, division
+from json.decoder import JSONDecodeError
 import glob
 import os
+import six
 import sys
 import tempfile
-from dials.array_family import flex
-from dxtbx.model.experiment_list import ExperimentList
+
+from dials.array_family import flex  # noqa
+from dxtbx.model.experiment_list import ExperimentList  # noqa
 from libtbx.phil import parse
 from libtbx.utils import Sorry
+
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 from matplotlib.lines import Line2D
@@ -26,12 +30,24 @@ message = ''' This script aims to investigate the spatial drift of a detector
               xfel`/util/drifter.py input.glob=batch*TDER/`, where `batch*TDER`
               describes folders (and thus dataset names) with merging results.
 '''
+
+
+################################ PHIL HANDLING ################################
+
+
 phil_scope = parse('''
   input {
     glob = None
       .type = str
       .multiple = True
       .help = glob which matches directories after TDER to be investigated.
+    exclude = None
+      .type = str
+      .multiple = True
+      .help = glob which matches merging directories to exclude from input.glob
+    kind = tder_expt_files *merging_directory
+      .type = choice
+      .help = The type of files located by input.glob
   }
   plot {
     show = True
@@ -87,6 +103,9 @@ DEFAULT_INPUT_SCOPE = parse("""
 """)
 
 
+############################## UTILITY FUNCTIONS ##############################
+
+
 def average(sequence, weights=None):
   weights = [1] * len(sequence) if weights is None else weights
   return sum(s * w for s, w in zip(sequence, weights)) / sum(weights)
@@ -124,9 +143,11 @@ class CorrelationMatrix(object):
       for i2, k2 in enumerate(self.keys):
         if i1 == i2:
           self.corr[k1][k2] = self.corr[k2][k1] = 1.0
+        elif len(variables[k1]) < 2:
+          self.corr[k1][k2] = self.corr[k2][k1] = 0.0
         elif i2 > i1:
-          corr = correlation(variables[k1], variables[k2], weights=weights)
-          self.corr[k1][k2] = self.corr[k2][k1] = corr
+          self.corr[k1][k2] = self.corr[k2][k1] = \
+            correlation(variables[k1], variables[k2], weights=weights)
 
   def __str__(self):
     s = 'Correl. ' + ' '.join('{:>7}'.format(k) for k in self.keys)
@@ -137,8 +158,32 @@ class CorrelationMatrix(object):
     return s
 
 
-class DriftScraper(object):
-  """Class for scraping cctbx.xfel output into instance of `DriftTable`"""
+############################### DRIFT SCRAPPING ###############################
+
+
+class DriftScraperRegistrar(type):
+  """Metaclass for `DriftScraper`s, auto-registers them by `input_kind`."""
+  REGISTRY = {}
+  def __new__(mcs, name, bases, attrs):
+    new_cls = type.__new__(mcs, name, bases, attrs)
+    if hasattr(new_cls, 'input_kind') and new_cls.input_kind:
+      mcs.REGISTRY[new_cls.input_kind] = new_cls
+    return new_cls
+
+
+class DriftScraperFactory(object):
+  """Produces appropriate DriftScraper class based on phil `params`."""
+  @classmethod
+  def get_drift_scraper(cls, table, parameters):
+    drift_scraper_class = DriftScraperRegistrar.REGISTRY[parameters.input.kind]
+    return drift_scraper_class(table=table, parameters=parameters)
+
+
+@six.add_metaclass(DriftScraperRegistrar)
+class BaseDriftScraper(object):
+  """Base class for scraping cctbx.xfel output into instance of `DriftTable`,
+  with automatic registration into the `DriftScraperRegistrar`."""
+
   def __init__(self, table, parameters):
     self.table = table
     self.parameters = parameters
@@ -147,15 +192,15 @@ class DriftScraper(object):
   def load_experiments(*expt_paths):
     """Create an instance of ExperimentList from *expt_paths"""
     expts = ExperimentList()
-    for expt_path in expt_paths:
+    for expt_path in set(expt_paths):
       expts.extend(ExperimentList.from_file(expt_path, check_format=False))
     return expts
 
   @staticmethod
   def load_reflections(*refl_paths):
     """Create an instance of flex.reflection_table from *refl_paths"""
-    refls_list = [flex.reflection_table.from_file(rp) for rp in refl_paths]
-    return flex.reflection_table.concat(refls_list)
+    refl_list = [flex.reflection_table.from_file(rp) for rp in set(refl_paths)]
+    return flex.reflection_table.concat(refl_list)
 
   @staticmethod
   def path_join(*path_elements):
@@ -165,7 +210,7 @@ class DriftScraper(object):
 
   def path_lookup(self, *path_elements):
     """Join path elements and return a list of all matching files/dirs"""
-    return glob.glob(self.path_join(*path_elements))
+    return glob.glob(self.path_join(*path_elements), recursive=True)
 
   @staticmethod
   def path_split(path):
@@ -173,41 +218,51 @@ class DriftScraper(object):
     return os.path.normpath(path).split(os.sep)
 
   @staticmethod
-  def extract_origin(expt_path):
-    """Read origin from lines 14-16 after 'hierarchy' text in expt file"""
-    with open(expt_path, 'r') as expt_file:
-      expt_lines = expt_file.read().splitlines()
-      hierarchy_word_pos = [i for i, li in enumerate(expt_lines)
-                            if 'hierarchy' in li][0]
-      x = float(expt_lines[hierarchy_word_pos + 14].replace(',', '').strip())
-      y = float(expt_lines[hierarchy_word_pos + 15].replace(',', '').strip())
-      z = float(expt_lines[hierarchy_word_pos + 16].replace(',', '').strip())
+  def return_string_value_or_range(sorted_iterable):
+    """Return str in only one in iterable, range e.g. "r00[81-94]" otherwise"""
+    fs, ls = str(sorted_iterable[0]), str(sorted_iterable[-1])
+    d = min([i for i, (fl, ll) in enumerate(zip(fs, ls)) if fl != ll] or [None])
+    return fs if not d else fs[:d] + '[' + fs[d:] + '-' + ls[d:] + ']'
+
+  def extract_db_metadata(self, combine_phil_path):
+    """Get trial, task, rungroup, chunk, run info based on combining phil"""
+    parsed_combine_phil = parse(file_name=combine_phil_path)
+    phil = DEFAULT_INPUT_SCOPE.fetch(sources=[parsed_combine_phil]).extract()
+    index_dirs = [self.path_join(pie, '..') for pie in phil.input.experiments]
+    rungroups = sorted(set(index_dir[-7:-4] for index_dir in index_dirs))
+    trials = sorted(set(index_dir[-13:-10] for index_dir in index_dirs))
+    runs = sorted(set(index_dir[-19:-14] for index_dir in index_dirs))
+    return {'chunk': self.path_split(combine_phil_path)[-1][16:19],
+            'run': self.return_string_value_or_range(runs),
+            'rungroup': self.return_string_value_or_range(rungroups),
+            'task': self.path_split(combine_phil_path)[-4],
+            'trial': self.return_string_value_or_range(trials)}
+
+  @staticmethod
+  def extract_origin(expts):
+    """Read detector origin (x, y, z) from the first expt file"""
+    x, y, z = expts[0].detector.hierarchy().get_origin()
     return {'x': x, 'y': y, 'z': z}
 
-  def extract_size_and_origin_deltas(self, expt_paths, refl_paths):
-    """Get number of experiments and reflections, as well as uncertainties
-    of origin positions from refined TDER reflection position deviations"""
-    tder_expts = self.load_experiments(*expt_paths)
-    tder_refls = self.load_reflections(*refl_paths)
-    return_dict = {'expts': len(tder_expts), 'refls': len(tder_refls)}
+  @staticmethod
+  def extract_origin_deltas(expts, refls):
+    """Get uncertainties of origin positions from refl. position deviations"""
     deltas_flex = flex.vec3_double()
-    if self.parameters.uncertainties:
-      for panel in tder_expts[0].detector:               # pr:  panel refls
-        pr = tder_refls.select(tder_refls['panel'] == panel.index())
-        pr_obs_det = pr['xyzobs.mm.value'].parts()[0:2]  # det: in det space
-        pr_cal_det = pr['xyzcal.mm'].parts()[0:2]        # lab: in lab space
-        pr_obs_lab = panel.get_lab_coord(flex.vec2_double(*pr_obs_det))
-        pr_cal_lab = panel.get_lab_coord(flex.vec2_double(*pr_cal_det))
-        deltas_flex.extend(pr_obs_lab - pr_cal_lab)
-      d = [flex.mean(flex.abs(deltas_flex.parts()[i])) for i in range(3)]
-      return_dict.update({'delta_x': d[0], 'delta_y': d[1], 'delta_z': d[2]})
-    return return_dict
+    for panel in expts[0].detector:
+      pr = refls.select(refls['panel'] == panel.index())      # pr: panel refls
+      pr_obs_det = pr['xyzobs.mm.value'].parts()[0:2]  # det: in detector space
+      pr_cal_det = pr['xyzcal.mm'].parts()[0:2]        # lab: in labor. space
+      pr_obs_lab = panel.get_lab_coord(flex.vec2_double(*pr_obs_det))
+      pr_cal_lab = panel.get_lab_coord(flex.vec2_double(*pr_cal_det))
+      deltas_flex.extend(pr_obs_lab - pr_cal_lab)
+    d = [flex.mean(flex.abs(deltas_flex.parts()[i])) for i in range(3)]
+    return {'delta_x': d[0], 'delta_y': d[1], 'delta_z': d[2]}
 
-  def extract_unit_cell_distribution(self, scaling_expt_paths):
+  def extract_unit_cell_distribution(self, scaling_expts):
     """Retrieve average a, b, c and their deltas using expt paths"""
     af, bf, cf = flex.double(), flex.double(), flex.double()
     with tempfile.NamedTemporaryFile() as tdata_file:
-      self._write_tdata(scaling_expt_paths, tdata_file.name)
+      self._write_tdata(scaling_expts, tdata_file.name)
       with open(tdata_file.name, 'r') as tdata:
         for line in tdata.read().splitlines():
           a, b, c = line.strip().split(' ')[:3]
@@ -220,10 +275,24 @@ class DriftScraper(object):
             'delta_c': cf.standard_deviation_of_the_sample()}
 
   def locate_input_tags(self):
-    input_paths = []
+    """Return all tags (paths relative to working directory)
+    which contain merging results to be processed"""
+    input_tags, exclude_tags = [], []
     for ig in self.parameters.input.glob:
-        input_paths.extend(glob.glob(ig))
-    return input_paths
+      input_tags.extend(glob.glob(ig))
+    for ie in self.parameters.input.exclude:
+      exclude_tags.extend(glob.glob(ie))
+    return [it for it in input_tags if it not in exclude_tags]
+
+  def locate_combining_phil_paths(self, scaling_phil_paths):
+    """Return paths to all phil files used to combine later-scaled expts"""
+    parsed_scaling_phil = [parse(file_name=spp) for spp in scaling_phil_paths]
+    phil = DEFAULT_INPUT_SCOPE.fetch(sources=parsed_scaling_phil).extract()
+    combine_dirs = [self.path_join(ip, '..') for ip in phil.input.path]
+    combine_phil_paths = []
+    for cd in combine_dirs:
+      combine_phil_paths.extend(self.path_lookup(cd, '*chunk*_combine_*.phil'))
+    return sorted(set(combine_phil_paths))
 
   @staticmethod
   def locate_scaling_directories(merging_phil_paths):
@@ -232,26 +301,30 @@ class DriftScraper(object):
     phil = DEFAULT_INPUT_SCOPE.fetch(sources=merging_phils).extract()
     return sorted(set(phil.input.path))
 
-  @staticmethod
-  def locate_tder_refined_expts_and_refls(scaling_phil_paths):
-    """Return paths to refined expt and refl files mentioned in scaling phil"""
-    expt_paths, refl_paths = [], []
-    scaling_phils = [parse(file_name=spp) for spp in scaling_phil_paths]
-    phil = DEFAULT_INPUT_SCOPE.fetch(sources=scaling_phils).extract()
-    refined_tder_input_paths = [ip.replace('*reintegrated*', '*refined*')
-                                for ip in phil.input.path]
-    for rip in refined_tder_input_paths:
-      expt_glob = os.path.join(rip + phil.input.experiments_suffix)
-      refl_glob = os.path.join(rip + phil.input.reflections_suffix)
-      expt_paths.extend(glob.glob(expt_glob))
-      refl_paths.extend(glob.glob(refl_glob))
-    return sorted(set(expt_paths)), sorted(set(refl_paths))
+  def locate_refined_expts_refls(self, combine_phil_path):
+    """Return all refined expts and refls down-stream from combine_phil_path"""
+    path_stem = combine_phil_path.replace('_combine_experiments.phil', '')
+    expts_paths = self.path_lookup(path_stem + '_refined.expt')
+    refls_paths = self.path_lookup(path_stem + '_refined.refl')
+    expts = self.load_experiments(*expts_paths)
+    refls = self.load_reflections(*refls_paths)
+    return expts, refls
 
-  def _write_tdata(self, expt_paths, tdata_path):
+  @staticmethod
+  def select_refls_on_experiment_identifiers(refls, identifiers):
+    selection = flex.bool(len(refls), False)
+    id_map = refls.experiment_identifiers()
+    inv_identifiers = {v: k for k, v in zip(id_map.keys(), id_map.values())}
+    for identifier in identifiers:
+      selection |= (refls['id'] == inv_identifiers.get(identifier, -1))
+    return refls.select(selection)
+
+  @staticmethod
+  def _write_tdata(expts, tdata_path):
     """Read all expt_paths and write a tdata file with unit cells in lines"""
     s = '{:.4f} {:.4f} {:.4f} {:.4f} {:.4f} {:.4f} {}'
     tdata_lines = []
-    for expt in self.load_experiments(*expt_paths):
+    for expt in expts:
       uc_params = expt.crystal.get_unit_cell().parameters()
       sg = expt.crystal.get_space_group().type().universal_hermann_mauguin_symbol()
       tdata_lines.append(s.format(*uc_params, sg.replace(' ', '')))
@@ -260,33 +333,61 @@ class DriftScraper(object):
 
   def scrap(self):
     for tag in self.locate_input_tags():
-      last_v_dir = sorted(self.path_lookup(tag, 'v*/'))[-1]
-      merging_phil_files = self.path_lookup(last_v_dir, '*_params.phil')
-      for scaling_dir in self.locate_scaling_directories(merging_phil_files):
-        scaling_expts = self.path_lookup(scaling_dir, 'scaling_*.expt')
-        try:
-          first_scaling_expt_path = sorted(scaling_expts)[0]
-        except IndexError:
-          continue
-        task_dir = self.path_join(first_scaling_expt_path, '..', '..')
-        trial_dir = self.path_join(task_dir, '..')
-        scrap_dict = {'tag': tag, 'trial': int(trial_dir[-9:-6]),
-                      'task': int(self.path_split(task_dir)[-1].lstrip('task')),
-                      'rungroup': int(trial_dir[-3:]),
-                      'run': self.path_split(trial_dir)[-2]}
-        print('Processing run {} in tag {}'.format(scrap_dict['run'], tag))
-        scrap_dict.update(self.extract_origin(first_scaling_expt_path))
-        if self.parameters.uncertainties:
-          scaling_phils = self.path_lookup(task_dir, 'params_1.phil')
-          expt_p, refl_p = self.locate_tder_refined_expts_and_refls(scaling_phils)
-          scrap_dict.update(self.extract_size_and_origin_deltas(expt_p, refl_p))
-          scrap_dict.update(self.extract_unit_cell_distribution(scaling_expts))
-        self.table.add(**scrap_dict)
+      merging_phil_paths = self.path_lookup(tag, '**', '*.phil')
+      merging_phil_paths.sort(key=os.path.getmtime)
+      for scaling_dir in self.locate_scaling_directories(merging_phil_paths):
+        scaled_expt_paths = self.path_lookup(scaling_dir, 'scaling_*.expt')
+        scaled_expts = self.load_experiments(*scaled_expt_paths)
+        scaled_identifiers = list(scaled_expts.identifiers())
+        scaling_phil_paths = []
+        for sep in scaled_expt_paths:
+          scaling_phil_paths.extend(self.path_lookup(sep, '..', '..', '*.phil'))
+        comb_phil_paths = self.locate_combining_phil_paths(scaling_phil_paths)
+        for cpp in comb_phil_paths:
+          try:
+            scrap_dict = {'tag': tag}
+            scrap_dict.update(self.extract_db_metadata(cpp))
+            print('Processing run {} in tag {}'.format(scrap_dict['run'], tag))
+            refined_expts, refined_refls = self.locate_refined_expts_refls(cpp)
+            print('  # expts, refls before selecting good:',
+                  len(refined_expts), len(refined_refls))
+            refined_expts.select_on_experiment_identifiers(scaled_identifiers)
+            refined_refls = self.select_refls_on_experiment_identifiers(
+              refined_refls, scaled_identifiers)
+            print('  # expts, refls after selecting good:',
+                  len(refined_expts), len(refined_refls))
+            scrap_dict.update({'expts': len(refined_expts)})
+            scrap_dict.update({'refls': len(refined_refls)})
+            scrap_dict.update(self.extract_origin(refined_expts))
+            scrap_dict.update(self.extract_unit_cell_distribution(refined_expts))
+            if self.parameters.uncertainties:
+              o_deltas = self.extract_origin_deltas(refined_expts, refined_refls)
+              scrap_dict.update(o_deltas)
+          except (KeyError, IndexError, JSONDecodeError) as e:
+            print(e)
+          else:
+            self.table.add(**scrap_dict)
+            print('Updating table with: {}'.format(scrap_dict))
+    for key in self.table.KEYS:
+      print('KEY: {}, LEN: {}'.format(key, len(self.table[key])))
+
+
+class MergingDirectoryDriftScraper(BaseDriftScraper):
+  input_kind = 'merging_directory'
+
+
+
+class TderExptFilesDriftScraper(BaseDriftScraper):
+  input_kind = 'tder_expt_files'
+
+
+
+################################ DRIFT STORAGE ################################
 
 
 class DriftTable(object):
   """Class responsible for storing info about all DriftDataclass instances"""
-  KEYS = ['tag', 'run', 'rungroup', 'trial', 'task', 'x', 'y', 'z',
+  KEYS = ['tag', 'run', 'rungroup', 'trial', 'chunk', 'task', 'x', 'y', 'z',
           'delta_x', 'delta_y', 'delta_z', 'expts', 'refls',
           'a', 'b', 'c', 'delta_a', 'delta_b', 'delta_c']
 
@@ -331,12 +432,15 @@ class DriftTable(object):
     return {'density': density}
 
 
+############################## DRIFT VISUALIZING ##############################
+
+
 class DriftArtist(object):
   """Object responsible for plotting an instance of `DriftTable`."""
   def __init__(self, table, parameters):
     self.colormap = plt.get_cmap('tab10')
     self.colormap_period = 10
-    self.color_by = 'tag'
+    self.color_by = 'tag' if len(set(table['tag'])) > 1 else 'task'
     self.order_by = 'run'
     self.cov_colormap = plt.get_cmap('seismic')
     self.table = table
@@ -374,10 +478,6 @@ class DriftArtist(object):
     self.axc.tick_params(axis='x', labelbottom=True, rotation=90)
     self.axc.set_xlabel(self.order_by.title())
     self.axh.set_ylabel('# expts')
-
-  @property
-  def _refl_to_expt_ratios(self):
-    return [r / e for e, r in zip(self.table['expts'], self.table['refls'])]
 
   @property
   def color_array(self):
@@ -472,9 +572,12 @@ class DriftArtist(object):
       plt.show()
 
 
+################################ ENTRY POINTS #################################
+
+
 def run(params_):
   dt = DriftTable(parameters=params_)
-  ds = DriftScraper(table=dt, parameters=params_)
+  ds = DriftScraperFactory.get_drift_scraper(table=dt, parameters=params_)
   da = DriftArtist(table=dt, parameters=params_)
   ds.scrap()
   dt.sort(by_key='run')
@@ -482,6 +585,7 @@ def run(params_):
   da.publish()
 
 
+params = []
 if __name__ == '__main__':
   if '--help' in sys.argv[1:] or '-h' in sys.argv[1:]:
     print(message)

--- a/xfel/util/drifter.py
+++ b/xfel/util/drifter.py
@@ -386,9 +386,6 @@ class TderTaskDirectoryDriftScraper(BaseDriftScraper):
         print(e)
       else:
         self.table.add(**scrap_dict)
-        print('Updating table with: {}'.format(scrap_dict))
-    for key in self.table.KEYS:
-      print('KEY: {}, LEN: {}'.format(key, len(self.table[key])))
 
 
 class MergingDirectoryDriftScraper(BaseDriftScraper):

--- a/xfel/util/drifter.py
+++ b/xfel/util/drifter.py
@@ -328,15 +328,6 @@ class BaseDriftScraper(object):
     return expts, refls
 
   @staticmethod
-  def select_refls_on_experiment_identifiers(refls, identifiers):
-    selection = flex.bool(len(refls), False)
-    id_map = refls.experiment_identifiers()
-    inv_identifiers = {v: k for k, v in zip(id_map.keys(), id_map.values())}
-    for identifier in identifiers:
-      selection |= (refls['id'] == inv_identifiers.get(identifier, -1))
-    return refls.select(selection)
-
-  @staticmethod
   def _write_tdata(expts, tdata_path):
     """Read all expt_paths and write a tdata file with unit cells in lines"""
     s = '{:.4f} {:.4f} {:.4f} {:.4f} {:.4f} {:.4f} {}'
@@ -369,8 +360,7 @@ class BaseDriftScraper(object):
             print('  # expts, refls before selecting good:',
                   len(refined_expts), len(refined_refls))
             refined_expts.select_on_experiment_identifiers(scaled_identifiers)
-            refined_refls = self.select_refls_on_experiment_identifiers(
-              refined_refls, scaled_identifiers)
+            refined_refls = refined_refls.select(refined_expts)
             print('  # expts, refls after selecting good:',
                   len(refined_expts), len(refined_refls))
             scrap_dict.update({'expts': len(refined_expts)})


### PR DESCRIPTION
Improve robustness and plotting capabilities of the `drift.py` (previously `drifter.py`) tools. Allow reading and visualizing series of data (instead of averages/firsts only) by modifying existing reading tools and drawing with 2D heat maps. New capabilities are available via phil parameters. Some steps still need to be taken to increase the robustness of `DriftScraper` and `DriftTable`; this will be handled in near future.