### PR TITLE
shuffle ids for even/odd merge stats

### DIFF
--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -569,6 +569,9 @@ output {
 
 statistics_phil = """
 statistics {
+  shuffle_ids = False
+    .type = bool
+    .help = shuffle the IDs when dividing into even/odd. This adds variation to half dataset stats like CC1/2
   n_bins = 10
     .type = int(value_min=1)
     .help = Number of resolution bins in statistics table

--- a/xfel/merging/application/reflection_table_utils.py
+++ b/xfel/merging/application/reflection_table_utils.py
@@ -27,16 +27,16 @@ class reflection_table_utils(object):
     yield reflections[i_begin:i+1]
 
   @staticmethod
-  def select_odd_experiment_reflections(reflections):
+  def select_odd_experiment_reflections(reflections, col='id'):
     'Select reflections from experiments with odd ids.'
-    sel = reflections['id'] % 2 == 1
+    sel = reflections[col] % 2 == 1
     reflections["is_odd_experiment"] = sel  # store this for later use, NOTE this is un-prunable if expanded_bookkeeping=True
     return reflections.select(sel)
 
   @staticmethod
-  def select_even_experiment_reflections(reflections):
+  def select_even_experiment_reflections(reflections, col='id'):
     'Select reflections from experiments with even ids'
-    sel = reflections['id'] % 2 == 0
+    sel = reflections[col] % 2 == 0
     return reflections.select(sel)
 
   @staticmethod


### PR DESCRIPTION
I made this change to add variability to CC1/2, but I failed to notice there was an existing phil switch for this: `statistics.cc1_2.hash_filenames` . However, when I tested `hash_filenames=True`, it didnt seem to randomize CC1/2.. Anyway, id like this functionality.. 