### PR TITLE
MMTBX: remove comparison of int with NoneType

### DIFF
--- a/mmtbx/scaling/data_statistics.py
+++ b/mmtbx/scaling/data_statistics.py
@@ -862,10 +862,10 @@ or omission of reflections by data-processing software.""")
         issues.append((0,
           "The resolution cutoff appears to be similar in all directions.",
           "Analysis of resolution limits"))
-    if (0 < self.low_resolution_completeness_overall < 0.75):
+    if self.low_resolution_completeness_overall and 0 < self.low_resolution_completeness_overall < 0.75:
       issues.append((2, "The overall completeness in low-resolution shells "+
         "is less than 90%.", "Low resolution completeness analyses"))
-    elif (0.75 <= self.low_resolution_completeness_overall < 0.9):
+    elif self.low_resolution_completeness_overall and 0.75 <= self.low_resolution_completeness_overall < 0.9:
       issues.append((1, "The overall completeness in low-resolution shells "+
         "is less than 90%.", "Low resolution completeness analyses"))
     else :

--- a/mmtbx/scaling/twin_analyses.py
+++ b/mmtbx/scaling/twin_analyses.py
@@ -2198,11 +2198,11 @@ refinement might provide an answer.
           "data has a higher "+
           "crystallographic symmetry (%s)." % str(self.suspected_point_group),
           "Point group and R-factor analysis"))
-    if (self.patterson_height > 75):
+    if self.patterson_height and self.patterson_height > 75:
       issues.append((2, "Translational NCS is present at a level that might "+
         "be a result of a missed centering operation (one or more peaks "+
         "greater than 75% of the origin).", "Patterson analyses"))
-    elif (self.patterson_height > 20):
+    elif self.patterson_height and self.patterson_height > 20:
       issues.append((2, "Translational NCS is present at a level that may "+
         "complicate refinement (one or more peaks greater than 20% of the "+
         "origin)", "Patterson analyses"))


### PR DESCRIPTION
Fix a couple of places in `mmtbx.scaling` where the attribute of a class, initially set to `None`, is implicitly expected to have since become an `int`.  There are seemingly valid paths through the code in which the attribute values remain `None`, so this leads to a comparison `TypeError`.  Removing these code paths seems pretty trivial.

@phyy-nx and I stubbed our toes on this last week when trying to run [`xia2.multiplex`](https://dials.github.io/documentation/programs/xia2_multiplex.html), of which MMTBX is a dependency.

I've no idea why tests are failing in the CI.  They don't, at first glance, seem to be related to these changes.  @bkpoon, could you please advise as to how you would like me to proceed?