### PR TITLE
Evaluation of preferential orientation

### DIFF
--- a/.azure-pipelines/py2_syntax_exceptions.txt
+++ b/.azure-pipelines/py2_syntax_exceptions.txt
@@ -13,7 +13,7 @@ xfel/ui/db/job.py
 xfel/command_line/cxi_mpi_submit.py
 xfel/command_line/fee_calibration.py
 xfel/util/drift.py
-xfel/util/preferential_orientation.py
+xfel/util/preference.py
 cctbx/maptbx/qscore.py
 cctbx/maptbx/tst_qscore.py
 mmtbx/geometry_restraints/geo_file_parsing.py

--- a/.azure-pipelines/py2_syntax_exceptions.txt
+++ b/.azure-pipelines/py2_syntax_exceptions.txt
@@ -13,6 +13,7 @@ xfel/ui/db/job.py
 xfel/command_line/cxi_mpi_submit.py
 xfel/command_line/fee_calibration.py
 xfel/util/drift.py
+xfel/util/preferential_orientation.py
 cctbx/maptbx/qscore.py
 cctbx/maptbx/tst_qscore.py
 mmtbx/geometry_restraints/geo_file_parsing.py

--- a/xfel/command_line/drift.py
+++ b/xfel/command_line/drift.py
@@ -4,7 +4,6 @@ from __future__ import division
 import sys
 from xfel.util.drift import params_from_phil, run, message
 
-
 if __name__ == '__main__':
   if '--help' in sys.argv[1:] or '-h' in sys.argv[1:]:
     print(message)

--- a/xfel/command_line/drift.py
+++ b/xfel/command_line/drift.py
@@ -2,11 +2,11 @@
 
 from __future__ import division
 import sys
-from xfel.util.drift import params_from_phil, run, message
+from xfel.util.drift import phil_scope, params_from_phil, run, message
 
 if __name__ == '__main__':
   if '--help' in sys.argv[1:] or '-h' in sys.argv[1:]:
     print(message)
     exit()
-  params = params_from_phil(sys.argv[1:])
+  params = params_from_phil(phil_scope, sys.argv[1:])
   run(params)

--- a/xfel/command_line/preference.py
+++ b/xfel/command_line/preference.py
@@ -1,8 +1,8 @@
-# LIBTBX_SET_DISPATCHER_NAME cctbx.xfel.preferential_orientation
+# LIBTBX_SET_DISPATCHER_NAME cctbx.xfel.preference
 
 from __future__ import division
 import sys
-from xfel.util.preferential_orientation import params_from_phil, phil_scope, run, message
+from xfel.util.preference import params_from_phil, phil_scope, run, message
 
 
 if __name__ == '__main__':

--- a/xfel/command_line/preferential_orientation.py
+++ b/xfel/command_line/preferential_orientation.py
@@ -2,12 +2,12 @@
 
 from __future__ import division
 import sys
-from xfel.util.preferential_orientation import params_from_phil, run, message
+from xfel.util.preferential_orientation import params_from_phil, phil_scope, run, message
 
 
 if __name__ == '__main__':
   if '--help' in sys.argv[1:] or '-h' in sys.argv[1:]:
     print(message)
     exit()
-  params = params_from_phil(sys.argv[1:])
+  params = params_from_phil(phil_scope, sys.argv[1:])
   run(params)

--- a/xfel/merging/application/preference/factory.py
+++ b/xfel/merging/application/preference/factory.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import, division, print_function
+from xfel.merging.application.preference.preference import PreferenceWorker
+from xfel.merging.application.worker import factory as factory_base
+
+
+class factory(factory_base):
+  """Factory for PreferenceWorker which evaluates preferential orientation"""
+  @staticmethod
+  def from_parameters(params, additional_info=None, mpi_helper=None, mpi_logger=None):
+    return PreferenceWorker(params, mpi_helper, mpi_logger)

--- a/xfel/merging/application/preference/factory.py
+++ b/xfel/merging/application/preference/factory.py
@@ -7,4 +7,4 @@ class factory(factory_base):
   """Factory for PreferenceWorker which evaluates preferential orientation"""
   @staticmethod
   def from_parameters(params, additional_info=None, mpi_helper=None, mpi_logger=None):
-    return PreferenceWorker(params, mpi_helper, mpi_logger)
+    return [PreferenceWorker(params, mpi_helper, mpi_logger)]

--- a/xfel/merging/application/preference/preference.py
+++ b/xfel/merging/application/preference/preference.py
@@ -5,7 +5,7 @@ from functools import wraps
 import numpy as np
 
 from xfel.merging.application.worker import worker
-from xfel.util.preference import DirectSpaceBases, \
+from xfel.util.preference import ascii_plot, DirectSpaceBases, \
   find_preferential_distribution, space_group_auto
 
 
@@ -45,5 +45,10 @@ class PreferenceWorker(worker):
     distributions = find_preferential_distribution(abc_stack, sg)
     self.logger.log('')
     self.logger.log(distributions.table)
+    self.logger.log('')
+    pref_direction, pref_distribution = distributions.best
+    self.logger.log(f'Vector distribution for the most offending'
+                    f'zone axes family {pref_direction}:')
+    self.logger.log(ascii_plot(pref_distribution.vectors))
     self.logger.log('')
     return experiments, reflections

--- a/xfel/merging/application/preference/preference.py
+++ b/xfel/merging/application/preference/preference.py
@@ -34,8 +34,9 @@ class PreferenceWorker(worker):
   def run(self, experiments, reflections):
     sg, message_ = space_group_auto(experiments, comm=self.mpi_helper.comm)
     if self.mpi_helper.rank == 0:
-      self.logger.log(message_)
-      self.logger.log('')
+      for message_line in message_.split('\n'):
+        self.logger.main_log(message_line)
+      self.logger.main_log('')
     abc_stack = DirectSpaceBases.from_expts(experiments, sg)
     abc_stack = abc_stack.symmetrize(sg.build_derived_point_group())
     abc_stacks = self.mpi_helper.comm.gather(abc_stack)

--- a/xfel/merging/application/preference/preference.py
+++ b/xfel/merging/application/preference/preference.py
@@ -36,7 +36,7 @@ class PreferenceWorker(worker):
     if self.mpi_helper.rank == 0:
       for message_line in message_.split('\n'):
         self.logger.main_log(message_line)
-      self.logger.main_log('')
+    self.logger.main_log('')
     abc_stack = DirectSpaceBases.from_expts(experiments, sg)
     abc_stack = abc_stack.symmetrize(sg.build_derived_point_group())
     abc_stacks = self.mpi_helper.comm.gather(abc_stack)
@@ -44,12 +44,11 @@ class PreferenceWorker(worker):
       return experiments, reflections
     abc_stack = DirectSpaceBases(np.concatenate(abc_stacks, axis=0))
     distributions = find_preferential_distribution(abc_stack, sg)
-    self.logger.main_log('')
     self.logger.main_log(distributions.table)
     self.logger.main_log('')
     pref_direction, pref_distribution = distributions.best
