### PR TITLE
Xfel match directories

### DIFF
--- a/xfel/merging/application/input/file_lister.py
+++ b/xfel/merging/application/input/file_lister.py
@@ -1,12 +1,23 @@
 from __future__ import absolute_import, division, print_function
 import glob, os
+from six.moves import UserDict
 import numpy as np
+
+
+class ImmutableValuesDict(UserDict):
+  def __setitem__(self, key, value):
+    try:
+      old_value = self.__getitem__(key)
+      if value != old_value:
+        raise ValueError("Attempting to change value of existing key: ", key)
+    except KeyError:
+      super(ImmutableValuesDict, self).__setitem__(key, value)
+
 
 class file_lister(object):
   """ Class for matching jsons to reflection table pickles """
   def __init__(self, params):
     self.params = params
-
     self.reject_alisters = self.params.input.alist.op == "reject"
     self.keep_alisters = not self.reject_alisters
     self.alist = set()  # contains image tags or absolute experiment paths
@@ -32,8 +43,16 @@ class file_lister(object):
   def num_alist(self):
     return len(self.alist)
 
+  @property
   def filepair_generator(self):
     """ Used by rank 0, client/server to yield a list of json/reflection table pairs """
+    if self.params.input.match_directories:
+      return self._matching_path_name_filepair_generator
+    else:
+      return self._matching_file_name_filepath_generator
+
+  def _matching_path_name_filepair_generator(self):
+    """File pair generator used when input expt/refl must come from same dir"""
     for pathstring in self.params.input.path:
       for path in glob.glob(pathstring):
         if os.path.isdir(path):
@@ -41,7 +60,7 @@ class file_lister(object):
             if filename.endswith(self.params.input.reflections_suffix):
               experiments_path = os.path.join(path, filename.split(self.params.input.reflections_suffix)[0] +
                  self.params.input.experiments_suffix)
-              if self._is_accepted(experiments_path):
+              if self._is_accepted_expt(experiments_path):
                 yield experiments_path, os.path.join(path, filename)
         else:
           dirname = os.path.dirname(path)
@@ -49,10 +68,40 @@ class file_lister(object):
           if filename.endswith(self.params.input.reflections_suffix):
             experiments_path = os.path.join(dirname, filename.split(self.params.input.reflections_suffix)[0] +
                self.params.input.experiments_suffix)
-            if self._is_accepted(experiments_path):
+            if self._is_accepted_expt(experiments_path):
               yield experiments_path, path
 
-  def _is_accepted(self, experiment_path):
+  def _matching_file_name_filepath_generator(self):
+    """File pair generator used when input expt/refl can be in different dir"""
+    expt_paths = ImmutableValuesDict()
+    refl_paths = ImmutableValuesDict()
+    expt_suffix_len = len(self.params.input.experiments_suffix)
+    refl_suffix_len = len(self.params.input.reflections_suffix)
+    for pathstring in self.params.input.path:
+      for path in glob.glob(pathstring):
+        if os.path.isdir(path):
+          for filename in os.listdir(path):
+            if filename.endswith(self.params.input.reflections_suffix):
+              file_stem = filename[:-refl_suffix_len]
+              refl_paths[file_stem] = os.path.join(path, filename)
+            if filename.endswith(self.params.input.experiments_suffix):
+              if self._is_accepted_expt(filename):
+                file_stem = filename[:-expt_suffix_len]
+                expt_paths[file_stem] = os.path.join(path, filename)
+        else:
+          filename = os.path.basename(path)
+          if filename.endswith(self.params.input.reflections_suffix):
+            file_stem = filename[:-refl_suffix_len]
+            refl_paths[file_stem] = path
+          if filename.endswith(self.params.input.experiments_suffix):
+            if self._is_accepted_expt(filename):
+              file_stem = filename[:-expt_suffix_len]
+              expt_paths[file_stem] = path
+    for common_file_stem in set(expt_paths).intersection(set(refl_paths)):
+      yield expt_paths[common_file_stem], refl_paths[common_file_stem]
+
+
+  def _is_accepted_expt(self, experiment_path):
     """returns True if the experiment is deemed worthy"""
     if not os.path.exists(experiment_path):
       return False

--- a/xfel/merging/application/input/file_lister.py
+++ b/xfel/merging/application/input/file_lister.py
@@ -85,16 +85,17 @@ class file_lister(object):
               file_stem = filename[:-refl_suffix_len]
               refl_paths[file_stem] = os.path.join(path, filename)
             if filename.endswith(self.params.input.experiments_suffix):
-              if self._is_accepted_expt(filename):
+              full_path = os.path.join(path, filename)
+              if self._is_accepted_expt(full_path):
                 file_stem = filename[:-expt_suffix_len]
-                expt_paths[file_stem] = os.path.join(path, filename)
+                expt_paths[file_stem] = full_path
         else:
           filename = os.path.basename(path)
           if filename.endswith(self.params.input.reflections_suffix):
             file_stem = filename[:-refl_suffix_len]
             refl_paths[file_stem] = path
           if filename.endswith(self.params.input.experiments_suffix):
-            if self._is_accepted_expt(filename):
+            if self._is_accepted_expt(path):
               file_stem = filename[:-expt_suffix_len]
               expt_paths[file_stem] = path
     for common_file_stem in set(expt_paths).intersection(set(refl_paths)):

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -54,6 +54,11 @@ input {
     .help = however, validation is delayed until data are assigned to parallel ranks.
     .help = integrated experiments (.expt) and reflection tables (.refl) must both be
     .help = present as matching files.  Only one need be explicitly specified.
+  match_directories = True
+    .type = bool
+    .help = If True, matching experiment (.expt) and reflection table (.refl)
+    .help = must be in the same directory. Else, they might occupy directories,
+    .help = but their filenames must be unique across the entire input.
   reflections_suffix = _integrated.refl
     .type = str
     .help = Find file names with this suffix for reflections


### PR DESCRIPTION
By default,`cctbx.xfel.merge` requires that `input` expts and refls reside in the same directory. Whether the `input` is specified using directory paths or file globs, the current `file_lister` matches expts and refls in the following way:

    for refl_path in input_paths:
        if refl_path.endswith(reflection_suffix):
            expt_path = refl_path - reflection_suffix + experiment_suffix
            yield expt_path, refl_path

In my particular case, I need `cctbx.xfel.merge` to read input expts and refls from two different directories. To this aim, I added a phil parameter `input.match_directories` and implemented a second `file_lister` matching method, which does not require the files to be in the same directory BUT requires the filenames to be unique across all input directories:

    for path in input_paths:
        if path.endswith(experiment_suffix):
            expt_paths.append(path)
        if path.endswith(reflection_suffix):
            refl_paths.append(path)
    for expt_path, refl_path with matching names in zip(expt_paths, refl_paths):
       yield expt_path, refl_path

I have already implemented this feature here for my own use, but I would like to ask if this functionality is potentially useful for anyone other than me. Or should we refrain from merging this change to master since the case is too specific?