### PR TITLE
Refactoring out any_file usage where the type of the file is obvious.

### DIFF
--- a/simtbx/diffBragg/utils.py
+++ b/simtbx/diffBragg/utils.py
@@ -24,7 +24,6 @@ from dxtbx.model.experiment_list import ExperimentListFactory
 import libtbx
 from libtbx.phil import parse
 from dials.array_family import flex as dials_flex
-from iotbx import file_reader
 import mmtbx.command_line.fmodel
 import mmtbx.utils
 from cctbx.eltbx import henke
@@ -285,8 +284,8 @@ ATOM      5  O   HOH A   5      46.896  37.790  41.629  1.00 20.00           O
 ATOM      6 SED  MSE A   6       1.000   2.000   3.000  1.00 20.00          SE
 END
 """
-    from iotbx import pdb
-    pdb_inp = pdb.input(source_info=None, lines=pdb_lines)
+    import iotbx.pdb
+    pdb_inp = iotbx.pdb.input(source_info=None, lines=pdb_lines)
     xray_structure = pdb_inp.xray_structure_simple()
     if ucell is not None:
         assert symbol is not None
@@ -898,10 +897,9 @@ def get_complex_fcalc_from_pdb(
     produce a structure factor from PDB coords, see mmtbx/command_line/fmodel.py for formulation
     k_sol, b_sol form the solvent component of the Fcalc: Fprotein + k_sol*exp(-b_sol*s^2/4) (I think)
     """
-
-    pdb_in = file_reader.any_file(pdb_file, force_type="pdb")
-    pdb_in.assert_file_type("pdb")
-    xray_structure = pdb_in.file_object.xray_structure_simple()
+    import iotbx.pdb
+    pdb_in = iotbx.pdb.input(pdb_file)
+    xray_structure = pdb_in.xray_structure_simple()
     if show_pdb_summary:
         xray_structure.show_summary()
     for sc in xray_structure.scatterers():

--- a/xfel/merging/application/model/crystal_model.py
+++ b/xfel/merging/application/model/crystal_model.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 from xfel.merging.application.worker import worker
 import mmtbx.command_line.fmodel
 import mmtbx.utils
-from iotbx import file_reader
 import libtbx.phil.command_line
 from cctbx import miller
 from cctbx.crystal import symmetry
@@ -97,10 +96,9 @@ class crystal_model(worker):
       model_ext = os.path.splitext(model_file_path)[-1].lower()
       assert model_ext in [".pdb", ".cif"]
       if model_ext == ".pdb":
-        from iotbx import file_reader
-        pdb_in = file_reader.any_file(model_file_path, force_type="pdb")
-        pdb_in.assert_file_type("pdb")
-        xray_structure = pdb_in.file_object.xray_structure_simple()
+        import iotbx.pdb
+        pdb_in = iotbx.pdb.input(model_file_path)
+        xray_structure = pdb_in.xray_structure_simple()
       elif model_ext == ".cif":
         from libtbx.utils import Sorry
         try:

--- a/xfel/merging/general_fcalc.py
+++ b/xfel/merging/general_fcalc.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 import mmtbx.command_line.fmodel
 import mmtbx.utils
-from iotbx import file_reader
+import iotbx.pdb
 import libtbx.phil.command_line
 import sys
 import math
@@ -24,9 +24,8 @@ def run (params) :
        return c_array
     raise Exception("mtz did not contain expected label Iobs or IMEAN")
 
-  pdb_in = file_reader.any_file(params.model, force_type="pdb")
-  pdb_in.assert_file_type("pdb")
-  xray_structure = pdb_in.file_object.xray_structure_simple()
+  pdb_in = iotbx.pdb.input(params.model)
+  xray_structure = pdb_in.xray_structure_simple()
   xray_structure.show_summary()
   phil2 = mmtbx.command_line.fmodel.fmodel_from_xray_structure_master_params
   params2 = phil2.extract()


### PR DESCRIPTION
Preparing to eliminate iotbx.pdb.hierarchy.input class, which will change the outcome of any_file() when reading model files. It will return iotbx.pdb.
file_reader.any_file().xray_structure_simple() indeed calls the same code as pdb.input().xray_structure_simple().