### PR TITLE
Merging program supports both mtz and sf.cif

### DIFF
--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -584,11 +584,14 @@ statistics {
   cciso {
     mtz_file = None
       .type = str
-      .help = for Riso/ CCiso, the reference structure factors, must have data type F
+      .help = The isomorphous reference structure factors for Riso/ CCiso.
       .help = a fake file is written out to this file name if model is None
+      .help = The experimental reference file can be old type *.mtz or new *sf.cif
     mtz_column_F = fobs
       .type = str
-      .help = for Riso/ CCiso, the column name containing reference structure factors
+      .help = For Riso/ CCiso, the array name containing reference structure factors
+      .help = As an example, could be intensity from *sf.cif
+      .help = Specifically this is a tag searched for in the array name, could be 'tensity' from 'intensity'
   }
   predictions_to_edge {
     apply = False

--- a/xfel/merging/application/statistics/intensity_resolution_statistics_cxi.py
+++ b/xfel/merging/application/statistics/intensity_resolution_statistics_cxi.py
@@ -476,11 +476,12 @@ class intensity_resolution_statistics_cxi(worker):
        (it is necessary to pick which indexing choice gives the sensible CC iso):'''%self.params.scaling.model_reindex_op)
 
     try:
-
-      #TODO: respect params.statistics.cciso.mtz_column_F
-
-      data_SR = mtz.object(self.params.statistics.cciso.mtz_file)
-
+      model_file_path = self.params.statistics.cciso.mtz_file
+      assert model_file_path.endswith("mtz") or model_file_path.endswith("sf.cif")
+      # support both old-style *.mtz and structure factor *-sf.cif
+      from iotbx import reflection_file_reader
+      data_SR = reflection_file_reader.any_reflection_file(
+                file_name = model_file_path)
       have_iso_ref = True
     except RuntimeError:
       data_SR = None
@@ -517,7 +518,7 @@ class intensity_resolution_statistics_cxi(worker):
            self.logger.main_log(this_label + ' ' + str(array.observation_type()))
            uniform.append(array.as_intensity_array())
            break
-         if this_label.find(self.params.statistics.cciso.mtz_column_F) == 0:
+         if self.params.statistics.cciso.mtz_column_F in this_label:
            self.logger.main_log(this_label + ' ' + str(array.observation_type()))
            uniform.append(array.as_intensity_array())
            break


### PR DESCRIPTION
Reference structure factors for CCiso(morphous) can come from both *.mtz or the native PDB format, *-sf.cif

Merge workers crystal_model and statistics have been updated to support sf.cif.