### PR TITLE
Use `mpl.plt.get_cmap` instead of deprecated `mpl.cm.get_cmap`

### DIFF
--- a/xfel/command_line/cspad_detector_congruence.py
+++ b/xfel/command_line/cspad_detector_congruence.py
@@ -170,10 +170,7 @@ def detector_plot_dict(params, detector, data, title, units_str, show=True, reve
   # initialize the color map
   values = flex.double(list(data.values()))
   norm = Normalize(vmin=flex.min(values), vmax=flex.max(values))
-  if reverse_colormap:
-    cmap = plt.cm.get_cmap(params.colormap + "_r")
-  else:
-    cmap = plt.cm.get_cmap(params.colormap)
+  cmap = plt.get_cmap(params.colormap + ("_r" if reverse_colormap else ''))
   sm = cm.ScalarMappable(norm=norm, cmap=cmap)
   if len(values) == 0:
     print("no values")

--- a/xfel/command_line/cspad_detector_congruence2.py
+++ b/xfel/command_line/cspad_detector_congruence2.py
@@ -836,10 +836,7 @@ class Script(object):
     # initialize the color map
     values = flex.double(data.values())
     norm = Normalize(vmin=flex.min(values), vmax=flex.max(values))
-    if reverse_colormap:
-      cmap = plt.cm.get_cmap(self.params.colormap + "_r")
-    else:
-      cmap = plt.cm.get_cmap(self.params.colormap)
+    cmap = plt.get_cmap(self.params.colormap + ("_r" if reverse_colormap else ''))
     sm = cm.ScalarMappable(norm=norm, cmap=cmap)
     if len(values) == 0:
       print("no values")

--- a/xfel/command_line/detector_residuals.py
+++ b/xfel/command_line/detector_residuals.py
@@ -473,7 +473,7 @@ class ResidualsPlotter(object):
 
     # initialize the color map
     norm = Normalize(vmin=vmin, vmax=vmax)
-    cmap = plt.cm.get_cmap(self.params.colormap)
+    cmap = plt.get_cmap(self.params.colormap)
     sm = cm.ScalarMappable(norm=norm, cmap=cmap)
     color_vals = np.linspace(vmin, vmax, 11)
     sm.set_array(color_vals) # needed for colorbar

--- a/xfel/metrology/panel_fitting.py
+++ b/xfel/metrology/panel_fitting.py
@@ -90,8 +90,8 @@ the refls using a Mahalanobis cutoff.
       mahal_emp_cov = mahal_emp_cov.reshape(xx.shape)
       emp_cov_contour = ax.contour(xx, yy, np.sqrt(mahal_emp_cov),
                                   levels=[1.,2.,3.,4.,5.],
-                                  #cmap=plt.cm.PuBu_r,
-                                  cmap=plt.cm.cool_r,
+                                  #cmap=plt.get_cmap('PuBu_r'),
+                                  cmap=plt.get_cmap('cool_r'),
                                   linestyles='dashed')
 
     COV = self.rob_cov
@@ -111,8 +111,8 @@ the refls using a Mahalanobis cutoff.
       mahal_robust_cov = mahal_robust_cov.reshape(xx.shape)
       robust_contour = ax.contour(xx, yy, np.sqrt(mahal_robust_cov),
                                  levels=[1.,2.,3.,4.,5.],
-                                 #cmap=plt.cm.YlOrBr_r,
-                                 cmap=plt.cm.spring_r,
+                                 #cmap=plt.get_cmap('YlOrBr_r'),
+                                 cmap=plt.get_cmap('spring_r'),
                                  linestyles='dotted')
 
 class three_feature_fit(Panel_MCD_Filter):


### PR DESCRIPTION
In `cctbx.xfel`, the `matplotlib` colormaps are sometimes accessed using `matplotlib.cm.get_cmap`, which is deprecated starting from matplotlib version 3.7, see issue #894. This PR replaces these calls with a supported equivalent `plt.get_cmap`.

Furthermore, while browsing for colormap usage in cctbx, I have found multiple instances of colormaps being accessed directly, e.g. `matplotlib.cm.jet`. This way of accessing colormaps works in maplotlib 3.7 without raising a warning. I asked the developers whether this interface is expected to stay and currently left this code as-is.