### PR TITLE
boost: switch deprecated boost/timer.hpp to boost/timer/timer.hpp

### DIFF
--- a/boost_adaptbx/SConscript
+++ b/boost_adaptbx/SConscript
@@ -227,6 +227,7 @@ e.g. with "yum install python-dev" or "apt-get install python-dev".
     env.SharedLibrary(
       target="#lib/boost_tuple_ext",
       source="tuple_ext.cpp")
+    env.Append(LIBS=['boost_timer'])
     env.SharedLibrary(
       target="#lib/boost_adaptbx_python_streambuf_test_ext",
       source="tests/python_streambuf_test_ext.cpp")
@@ -356,7 +357,7 @@ e.g. with "yum install python-dev" or "apt-get install python-dev".
             source=boost_system_src)
 
       #Boost.Chrono?
-      if boost_thread_uses_winthreads:
+      if os.path.isdir(os.path.join(env_etc.boost_dist, 'boost', 'chrono')):
         env_boost_chrono = env_boost_thread_and_co.Clone()
         simple_darwin_shlinkcom(env_etc, env, 'chrono')
         boost_chrono_src = [
@@ -365,10 +366,37 @@ e.g. with "yum install python-dev" or "apt-get install python-dev".
             os.path.join(env_etc.boost_dist, 'libs', 'chrono', 'src', '*.cpp'))]
         # For Windows (c.f. point 2 above)
         env_boost_chrono.Append(CPPDEFINES={'BOOST_CHRONO_DYN_LINK':1})
-        env_boost_chrono.StaticLibrary(
-          target='#lib/boost_chrono',
-          source=boost_chrono_src,
-          LIBS=['boost_system'])
+        if boost_thread_uses_winthreads:
+          env_boost_chrono.StaticLibrary(
+            target='#lib/boost_chrono',
+            source=boost_chrono_src,
+            LIBS=['boost_system'])
+        else:
+          env_boost_chrono.SharedLibrary(
+            target='#lib/boost_chrono',
+            source=boost_chrono_src,
+            LIBS=['boost_system'])
+
+      #Boost.Timer?
+      if os.path.isdir(os.path.join(env_etc.boost_dist, 'boost', 'timer')):
+        env_boost_timer = env_boost_thread_and_co.Clone()
+        simple_darwin_shlinkcom(env_etc, env, 'timer')
+        boost_timer_src = [
+          '#' + os.path.relpath(p, os.path.dirname(env_etc.boost_dist))
+          for p in glob.glob(
+            os.path.join(env_etc.boost_dist, 'libs', 'timer', 'src', '*.cpp'))]
+        # For Windows (c.f. point 2 above)
+        env_boost_timer.Append(CPPDEFINES={'BOOST_TIMER_DYN_LINK':1})
+        if boost_thread_uses_winthreads:
+          env_boost_timer.StaticLibrary(
+            target='#lib/boost_timer',
+            source=boost_timer_src,
+            LIBS=['boost_chrono'])
+        else:
+          env_boost_timer.SharedLibrary(
+            target='#lib/boost_timer',
+            source=boost_timer_src,
+            LIBS=['boost_chrono'])
 
   # Build a Python extension using Boost.Thread so as to test it works.
   # This also constitutes a nice real-life example of

