### PR TITLE
mpi_abort_on_exception: do nothing if communicator size is 1

### DIFF
--- a/libtbx/mpi4py.py
+++ b/libtbx/mpi4py.py
@@ -78,7 +78,7 @@ def mpi_abort_on_exception(func):
       if e.code:
         sys.stderr.write(e.code + '\n')
       MPI.COMM_WORLD.Abort(1)
-  if using_mpi:
+  if using_mpi and MPI.COMM_WORLD.size > 1:
     return wrapped_func
   else:
     return func


### PR DESCRIPTION
This prevents confusing error messages in some cases where the system has mpi4py but we are running single-process. One example is `cctbx.xfel.merge -h`, which currently prints:

```
Abort(1) on node 0 (rank 0 in comm 0): application called MPI_Abort(MPI_COMM_WORLD, 1) - process 0
```

at the end of its output because it hits a SystemExit inside the wrapped function. With this PR, in the given case we won't attempt to clean up the nonexistent MPI communicator.