### PR TITLE
update for kokkos 4.0

### DIFF
--- a/kokkostbx/Legacy/kokkos_matrix.h
+++ b/kokkostbx/Legacy/kokkos_matrix.h
@@ -156,7 +156,7 @@ namespace kokkostbx {
         }
 
         KOKKOS_INLINE_FUNCTION NumType length() const {
-            return ::Kokkos::Experimental::sqrt(length_sqr());
+            return ::Kokkos::sqrt(length_sqr());
         }
 
         KOKKOS_INLINE_FUNCTION NumType dot(const matrix<NumType>& v) const {

--- a/kokkostbx/Legacy/kokkos_matrix3.h
+++ b/kokkostbx/Legacy/kokkos_matrix3.h
@@ -147,7 +147,7 @@ namespace kokkostbx {
         }
 
         KOKKOS_INLINE_FUNCTION NumType length() const {
-            return ::Kokkos::Experimental::sqrt(length_sqr());
+            return ::Kokkos::sqrt(length_sqr());
         }
 
         KOKKOS_INLINE_FUNCTION NumType dot(const matrix3<NumType>& v) const {

--- a/kokkostbx/Legacy/kokkos_vector.h
+++ b/kokkostbx/Legacy/kokkos_vector.h
@@ -215,7 +215,7 @@ namespace kokkostbx {
         }
 
         KOKKOS_INLINE_FUNCTION NumType length() const {
-            return ::Kokkos::Experimental::sqrt(length_sqr());
+            return ::Kokkos::sqrt(length_sqr());
         }
 
         KOKKOS_INLINE_FUNCTION NumType dot(const vector3<NumType>& v) const {
@@ -248,8 +248,8 @@ namespace kokkostbx {
 
         // rotate a point about a unit vector3 axis
         KOKKOS_INLINE_FUNCTION vector3<NumType> rotate_around_axis(const vector3<NumType>& axis, NumType angle) const {
-            NumType sinphi = ::Kokkos::Experimental::sin(angle);
-            NumType cosphi = ::Kokkos::Experimental::cos(angle);
+            NumType sinphi = ::Kokkos::sin(angle);
+            NumType cosphi = ::Kokkos::cos(angle);
             NumType dot_factor = axis.dot(*this) * (1.0-cosphi);
 
             vector3<NumType> vector_rot = axis.cross(*this) * sinphi;

--- a/kokkostbx/Legacy/kokkos_vector3.h
+++ b/kokkostbx/Legacy/kokkos_vector3.h
@@ -144,7 +144,7 @@ namespace kokkostbx {
         }
 
         KOKKOS_INLINE_FUNCTION NumType length() const {
-            return ::Kokkos::Experimental::sqrt(length_sqr());
+            return ::Kokkos::sqrt(length_sqr());
         }
 
         KOKKOS_INLINE_FUNCTION NumType dot(const vector3<NumType>& v) const {
@@ -177,8 +177,8 @@ namespace kokkostbx {
 
         // rotate a point about a unit vector3 axis
         KOKKOS_INLINE_FUNCTION vector3<NumType> rotate_around_axis(const vector3<NumType>& axis, NumType angle) const {
-            NumType sinphi = ::Kokkos::Experimental::sin(angle);
-            NumType cosphi = ::Kokkos::Experimental::cos(angle);
+            NumType sinphi = ::Kokkos::sin(angle);
+            NumType cosphi = ::Kokkos::cos(angle);
             NumType dot_factor = axis.dot(*this) * (1.0-cosphi);
 
             vector3<NumType> vector_rot = axis.cross(*this) * sinphi;

--- a/kokkostbx/SConscript
+++ b/kokkostbx/SConscript
@@ -136,7 +136,8 @@ if env_etc.enable_kokkos:
         '-DKokkos_ENABLE_CUDA={}'.format(OnOff[use_cuda]),
         '-DKokkos_ENABLE_CUDA_UVM={}'.format(OnOff[use_cuda]),
         '-DKokkos_ENABLE_HIP={}'.format(OnOff[use_hip]),
-        '-DKokkos_ENABLE_SYCL={}'.format(OnOff[use_sycl])
+        '-DKokkos_ENABLE_SYCL={}'.format(OnOff[use_sycl]),
+        '-DKokkos_ENABLE_IMPL_MDSPAN={}'.format(OnOff[True])
       ],
       cwd=kokkos_build_dir)
 

--- a/kokkostbx/SConscript
+++ b/kokkostbx/SConscript
@@ -37,10 +37,6 @@ if env_etc.enable_kokkos:
     linked_libraries += " -lcudart -lcuda"
   os.environ['LDLIBS'] = linked_libraries
 
-  cxx_standard = '14'
-  if use_sycl:
-    cxx_standard = '17'
-
   original_cxx = None
   kokkos_lib = 'libkokkos.a'
   kokkos_cxxflags = None
@@ -119,7 +115,7 @@ if env_etc.enable_kokkos:
     returncode = subprocess.call([
         'cmake',
         os.environ['KOKKOS_PATH'],
-        '-DCMAKE_CXX_STANDARD={}'.format(cxx_standard),
+        '-DCMAKE_CXX_STANDARD={}'.format('17'),
         '-DCMAKE_INSTALL_PREFIX={}'.format(libtbx.env.under_build('.')),
         '-DCMAKE_INSTALL_LIBDIR=lib',
         '-DBUILD_SHARED_LIBS={}'.format(OnOff[True]),

--- a/kokkostbx/kokkos_types.h
+++ b/kokkostbx/kokkos_types.h
@@ -6,7 +6,7 @@
     #define MemSpace Kokkos::CudaUVMSpace
 #endif
 #ifdef KOKKOS_ENABLE_HIP
-    #define MemSpace Kokkos::Experimental::HIPSpace
+    #define MemSpace Kokkos::HIPSpace
 #endif
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
     #define MemSpace Kokkos::OpenMPTargetSpace

--- a/kokkostbx/kokkos_vector.h
+++ b/kokkostbx/kokkos_vector.h
@@ -261,7 +261,7 @@ struct vector_base {
 
     KOKKOS_FUNCTION NumType length() const {
         // return sqrt_func(length_sqr());
-        return ::Kokkos::Experimental::sqrt(length_sqr());
+        return ::Kokkos::sqrt(length_sqr());
     }
 
     KOKKOS_FUNCTION void normalize() {

--- a/kokkostbx/kokkos_vector3.h
+++ b/kokkostbx/kokkos_vector3.h
@@ -60,8 +60,8 @@ struct vector3 : public vector<NumType, 3> {
         const {
         // NumType sinphi = sin_func(angle);
         // NumType cosphi = cos_func(angle);
-        NumType sinphi = ::Kokkos::Experimental::sin(angle);
-        NumType cosphi = ::Kokkos::Experimental::cos(angle);
+        NumType sinphi = ::Kokkos::sin(angle);
+        NumType cosphi = ::Kokkos::cos(angle);
 
         NumType dot_factor = axis.dot(*this) * (1.0 - cosphi);
 

--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -1002,17 +1002,17 @@ class xia2_module(SourceModule):
 
 class kokkos_module(SourceModule):
   module = 'kokkos'
-  anonymous = ['git', '-b 3.7.01',
+  anonymous = ['git',
                'git@github.com:kokkos/kokkos.git',
                'https://github.com/kokkos/kokkos.git',
-               'https://github.com/kokkos/kokkos/archive/refs/tags/3.7.01.zip']
+               'https://github.com/kokkos/kokkos/archive/master.zip']
 
 class kokkos_kernels_module(SourceModule):
   module = 'kokkos-kernels'
-  anonymous = ['git', '-b 3.7.01',
+  anonymous = ['git',
                'git@github.com:kokkos/kokkos-kernels.git',
                'https://github.com/kokkos/kokkos-kernels.git',
-               'https://github.com/kokkos/kokkos-kernels/archive/refs/tags/3.7.01.zip']
+               'https://github.com/kokkos/kokkos-kernels/archive/master.zip']
 
 # Duke repositories
 class probe_module(SourceModule):

--- a/simtbx/diffBragg/src/diffBragg_ext.cpp
+++ b/simtbx/diffBragg/src/diffBragg_ext.cpp
@@ -453,9 +453,8 @@ namespace boost_python { namespace {
   }
 
   void initialize_kokkos(int dev){
-    Kokkos::InitArguments kokkos_init;
-    kokkos_init.device_id = dev;
-    Kokkos::initialize(kokkos_init);
+    Kokkos::initialize(Kokkos::InitializationSettings()
+                           .set_device_id(dev));
   }
 #endif
 

--- a/simtbx/diffBragg/src/diffBragg_kokkos_kernel.cpp
+++ b/simtbx/diffBragg/src/diffBragg_kokkos_kernel.cpp
@@ -426,10 +426,10 @@ void kokkos_sum_over_steps(
                         if (detector_thick > 0.0 && detector_attnlen > 0.0) {
                             // inverse of effective thickness increase
                             CUDAREAL _parallax = _diffracted.dot(_o_vec);
-                            _capture_fraction = ::Kokkos::Experimental::exp(
+                            _capture_fraction = ::Kokkos::exp(
                                                     -_thick_tic * detector_thickstep /
                                                     detector_attnlen / _parallax) -
-                                                ::Kokkos::Experimental::exp(
+                                                ::Kokkos::exp(
                                                     -(_thick_tic + 1) * detector_thickstep /
                                                     detector_attnlen / _parallax);
                         }
@@ -505,10 +505,10 @@ void kokkos_sum_over_steps(
 
                                 if (exparg < 35)
                                     if (no_Nabc_scale)
-                                        I0 = ::Kokkos::Experimental::exp(-2 * exparg);
+                                        I0 = ::Kokkos::exp(-2 * exparg);
                                     else
                                         I0 = (NABC_det_sq) *
-                                             ::Kokkos::Experimental::exp(-2 * exparg);
+                                             ::Kokkos::exp(-2 * exparg);
 
                                 // are we doing diffuse scattering
                                 CUDAREAL step_diffuse_param[6] = {0, 0, 0, 0, 0, 0};
@@ -570,14 +570,14 @@ void kokkos_sum_over_steps(
                                             CUDAREAL atom_y = atom_data(i_atom * 5 + 1);
                                             CUDAREAL atom_z = atom_data(i_atom * 5 + 2);
                                             CUDAREAL B = atom_data(i_atom * 5 + 3);  // B factor
-                                            B = ::Kokkos::Experimental::exp(
+                                            B = ::Kokkos::exp(
                                                 -B * S_2 / 4.0);  // TODO: speed me up?
                                             CUDAREAL occ = atom_data(i_atom * 5 + 4);  // occupancy
                                             CUDAREAL r_dot_h =
                                                 _h0 * atom_x + _k0 * atom_y + _l0 * atom_z;
                                             CUDAREAL phase = 2 * M_PI * r_dot_h;
-                                            CUDAREAL s_rdoth = ::Kokkos::Experimental::sin(phase);
-                                            CUDAREAL c_rdoth = ::Kokkos::Experimental::cos(phase);
+                                            CUDAREAL s_rdoth = ::Kokkos::sin(phase);
+                                            CUDAREAL c_rdoth = ::Kokkos::cos(phase);
                                             CUDAREAL Bocc = B * occ;
                                             CUDAREAL BC = B * c_rdoth;
                                             CUDAREAL BS = B * s_rdoth;
@@ -601,7 +601,7 @@ void kokkos_sum_over_steps(
                                     CUDAREAL Freal = _F_cell;
                                     CUDAREAL Fimag = _F_cell2;
                                     _F_cell =
-                                        ::Kokkos::Experimental::sqrt(Freal * Freal + Fimag * Fimag);
+                                        ::Kokkos::sqrt(Freal * Freal + Fimag * Fimag);
                                     if (refine_fp_fdp) {
                                         c_deriv_Fcell =
                                             Freal * c_deriv_Fcell_real + Fimag * c_deriv_Fcell_imag;
@@ -1125,7 +1125,7 @@ void kokkos_sum_over_steps(
                 // correction for polarized _incident beam
                 _polar =
                     0.5 * (1.0 + cos2theta_sqr -
-                           kahn_factor * ::Kokkos::Experimental::cos(2 * _psi) * sin2theta_sqr);
+                           kahn_factor * ::Kokkos::cos(2 * _psi) * sin2theta_sqr);
             }
 
             CUDAREAL _om = 1;

--- a/simtbx/kokkos/SConscript
+++ b/simtbx/kokkos/SConscript
@@ -43,10 +43,6 @@ elif use_sycl:
   linked_libraries = ""
 os.environ['LDLIBS'] = linked_libraries
 
-cxx_standard = '14'
-if use_sycl:
-  cxx_standard = '17'
-
 
 print("-"*40)
 print("         Kokkos configuration\n")

--- a/simtbx/kokkos/kokkos_instance.cpp
+++ b/simtbx/kokkos/kokkos_instance.cpp
@@ -1,6 +1,6 @@
 #include "simtbx/kokkos/kokkos_instance.h"
 
-using Kokkos::InitArguments;
+using Kokkos::InitializationSettings;
 using Kokkos::initialize;
 using Kokkos::finalize;
 
@@ -15,11 +15,9 @@ namespace Kokkos {
   }
 
   kokkos_instance::kokkos_instance(int const& t_deviceID) {
-    InitArguments kokkos_init;
-    kokkos_init.device_id = t_deviceID;
-
     if (!m_isInitialized) {
-      initialize(kokkos_init);
+      initialize(InitializationSettings()
+                      .set_device_id(t_deviceID));
 
       m_isInitialized = true;
       m_isFinalized = false;


### PR DESCRIPTION
This PR updates the code to build and run with kokkos 4.0

**Warning:** these updates are not compatible with kokkos versions before 4.0

To update kokkos, please go to `modules/kokkos` and run `git pull`.
If this does not fast-forward, you might need to also run `git checkout 4.0.00`.