### PR TITLE
minor updates for kokkos in diffBragg

### DIFF
--- a/simtbx/diffBragg/__init__.py
+++ b/simtbx/diffBragg/__init__.py
@@ -7,6 +7,10 @@ ext = boost.python.import_ext("simtbx_diffBragg_ext")
 import numpy as np
 from simtbx_diffBragg_ext import *
 
+import os
+if os.environ.get("DIFFBRAGG_USE_CUDA") is not None and os.environ.get("DIFFBRAGG_USE_KOKKOS") is not None:
+    raise RuntimeError("Only set one of DIFFBRAGG_USE_CUDA, DIFFBRAGG_USE_KOKKOS.")
+
 @bp.inject_into(ext.diffBragg)
 class _():
     def get_derivative_pixels(self, refine_id):

--- a/simtbx/diffBragg/src/diffBragg.cpp
+++ b/simtbx/diffBragg/src/diffBragg.cpp
@@ -2114,6 +2114,8 @@ void diffBragg::add_diffBragg_spots(const af::shared<size_t>& panels_fasts_slows
         printf("DIFFBRAGG isotropic Ncells=%d\n", isotropic_ncells);
         if(use_cuda || getenv("DIFFBRAGG_USE_CUDA")!= NULL)
             printf("TIME TO RUN DIFFBRAGG -GPU- (%llu iterations):  %3.10f ms \n",n_total_iter, time);
+        else if(getenv("DIFFBRAGG_USE_KOKKOS")!= NULL)
+            printf("TIME TO RUN DIFFBRAGG -KOKKOS- (%llu iterations):  %3.10f ms \n",n_total_iter, time);
         else
             printf("TIME TO RUN DIFFBRAGG -CPU- (%llu iterations):  %3.10f ms \n",n_total_iter, time);
     }


### PR DESCRIPTION
* raise error if DIFFBRAGG_USE_CUDA and DIFFBRAGG_USE_KOKKOS are both defined
* correctly print that kokkos was used (if diffBragg.verbose > 0)