-    self.logger.main_log(f'Vector distribution for the most offending'
-                         f'zone axes family {pref_direction}:')
+    self.logger.main_log(f'Vector distribution for zone axes '
+                         f'family {pref_direction}:')
     self.logger.main_log(ascii_plot(pref_distribution.vectors))
     self.logger.main_log('')
     return experiments, reflections

--- a/xfel/merging/application/preference/preference.py
+++ b/xfel/merging/application/preference/preference.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import, division, print_function
+
+from functools import wraps
+
+import numpy as np
+
+from xfel.merging.application.worker import worker
+from xfel.util.preference import DirectSpaceBases, \
+  find_preferential_distribution, space_group_auto
+
+
+def return_input_expts_refls_if_error(run_method):
+  @wraps(run_method)
+  def run_method_wrapper(worker_instance, experiments, reflections):
+    try:
+      return run_method(worker_instance, experiments, reflections)
+    except Exception:  # noqa - this is meant to catch everything
+      worker_instance.logger.log('Error when running worker, returning input')
+      return experiments, reflections
+  return run_method_wrapper
+
+
+class PreferenceWorker(worker):
+  """Read lattice vectors, apply symmetry, look for preferential orientation"""
+
+  def __init__(self, params, mpi_helper=None, mpi_logger=None):
+    kwargs = dict(params=params, mpi_helper=mpi_helper, mpi_logger=mpi_logger)
+    super(PreferenceWorker, self).__init__(**kwargs)
+
+  def __repr__(self):
+    return 'Evaluate preferential orientation'
+
+  @return_input_expts_refls_if_error
+  def run(self, experiments, reflections):
+    sg, message_ = space_group_auto(experiments, comm=self.mpi_helper.comm)
+    if self.mpi_helper.rank == 0:
+      self.logger.log(message_)
+      self.logger.log('')
+    abc_stack = DirectSpaceBases.from_expts(experiments, sg)
+    abc_stack = abc_stack.symmetrize(sg.build_derived_point_group())
+    abc_stacks = self.mpi_helper.comm.gather(abc_stack)
+    if self.mpi_helper.comm.rank != 0:
+      return experiments, reflections
+    abc_stack = DirectSpaceBases(np.concatenate(abc_stacks, axis=0))
+    distributions = find_preferential_distribution(abc_stack, sg)
+    self.logger.log('')
+    self.logger.log(distributions.table)
+    self.logger.log('')
+    return experiments, reflections

--- a/xfel/merging/application/preference/preference.py
+++ b/xfel/merging/application/preference/preference.py
@@ -47,8 +47,8 @@ class PreferenceWorker(worker):
     self.logger.main_log(distributions.table)
     self.logger.main_log('')
     pref_direction, pref_distribution = distributions.best
-    self.logger.main_log(f'Vector distribution for zone axes '
-                         f'family {pref_direction}:')
+    self.logger.main_log('Vector distribution for zone axes family '
+                         + pref_direction)
     self.logger.main_log(ascii_plot(pref_distribution.vectors))
     self.logger.main_log('')
     return experiments, reflections

--- a/xfel/merging/application/preference/preference.py
+++ b/xfel/merging/application/preference/preference.py
@@ -44,12 +44,12 @@ class PreferenceWorker(worker):
       return experiments, reflections
     abc_stack = DirectSpaceBases(np.concatenate(abc_stacks, axis=0))
     distributions = find_preferential_distribution(abc_stack, sg)
-    self.logger.log('')
-    self.logger.log(distributions.table)
-    self.logger.log('')
+    self.logger.main_log('')
+    self.logger.main_log(distributions.table)
+    self.logger.main_log('')
     pref_direction, pref_distribution = distributions.best
-    self.logger.log(f'Vector distribution for the most offending'
-                    f'zone axes family {pref_direction}:')
-    self.logger.log(ascii_plot(pref_distribution.vectors))
-    self.logger.log('')
+    self.logger.main_log(f'Vector distribution for the most offending'
+                         f'zone axes family {pref_direction}:')
+    self.logger.main_log(ascii_plot(pref_distribution.vectors))
+    self.logger.main_log('')
     return experiments, reflections

--- a/xfel/merging/application/preference/preference.py
+++ b/xfel/merging/application/preference/preference.py
@@ -36,7 +36,7 @@ class PreferenceWorker(worker):
     if self.mpi_helper.rank == 0:
       for message_line in message_.split('\n'):
         self.logger.main_log(message_line)
