### PR TITLE
absolute_scaling IndexError

### DIFF
--- a/mmtbx/scaling/absolute_scaling.py
+++ b/mmtbx/scaling/absolute_scaling.py
@@ -996,8 +996,7 @@ class kernel_normalisation(object):
         number=number_of_sorted_reflections_for_auto_kernel
       else:
         number=int(auto_kernel)
-      if number >= d_star_sq_hkl.size():
-        number = d_star_sq_hkl.size()-1
+      number = min(number, d_star_sq_hkl.size()-1)
       self.kernel_width = d_star_sq_hkl[sort_permut[number]]-d_star_sq_low
       if self.kernel_width ==0:
         original_number=number

--- a/mmtbx/scaling/absolute_scaling.py
+++ b/mmtbx/scaling/absolute_scaling.py
@@ -996,7 +996,7 @@ class kernel_normalisation(object):
         number=number_of_sorted_reflections_for_auto_kernel
       else:
         number=int(auto_kernel)
-      if number > d_star_sq_hkl.size():
+      if number >= d_star_sq_hkl.size():
         number = d_star_sq_hkl.size()-1
       self.kernel_width = d_star_sq_hkl[sort_permut[number]]-d_star_sq_low
       if self.kernel_width ==0:


### PR DESCRIPTION
With the previous code, if `number == d_star_sq_hkl.size()` then the following line would fail with `IndexError` (https://github.com/xia2/xia2/issues/749):

```
self.kernel_width = d_star_sq_hkl[sort_permut[number]]-d_star_sq_low
```

The change ensures that `number` does not exceed `d_star_sq_hkl.size()-1`