### PR TITLE
Fix miller array `repr` when `label_string()` returns `None`

### DIFF
--- a/cctbx/miller/__init__.py
+++ b/cctbx/miller/__init__.py
@@ -3978,7 +3978,7 @@ class array(set):
     """
     mstr = self.crystal_symmetry().__repr__()
     if self._info:
-      mstr = mstr + "\n" + self._info.label_string()
+      mstr = mstr + "\n" + str(self._info.label_string())
     mstr = mstr + "\n" + self._data.__repr__()
     if self._sigmas:
       mstr = mstr + "\n" + self._sigmas.__repr__()


### PR DESCRIPTION
I came across this whilst running [this script](https://github.com/dials/dials/issues/2625#issuecomment-2015145506) on data in space group $F d d 2$. Simplest solution: if `label_string()` returns `None` just wrap it in a `str()` call.