-    self.logger.main_log('')
+      self.logger.main_log('')
     abc_stack = DirectSpaceBases.from_expts(experiments, sg)
     abc_stack = abc_stack.symmetrize(sg.build_derived_point_group())
     abc_stacks = self.mpi_helper.comm.gather(abc_stack)

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -140,7 +140,7 @@ phil_scope_str = """
 phil_scope = parse(phil_scope_str)
 
 
-def params_from_phil(args):
+def params_from_phil(phil_scope_, args):
   user_phil = []
   for arg in args:
     if os.path.isfile(arg):
@@ -150,7 +150,7 @@ def params_from_phil(args):
         user_phil.append(parse(arg))
       except Exception:
         raise Sorry("Unrecognized argument: %s" % arg)
-  params_ = phil_scope.fetch(sources=user_phil).extract()
+  params_ = phil_scope_.fetch(sources=user_phil).extract()
   return params_
 
 
@@ -1007,5 +1007,5 @@ if __name__ == '__main__':
   if '--help' in sys.argv[1:] or '-h' in sys.argv[1:]:
     print(message)
     exit()
-  params = params_from_phil(sys.argv[1:])
+  params = params_from_phil(phil_scope, sys.argv[1:])
   run(params)

--- a/xfel/util/drift.py
+++ b/xfel/util/drift.py
@@ -280,18 +280,17 @@ def path_split(path: str) -> List[str]:
   return os.path.normpath(path).split(os.sep)
 
 
-def read_experiments(expt_paths: Sequence[str]) -> ExperimentList:
+def read_experiments(*expt_paths: str) -> ExperimentList:
   """Create an instance of ExperimentList from one or more `*expt_paths`"""
   expts = ExperimentList()
-  for expt_path in unique_elements(tuple(expt_paths)):
+  for expt_path in unique_elements(expt_paths):
     expts.extend(ExperimentList.from_file(expt_path, check_format=False))
   return expts
 
 
-def read_reflections(refl_paths: Sequence[str]) -> flex.reflection_table:
+def read_reflections(*refl_paths: str) -> flex.reflection_table:
   """Create an instance of flex.reflection_table from one/more `*refl_paths`"""
-  r = [flex.reflection_table.from_file(p)
-       for p in unique_elements(tuple(refl_paths))]
+  r = [flex.reflection_table.from_file(p) for p in unique_elements(refl_paths)]
   return flex.reflection_table.concat(r)
 
 
@@ -505,8 +504,8 @@ class BaseDriftScraper(object):
     path_stem = combine_phil_path.replace('_combine_experiments.phil', '')
     expts_paths = path_lookup(path_stem + '_refined.expt')
     refls_paths = path_lookup(path_stem + '_refined.refl')
-    expts = read_experiments(expts_paths)
-    refls = read_reflections(refls_paths)
+    expts = read_experiments(*expts_paths)
+    refls = read_reflections(*refls_paths)
     return expts, refls
 
   @autoupdate_scrap_dict_with_return
@@ -572,7 +571,7 @@ class MergingDirectoryDriftScraper(BaseDriftScraper):
       merging_phil_paths.sort(key=os.path.getmtime)
       for scaling_dir in self.locate_scaling_directories(merging_phil_paths):
         scaled_expt_paths = path_lookup(scaling_dir, 'scaling_*.expt')
-        scaled_expts = read_experiments(scaled_expt_paths)
+        scaled_expts = read_experiments(*scaled_expt_paths)
         scaled_identifiers = list(scaled_expts.identifiers())
         scaling_phil_paths = []
         for sep in scaled_expt_paths:

--- a/xfel/util/preference.py
+++ b/xfel/util/preference.py
@@ -108,15 +108,15 @@ def space_group_auto(expts: Iterable[ExperimentList],
                      comm: type(COMM) = None,
                      ) -> Tuple[SgtbxSpaceGroup, str]:
   """Return the most common space groups across comm world, and summary str"""
-  counter = Counter([expt.crystal.get_space_group() for expt in expts])
+  counter = Counter([e.crystal.get_space_group().make_tidy() for e in expts])
   if comm is not None:
     counters = comm.allgather(counter)
     counter = sum(counters, Counter())
   message_ = ''
-  for sg, sg_count in counter:
-    message_ += f'Found {sg_count:6d} expts with space group {sg.info()!s}'
+  for sg, sg_count in counter.items():
+    message_ += f'Found {sg_count:6d} expts with space group {sg.info()}\n'
   most_common = counter.most_common(1)[0][0]
-  message_ += f'Evaluating the most common space group {most_common} only'
+  message_ += f'Evaluating the most common space group {most_common.info()}'
   return most_common, message_
 
 

--- a/xfel/util/preference.py
+++ b/xfel/util/preference.py
@@ -646,11 +646,12 @@ def exercise_watson_distribution():
   ha = HammerArtist()
   for kappa in [-10.0, -1.0, -0.1, -0.01, .000001, 0.01, 0.1, 1.0, 10.]:
     wd = WatsonDistribution(mu=np.array([0, 0, 1]), kappa=kappa)
-    wd.sample(100000)
+    wd.sample(1_000_000)
     wd.fit(wd.vectors)
     print(wd)
     hh = Hedgehog(distribution=wd, color='r', name='kappa=' + str(kappa))
     ha.register_hedgehog(hh)
+    print(ascii_plot(hh.distribution))
   ha.plot()
 
 

--- a/xfel/util/preference.py
+++ b/xfel/util/preference.py
@@ -651,7 +651,7 @@ def exercise_watson_distribution():
     print(wd)
     hh = Hedgehog(distribution=wd, color='r', name='kappa=' + str(kappa))
     ha.register_hedgehog(hh)
-    print(ascii_plot(hh.distribution))
+    print(ascii_plot(hh.distribution.vectors))
   ha.plot()
 
 

--- a/xfel/util/preference.py
+++ b/xfel/util/preference.py
@@ -582,7 +582,7 @@ class HammerArtist(BaseDistributionArtist):
 
 def ascii_plot(vectors: np.ndarray, n_bins: int = 10) -> str:
   """A string with geographic heat plot on a simple xy cartesian coords"""
-  px_width = 3
+  px_width = 4
   _, _, heat = calculate_geographic_heat(vectors=vectors)
   minh, maxh = np.min(heat), np.max(heat)
   int_heat = np.rint(4.0 / (maxh - minh) * (heat.T - minh)).astype(int)

--- a/xfel/util/preference.py
+++ b/xfel/util/preference.py
@@ -643,15 +643,15 @@ def run(params_):
 
 
 def exercise_watson_distribution():
-  hha = HedgehogArtist()
-  for kappa in [-1000, -100, -10, 0.000001, 10, 100]:
+  ha = HammerArtist()
+  for kappa in [-10.0, -1.0, -0.1, -0.01, .000001, 0.01, 0.1, 1.0, 10.]:
     wd = WatsonDistribution(mu=np.array([0, 0, 1]), kappa=kappa)
-    wd.sample(1000)
+    wd.sample(100000)
     wd.fit(wd.vectors)
     print(wd)
     hh = Hedgehog(distribution=wd, color='r', name='kappa=' + str(kappa))
-    hha.register_hedgehog(hh)
-  hha.plot()
+    ha.register_hedgehog(hh)
+  ha.plot()
 
 
 params = []

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -117,7 +117,7 @@ class DirectSpaceBases(np.ndarray):
   @classmethod
   def from_expts(cls,
                  expts: ExperimentList,
-                 space_group=sgtbx.space_group('P 1'),
+                 space_group: SgtbxSpaceGroup = sg_p1,
                  ) -> 'DirectSpaceBases':
     """Extract N vectors a, b, c from N expts into a 3xNx3 ndarray, return"""
     abcs = []
@@ -142,7 +142,7 @@ class DirectSpaceBases(np.ndarray):
     """Read and return a Nx3x3 orientation matrix based on input parameters"""
     expt_paths = cls.locate_input_paths(parameters=parameters)
     expts = read_experiments(*expt_paths)
-    return cls.from_expts(expts)
+    return cls.from_expts(expts, space_group=parameters.input.spacee_group)
 
   @staticmethod
   def locate_input_paths(parameters) -> List[str]:

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -470,7 +470,7 @@ class BaseDistributionArtist(abc.ABC):
     for h in range(axes_grid_height):
       for w in range(axes_grid_width):
         ax = self.fig.add_subplot(gs[h, w], projection=self.PROJECTION)
-        if len(self.axes) > len_:
+        if len(self.axes) >= len_:
           ax.set_axis_off()
         self.axes.append(ax)
 
@@ -529,8 +529,9 @@ class HammerArtist(BaseDistributionArtist):
     ax.pcolor(azim_edges, polar_edges, heat.T, cmap=self.CMAP)
     axes_params = {'ls': '', 'marker': '.', 'mec': 'w'}  # lab x, y, and z-axes
     ax.plot(0., 0., c='r', **axes_params)
-    ax.plot([-.999 * np.pi, .999 * np.pi], [0., 0.], c='b', **axes_params)
+    ax.plot([-.999 * np.pi, .999 * np.pi], [0., 0.], c='g', **axes_params)
     ax.plot([0., 0.], [-np.pi / 2, np.pi / 2], c='b', **axes_params)
+    ax.tick_params(labelbottom=False, labelleft=False)
     ax.set_title(hedgehog.name)
 
   def plot(self) -> None:

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -294,7 +294,7 @@ class UniquePseudoNodeGenerator:
         self.nodes_to_yield.append(node)
         self.nodes_considered.add(node)
 
-  def expand(self, around: np.ndarray, radius=3) -> None:
+  def expand(self, around: np.ndarray, radius=2) -> None:
     """Generate new direction pseudo-vectors in a `RADIUS` around `around`."""
     p_range = np.arange(around[0] - radius, around[0] + radius + .1)
     q_range = np.arange(around[1] - radius, around[1] + radius + .1)
@@ -315,8 +315,9 @@ def find_preferential_orientation_direction(dsv: DirectSpaceVectors) -> dict:
   for upn in unique_pseudo_node_generator:
     vectors = dsv.a * upn[0] + dsv.b * upn[1] + dsv.c * upn[2]
     wd = WatsonDistribution.from_vectors(vectors)
-    watson_distributions[upn] =
+    watson_distributions[upn] = wd
     print(f'Direction {upn}: {wd.nll=}, {wd.kappa=}, {wd.mu=}')
+  return watson_distributions
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~ ORIENTATION VISUALIZING ~~~~~~~~~~~~~~~~~~~~~~~~~ #
@@ -382,11 +383,10 @@ class HedgehogArtist:
 
 def run(params_):
   abc_stack = DirectSpaceVectors.from_glob(params_)
+  distributions = find_preferential_orientation_direction(abc_stack)
   hha = HedgehogArtist(parameters=params_)
-  for vectors, color, name in zip(abc_stack, 'rgb', 'abc'):
-    wd = WatsonDistribution.from_vectors(vectors)
-    print(name + ': ' + str(wd))
-    hh = Hedgehog(distribution=wd, color=color, name=name)
+  for lattice_direction, distribution in distributions.items():
+    hh = Hedgehog(distribution=distribution, color='r', name=lattice_direction)
     hha.register_hedgehog(hh)
   hha.plot()
 

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -417,10 +417,10 @@ class PreferentialDistributionResults(UserDict[Int3, WatsonDistribution]):
     """Prepare a pretty string for logging"""
     table_data = [['Direction', 'kappa', 'mu', 'NLL']]
     for k, v in self.sorted.items():
-      dir_ = f'<{k[0]:+d},{k[1]:+d},{k[2]:+d}>'
+      dir_ = f'<{k[0]:d},{k[1]:d},{k[2]:d}>'
       dir_ = dir_.replace('(', '<').replace(')', '>').replace(' ', '')
-      kappa = f'{v.kappa:+8f}'
-      mu = f'[{v.mu[0]:+3f},{v.mu[1]:+3f},{v.mu[2]:+3f}]'
+      kappa = f'{v.kappa:+.8f}'
+      mu = f'[{v.mu[0]:+.3f},{v.mu[1]:+.3f},{v.mu[2]:+.3f}]'
       nll = f'{v.nll:.2E}'
       table_data.append([dir_, kappa, mu, nll])
     return table_utils.format(table_data, has_header=1, delim=' ')
@@ -524,12 +524,12 @@ class HammerArtist(BaseDistributionArtist):
       x=azim, y=polar, bins=[azim_edges, polar_edges])
     heat = np.divide(heat, np.tile(np.cos(polar_centers), (bin_number, 1)))
     axes.grid(True)
-    axes.set_xticklabels([])
-    axes.set_xticklabels([])
     axes.pcolor(azim_edges, polar_edges, heat.T, cmap=self.CMAP)
-    axes.plot(0., 0., 'ro')                         # laboratory frame x-axis
-    axes.plot([-np.pi, np.pi], [0., 0.], 'ro')      # laboratory frame y-axis
-    axes.plot([0., 0.], [-np.pi/2, np.pi/2], 'ro')  # laboratory frame z-axis
+    axes.plot(0., 0., 'r.')                         # laboratory frame x-axis
+    axes.plot([-np.pi, np.pi], [0., 0.], 'g.')      # laboratory frame y-axis
+    axes.plot([0., 0.], [-np.pi/2, np.pi/2], 'b.')  # laboratory frame z-axis
+    axes.set_xticklabels([])
+    axes.set_xticklabels([])
     axes.set_title(hedgehog.name)
 
   def plot(self) -> None:

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -88,7 +88,7 @@ def transform(vectors: Iterable[Number3],
   """Transform Number3 or Nx3 Iterable of Number3-s using symm_op """
   vectors = np.array(list(vectors))  # read generators, avoid tuples
   symm_op_m3 = np.array(symm_op.as_double_array()[:9]).reshape((3, 3))
-  return vectors @ symm_op_m3
+  return vectors @ symm_op_m3.T
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~ ORIENTATION SCRAPPING ~~~~~~~~~~~~~~~~~~~~~~~~~~ #

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -182,7 +182,7 @@ class WatsonDistribution(SphericalDistribution):
   def from_vectors(cls, vectors: np.ndarray) -> 'WatsonDistribution':
     """Define the distribution by fitting it to a list of vectors"""
     new = WatsonDistribution()
-    new.fit(vectors=vectors)
+    new.fit(vectors=cls.normalized(vectors))
     return new
 
   @property

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -527,7 +527,7 @@ class HammerArtist(BaseDistributionArtist):
     heat = np.divide(heat, np.tile(np.cos(polar_centers), (bin_number, 1)))
     ax.grid(False)
     ax.pcolor(azim_edges, polar_edges, heat.T, cmap=self.CMAP)
-    axes_params = {'ls': '', 'marker': '.', 'mec': 'w'}  # lab x, y, and z-axes
+    axes_params = {'ls': '', 'marker': 'o', 'mec': 'w'}  # lab x, y, and z-axes
     ax.plot(0., 0., c='r', **axes_params)
     ax.plot([-.999 * np.pi, .999 * np.pi], [0., 0.], c='g', **axes_params)
     ax.plot([0., 0.], [-np.pi / 2, np.pi / 2], c='b', **axes_params)

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -312,7 +312,7 @@ def run(params_):
     hha = HedgehogArtist(parameters=params_)
     for vectors, color, name in zip(abc_stack, 'rgb', 'abc'):
       wd = WatsonDistribution.from_vectors(vectors)
-      print(name + ': ' + wd)
+      print(name + ': ' + str(wd))
       hh = Hedgehog(distribution=wd, color=color, name=name)
       hha.register_hedgehog(hh)
     hha.plot()

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -79,14 +79,6 @@ SgtbxSpaceGroup = Any
 SgtbxSymmOp = Any
 
 
-def positive_first_range(around: int, radius: int):
-  """Return range where numbers >= 0 are given first, in order ~ abs value"""
-  full_arange = np.arange(around - radius, around + radius + 1)
-  non_negative_arange = full_arange[full_arange >= 0]
-  negative_arange = np.flip(full_arange[full_arange < 0])
-  return np.concatenate([non_negative_arange, negative_arange])
-
-
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ SYMMETRY HANDLING ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
@@ -378,9 +370,9 @@ class UniquePseudoNodeGenerator:
 
   def expand(self, around: Int3, radius: int = 2) -> None:
     """Generate new direction pseudo-vectors in a `RADIUS` around `around`."""
-    p_range = positive_first_range(around[0], radius)
-    q_range = positive_first_range(around[1], radius)
-    r_range = positive_first_range(around[2], radius)
+    p_range = np.arange(around[0] - radius, around[0] + radius + 1)
+    q_range = np.arange(around[1] - radius, around[1] + radius + 1)
+    r_range = np.arange(around[2] - radius, around[2] + radius + 1)
     pqr_mesh = np.meshgrid(p_range, q_range, r_range)
     pqr = np.column_stack([mesh_comp.ravel() for mesh_comp in pqr_mesh])
     pqr = pqr[np.linalg.norm(pqr, axis=1) <= radius]

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -59,13 +59,13 @@ phil_scope_str = """
 phil_scope = parse(phil_scope_str)
 
 
