### PR TITLE
Preserve `expt.identifier` in diffBragg hopper

### DIFF
--- a/simtbx/diffBragg/hopper_io.py
+++ b/simtbx/diffBragg/hopper_io.py
@@ -131,6 +131,7 @@ def save_to_pandas(x, Mod, SIM, orig_exp_name, params, expt, rank_exp_idx, stg1_
     new_expt.crystal = new_cryst
     new_expt.detector = expt.detector
     new_expt.beam = expt.beam
+    new_expt.identifier = expt.identifier
     new_expt.imageset = expt.imageset
     # expt.detector = refiner.get_optimized_detector()
     new_exp_list = ExperimentList()


### PR DESCRIPTION
This miniature PR will cause `simtbx.diffBragg.hopper` (or just `hopper`) to preserve the experimental identifier when saving a refined expt file from Modeler. I am staging the change here as a PR instead of committing directly mostly to avoid getting put on the blame list, as the current master does not build properly, and to remember to commit eventually.