### PR TITLE
Normalize diffuse rotations

### DIFF
--- a/iotbx/regression/tst_hierarchy_long_chain_ids_1.py
+++ b/iotbx/regression/tst_hierarchy_long_chain_ids_1.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 import time
 import iotbx.pdb
-from libtbx.utils import null_out
 from libtbx.test_utils import assert_lines_in_text
 
 # ------------------------------------------------------------------------------

--- a/simtbx/diffBragg/src/diffuse_util.h
+++ b/simtbx/diffBragg/src/diffuse_util.h
@@ -16,7 +16,7 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
     return 0;
   }
 
-  double one_over_root2 = 1./sqrt(2.);
+  const double one_over_root2 = 1./sqrt(2.);
 
   if ( laue_group_num == 1 ) {
   // P -1

--- a/simtbx/diffBragg/src/diffuse_util.h
+++ b/simtbx/diffBragg/src/diffuse_util.h
@@ -15,6 +15,9 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
   if ( laue_group_num < 1 or laue_group_num > 14) {
     return 0;
   }
+
+  double one_over_root2 = 1./sqrt(2.);
+  
   if ( laue_group_num == 1 ) {
   // P -1
 
@@ -175,11 +178,11 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
 
               // -y,x-y,z
     lmats[1] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[2] << -1, 1, 0,
+    lmats[2] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
@@ -195,22 +198,22 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
 
               // -y,x-y,z
     lmats[1] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[2] << -1, 1, 0,
+    lmats[2] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
               // x-y,-y,-z
-    lmats[3] <<  1,-1, 0,
+    lmats[3] <<  one_over_root2,-one_over_root2, 0,
                  0,-1, 0,
                  0, 0,-1;
 
               // -x,-x+y,-z
     lmats[4] << -1, 0, 0,
-                -1, 1, 0,
+                -one_over_root2, one_over_root2, 0,
                  0, 0,-1;
 
               // y,x,-z
@@ -230,11 +233,11 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
 
               // -y,x-y,z
     lmats[1] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[2] << -1, 1, 0,
+    lmats[2] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
@@ -244,13 +247,13 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
                  0, 0,-1;
 
               // -x+y,y,-z
-    lmats[4] << -1, 1, 0,
+    lmats[4] << -one_over_root2, one_over_root2, 0,
                  0, 1, 0,
                  0, 0,-1;
 
               // x,x-y,-z
     lmats[5] <<  1, 0, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0,-1;
 
     return 6;
@@ -264,22 +267,22 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
                  0, 0, 1;
 
               // x-y,x,z
-    lmats[1] <<  1,-1, 0,
+    lmats[1] <<  one_over_root2,-one_over_root2, 0,
                  1, 0, 0,
                  0, 0, 1;
 
               // y,-x+y,z
     lmats[2] <<  0, 1, 0,
-                -1, 1, 0,
+                -one_over_root2, one_over_root2, 0,
                  0, 0, 1;
 
               // -y,x-y,z
     lmats[3] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[4] << -1, 1, 0,
+    lmats[4] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
@@ -299,33 +302,33 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
                  0, 0, 1;
 
               // x-y,x,z
-    lmats[1] <<  1,-1, 0,
+    lmats[1] <<  one_over_root2,-one_over_root2, 0,
                  1, 0, 0,
                  0, 0, 1;
 
               // y,-x+y,z
     lmats[2] <<  0, 1, 0,
-                -1, 1, 0,
+                -one_over_root2, one_over_root2, 0,
                  0, 0, 1;
 
               // -y,x-y,z
     lmats[3] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[4] << -1, 1, 0,
+    lmats[4] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
               // x-y,-y,-z
-    lmats[5] <<  1,-1, 0,
+    lmats[5] <<  one_over_root2,-one_over_root2, 0,
                  0,-1, 0,
                  0, 0,-1;
 
               // -x,-x+y,-z
     lmats[6] << -1, 0, 0,
-                -1, 1, 0,
+                -one_over_root2, one_over_root2, 0,
                  0, 0,-1;
 
               // -x,-y,z
@@ -344,13 +347,13 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
                  0, 0,-1;
 
               // -x+y,y,-z
-    lmats[10] << -1, 1, 0,
+    lmats[10] << -one_over_root2, one_over_root2, 0,
                   0, 1, 0,
                   0, 0,-1;
 
               // x,x-y,-z
     lmats[11] <<  1, 0, 0,
-                  1,-1, 0,
+                  one_over_root2,-one_over_root2, 0,
                   0, 0,-1;
 
     return 12;
@@ -587,20 +590,19 @@ void calc_diffuse_at_hkl(VEC3 H_vec, VEC3 H0, VEC3 dHH, VEC3 Hmin, VEC3 Hmax, VE
             _this_diffuse_scale = 1.0;
 
           _this_diffuse_scale *= _this_diffuse_scale/(REAL)num_laue_mats/(REAL)num_stencil_points;
-          /* TODO: Apply discrete transformations to H0 and delta_H_offset
-             like the following to reorient G and recover calmodulin diffuse
-          MAT3 xform;
-          xform << 0.70710678,  -0.70710678,  0., 0.70710678,  0.70710678,  0., 0.,  0., 1.;
-          */
-          MAT3 xform;
-          xform << 0.70710678,  -0.70710678,  0., 0.70710678,  0.70710678,  0., 0.,  0., 1.;
+          // Use (a-b, a+b, c) as the principal axes of the diffuse model
+          // TODO: Add an option to select (a, b, c) as the principal axes
+          MAT3 rotate_principal_axes;
+          rotate_principal_axes << 0.70710678,-0.70710678,0.,
+                                   0.70710678, 0.70710678,0.,
+                                   0.,0.,1.;
           for ( int iL = 0; iL < num_laue_mats; iL++ ){
-            VEC3 Q0 =Ainv*laue_mats[iL]*xform*H0;
+            VEC3 Q0 =Ainv*laue_mats[iL]*rotate_principal_axes*H0;
             REAL exparg = four_mpi_sq*Q0.dot(anisoU_local*Q0);
             REAL dwf = exp(-exparg);
             VEC3 H0_offset(H0[0]+hh, H0[1]+kk, H0[2]+ll);
             VEC3 delta_H_offset = H_vec - H0_offset;
-            VEC3 delta_Q = Ainv*laue_mats[iL]*xform*delta_H_offset;
+            VEC3 delta_Q = Ainv*laue_mats[iL]*rotate_principal_axes*delta_H_offset;
             VEC3 anisoG_q = anisoG_local*delta_Q;
 
             REAL V_dot_V = anisoG_q.dot(anisoG_q);

--- a/simtbx/diffBragg/src/diffuse_util.h
+++ b/simtbx/diffBragg/src/diffuse_util.h
@@ -17,7 +17,7 @@ int gen_laue_mats(int laue_group_num, MAT3 *lmats) {
   }
 
   double one_over_root2 = 1./sqrt(2.);
-  
+
   if ( laue_group_num == 1 ) {
   // P -1
 

--- a/simtbx/diffBragg/src/diffuse_util_kokkos.h
+++ b/simtbx/diffBragg/src/diffuse_util_kokkos.h
@@ -10,7 +10,7 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
   }
 
   double one_over_root2 = 1./sqrt(2.);
-  
+
   if ( laue_group_num == 1 ) {
   // P -1
 

--- a/simtbx/diffBragg/src/diffuse_util_kokkos.h
+++ b/simtbx/diffBragg/src/diffuse_util_kokkos.h
@@ -8,6 +8,9 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
   if ( laue_group_num < 1 or laue_group_num > 14) {
     return 0;
   }
+
+  double one_over_root2 = 1./sqrt(2.);
+  
   if ( laue_group_num == 1 ) {
   // P -1
 
@@ -168,11 +171,11 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
 
               // -y,x-y,z
     lmats[1] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[2] << -1, 1, 0,
+    lmats[2] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
@@ -188,22 +191,22 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
 
               // -y,x-y,z
     lmats[1] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[2] << -1, 1, 0,
+    lmats[2] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
               // x-y,-y,-z
-    lmats[3] <<  1,-1, 0,
+    lmats[3] <<  one_over_root2,-one_over_root2, 0,
                  0,-1, 0,
                  0, 0,-1;
 
               // -x,-x+y,-z
     lmats[4] << -1, 0, 0,
-                -1, 1, 0,
+                -one_over_root2, one_over_root2, 0,
                  0, 0,-1;
 
               // y,x,-z
@@ -223,11 +226,11 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
 
               // -y,x-y,z
     lmats[1] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[2] << -1, 1, 0,
+    lmats[2] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
@@ -237,13 +240,13 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
                  0, 0,-1;
 
               // -x+y,y,-z
-    lmats[4] << -1, 1, 0,
+    lmats[4] << -one_over_root2, one_over_root2, 0,
                  0, 1, 0,
                  0, 0,-1;
 
               // x,x-y,-z
     lmats[5] <<  1, 0, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0,-1;
 
     return 6;
@@ -257,22 +260,22 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
                  0, 0, 1;
 
               // x-y,x,z
-    lmats[1] <<  1,-1, 0,
+    lmats[1] <<  one_over_root2,-one_over_root2, 0,
                  1, 0, 0,
                  0, 0, 1;
 
               // y,-x+y,z
     lmats[2] <<  0, 1, 0,
-                -1, 1, 0,
+                -one_over_root2, one_over_root2, 0,
                  0, 0, 1;
 
               // -y,x-y,z
     lmats[3] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[4] << -1, 1, 0,
+    lmats[4] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
@@ -292,33 +295,33 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
                  0, 0, 1;
 
               // x-y,x,z
-    lmats[1] <<  1,-1, 0,
+    lmats[1] <<  one_over_root2,-one_over_root2, 0,
                  1, 0, 0,
                  0, 0, 1;
 
               // y,-x+y,z
     lmats[2] <<  0, 1, 0,
-                -1, 1, 0,
+                -one_over_root2, one_over_root2, 0,
                  0, 0, 1;
 
               // -y,x-y,z
     lmats[3] <<  0,-1, 0,
-                 1,-1, 0,
+                 one_over_root2,-one_over_root2, 0,
                  0, 0, 1;
 
               // -x+y,-x,z
-    lmats[4] << -1, 1, 0,
+    lmats[4] << -one_over_root2, one_over_root2, 0,
                 -1, 0, 0,
                  0, 0, 1;
 
               // x-y,-y,-z
-    lmats[5] <<  1,-1, 0,
+    lmats[5] <<  one_over_root2,-one_over_root2, 0,
                  0,-1, 0,
                  0, 0,-1;
 
               // -x,-x+y,-z
     lmats[6] << -1, 0, 0,
-                -1, 1, 0,
+                -one_over_root2, one_over_root2, 0,
                  0, 0,-1;
 
               // -x,-y,z
@@ -337,13 +340,13 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
                  0, 0,-1;
 
               // -x+y,y,-z
-    lmats[10] << -1, 1, 0,
+    lmats[10] << -one_over_root2, one_over_root2, 0,
                   0, 1, 0,
                   0, 0,-1;
 
               // x,x-y,-z
     lmats[11] <<  1, 0, 0,
-                  1,-1, 0,
+                  one_over_root2,-one_over_root2, 0,
                   0, 0,-1;
 
     return 12;
@@ -574,18 +577,19 @@ void calc_diffuse_at_hkl(KOKKOS_VEC3 H_vec, KOKKOS_VEC3 H0, KOKKOS_VEC3 dHH, KOK
 
           _this_diffuse_scale *= _this_diffuse_scale/(CUDAREAL)num_laue_mats/
             (CUDAREAL)num_stencil_points;
-          // TODO: Apply discrete transformations to H0 and delta_H_offset
-          //    like the following to reorient G and recover calmodulin diffuse
-           KOKKOS_MAT3 xform;
-           xform << 0.70710678,  -0.70710678,  0., 0.70710678,  0.70710678,  0., 0.,  0., 1.;
-
+          // Use (a-b, a+b, c) as the principal axes of the diffuse model
+          // TODO: Add an option to select (a, b, c) as the principal axes
+          KOKKOS_MAT3 rotate_principal_axes;
+          rotate_principal_axes << 0.70710678,-0.70710678,0.,
+                                   0.70710678, 0.70710678,0.,
+                                   0.,0.,1.;
           for ( int iL = 0; iL < num_laue_mats; iL++ ){
-            KOKKOS_VEC3 Q0 =Ainv*laue_mats[iL]*xform*H0;
+            KOKKOS_VEC3 Q0 =Ainv*laue_mats[iL]*rotate_principal_axes*H0;
             CUDAREAL exparg = four_mpi_sq*Q0.dot(anisoU_local*Q0);
             CUDAREAL dwf = exp(-exparg);
             KOKKOS_VEC3 H0_offset(H0[0]+hh, H0[1]+kk, H0[2]+ll);
             KOKKOS_VEC3 delta_H_offset = H_vec - H0_offset;
-            KOKKOS_VEC3 delta_Q = Ainv*laue_mats[iL]*xform*delta_H_offset;
+            KOKKOS_VEC3 delta_Q = Ainv*laue_mats[iL]*rotate_principal_axes*delta_H_offset;
             KOKKOS_VEC3 anisoG_q = anisoG_local*delta_Q;
 
             CUDAREAL V_dot_V = anisoG_q.dot(anisoG_q);

--- a/simtbx/diffBragg/src/diffuse_util_kokkos.h
+++ b/simtbx/diffBragg/src/diffuse_util_kokkos.h
@@ -9,7 +9,7 @@ int gen_laue_mats(int laue_group_num, KOKKOS_MAT3 *lmats) {
     return 0;
   }
 
-  double one_over_root2 = 1./sqrt(2.);
+  const double one_over_root2 = 1./sqrt(2.);
 
   if ( laue_group_num == 1 ) {
   // P -1


### PR DESCRIPTION
Normalize rotation matrices used to apply diffuse symmetry in diffBragg
o Required to make a number of them proper rotation matrices 
o Also add some comments and change matrix name to clarify what's
  going on when the principal axes of the diffuse model are rotated