-############################ CONVENIENCE AND TYPING ###########################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~ CONVENIENCE AND TYPING ~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
 cctbx_point_group_type = typing.Any
 
 
-############################ ORIENTATION SCRAPPING ############################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~ ORIENTATION SCRAPPING ~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
 class DirectSpaceVectors(np.ndarray):
@@ -122,7 +122,7 @@ class DirectSpaceVectors(np.ndarray):
     return self[2]
 
 
-##################### PREFERENTIAL ORIENTATION CALCULATOR #####################
+# ~~~~~~~~~~~~~~~~~~~ PREFERENTIAL ORIENTATION CALCULATOR ~~~~~~~~~~~~~~~~~~~ #
 
 
 class SphericalDistribution:
@@ -303,7 +303,7 @@ def find_preferential_orientation(dsv: DirectSpaceVectors, params_) -> dict:
   print(f'Best fit found for direction {pqr_array.pqr[i]}: {str(wds[i])}')
 
 
-########################### ORIENTATION VISUALIZING ###########################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~ ORIENTATION VISUALIZING ~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 @dataclass
 class Hedgehog:
@@ -361,7 +361,7 @@ class HedgehogArtist:
     plt.show()
 
 
-################################ ENTRY POINTS #################################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ENTRY POINTS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 
 def run(params_):

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -7,6 +7,7 @@ from typing import List
 import sys
 
 from dxtbx.model import ExperimentList