--- a/boost_adaptbx/tests/python_streambuf_test_ext.cpp
+++ b/boost_adaptbx/tests/python_streambuf_test_ext.cpp
@@ -2,7 +2,7 @@
 #include <boost/python/def.hpp>
 
 #include <boost_adaptbx/python_streambuf.h>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 #include <fstream>
 
 namespace boost_adaptbx { namespace python { namespace {
@@ -104,14 +104,14 @@ namespace boost_adaptbx { namespace python { namespace {
   }
 
   void time_read(char const *path, streambuf& input) {
-    boost::timer t;
+    boost::timer::auto_cpu_timer t;
     streambuf::istream is(input);
     work_for_time_read(is);
-    double py_t = t.elapsed();
+    double py_t = t.elapsed().wall;
     std::ifstream std_is(path);
-    t.restart();
+    t.start();
     work_for_time_read(std_is);
-    double py_cpp = t.elapsed();
+    double py_cpp = t.elapsed().wall;
     std::cout << "- Reading -\nPython adaptor: " << py_t;
     std::cout << "\nPure C++: " << py_cpp;
     if (py_t > py_cpp) {
@@ -121,14 +121,14 @@ namespace boost_adaptbx { namespace python { namespace {
   }
 
   void time_write(char const *path, streambuf& output) {
-    boost::timer t;
+    boost::timer::auto_cpu_timer t;
     streambuf::ostream os(output);
     work_for_time_write(os);
-    double py_t = t.elapsed();
+    double py_t = t.elapsed().wall;
     std::ofstream std_os(path);
-    t.restart();
+    t.start();
     work_for_time_write(std_os);
-    double py_cpp = t.elapsed();
+    double py_cpp = t.elapsed().wall;
     std::cout << "- Writing -\nPython adaptor: " << py_t;
     std::cout << "\nPure C++: " << py_cpp;
     if (py_t > py_cpp) {

--- a/cbflib_adaptbx/detectors/cbf_adaptor.h
+++ b/cbflib_adaptbx/detectors/cbf_adaptor.h
@@ -16,7 +16,6 @@
 #define cbf_failnez(x) { int err; err = (x); if (err) { \
   std::cout<<"error code "<<err<<std::endl; throw iotbx::detectors::Error ( \
   "CBFlib error in " #x " "); }}
-//#include <boost/timer.hpp>
 
 namespace iotbx {
   namespace detectors {

--- a/cctbx/math/SConscript
+++ b/cctbx/math/SConscript
@@ -3,6 +3,7 @@ env = env_base.Clone(
   CXXFLAGS=env_etc.cxxflags_base,
 )
 env.Prepend(LIBS=["cctbx"])
+env.Append(LIBS='boost_timer')
 env.Append(LIBS=env_etc.libm)
 env_etc.include_registry.append(
   env=env,

--- a/cctbx/math/time_trigonometry.cpp
+++ b/cctbx/math/time_trigonometry.cpp
@@ -1,23 +1,23 @@
 #include <cctbx/math/cos_sin_table.h>
 #include <iostream>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 int main() {
   unsigned const n = 1024, p = 1024;
   cctbx::math::cos_sin_table<double> table(n);
   cctbx::math::cos_sin_exact<double> exact;
   std::complex<double> sum = 0;
-  boost::timer t;
+  boost::timer::auto_cpu_timer t;
   for (unsigned i=0; i<p*n; ++i) {
     sum += table(i);
   }
-  std::cout << t.elapsed() << "\t" << sum << std::endl;
+  std::cout << boost::timer::format(t.elapsed()) << "\t" << sum << std::endl;
   sum = 0;
-  t.restart();
+  t.start();
   for (unsigned i=0; i<p*n; ++i) {
     sum += exact(i);
   }
-  std::cout << t.elapsed() << "\t" << sum << std::endl;
+  std::cout << boost::timer::format(t.elapsed()) << "\t" << sum << std::endl;
   std::cout << "OK\n" << std::endl;
   return 0;
 }

--- a/scitbx/lbfgsb/boost_python/SConscript
+++ b/scitbx/lbfgsb/boost_python/SConscript
@@ -7,6 +7,7 @@ if (os.path.isfile(os.path.join(env_etc.libtbx_lib, "liblbfgsb_fortran.a"))):
   if (env_etc.compiler == "unix_gcc"):
     env.Append(LIBS=["g2c"])
   env.Prepend(CPPFLAGS=["-DSCITBX_LBFGSB_HAVE_FORTRAN_LIB"])
+env.Append(LIBS=['boost_timer'])
 env.SharedLibrary(
   target="#lib/scitbx_lbfgsb_ext",
   source=[

--- a/scitbx/lbfgsb/dev/SConscript
+++ b/scitbx/lbfgsb/dev/SConscript
@@ -4,6 +4,6 @@ env_etc.enable_more_warnings(env=env)
 env_etc.include_registry.append(
   env=env,
   paths=env_etc.scitbx_common_includes)
-envlm = env.Clone(LIBS=env_etc.libm)
+envlm = env.Clone(LIBS=['boost_timer', 'boost_chrono', env_etc.libm])
 for i in [1,2,3]:
   envlm.Program(target="driver%d"%i, source="driver%d.cpp"%i)

--- a/scitbx/lbfgsb/raw.h
+++ b/scitbx/lbfgsb/raw.h
@@ -6,7 +6,7 @@
 #include <scitbx/array_family/ref.h>
 #include <scitbx/array_family/accessors/c_grid.h>
 #include <scitbx/error.h>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <cstdio>
 
@@ -168,8 +168,8 @@ namespace raw {
   void
   timer(FloatType& ttime)
   {
-    static boost::timer timer_;
-    ttime = static_cast<FloatType>(timer_.elapsed());
+    static boost::timer::auto_cpu_timer timer_;
+    ttime = 1.0e-9 * static_cast<FloatType>(timer_.elapsed().wall);
   }
 
   //! Emulation of write statement with implicit loop.

--- a/spotfinder/core_toolbox/libdistl.cpp
+++ b/spotfinder/core_toolbox/libdistl.cpp
@@ -55,7 +55,7 @@
  */
 
 #include <spotfinder/core_toolbox/libdistl.h>
-//#include <boost/timer.hpp>
+//#include <boost/timer/timer.hpp>
 //#include <omptbx/omp_or_stubs.h>
 #include <stack> // to implement std::stack fix for stack overflow, see search_border_spot
 


### PR DESCRIPTION
- Change header from boost/timer.hpp to boost/timer/timer.hpp
- Change boost::timer to boost::timer::auto_cpu_timer
- Handle switch to nanoseconds
- Build Boost timer library if needed

Fixes  #944 