+from libtbx.phil import parse
 from xfel.util.drift import params_from_phil, read_experiments
 
 from mpl_toolkits.mplot3d import Axes3D  # noqa: required to use 3D axes
@@ -52,6 +53,7 @@ phil_scope_str = """
       .help = glob which matches all expt files to be excluded from input.
   }
 """
+phil_scope = parse(phil_scope_str)
 
 
 ############################ CONVENIENCE AND TYPING ###########################
@@ -350,7 +352,7 @@ class HedgehogArtist:
 
 
 def run(params_):
-  abc_stack = DirectSpaceVectors.from_glob(params_).abc
+  abc_stack = DirectSpaceVectors.from_glob(params_)
   hha = HedgehogArtist(parameters=params_)
   for vectors, color, name in zip(abc_stack, 'rgb', 'abc'):
     wd = WatsonDistribution.from_vectors(vectors)
@@ -377,5 +379,5 @@ if __name__ == '__main__':
   if '--help' in sys.argv[1:] or '-h' in sys.argv[1:]:
     print(message)
     exit()
-  params = params_from_phil(sys.argv[1:])
+  params = params_from_phil(phil_scope, sys.argv[1:])
   run(params)

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -71,7 +71,7 @@ class DirectSpaceVectors(np.ndarray):
     if len(abc.shape) < 3 or abc.shape[0] != 3 or abc.shape[2] != 3:
       msg = 'DirectSpaceVectors must be init with a 3xNx3 array of abc vectors'
       raise ValueError(msg)
-    super().__new__(cls, abc.shape, dtype=float, buffer=abc)
+    return super().__new__(cls, abc.shape, dtype=float, buffer=abc)
 
   @classmethod
   def from_expts(cls, expts: ExperimentList) -> 'DirectSpaceVectors':
@@ -138,8 +138,8 @@ class SphericalDistribution:
     """Basis vector of cartesian system in which e1 = mu; e2 & e3 arbitrary"""
     e1 = self.mu / np.linalg.norm(self.mu)
     e0 = self.E1 if not self.are_parallel(e1, self.E1) else self.E2
-    e2 = np.cross(e1, e0)
-    e3 = np.cross(e1, e2)
+    e2 = (e := np.cross(e1, e0)) / np.linalg.norm(e)
+    e3 = (e := np.cross(e1, e2)) / np.linalg.norm(e)
     return e1, e2, e3
 
   @property
@@ -148,7 +148,7 @@ class SphericalDistribution:
     azim = np.linspace(0.0, 2*np.pi, num=100, endpoint=True)
     r = np.ones_like(azim)
     polar = np.full_like(azim, np.pi / 2)
-    return self.mu_sph2cart(np.vstack(r, polar, azim).T)
+    return self.mu_sph2cart(np.vstack([r, polar, azim]).T)
 
   def mu_sph2cart(self, r_polar_azim: np.ndarray):
     """Convert spherical coordinates r, polar, azim to cartesian in mu basis"""

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -409,7 +409,7 @@ class PreferentialDistributionResults(UserDict[Int3, WatsonDistribution]):
     artist = artists[kind]()
     for direction, distribution in self.items():
       hh = Hedgehog(distribution=distribution, color='r', name=str(direction))
-      artist.register4(hh)
+      artist.register_hedgehog(hh)
     artist.plot()
 
   @property

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -403,7 +403,14 @@ class PreferentialDistributionResults(UserDict[Int3, WatsonDistribution]):
         hh = Hedgehog(distribution=distribution, color='r', name=direction)
         hha.register_hedgehog(hh)
       hha.plot()
-    pass
+    elif kind == 'hammer':
+      ha = HammerArtist()
+      for direction, distribution in self.items():
+        hh = Hedgehog(distribution=distribution, color='r', name=direction)
+        ha.register_hedgehog(hh)
+      ha.plot()
+    else:
+      raise KeyError('Unknown kind of plot requested: ' + str(kind))
 
   def report(self) -> str:
     """Prepare a pretty string for logging"""
@@ -532,6 +539,7 @@ def run(params_):
   distributions = find_preferential_distribution(abc_stack, space_group)
   distributions.plot('hedgehog')
   distributions.plot('hammer')
+  print(distributions)
 
 
 def exercise_watson_distribution():

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -419,11 +419,11 @@ class PreferentialDistributionResults(UserDict[Int3, WatsonDistribution]):
     for k, v in self.sorted.items():
       dir_ = f'<{k[0]:d},{k[1]:d},{k[2]:d}>'
       dir_ = dir_.replace('(', '<').replace(')', '>').replace(' ', '')
-      kappa = f'{v.kappa:+.8f}'
+      kappa = f'{v.kappa:+.3f}'
       mu = f'[{v.mu[0]:+.3f},{v.mu[1]:+.3f},{v.mu[2]:+.3f}]'
       nll = f'{v.nll:.2E}'
       table_data.append([dir_, kappa, mu, nll])
-    return table_utils.format(table_data, has_header=1, delim=' ')
+    return table_utils.format(table_data, has_header=1, delim='  ')
 
 
 def find_preferential_distribution(
@@ -512,7 +512,7 @@ class HammerArtist(BaseDistributionArtist):
   CMAP = plt.get_cmap('viridis')
   PROJECTION = 'hammer'
 
-  def _plot_hammer(self, axes: plt.Axes, hedgehog: Hedgehog) -> None:
+  def _plot_hammer(self, ax: plt.Axes, hedgehog: Hedgehog) -> None:
     bin_number = 10
     polar_edges = np.linspace(-np.pi / 2., np.pi / 2., bin_number + 1)
     azim_edges = np.linspace(-np.pi, np.pi, bin_number + 1)
@@ -523,19 +523,20 @@ class HammerArtist(BaseDistributionArtist):
     heat, azim_edges, polar_edges = np.histogram2d(
       x=azim, y=polar, bins=[azim_edges, polar_edges])
     heat = np.divide(heat, np.tile(np.cos(polar_centers), (bin_number, 1)))
-    axes.grid(True)
-    axes.pcolor(azim_edges, polar_edges, heat.T, cmap=self.CMAP)
-    axes.plot(0., 0., 'r.')                         # laboratory frame x-axis
-    axes.plot([-np.pi, np.pi], [0., 0.], 'g.')      # laboratory frame y-axis
-    axes.plot([0., 0.], [-np.pi/2, np.pi/2], 'b.')  # laboratory frame z-axis
-    axes.set_xticklabels([])
-    axes.set_xticklabels([])
-    axes.set_title(hedgehog.name)
+    ax.grid(True)
+    ax.pcolor(azim_edges, polar_edges, heat.T, cmap=self.CMAP)
+    axes_params = {'ls': '', 'marker': '.', 'mec': 'w'}  # lab x, y, and z-axes
+    ax.plot(0., 0., c='r', **axes_params)
+    ax.plot([-.999 * np.pi, .999 * np.pi], [0., 0.], c='b', **axes_params)
+    ax.plot([0., 0.], [-np.pi / 2, np.pi / 2], c='b', **axes_params)
+    ax.set_xticks([])
+    ax.set_xticks([])
+    ax.set_title(hedgehog.name)
 
   def plot(self) -> None:
     self._generate_axes()
     for axes, hedgehog in zip(self.axes, self.hedgehogs):
-      self._plot_hammer(axes=axes, hedgehog=hedgehog)
+      self._plot_hammer(ax=axes, hedgehog=hedgehog)
     plt.show()
 
 

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -74,7 +74,7 @@ class DirectSpaceVectors:
   def from_glob(cls, parameters) -> 'DirectSpaceVectors':
     """Read and return a Nx3x3 orientation matrix based on scrap parameters"""
     expt_paths = cls.locate_input_paths(parameters=parameters)
-    expts = read_experiments(expt_paths)
+    expts = read_experiments(*expt_paths)
     return cls(abc=cls.assemble_abc_stack(expts))
 
   @staticmethod

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -67,11 +67,11 @@ cctbx_point_group_type = typing.Any
 
 class DirectSpaceVectors(np.ndarray):
   """Class responsible for scraping and storing vectors a, b, c from expts"""
-  def __init__(self, shape, *args, **kwargs):
-    super().__init__(shape, *args, **kwargs)
-    if len(shape) < 3 or shape[0] != 3 or shape[2] != 3:
+  def __new__(cls, abc: np.ndarray):
+    if len(abc.shape) < 3 or abc.shape[0] != 3 or abc.shape[2] != 3:
       msg = 'DirectSpaceVectors must be init with a 3xNx3 array of abc vectors'
       raise ValueError(msg)
+    super().__new__(abc.shape, dtype=float, buffer=abc)
 
   @classmethod
   def from_expts(cls, expts: ExperimentList) -> 'DirectSpaceVectors':

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -277,8 +277,8 @@ class HedgehogArtist:
     self.axes = []
 
   def _generate_axes(self) -> None:
-    gs_width = np.ceil(np.sqrt(len(self)))
-    gs_height = np.ceil(len(self) / gs_width)
+    gs_width = np.ceil(np.sqrt(len(self))).astype(int)
+    gs_height = np.ceil(len(self) / gs_width).astype(int)
     gs = GridSpec(gs_height, gs_width, hspace=0, wspace=0)
     for h in range(gs_height):
       for w in range(gs_width):

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -284,9 +284,13 @@ class UniquePseudoNodeGenerator:
     self.nodes_considered = set()
     self.expand(around=(0, 0, 0), radius=3)
 
+  def __iter__(self) -> 'UniquePseudoNodeGenerator':
+    return self
+
   def __next__(self) -> Int3:
-    while self.nodes_to_yield:
-      yield self.nodes_to_yield.popleft()
+    if self.nodes_to_yield:
+      return self.nodes_to_yield.popleft()
+    raise StopIteration
 
   def add(self, nodes: Iterable[Int3]) -> None:
     """Add new pseudo-nodes, but only if they hadn't been yielded yet"""
@@ -313,7 +317,7 @@ class UniquePseudoNodeGenerator:
 def find_preferential_orientation_direction(dsv: DirectSpaceVectors) -> dict:
   """Look for a preferential orientation in any direct space direction pqr"""
   unique_pseudo_node_generator = UniquePseudoNodeGenerator()
-  watson_distributions: Dict[np.ndarray, WatsonDistribution] = {}
+  watson_distributions: Dict[Int3, WatsonDistribution] = {}
   for upn in unique_pseudo_node_generator:
     vectors = dsv.a * upn[0] + dsv.b * upn[1] + dsv.c * upn[2]
     wd = WatsonDistribution.from_vectors(vectors)

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -529,7 +529,7 @@ class HammerArtist(BaseDistributionArtist):
     ax.pcolor(azim_edges, polar_edges, heat.T, cmap=self.CMAP)
     axes_params = {'ls': '', 'marker': 'o', 'mec': 'w'}  # lab x, y, and z-axes
     ax.plot(0., 0., c='r', **axes_params)
-    ax.plot([-.999 * np.pi, .999 * np.pi], [0., 0.], c='g', **axes_params)
+    ax.plot([-np.pi / 2, np.pi / 2], [0., 0.], c='g', **axes_params)
     ax.plot([0., 0.], [-np.pi / 2, np.pi / 2], c='b', **axes_params)
     ax.tick_params(labelbottom=False, labelleft=False)
     ax.set_title(hedgehog.name)

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -469,8 +469,10 @@ class BaseDistributionArtist(abc.ABC):
     gs = GridSpec(axes_grid_height, axes_grid_width, hspace=0, wspace=0)
     for h in range(axes_grid_height):
       for w in range(axes_grid_width):
-        subplot = self.fig.add_subplot(gs[h, w], projection=self.PROJECTION)
-        self.axes.append(subplot)
+        ax = self.fig.add_subplot(gs[h, w], projection=self.PROJECTION)
+        if len(self.axes) > len_:
+          ax.set_axis_off()
+        self.axes.append(ax)
 
   def register_hedgehog(self, hedgehog: Hedgehog) -> None:
     self.hedgehogs.append(hedgehog)
@@ -502,8 +504,8 @@ class HedgehogArtist(BaseDistributionArtist):
 
   def plot(self):
     self._generate_axes()
-    for axes, hedgehog in zip(self.axes, self.hedgehogs):
-      self._plot_hedgehog(axes=axes, hedgehog=hedgehog)
+    for ax, hedgehog in zip(self.axes, self.hedgehogs):
+      self._plot_hedgehog(axes=ax, hedgehog=hedgehog)
     plt.show()
 
 
@@ -523,20 +525,18 @@ class HammerArtist(BaseDistributionArtist):
     heat, azim_edges, polar_edges = np.histogram2d(
       x=azim, y=polar, bins=[azim_edges, polar_edges])
     heat = np.divide(heat, np.tile(np.cos(polar_centers), (bin_number, 1)))
-    ax.grid(True)
+    ax.grid(False)
     ax.pcolor(azim_edges, polar_edges, heat.T, cmap=self.CMAP)
     axes_params = {'ls': '', 'marker': '.', 'mec': 'w'}  # lab x, y, and z-axes
     ax.plot(0., 0., c='r', **axes_params)
     ax.plot([-.999 * np.pi, .999 * np.pi], [0., 0.], c='b', **axes_params)
     ax.plot([0., 0.], [-np.pi / 2, np.pi / 2], c='b', **axes_params)
-    ax.set_xticks([])
-    ax.set_xticks([])
     ax.set_title(hedgehog.name)
 
   def plot(self) -> None:
     self._generate_axes()
-    for axes, hedgehog in zip(self.axes, self.hedgehogs):
-      self._plot_hammer(ax=axes, hedgehog=hedgehog)
+    for ax, hedgehog in zip(self.axes, self.hedgehogs):
+      self._plot_hammer(ax=ax, hedgehog=hedgehog)
     plt.show()
 
 

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -71,7 +71,7 @@ class DirectSpaceVectors(np.ndarray):
     if len(abc.shape) < 3 or abc.shape[0] != 3 or abc.shape[2] != 3:
       msg = 'DirectSpaceVectors must be init with a 3xNx3 array of abc vectors'
       raise ValueError(msg)
-    super().__new__(abc.shape, dtype=float, buffer=abc)
+    super().__new__(cls, abc.shape, dtype=float, buffer=abc)
 
   @classmethod
   def from_expts(cls, expts: ExperimentList) -> 'DirectSpaceVectors':

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -142,7 +142,8 @@ class DirectSpaceBases(np.ndarray):
     """Read and return a Nx3x3 orientation matrix based on input parameters"""
     expt_paths = cls.locate_input_paths(parameters=parameters)
     expts = read_experiments(*expt_paths)
-    return cls.from_expts(expts, space_group=parameters.input.spacee_group)
+    space_group = parameters.input.space_group.group()
+    return cls.from_expts(expts, space_group)
 
   @staticmethod
   def locate_input_paths(parameters) -> List[str]:
@@ -458,7 +459,7 @@ class HedgehogArtist:
 
 def run(params_):
   abc_stack = DirectSpaceBases.from_glob(params_)
-  space_group = params_.input.space_group
+  space_group = params_.input.space_group.group()
   abc_stack = abc_stack.symmetrize(space_group.build_derived_point_group())
   distributions = find_preferential_orientation_direction(abc_stack, space_group)
   hha = HedgehogArtist(parameters=params_)

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -315,7 +315,8 @@ class HedgehogArtist:
     origin = [0., 0., 0.]
     name = hedgehog.name
     v = hedgehog.distribution.vectors
-    axes.quiver(*origin, v[:, 0], v[:, 1], v[:, 2], colors=hedgehog.color, alpha=0.1)
+    axes.quiver(*origin, v[:, 0], v[:, 1], v[:, 2], colors=hedgehog.color,
+                alpha=0.1, arrow_length_ratio=0.0)
     axes.set_xlim([-1, 1])
     axes.set_ylim([-1, 1])
     axes.set_zlim([-1, 1])

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -9,7 +9,7 @@ import sys
 
 from cctbx import sgtbx
 from dxtbx.model import ExperimentList
-from libtbx.phil import parse
+from iotbx.phil import parse
 from xfel.util.drift import params_from_phil, read_experiments
 
 from mpl_toolkits.mplot3d import Axes3D  # noqa: required to use 3D axes
@@ -71,7 +71,7 @@ phil_scope = parse(phil_scope_str)
 
 
 Int3 = Tuple[int, int, int]
-Number3 = Sequence[Number, Number, Number]
+Number3 = Sequence[Number]
 sg_p1 = sgtbx.space_group('P 1')  # noqa
 pg_i1 = sg_p1.build_derived_laue_group()
 SgtbxPointGroup = Any

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -216,8 +216,8 @@ class WatsonDistribution(SphericalDistribution):
     of kappa, with `mu` and `vectors` fixed and given in `params`"""
     return -self.log_likelihood(mu=mu, kappa=kappa)
 
-  def fit(self, vectors: np.ndarray) -> dict:
-    """Fit distribution to `vectors`, return dict with 'mu', 'kappa' & 'nll'"""
+  def fit(self, vectors: np.ndarray) -> None:
+    """Fit distribution to `vectors`, update `self.mu` and `self.kappa`"""
     self.vectors = vectors
     eig_val, eig_vec = np.linalg.eig(self.scatter_matrix)
     fitted = {'mu': np.array([1., 0., 0.]), 'kappa': 0., 'nll': np.inf}
@@ -225,7 +225,8 @@ class WatsonDistribution(SphericalDistribution):
         res = sp.optimize.minimize(self.nll_of_kappa, x0=0., args=eig_vec)
         if (nll := res['fun']) < fitted['nll']:
             fitted = {'mu': eig_vec, 'kappa': res['x'][0], 'nll': nll}
-    return fitted
+    self.mu = fitted['mu']
+    self.kappa = fitted['kappa']
 
   def sample(self, n: int) -> np.ndarray:
     """Sample `n` vectors from self, based on doi 10.1080/03610919308813139"""

--- a/xfel/util/preferential_orientation.py
+++ b/xfel/util/preferential_orientation.py
@@ -176,7 +176,7 @@ class WatsonDistribution(SphericalDistribution):
     self.mu: np.ndarray = mu
 
   def __str__(self):
-    return f'Watson Distribution around mu={self.mu} with kappa={self.mu}'
+    return f'Watson Distribution around mu={self.mu} with kappa={self.kappa}'
 
   @classmethod
   def from_vectors(cls, vectors: np.ndarray) -> 'WatsonDistribution':


### PR DESCRIPTION
This PR introduces a method to analyze the kind and degree of preferential orientation across multiple experiments. The method can be accessed in two different ways. Firstly, it is accessible as a standalone tool via `cctbx.xfel.preference`, providing a quick method to analyze small amounts of data. Additionally, preferential orientation can be analyzed via a dedicated `cctbx.xfel.merge` worker called `preference`, which takes no phil parameters and can be easily introduced before merging. Both methods can be run using MPI.

The degree of preferential orientation, i.e. the "preference", is evaluated by fitting a Watson Distribution to the list of normalized lattice directions across all experiments. The [Watson distribution](https://doi.org/10.2307%2F3213566) is a conceptually simple generalization of the Gaussian distribution for a sphere (though I really struggled to find good resources about it). The concentration of unit vectors is described using two parameters – vector μ and scalar κ:
- In a distribution described by κ << 0, vectors focus around equator away from ±μ;
- In a distribution described by κ ≈ 0, vectors are distributed ~uniformly on the sphere. 
- In a distribution described by κ >> 0, vectors focus around ±μ;

![Screen Shot 2024-02-08 at 5 30 43 PM](https://github.com/cctbx/cctbx_project/assets/24624030/4cc89f06-7840-4316-b07f-24c507022c6c)
_Figure: Red vectors following Watson distribution around black μ=[0,0,1] with κ = -10, ~0, and 10, respectively._

With that in mind, the general algorithm for evaluating preference is as follows:
- Read experiments from `input.glob` or the previous worker;
- Choose the space group:
  - EITHER Read from `input.space_group` (standalone only)...
  - OR Automatically find the most common space group;
- Generate a list of small symmetrically unique zone axes indices {h,k,l} to be investigated;
  - Each unique zone axis describes a unique possible type of crystal face;
  - In particular, zone axes {1,0,0}, {0,1,0}, and {0,0,1} include vectors **a***, **b***, and **c***.
- For each unique zone axis:
  - Generate a list of directions of the zone axis across all experiments;
  - Apply all Laue Class symmetry operations to vectors to avoid selection bias (`input.symmetrize`);
  - Fit Watson distribution to the list of directions
- Write out a table of Watson κ and μ parameters
- Plot the distribution of vectors

The most important product is the listing of κ and μ values for zone axes, in particular, the value of κ in the first row.
```
----------------------------------------------------
Direction  kappa   mu                      NLL
----------------------------------------------------
{0,0,1}    -1.208  [-0.708,+0.706,-0.027]  -7.41E+03
{1,0,0}    +0.593  [+0.711,-0.703,+0.011]  -2.29E+03
{2,-1,0}   +0.581  [+0.710,-0.704,+0.012]  -2.21E+03
{0,1,0}    -0.623  [-0.709,-0.701,+0.083]  -2.17E+03
{0,1,-2}   -0.609  [-0.709,+0.705,-0.020]  -2.08E+03
{1,-1,0}   +0.555  [+0.709,-0.705,+0.017]  -2.00E+03
{2,0,-1}   +0.539  [-0.711,+0.703,-0.010]  -1.89E+03
{2,-1,-1}  +0.531  [+0.711,-0.704,+0.012]  -1.83E+03
{2,-2,-1}  +0.513  [+0.710,-0.704,+0.016]  -1.71E+03
{1,-2,0}   +0.500  [+0.708,-0.706,+0.029]  -1.62E+03
{0,2,-1}   -0.429  [-0.710,-0.699,+0.079]  -1.06E+03
{1,-2,-1}  +0.407  [+0.708,-0.706,+0.029]  -1.06E+03
{1,-1,-1}  +0.401  [+0.710,-0.704,+0.014]  -1.03E+03
{2,-1,-2}  +0.398  [-0.711,+0.703,-0.009]  -1.02E+03
{1,0,-1}   +0.397  [+0.712,-0.702,+0.007]  -1.01E+03
{1,-2,-2}  +0.181  [+0.707,-0.706,+0.032]  -2.05E+02
{0,1,-1}   +0.144  [+0.050,+0.026,+0.998]  -1.29E+02
{1,0,-2}   -0.134  [+0.072,+0.018,+0.997]  -1.08E+02
{1,-1,-2}  -0.090  [+0.037,+0.027,+0.999]  -4.95E+01
----------------------------------------------------
```
This is how the table might look for Laue class mmm. Here, κ < -1 suggests a strong preference for zone axes {001} = (001) and (00-1) to point away from direction [-1,1,0] in the laboratory space due to the use of tilted Kapton tape. Other zone axes also feature κ < -0.1 or κ > +0.1 strongly suggesting, that preferential orientation might be present. For decently large datasets of ~> 10000 experiments, uniform distributions should yield κ below 0.1.

The distribution of individual zone axes is additionally plotted; in standalone, the default `plot.style=hammer`, which shows one heatmap of vector distribution on a unit sphere for each zone axis:

![Screen Shot 2024-02-08 at 6 06 42 PM](https://github.com/cctbx/cctbx_project/assets/24624030/2f46402e-da39-42e0-b994-a73812908e6d)

Since the worker will usually run in a headless environment, a single small 2d heatmap of vector density across azimuth/polar coordinates will be printed in the main log using ASCII characters instead:

```
Ascii distribution heat plot for direction {0,0,1}:
┌────────────────────Z───────────────────┐
│▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▓▓▓▓▒▒▒▒▒▒▒▒▒▒▒▒│
│▒▒▒▒▒▒▒▒▒▒▒▒░░░░░░░░▓▓▓▓▓▓▓▓▒▒▒▒░░░░▒▒▒▒│
│▒▒▒▒▓▓▓▓░░░░░░░░░░░░▓▓▓▓▓▓▓▓▒▒▒▒░░░░░░░░│
│▒▒▒▒▓▓▓▓░░░░░░░░░░░░▒▒▒▒▓▓▓▓░░░░    ░░░░│
│▒▒▒▒████░░░░        ▒▒▒▒████░░░░        │
X▒▒▒▒████░Y░░        X▒▒▒████░░Y░        X
│▒▒▒▒▓▓▓▓░░░░    ░░░░▒▒▒▒▓▓▓▓░░░░░░░░░░░░│
│▓▓▓▓▓▓▓▓▒▒▒▒░░░░░░░░▒▒▒▒▓▓▓▓░░░░░░░░░░░░│
│▓▓▓▓▓▓▓▓▒▒▒▒░░░░▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░░░░░░░│
│▒▒▒▒▓▓▓▓▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒│
└────────────────────Z───────────────────┘

```
![Screen Shot 2024-02-08 at 6 09 04 PM](https://github.com/cctbx/cctbx_project/assets/24624030/aad01ce8-f126-4a3c-81f8-faaef243d6e7)

These maps can be also generated for all zone axes in the standalone using `plot.style=ascii`. Since they only use ASCII characters, there shouldn't be any problems writing them or storing code in cctbx.

To sum up, this is not the best way to analyze preferential orientation, but in my opinion, it is simple and intuitive. The better way would be to analyze the distribution of entire [**a**,**b**,**c**] matrices instead of individual vectors, but I don't know how to do it. Also, the numeric value of κ will be 0 in cubic systems, even if there is some preferential orientation, due to its inherent symmetry. In this case, one would need to look at the plots to find it. This isn't a big issue since preferential orientation should not cause any significant problems for cubic crystals.