### PR TITLE
Clashscore2

### DIFF
--- a/cctbx_website/html_files/doc_models_hierarchy.html
+++ b/cctbx_website/html_files/doc_models_hierarchy.html
@@ -88,7 +88,7 @@ print("File name written: %s" %(model_file_name))
 </code></pre>
 <p>We also wrote the model out using the data manager and obtained the
 actual file name written.  This last step is necessary because a model that
-does not fit in PDB format will be written out as mmCIF with the suffix .cif. 
+does not fit in PDB format will be written out as mmCIF with the suffix .cif.
 </p>
 
 <p>It is possible to get a <code>pdb_hierarchy()</code> object directly:</p>

--- a/mmtbx/command_line/clashscore2.py
+++ b/mmtbx/command_line/clashscore2.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import, division, print_function
+# LIBTBX_SET_DISPATCHER_NAME phenix.clashscore2
+# LIBTBX_SET_DISPATCHER_NAME molprobity.clashscore2
+# LIBTBX_SET_DISPATCHER_NAME mmtbx.clashscore2
+# LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
+
+import sys
+
+from iotbx.cli_parser import CCTBXParser
+from libtbx.utils import multi_out, show_total_time
+from mmtbx.programs import clashscore2
+from iotbx.cli_parser import run_program
+
+#=============================================================================
+def old_run(args):
+
+  # create parser
+  logger = multi_out()
+  logger.register('stderr', sys.stderr)
+  logger2 = multi_out()
+  logger2.register('stdout', sys.stdout)
+
+  parser = CCTBXParser(
+    program_class=clashscore2.Program,
+    logger=logger)
+  namespace = parser.parse_args(sys.argv[1:])
+
+  # start program
+  print('Starting job', file=logger)
+  print('='*79, file=logger)
+  task = clashscore2.Program(
+    parser.data_manager, parser.working_phil.extract(), logger=logger2)
+
+  # validate inputs
+  task.validate()
+
+  # run program
+  task.run()
+
+  # stop timer
+  print('', file=logger)
+  print('='*79, file=logger)
+  print('Job complete', file=logger)
+  show_total_time(out=logger)
+
+# =============================================================================
+if __name__ == '__main__':
+  #run(sys.argv[1:])
+  run_program(program_class=clashscore2.Program, hide_parsing_output=True)

--- a/mmtbx/programs/clashscore2.py
+++ b/mmtbx/programs/clashscore2.py
@@ -96,22 +96,6 @@ Example:
   def validate(self):
     self.data_manager.has_models(raise_sorry=True)
 
-  def get_results_as_JSON(self):
-    if self.params.do_flips : self.params.keep_hydrogens = False
-
-    result = clashscore2(
-      self.params.probe,
-      data_manager=self.data_manager,
-      fast = self.params.fast,
-      condensed_probe = self.params.condensed_probe,
-      keep_hydrogens=self.params.keep_hydrogens,
-      nuclear=self.params.nuclear,
-      out=self.logger,
-      verbose=self.params.verbose and not quiet,
-      b_factor_cutoff=self.params.b_factor_cutoff,
-      do_flips=self.params.do_flips)
-    return result.as_JSON()
-
   def run(self, quiet=None): #preserved how quiet was passed to the old run, not sure why
     """
   Calculates nonbonded clashscore using MolProbity (PROBE)

--- a/mmtbx/programs/clashscore2.py
+++ b/mmtbx/programs/clashscore2.py
@@ -2,7 +2,8 @@
 All-atom contact analysis.
 This is a rewrite of the original clashscore.  This version uses mmtbx.reduce and
 mmtbx.probe to generate the contact information rather than stand-alone programs.
-It take the same parameters as the original clashscore.
+It take the same parameters as the original clashscore (except for time_limit)
+and it also takes mmtbx.probe parameters.
 """
 
 from __future__ import absolute_import, division, print_function
@@ -11,6 +12,7 @@ import os
 from mmtbx.validation.clashscore2 import clashscore2
 from libtbx.program_template import ProgramTemplate
 from datetime import datetime
+from mmtbx.probe import Helpers
 
 try:
   from phenix.program_template import ProgramTemplate
@@ -73,10 +75,6 @@ Example:
     .type = bool
     .help = '''Use nuclear hydrogen positions'''
 
-  time_limit = 120
-    .type = int
-    .help = '''Time limit (sec) for Reduce optimization'''
-
   b_factor_cutoff = None
     .type = int
     .help = '''B factor cutoff for use with MolProbity'''
@@ -84,7 +82,13 @@ Example:
   clash_cutoff = -0.4
     .type = float
     .help = '''dummy variable for MolProbity, will be removed after MP update'''
-"""
+""" + Helpers.probe_phil_parameters
+
+# Removed time_limit from the phil parameters
+#  time_limit = 120
+#    .type = int
+#    .help = '''Time limit (sec) for Reduce optimization'''
+
   datatypes = ['model','phil']
   data_manager_options = ['model_skip_expand_with_mtrix']
   known_article_ids = ['molprobity']
@@ -97,6 +101,7 @@ Example:
     data_manager_model = self.data_manager.get_model()
 
     result = clashscore2(
+      self.params.probe,
       data_manager_model=data_manager_model,
       fast = self.params.fast,
       condensed_probe = self.params.condensed_probe,
@@ -122,6 +127,7 @@ Example:
     self.info_json = {"model_name":self.data_manager.get_default_model_name(),
                       "time_analyzed": str(datetime.now())}
     self.results = clashscore2(
+      self.params.probe,
       data_manager_model=data_manager_model,
       fast = self.params.fast,
       condensed_probe = self.params.condensed_probe,

--- a/mmtbx/programs/clashscore2.py
+++ b/mmtbx/programs/clashscore2.py
@@ -98,11 +98,10 @@ Example:
 
   def get_results_as_JSON(self):
     if self.params.do_flips : self.params.keep_hydrogens = False
-    data_manager_model = self.data_manager.get_model()
 
     result = clashscore2(
       self.params.probe,
-      data_manager_model=data_manager_model,
+      data_manager=self.data_manager,
       fast = self.params.fast,
       condensed_probe = self.params.condensed_probe,
       keep_hydrogens=self.params.keep_hydrogens,
@@ -123,12 +122,11 @@ Example:
   """
     # if do_flips, make keep_hydrogens false
     if self.params.do_flips : self.params.keep_hydrogens = False
-    data_manager_model = self.data_manager.get_model()
     self.info_json = {"model_name":self.data_manager.get_default_model_name(),
                       "time_analyzed": str(datetime.now())}
     self.results = clashscore2(
       self.params.probe,
-      data_manager_model=data_manager_model,
+      data_manager=self.data_manager,
       fast = self.params.fast,
       condensed_probe = self.params.condensed_probe,
       keep_hydrogens=self.params.keep_hydrogens,

--- a/mmtbx/programs/clashscore2.py
+++ b/mmtbx/programs/clashscore2.py
@@ -1,0 +1,145 @@
+"""
+All-atom contact analysis.
+This is a rewrite of the original clashscore.  This version uses mmtbx.reduce and
+mmtbx.probe to generate the contact information rather than stand-alone programs.
+It take the same parameters as the original clashscore.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import os
+from mmtbx.validation.clashscore2 import clashscore2
+from libtbx.program_template import ProgramTemplate
+from datetime import datetime
+
+try:
+  from phenix.program_template import ProgramTemplate
+except ImportError:
+  pass
+#from libtbx.utils import Sorry
+
+class Program(ProgramTemplate):
+  prog = os.getenv('LIBTBX_DISPATCHER_NAME')
+  description="""
+%(prog)s file.pdb [params.eff] [options ...]
+
+Options:
+
+  model=input_file          input PDB file
+  fast = False              Produce only clashscore number, without anything else
+  condensed_probe=False     Run probe with -CON parameter
+  keep_hydrogens=False      keep input hydrogen atoms if True, regenerate if False
+  nuclear=False             use nuclear x-H distances and vdW radii
+  json=False                Outputs results as JSON compatible dictionary
+  verbose=True              verbose text output
+  b_factor_cutoff=40        B factor cutoff for clash analysis
+  do_flips=False            Do flips when adding Hs, overides keep_hydrogens
+
+Example:
+
+  %(prog)s model=1ubq.pdb keep_hydrogens=True
+""" % locals()
+
+  master_phil_str = """
+    model = None
+    .type = path
+    .optional = False
+    .help = '''input PDB file'''
+
+  fast = False
+    .type = bool
+    .help = ''' Produce only clashscore number, without anything else'''
+
+  condensed_probe = False
+    .type = bool
+    .help = ''' Run probe with -CON parameter '''
+
+  json = False
+    .type = bool
+    .help = "Prints results as JSON format dictionary"
+
+  verbose = True
+    .type = bool
+
+  keep_hydrogens = False
+    .type = bool
+    .help = '''Keep hydrogens in input file'''
+
+  do_flips = False
+    .type = bool
+    .help = '''Do flips when adding Hsi, overides keep_hydrogens=True'''
+
+  nuclear = False
+    .type = bool
+    .help = '''Use nuclear hydrogen positions'''
+
+  time_limit = 120
+    .type = int
+    .help = '''Time limit (sec) for Reduce optimization'''
+
+  b_factor_cutoff = None
+    .type = int
+    .help = '''B factor cutoff for use with MolProbity'''
+
+  clash_cutoff = -0.4
+    .type = float
+    .help = '''dummy variable for MolProbity, will be removed after MP update'''
+"""
+  datatypes = ['model','phil']
+  data_manager_options = ['model_skip_expand_with_mtrix']
+  known_article_ids = ['molprobity']
+
+  def validate(self):
+    self.data_manager.has_models(raise_sorry=True)
+
+  def get_results_as_JSON(self):
+    if self.params.do_flips : self.params.keep_hydrogens = False
+    data_manager_model = self.data_manager.get_model()
+
+    result = clashscore2(
+      data_manager_model=data_manager_model,
+      fast = self.params.fast,
+      condensed_probe = self.params.condensed_probe,
+      keep_hydrogens=self.params.keep_hydrogens,
+      nuclear=self.params.nuclear,
+      out=self.logger,
+      verbose=self.params.verbose and not quiet,
+      b_factor_cutoff=self.params.b_factor_cutoff,
+      do_flips=self.params.do_flips)
+    return result.as_JSON()
+
+  def run(self, quiet=None): #preserved how quiet was passed to the old run, not sure why
+    """
+  Calculates nonbonded clashscore using MolProbity (PROBE)
+
+  Returns:
+    When verbose=True the function print detailed results to log
+    When verbose=False it will print clashscore
+  """
+    # if do_flips, make keep_hydrogens false
+    if self.params.do_flips : self.params.keep_hydrogens = False
+    data_manager_model = self.data_manager.get_model()
+    self.info_json = {"model_name":self.data_manager.get_default_model_name(),
+                      "time_analyzed": str(datetime.now())}
+    self.results = clashscore2(
+      data_manager_model=data_manager_model,
+      fast = self.params.fast,
+      condensed_probe = self.params.condensed_probe,
+      keep_hydrogens=self.params.keep_hydrogens,
+      nuclear=self.params.nuclear,
+      out=self.logger,
+      verbose=self.params.verbose and not quiet,
+      b_factor_cutoff=self.params.b_factor_cutoff,
+      do_flips=self.params.do_flips)
+    if self.params.json:
+      print(self.results.as_JSON())
+    elif self.params.verbose:
+      self.results.show_old_output(out=self.logger)
+    else:
+      print(round(self.results.get_clashscore(),2), file=self.logger)
+
+  def get_results(self):
+    return self.results
+
+  def get_results_as_JSON(self):
+    return self.results.as_JSON(self.info_json)

--- a/mmtbx/programs/probe2.py
+++ b/mmtbx/programs/probe2.py
@@ -564,7 +564,7 @@ def Test():
 
 class Program(ProgramTemplate):
   description = '''
-Probe2 version {}
+probe2 version {}
 
 This program replaces the original "probe" program from the Richarson lab
 at Duke University and was developed by them as part of a supplemental award.

--- a/mmtbx/programs/probe2.py
+++ b/mmtbx/programs/probe2.py
@@ -920,11 +920,11 @@ Note:
             # Main branch if we're reporting other than bad clashes
             if (not spo.only_report_bad_clashes):
               # We are reporting other than bad clashes, see if our type is being reported
-              if spo.report_hydrogen_bonds and overlapType == probeExt.OverlapType.HydrogenBond:
+              if spo.report_hydrogen_bonds and (overlapType == probeExt.OverlapType.HydrogenBond):
                 show = True
-              elif spo.report_clashes and overlapType == probeExt.OverlapType.Clash:
+              elif spo.report_clashes and (overlapType == probeExt.OverlapType.Clash):
                 show = True
-              elif spo.report_vdws and overlapType == probeExt.OverlapType.NoOverlap:
+              elif spo.report_vdws and (overlapType == probeExt.OverlapType.NoOverlap):
                 show = True
             else:
               # We are only reporting bad clashes.  See if we're reporting clashes and this is
@@ -1163,7 +1163,7 @@ Note:
             else: # Hydrogen bond
               score = hydrogen_bond_weight * sl
 
-            if self.params.output.contact_summary:
+            if self.params.output.condensed:
               ret += "{}:".format(node.dotCount)
 
             ret += "{:.3f}:{:.3f}:{:.3f}:{:.3f}:{:.3f}:{:.3f}:{:.4f}".format(gap, dtgp,

--- a/mmtbx/programs/probe2.py
+++ b/mmtbx/programs/probe2.py
@@ -1130,7 +1130,7 @@ Note:
           chainID = a.parent().parent().parent().id
           iCode = a.parent().parent().icode
           alt = a.parent().altloc
-          ret += "{:>2s}{:>3s} {}{} {}{:1s}:".format(chainID, resID, iCode, resName, a.name, alt)
+          ret += "{:>2s}{:>4s}{}{} {}{:1s}:".format(chainID, resID, iCode, resName, a.name, alt)
 
           # Describe the target atom, if it exists
           t = node.target
@@ -1847,7 +1847,7 @@ Note:
     p.pdb_interpretation.clash_guard.nonbonded_distance_threshold=None
     p.pdb_interpretation.proceed_with_excessive_length_bonds=True
     try:
-      self.model.process(make_restraints=True, pdb_interpretation_params=p) # make restraints
+      self.model.process(make_restraints=True, pdb_interpretation_params=p, logger=self.logger) # make restraints
       geometry = self.model.get_restraints_manager().geometry
       sites_cart = self.model.get_sites_cart() # cartesian coordinates
       bondProxies, asu = \

--- a/mmtbx/programs/probe2.py
+++ b/mmtbx/programs/probe2.py
@@ -29,7 +29,7 @@ from iotbx.pdb import common_residue_names_get_class
 # @todo See if we can remove the shift and box once reduce_hydrogen is complete
 from cctbx.maptbx.box import shift_and_box_model
 
-version = "4.0.0"
+version = "4.1.0"
 
 master_phil_str = '''
 profile = False

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -1059,6 +1059,7 @@ NOTES:
     p.pdb_interpretation.clash_guard.nonbonded_distance_threshold=None
     p.pdb_interpretation.use_neutron_distances = self.params.use_neutron_distances
     p.pdb_interpretation.proceed_with_excessive_length_bonds=True
+    p.pdb_interpretation.disable_uc_volume_vs_n_atoms_check=True
     # We need to turn this on because without it 1zz0.txt kept flipping the ring
     # in A TYR 214 every time we re-interpreted. The original interpretation done
     # by Hydrogen placement will have flipped them, so we don't need to do it again.

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -1227,7 +1227,6 @@ NOTES:
         flipStates = self.params.set_flip_states,
         verbosity=self.params.verbosity,
         cliqueOutlineFileName=self.params.output.clique_outline_file_name,
-        keepExistingH = self.params.keep_existing_H,
         fillAtomDump = self.params.output.print_atom_info)
       doneOpt = time.time()
       outString += opt.getInfo()
@@ -1477,8 +1476,7 @@ NOTES:
             nonFlipPreference=self.params.non_flip_preference,
             skipBondFixup=self.params.skip_bond_fix_up,
             flipStates = flipStates,
-            verbosity=3,
-            keepExistingH = self.params.keep_existing_H)
+            verbosity=3)
           print('Results of optimization:', file=self.logger)
           print(opt.getInfo(), file=self.logger)
           self._ReinterpretModel()
@@ -1599,8 +1597,7 @@ NOTES:
             nonFlipPreference=self.params.non_flip_preference,
             skipBondFixup=self.params.skip_bond_fix_up,
             flipStates = flipStates,
-            verbosity=3,
-            keepExistingH = self.params.keep_existing_H)
+            verbosity=3)
           print('Results of optimization:', file=self.logger)
           print(opt.getInfo(), file=self.logger)
           self._ReinterpretModel()

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -861,7 +861,7 @@ def _AddFlipkinMovers(states, fileBaseName, name, color, model, alts, bondedNeig
 
 class Program(ProgramTemplate):
   description = '''
-Reduce2 version {}
+reduce2 version {}
 Add Hydrogens to a model and optimize their placement by adjusting movable groups and
 flippable groups of atoms.
 

--- a/mmtbx/reduce/Optimizers.py
+++ b/mmtbx/reduce/Optimizers.py
@@ -1381,6 +1381,7 @@ def _optimizeFragment(pdb_raw, bondedNeighborDepth = 4):
   p.pdb_interpretation.allow_polymer_cross_special_position=True
   p.pdb_interpretation.clash_guard.nonbonded_distance_threshold=None
   p.pdb_interpretation.proceed_with_excessive_length_bonds=True
+  p.pdb_interpretation.disable_uc_volume_vs_n_atoms_check=True
   model.process(make_restraints=True,pdb_interpretation_params=p) # make restraints
 
   # Optimization will place the movers.

--- a/mmtbx/reduce/Optimizers.py
+++ b/mmtbx/reduce/Optimizers.py
@@ -314,7 +314,7 @@ class Optimizer(object):
       # The command-line parameter matches the name of the model in the model file, which
       # starts with 1. The internal indexing starts with 0. So we subtract one.
       startModelIndex = (modelIndex - 1)
-      stopModelIndex = (modelIndex - 1) + 1
+      stopModelIndex = startModelIndex + 1
     for mi in range(startModelIndex, stopModelIndex):
       # Get the specified model from the hierarchy.
       myModel = model.get_hierarchy().models()[mi]

--- a/mmtbx/reduce/Optimizers.py
+++ b/mmtbx/reduce/Optimizers.py
@@ -163,7 +163,6 @@ class Optimizer(object):
                 flipStates = '',
                 verbosity = 1,
                 cliqueOutlineFileName = None,
-                keepExistingH = False,
                 fillAtomDump = True
               ):
     """Constructor.  This is the wrapper class for the C++ OptimizerC and
@@ -222,7 +221,6 @@ class Optimizer(object):
     colors as one master. It shows the outlines expanded by the probe radius, with a single color
     for each clique, as another master. These are useful for determining why the cliques are as
     they are.
-    :param keepExistingH: If True, then existing Hydrogens will be kept and not removed.
     :param fillAtomDump: If true, fill in the atomDump string with the atom information.
     This can take a long time to do, so the caller may want to turn it off if they don't need it.
     """

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -11,13 +11,8 @@ from cctbx.maptbx.box import shift_and_box_model
 from mmtbx.hydrogens import reduce_hydrogen
 from mmtbx.reduce import Optimizers
 from mmtbx.programs import probe2
-from mmtbx.probe import Helpers
-from mmtbx.utils import run_reduce_with_timeout
-from mmtbx.validation import validation, atoms, atom_info, residue
-from libtbx import phil
-from libtbx.math_utils import cmp
+from mmtbx.validation import validation, atoms, atom_info
 from libtbx.utils import Sorry, null_out
-import libtbx.load_env
 import iotbx.pdb
 import iotbx.cli_parser
 import mmtbx

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -79,11 +79,6 @@ class clashscore2(validation):
     self.clash_dict_b_cutoff = {}
     self.list_dict = {}
     self.probe_file = None
-    if (not libtbx.env.has_module(name="probe")):
-      raise RuntimeError(
-        "Probe could not be detected on your system.  Please make sure "+
-        "Probe is in your path.\nProbe is available at "+
-        "http://kinemage.biochem.duke.edu/")
     if verbose:
       if not nuclear:
         print("\nUsing electron cloud x-H distances and vdW radii")
@@ -109,21 +104,6 @@ class clashscore2(validation):
       keep_hydrogens=keep_hydrogens,
       do_flips = do_flips,
       log=out)
-
-    # @todo Remove this conversion once we are using MMTBX reduce and probe
-    pdb_hierarchy = data_manager_model.get_hierarchy()
-    if (not pdb_hierarchy.fits_in_pdb_format()):
-      from iotbx.pdb.forward_compatible_pdb_cif_conversion \
-        import forward_compatible_pdb_cif_conversion
-      conversion_info = forward_compatible_pdb_cif_conversion(
-        hierarchy = pdb_hierarchy)
-      conversion_info.\
-       convert_hierarchy_to_forward_compatible_pdb_representation(pdb_hierarchy)
-      if verbose:
-        print(
-        "Converted model to forward_compatible PDB for clashscore",file = out)
-    else:
-      conversion_info = None
 
     # Make a copy of the original model to use for submodel processing, we'll trim atoms out
     # of it for each submodel.
@@ -159,9 +139,6 @@ class clashscore2(validation):
       if (save_modified_hierarchy):
         self.pdb_hierarchy = iotbx.pdb.input(
           pdb_string=self.probe_clashscore_manager.h_pdb_string).construct_hierarchy()
-        if conversion_info:
-          conversion_info.convert_hierarchy_to_full_representation(
-             self.pdb_hierarchy)
 
       self.clash_dict[model.id] = self.probe_clashscore_manager.clashscore
       self.clash_dict_b_cutoff[model.id] = self.probe_clashscore_manager.\
@@ -173,11 +150,6 @@ class clashscore2(validation):
         self.clashscore = self.probe_clashscore_manager.clashscore
         self.clashscore_b_cutoff = self.probe_clashscore_manager.\
                                    clashscore_b_cutoff
-
-    if conversion_info:
-      if verbose:
-        print("Converted model back to full representation", file = out)
-      conversion_info.convert_hierarchy_to_full_representation(pdb_hierarchy)
 
   def get_clashscore(self):
     return self.clashscore

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -499,7 +499,6 @@ class probe_clashscore_manager(object):
     self.n_atoms = 0
     self.natoms_b_cutoff = 0
 
-    '''
     # Construct override parameters and then run probe2 using them and delete the resulting
     # temporary file.
     tempName = tempfile.mktemp()
@@ -521,10 +520,10 @@ class probe_clashscore_manager(object):
     dots, output = p2.run()
     probe_unformatted = output.splitlines()
     os.unlink(tempName)
-    '''
 
     # Debugging facility, do not remove!
     # import random
+    # pdb_string = hydrogenated_model.get_hierarchy().as_pdb_string()
     # tempdir = "tmp_for_probe_debug_%d" % random.randint(1000,9999)
     # while os.path.isdir(tempdir):
     #   tempdir = "tmp_for_probe_debug_%d" % random.randint(1000,9999)
@@ -537,11 +536,7 @@ class probe_clashscore_manager(object):
 
     # @todo
     pdb_string = hydrogenated_model.get_hierarchy().as_pdb_string()
-    probe_out = easy_run.fully_buffered(self.probe_txt, stdin_lines=pdb_string)
-    if (probe_out.return_code != 0):
-      raise RuntimeError("Probe crashed - dumping stderr:\n%s" %
-        "\n".join(probe_out.stderr_lines))
-    probe_unformatted = probe_out.stdout_lines
+
     if not self.fast:
       temp = self.process_raw_probe_output(probe_unformatted)
       self.n_clashes = len(temp)

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -1,0 +1,807 @@
+
+"""
+All-atom contact analysis.  Calls mmtbx.reduce and mmtbx.probe.
+This is a rewrite of the original clashscore that used stand-alone
+external reduce and probe programs.
+"""
+
+from __future__ import absolute_import, division, print_function
+from mmtbx.validation.clashscore import clash
+from mmtbx.reduce import Optimizers
+from mmtbx.utils import run_reduce_with_timeout
+from mmtbx.validation import validation, atoms, atom_info, residue
+from libtbx.math_utils import cmp
+from libtbx.utils import Sorry
+from libtbx import easy_run
+import libtbx.load_env
+import iotbx.pdb
+import os
+import re
+import sys
+import six
+import json
+
+class clashscore2(validation):
+  __slots__ = validation.__slots__ + [
+    "clashscore",
+    "clashscore_b_cutoff",
+    "clash_dict",
+    "clash_dict_b_cutoff",
+    "list_dict",
+    "b_factor_cutoff",
+    "fast",
+    "condensed_probe",
+    "probe_file",
+    "probe_clashscore_manager"
+  ]
+  program_description = "Analyze clashscore for protein model"
+  gui_list_headers = ["Atom 1", "Atom 2", "Overlap"]
+  gui_formats = ["%s", "%s", ".3f"]
+  wx_column_widths = [150, 150, 150] #actually set in GUI's Molprobity/Core.py
+
+  def get_result_class(self) : return clash
+
+  def __init__(self,
+      data_manager_model,
+      fast = False, # do really fast clashscore, produce only the number
+      condensed_probe = False, # Use -CON for probe. Reduces output 10x.
+      keep_hydrogens=True,
+      nuclear=False,
+      force_unique_chain_ids=False,
+      time_limit=120,
+      b_factor_cutoff=None,
+      save_modified_hierarchy=False,
+      verbose=False,
+      do_flips=False,
+      out=sys.stdout):
+    pdb_hierarchy = data_manager_model.get_hierarchy()
+    if (not pdb_hierarchy.fits_in_pdb_format()):
+      from iotbx.pdb.forward_compatible_pdb_cif_conversion \
+        import forward_compatible_pdb_cif_conversion
+      conversion_info = forward_compatible_pdb_cif_conversion(
+        hierarchy = pdb_hierarchy)
+      conversion_info.\
+       convert_hierarchy_to_forward_compatible_pdb_representation(pdb_hierarchy)
+      if verbose:
+        print(
+        "Converted model to forward_compatible PDB for clashscore",file = out)
+    else:
+      conversion_info = None
+    validation.__init__(self)
+    self.b_factor_cutoff = b_factor_cutoff
+    self.fast = fast
+    self.condensed_probe = condensed_probe
+    self.clashscore = None
+    self.clashscore_b_cutoff = None
+    self.clash_dict = {}
+    self.clash_dict_b_cutoff = {}
+    self.list_dict = {}
+    self.probe_file = None
+    if (not libtbx.env.has_module(name="probe")):
+      raise RuntimeError(
+        "Probe could not be detected on your system.  Please make sure "+
+        "Probe is in your path.\nProbe is available at "+
+        "http://kinemage.biochem.duke.edu/")
+    if verbose:
+      if not nuclear:
+        print("\nUsing electron cloud x-H distances and vdW radii")
+      else:
+        print("\nUsing nuclear cloud x-H distances and vdW radii")
+    import iotbx.pdb
+    from scitbx.array_family import flex
+    from mmtbx.validation import utils
+    n_models = len(pdb_hierarchy.models())
+    use_segids = utils.use_segids_in_place_of_chainids(
+                   hierarchy=pdb_hierarchy)
+    for i_mod, model in enumerate(pdb_hierarchy.models()):
+      input_str,_ = check_and_add_hydrogen(
+        pdb_hierarchy=pdb_hierarchy,
+        model_number=i_mod,
+        nuclear=nuclear,
+        verbose=verbose,
+        time_limit=time_limit,
+        keep_hydrogens=keep_hydrogens,
+        do_flips = do_flips,
+        log=out)
+      r = iotbx.pdb.hierarchy.root()
+      mdc = model.detached_copy()
+      r.append_model(mdc)
+      occ_max = flex.max(r.atoms().extract_occ())
+      self.probe_clashscore_manager = probe_clashscore_manager(
+        h_pdb_string=input_str,
+        nuclear=nuclear,
+        fast=self.fast,
+        condensed_probe=self.condensed_probe,
+        largest_occupancy=occ_max,
+        b_factor_cutoff=b_factor_cutoff,
+        use_segids=use_segids,
+        verbose=verbose,
+        model_id=model.id)
+      self.probe_clashscore_manager.run_probe_clashscore(input_str)
+      if (save_modified_hierarchy):
+        self.pdb_hierarchy = iotbx.pdb.input(
+          pdb_string=self.probe_clashscore_manager.h_pdb_string).construct_hierarchy()
+        if conversion_info:
+          conversion_info.convert_hierarchy_to_full_representation(
+             self.pdb_hierarchy)
+
+      self.clash_dict[model.id] = self.probe_clashscore_manager.clashscore
+      self.clash_dict_b_cutoff[model.id] = self.probe_clashscore_manager.\
+                                           clashscore_b_cutoff
+      self.list_dict[model.id] = self.probe_clashscore_manager.bad_clashes
+      if (n_models == 1) or (self.clashscore is None):
+        self.results = self.probe_clashscore_manager.bad_clashes
+        self.n_outliers = len(self.results)
+        self.clashscore = self.probe_clashscore_manager.clashscore
+        self.clashscore_b_cutoff = self.probe_clashscore_manager.\
+                                   clashscore_b_cutoff
+
+    if conversion_info:
+      if verbose:
+        print("Converted model back to full representation", file = out)
+      conversion_info.convert_hierarchy_to_full_representation(pdb_hierarchy)
+
+  def get_clashscore(self):
+    return self.clashscore
+
+  def get_clashscore_b_cutoff(self):
+    return self.clashscore_b_cutoff
+
+  def show_old_output(self, out=sys.stdout, verbose=False):
+    self.print_clashlist_old(out=out)
+    self.show_summary(out=out)
+
+  def show_summary(self, out=sys.stdout, prefix=""):
+    if self.clashscore is None:
+      raise Sorry("PROBE output is empty. Model is not compatible with PROBE.")
+    elif (len(self.clash_dict) == 1):
+      #FIXME indexing keys can break py2/3 compat if more than 1 key
+      k = list(self.clash_dict.keys())[0]
+      #catches case where file has 1 model, but also has model/endmdl cards
+      print(prefix + "clashscore = %.2f" % self.clash_dict[k], file=out)
+      if self.clash_dict_b_cutoff[k] is not None and self.b_factor_cutoff is not None:
+        print("clashscore (B factor cutoff = %d) = %f" % \
+          (self.b_factor_cutoff,
+           self.clash_dict_b_cutoff[k]), file=out)
+    else:
+      for k in sorted(self.clash_dict.keys()):
+        print(prefix + "MODEL %s clashscore = %.2f" % (k,
+          self.clash_dict[k]), file=out)
+        if self.clash_dict_b_cutoff[k] is not None and self.b_factor_cutoff is not None:
+          print("MODEL%s clashscore (B factor cutoff = %d) = %f" % \
+            (k, self.b_factor_cutoff, self.clash_dict_b_cutoff[k]), file=out)
+
+  def print_clashlist_old(self, out=sys.stdout):
+    if self.fast:
+      print("Bad Clashes >= 0.4 Angstrom - not available in fast=True mode", file=out)
+      return
+    for k in self.list_dict.keys():
+      if k == '':
+        print("Bad Clashes >= 0.4 Angstrom:", file=out)
+        for result in self.list_dict[k] :
+          print(result.format_old(), file=out)
+      else:
+        print("Bad Clashes >= 0.4 Angstrom MODEL%s" % k, file=out)
+        for result in self.list_dict[k] :
+          print(result.format_old(), file=out)
+
+  def show(self, out=sys.stdout, prefix="", outliers_only=None, verbose=None):
+    if (len(self.clash_dict) == 1):
+      for result in self.list_dict[''] :
+        print(prefix + str(result), file=out)
+    else :
+      for k in self.list_dict.keys():
+        for result in self.list_dict[k] :
+          print(prefix + str(result), file=out)
+    self.show_summary(out=out, prefix=prefix)
+
+  def as_JSON(self, addon_json={}):
+    if not addon_json:
+      addon_json = {}
+    addon_json["validation_type"] = "clashscore"
+    data = addon_json
+    flat_results = []
+    hierarchical_results = {}
+    residue_clash_list = []
+    summary_results = {}
+    for k in sorted(self.list_dict.keys()):
+      for result in self.list_dict[k]:
+        flat_results.append(json.loads(result.as_JSON()))
+        hier_result = json.loads(result.as_hierarchical_JSON())
+        hierarchical_results = self.merge_dict(hierarchical_results, hier_result)
+
+    data['flat_results'] = flat_results
+    data['hierarchical_results'] = hierarchical_results
+
+    for k in sorted(self.clash_dict.keys()):
+      summary_results[k] = {"clashscore": self.clash_dict[k],
+                            "num_clashes": len(self.list_dict[k])}
+    data['summary_results'] = summary_results
+    return json.dumps(data, indent=2)
+
+  def as_coot_data(self):
+    data = []
+    for result in self.results :
+      if result.is_outlier():
+        data.append((result.atoms_info[0].id_str(),
+          result.atoms_info[1].id_str(), result.overlap, result.xyz))
+    return data
+
+class probe_line_info(object): # this is parent
+  def __init__(self, line, model_id=""):
+    self.overlap_value = None
+    self.model_id = model_id
+
+  def is_similar(self, other):
+    assert type(self) is type(other)
+    return (self.srcAtom == other.srcAtom and self.targAtom == other.targAtom)
+
+  def as_clash_obj(self, use_segids):
+    assert self.overlap_value is not None
+    atom1 = decode_atom_string(self.srcAtom,  use_segids, self.model_id)
+    atom2 = decode_atom_string(self.targAtom, use_segids, self.model_id)
+    if (self.srcAtom < self.targAtom):
+      atoms = [ atom1, atom2 ]
+    else:
+      atoms = [ atom2, atom1 ]
+    clash_obj = clash(
+      atoms_info=atoms,
+      overlap=self.overlap_value,
+      probe_type=self.type,
+      outlier=self.overlap_value <= -0.4,
+      max_b_factor=max(self.sBval, self.tBval),
+      xyz=(self.x,self.y,self.z))
+    return clash_obj
+
+class condensed_probe_line_info(probe_line_info):
+  def __init__(self, line, model_id=""):
+    super(condensed_probe_line_info, self).__init__(line, model_id)
+    # What is in line:
+    # name:pat:type:srcAtom:targAtom:dot-count:mingap:gap:spX:spY:spZ:spikeLen:score:stype:ttype:x:y:z:sBval:tBval:
+    sp = line.split(":")
+    self.type = sp[2]
+    self.srcAtom = sp[3]
+    self.targAtom = sp[4]
+    self.min_gap = float(sp[6])
+    self.gap = float(sp[7])
+    self.x = float(sp[-5])
+    self.y = float(sp[-4])
+    self.z = float(sp[-3])
+    self.sBval = float(sp[-2])
+    self.tBval = float(sp[-1])
+    self.overlap_value = self.gap
+
+class raw_probe_line_info(probe_line_info):
+  def __init__(self, line, model_id=""):
+    super(raw_probe_line_info, self).__init__(line, model_id)
+    self.name, self.pat, self.type, self.srcAtom, self.targAtom, self.min_gap, \
+    self.gap, self.kissEdge2BullsEye, self.dot2BE, self.dot2SC, self.spike, \
+    self.score, self.stype, self.ttype, self.x, self.y, self.z, self.sBval, \
+    self.tBval = line.split(":")
+    self.gap = float(self.gap)
+    self.x = float(self.x)
+    self.y = float(self.y)
+    self.z = float(self.z)
+    self.sBval = float(self.sBval)
+    self.tBval = float(self.tBval)
+    self.overlap_value = self.gap
+
+
+class probe_clashscore_manager(object):
+  def __init__(self,
+               h_pdb_string,
+               fast = False,
+               condensed_probe=False,
+               nuclear=False,
+               largest_occupancy=10,
+               b_factor_cutoff=None,
+               use_segids=False,
+               verbose=False,
+               model_id=""):
+    """
+    Calculate probe (MolProbity) clashscore
+
+    Args:
+      h_pdb_string (str): PDB string that contains hydrogen atoms
+      nuclear (bool): When True use nuclear cloud x-H distances and vdW radii,
+        otherwise use electron cloud x-H distances and vdW radii
+      largest_occupancy (int)
+      b_factor_cutoff (float)
+      use_segids (bool)
+      verbose (bool): verbosity of printout
+      model_id (str): model ID number, used in json output
+    """
+    assert libtbx.env.has_module(name="probe")
+    if fast and not condensed_probe:
+      raise Sorry("Incompatible parameters: fast=True and condensed=False:\n"+\
+        "There's no way to work fast without using condensed output.")
+
+    self.b_factor_cutoff = b_factor_cutoff
+    self.fast = fast
+    self.condensed_probe = condensed_probe
+    self.use_segids=use_segids
+    self.model_id = model_id
+    ogt = 10
+    blt = self.b_factor_cutoff
+    if largest_occupancy < ogt:
+      ogt = largest_occupancy
+
+    self.probe_atom_b_factor = None
+    probe_command = libtbx.env.under_build(os.path.join('probe', 'exe', 'probe'))
+    if os.getenv('CCP4'):
+      ccp4_probe = os.path.join(os.environ['CCP4'],'bin','probe')
+      if (os.path.isfile(ccp4_probe) and not os.path.isfile(probe_command)):
+        probe_command = ccp4_probe
+    probe_command = '"%s"' % probe_command   # in case of spaces in path
+    self.probe_command = probe_command
+    nuclear_flag = ""
+    condensed_flag = ""
+    if nuclear:
+      nuclear_flag = "-nuclear"
+    if self.condensed_probe:
+      condensed_flag = "-CON"
+    self.probe_txt = \
+      '%s -u -q -mc -het -once -NOVDWOUT %s %s' % (probe_command, condensed_flag, nuclear_flag) +\
+        ' "ogt%d not water" "ogt%d" -' % (ogt, ogt)
+    #The -NOVDWOUT probe run above is faster for clashscore to parse,
+    # the full_probe_txt version below is for printing to file for coot usage
+    self.full_probe_txt = \
+      '%s -u -q -mc -het -once %s' % (probe_command, nuclear_flag) +\
+        ' "ogt%d not water" "ogt%d" -' % (ogt, ogt)
+    self.probe_atom_txt = \
+      '%s -q -mc -het -dumpatominfo %s' % (probe_command, nuclear_flag) +\
+        ' "ogt%d not water" -' % ogt
+    if blt is not None:
+      self.probe_atom_b_factor = \
+        '%s -q -mc -het -dumpatominfo %s' % (probe_command, nuclear_flag) +\
+          ' "blt%d ogt%d not water" -' % (blt, ogt)
+
+    self.h_pdb_string = h_pdb_string
+    #self.run_probe_clashscore(self.h_pdb_string)
+
+  def put_group_into_dict(self, line_info, clash_hash, hbond_hash):
+    key = line_info.targAtom+line_info.srcAtom
+    if (line_info.srcAtom < line_info.targAtom):
+      key = line_info.srcAtom+line_info.targAtom
+    if line_info.type == "bo":
+      if (line_info.overlap_value <= -0.4):
+        if (key in clash_hash):
+          if (line_info.overlap_value < clash_hash[key].overlap_value):
+            clash_hash[key] = line_info
+        else :
+          clash_hash[key] = line_info
+    elif (line_info.type == "hb"):
+      if self.condensed_probe:
+        hbond_hash[key] = line_info
+      else: # not condensed
+        if (key in hbond_hash):
+          if (line_info.gap < hbond_hash[key].gap):
+            hbond_hash[key] = line_info
+        else :
+          hbond_hash[key] = line_info
+
+  def filter_dicts(self, new_clash_hash, new_hbond_hash):
+    temp = []
+    for k,v in six.iteritems(new_clash_hash):
+      if k not in new_hbond_hash:
+        temp.append(v.as_clash_obj(self.use_segids))
+    return temp
+
+  def process_raw_probe_output(self, probe_unformatted):
+    new_clash_hash = {}
+    new_hbond_hash = {}
+    if self.condensed_probe:
+      for line in probe_unformatted:
+        try:
+          line_storage = condensed_probe_line_info(line, self.model_id)
+        except KeyboardInterrupt: raise
+        except ValueError:
+          continue # something else (different from expected) got into output
+        self.put_group_into_dict(line_storage, new_clash_hash, new_hbond_hash)
+    else: # not condensed
+      previous_line = None
+      for line in probe_unformatted:
+        processed=False
+        try:
+          line_storage = raw_probe_line_info(line, self.model_id)
+        except KeyboardInterrupt: raise
+        except ValueError:
+          continue # something else (different from expected) got into output
+
+        if previous_line is not None:
+          if line_storage.is_similar(previous_line):
+            # modify previous line to store this one if needed
+            previous_line.overlap_value = min(previous_line.overlap_value, line_storage.overlap_value)
+          else:
+            # seems like new group of lines, then dump previous and start new
+            # one
+            self.put_group_into_dict(previous_line, new_clash_hash, new_hbond_hash)
+            previous_line = line_storage
+        else:
+          previous_line = line_storage
+      if previous_line is not None:
+        self.put_group_into_dict(previous_line, new_clash_hash, new_hbond_hash)
+    return self.filter_dicts(new_clash_hash, new_hbond_hash)
+
+  def get_condensed_clashes(self, lines):
+    # Standalone faster parsing of output when only clashscore is needed.
+    def parse_line(line):
+      sp = line.split(':')
+      return sp[3], sp[4], float(sp[7])
+    def parse_h_line(line):
+      sp = line.split(':')
+      return sp[3], sp[4]
+
+    clashes = set() # [(src, targ), (src, targ)]
+    hbonds = [] # (src, targ), (targ, src)
+    for l in lines:
+      rtype = l[6:8]
+      if rtype == 'bo':
+        srcAtom, targAtom, gap = parse_line(l)
+        if gap <= -0.4:
+          # print l[:43], "good gap, saving", gap
+          if (srcAtom, targAtom) not in clashes and (targAtom, srcAtom) not in clashes:
+            clashes.add((srcAtom, targAtom))
+            # print (srcAtom, targAtom)
+      elif rtype == 'hb':
+        srcAtom, targAtom = parse_h_line(l)
+        hbonds.append((srcAtom, targAtom))
+        hbonds.append((targAtom, srcAtom))
+        prev_line = l
+    hbonds_set = set(hbonds)
+    n_clashes = 0
+    # print "clashes", len(clashes)
+    # print "hbonds", len(hbonds)
+    for clash in clashes:
+      if clash not in hbonds_set:
+        n_clashes += 1
+      # else:
+        # print "skipping", clash
+    return n_clashes
+
+  def run_probe_clashscore(self, pdb_string):
+    self.n_clashes = 0
+    self.n_clashes_b_cutoff = 0
+    self.clashscore_b_cutoff = None
+    self.bad_clashes = []
+    self.clashscore = None
+    self.n_atoms = 0
+    self.natoms_b_cutoff = 0
+
+    probe_out = easy_run.fully_buffered(self.probe_txt,
+      stdin_lines=pdb_string)
+    if (probe_out.return_code != 0):
+      raise RuntimeError("Probe crashed - dumping stderr:\n%s" %
+        "\n".join(probe_out.stderr_lines))
+    probe_unformatted = probe_out.stdout_lines
+
+    # Debugging facility, do not remove!
+    # import random
+    # tempdir = "tmp_for_probe_debug_%d" % random.randint(1000,9999)
+    # while os.path.isdir(tempdir):
+    #   tempdir = "tmp_for_probe_debug_%d" % random.randint(1000,9999)
+    # os.mkdir(tempdir)
+    # print ("Dumping info to %s" % tempdir)
+    # with open(tempdir + os.sep + 'model.pdb', 'w') as f:
+    #   f.write(pdb_string)
+    # with open(tempdir + os.sep + 'probe_out.txt', 'w') as f:
+    #   f.write('\n'.join(probe_unformatted))
+
+    if not self.fast:
+      temp = self.process_raw_probe_output(probe_unformatted)
+      self.n_clashes = len(temp)
+      # XXX Warning: one more probe call here
+      printable_probe_out = easy_run.fully_buffered(self.full_probe_txt,
+                                                    stdin_lines=pdb_string)
+      self.probe_unformatted = "\n".join(printable_probe_out.stdout_lines)
+    else:
+      self.n_clashes = self.get_condensed_clashes(probe_unformatted)
+
+    # getting number of atoms from probe
+    probe_info = easy_run.fully_buffered(self.probe_atom_txt,
+      stdin_lines=pdb_string) #.raise_if_errors().stdout_lines
+    err = probe_info.format_errors_if_any()
+    if err is not None and err.find("No atom data in input.")>-1:
+      return
+    #if (len(probe_info) == 0):
+    #  raise RuntimeError("Empty PROBE output.")
+    n_atoms = 0
+    for line in probe_info.stdout_lines:
+      try:
+        dump, n_atoms = line.split(":")
+      except KeyboardInterrupt: raise
+      except ValueError:
+        pass # something else (different from expected) got into output
+    self.n_atoms = int(n_atoms)
+    if self.n_atoms == 0:
+      self.clashscore = 0.0
+    else:
+      self.clashscore = (self.n_clashes * 1000) / self.n_atoms
+
+    if not self.fast:
+      # The rest is not necessary, we already got clashscore
+      if self.b_factor_cutoff is not None:
+        clashes_b_cutoff = 0
+        for clash_obj in temp:
+          if clash_obj.max_b_factor < self.b_factor_cutoff:
+            clashes_b_cutoff += 1
+        self.n_clashes_b_cutoff = clashes_b_cutoff
+      used = []
+
+      for clash_obj in sorted(temp):
+        test_key = clash_obj.id_str_no_atom_name()
+        test_key = clash_obj.id_str()
+        if test_key not in used:
+          used.append(test_key)
+          self.bad_clashes.append(clash_obj)
+
+      if self.probe_atom_b_factor is not None:
+        probe_info_b_factor = easy_run.fully_buffered(self.probe_atom_b_factor,
+          stdin_lines=pdb_string).raise_if_errors().stdout_lines
+        for line in probe_info_b_factor :
+          dump_b, natoms_b_cutoff = line.split(":")
+        self.natoms_b_cutoff = int(natoms_b_cutoff)
+      self.clashscore_b_cutoff = None
+      if self.natoms_b_cutoff == 0:
+        self.clashscore_b_cutoff = 0.0
+      else :
+        self.clashscore_b_cutoff = \
+          (self.n_clashes_b_cutoff*1000) / self.natoms_b_cutoff
+
+def decode_atom_string(atom_str, use_segids=False, model_id=""):
+  # Example:
+  # ' A  49 LEU HD11B'
+  if (not use_segids) or (len(atom_str) == 16):
+    return atom_info(
+      model_id=model_id,
+      chain_id=atom_str[0:2],
+      resseq=atom_str[2:6],
+      icode=atom_str[6],
+      resname=atom_str[7:10],
+      altloc=atom_str[15],
+      name=atom_str[11:15])
+  else:
+    return atom_info(
+      model_id=model_id,
+      chain_id=atom_str[0:4],
+      resseq=atom_str[4:8],
+      icode=atom_str[8],
+      resname=atom_str[9:12],
+      altloc=atom_str[17],
+      name=atom_str[13:17])
+
+def check_and_report_reduce_failure(fb_object, input_lines, output_fname):
+  if (fb_object.return_code != 0):
+    with open(output_fname, 'w') as f:
+      f.write(input_lines)
+    msg_str = "Reduce crashed with command '%s'.\nDumping stdin to file '%s'.\n" +\
+        "Return code: %d\nDumping stderr:\n%s"
+    raise Sorry(msg_str % (fb_object.command, output_fname, fb_object.return_code,
+                           "\n".join(fb_object.stderr_lines)))
+
+def check_and_add_hydrogen(
+        pdb_hierarchy=None,
+        file_name=None,
+        nuclear=False,
+        keep_hydrogens=True,
+        verbose=False,
+        model_number=0,
+        n_hydrogen_cut_off=0,
+        time_limit=120,
+        allow_multiple_models=True,
+        crystal_symmetry=None,
+        do_flips=False,
+        log=None):
+  """
+  If no hydrogens present, force addition for clashscore calculation.
+  Use REDUCE to add the hydrogen atoms.
+
+  Args:
+    pdb_hierarchy : pdb hierarchy
+    file_name (str): pdb file name
+    nuclear (bool): When True use nuclear cloud x-H distances and vdW radii,
+      otherwise use electron cloud x-H distances and vdW radii
+    keep_hydrogens (bool): when True, if there are hydrogen atoms, keep them
+    verbose (bool): verbosity of printout
+    model_number (int): the number of model to use
+    time_limit (int): limit the time it takes to add hydrogen atoms
+    n_hydrogen_cut_off (int): when number of hydrogen atoms < n_hydrogen_cut_off
+      force keep_hydrogens tp True
+    allow_multiple_models (bool): Allow models that contain more than one model
+    crystal_symmetry : must provide crystal symmetry when using pdb_hierarchy
+
+  Returns:
+    (str): PDB string
+    (bool): True when PDB string was updated
+  """
+  if not log: log = sys.stdout
+  if file_name:
+    pdb_inp = iotbx.pdb.input(file_name=file_name)
+    pdb_hierarchy = pdb_inp.construct_hierarchy()
+    cryst_sym = pdb_inp.crystal_symmetry()
+  elif not allow_multiple_models:
+    assert crystal_symmetry
+    cryst_sym = crystal_symmetry
+  else:
+    cryst_sym = None
+  assert pdb_hierarchy
+  assert model_number < len(pdb_hierarchy.models())
+  models = pdb_hierarchy.models()
+  if (len(models) > 1) and (not allow_multiple_models):
+    raise Sorry("When using CCTBX clashscore, provide only a single model.")
+  model = models[model_number]
+  r = iotbx.pdb.hierarchy.root()
+  mdc = model.detached_copy()
+  r.append_model(mdc)
+  if keep_hydrogens:
+    elements = r.atoms().extract_element()
+    # strangely the elements can have a space when coming from phenix.clashscore
+    # but no space when coming from phenix.molprobity
+    h_count = elements.count('H')
+    if h_count <= n_hydrogen_cut_off: h_count += elements.count(' H')
+    if h_count <= n_hydrogen_cut_off: h_count += elements.count('D')
+    if h_count <= n_hydrogen_cut_off: h_count += elements.count(' D')
+    if h_count > n_hydrogen_cut_off:
+      has_hd = True
+    else:
+      has_hd = False
+    if not has_hd:
+      if verbose:
+        print("\nNo H/D atoms detected - forcing hydrogen addition!\n", file=log)
+      keep_hydrogens = False
+  import libtbx.load_env
+  has_reduce = libtbx.env.has_module(name="reduce")
+  # add hydrogen if needed
+  if has_reduce and (not keep_hydrogens):
+    # set reduce running parameters
+    if verbose:
+      print("\nAdding H/D atoms with reduce...\n")
+    build = "-oh -his -flip -keep -allalt -limit{}"
+    if not do_flips : build += " -pen9999"
+    if nuclear:
+      build += " -nuc -"
+    else:
+      build += " -"
+    build = build.format(time_limit)
+    trim = " -quiet -trim -"
+    stdin_lines = r.as_pdb_string(cryst_sym)
+    clean_out = run_reduce_with_timeout(
+        parameters=trim,
+        stdin_lines=stdin_lines)
+    stdin_fname = "reduce_fail.pdb"
+    check_and_report_reduce_failure(
+        fb_object=clean_out,
+        input_lines=stdin_lines,
+        output_fname="reduce_fail.pdb")
+    build_out = run_reduce_with_timeout(
+        parameters=build,
+        stdin_lines=clean_out.stdout_lines)
+    check_and_report_reduce_failure(
+        fb_object=build_out,
+        input_lines=stdin_lines,
+        output_fname="reduce_fail.pdb")
+    reduce_str = '\n'.join(build_out.stdout_lines)
+    return reduce_str,True
+  else:
+    if not has_reduce:
+      msg = 'molprobity.reduce could not be detected on your system.\n'
+      msg += 'Cannot add hydrogen to PDB file'
+      print(msg, file=log)
+    if verbose:
+      print("\nUsing input model H/D atoms...\n")
+    return r.as_pdb_string(cryst_sym),False
+
+#-----------------------------------------------------------------------
+# this isn't really enough code to justify a separate module...
+#
+class nqh_flip(residue):
+  """
+  Backwards Asn/Gln/His sidechain, identified by Reduce's hydrogen-bond
+  network optimization.
+  """
+  def as_string(self):
+    return self.id_str()
+
+  def as_table_row_phenix(self):
+    if self.chain_id:
+      return [ self.chain_id, "%1s%s %s" % (self.altloc,self.resname,self.resid) ]
+    elif self.segid:
+      return [ self.segid, "%1s%s %s" % (self.altloc,self.resname,self.resid) ]
+    else:
+      raise Sorry("no chain_id or segid found for nqh flip table row")
+
+  #alternate residue class methods for segid compatibility
+  #more method overrides may be necessary
+  #a more robust propagation of segid would preferable, eventually
+  def atom_selection_string(self):
+    if self.chain_id:
+      return "(chain '%s' and resid '%s' and resname %s and altloc '%s')" % \
+        (self.chain_id, self.resid, self.resname, self.altloc)
+    elif self.segid:
+      return "(segid %s and resid '%s' and resname %s and altloc '%s')" % \
+          (self.segid, self.resid, self.resname, self.altloc)
+    else:
+      raise Sorry("no chain_id or segid found for nqh flip atom selection")
+
+  def id_str(self, ignore_altloc=False):
+    if self.chain_id:
+      base = "%2s%4s%1s" % (self.chain_id, self.resseq, self.icode)
+    elif self.segid:
+      base = "%4s%4s%1s" % (self.segid, self.resseq, self.icode)
+    else:
+      raise Sorry("no chain_id or segid found for nqh flip id_str")
+    if (not ignore_altloc):
+      base += "%1s" % self.altloc
+    else :
+      base += " "
+    base += "%3s" % self.resname
+    if (self.segid is not None):
+      base += " segid='%4s'" % self.segid
+    return base
+  #end segid compatibility
+
+class nqh_flips(validation):
+  """
+  N/Q/H sidechain flips identified by Reduce.
+  """
+  gui_list_headers = ["Chain", "Residue"]
+  gui_formats = ["%s", "%s"]
+  wx_column_widths = [75,220]
+  def __init__(self, pdb_hierarchy):
+    re_flip = re.compile(":FLIP")
+    validation.__init__(self)
+    in_lines = pdb_hierarchy.as_pdb_string()
+    reduce_out = run_reduce_with_timeout(
+        parameters="-BUILD -",
+        stdin_lines=in_lines)
+    check_and_report_reduce_failure(
+        fb_object=reduce_out,
+        input_lines=in_lines,
+        output_fname="reduce_fail.pdb")
+    from mmtbx.validation import utils
+    use_segids = utils.use_segids_in_place_of_chainids(
+      hierarchy=pdb_hierarchy)
+    for line in reduce_out.stdout_lines:
+    #chain format (2-char chain)
+    #USER  MOD Set 1.1: B  49 GLN     :FLIP  amide:sc=    -2.7! C(o=-5.8!,f=-1.3!)
+    #segid format (4-char segid)
+    #USER  MOD Set 1.1:B     49 GLN     :FLIP  amide:sc=    -2.7! C(o=-5.8!,f=-1.3!)
+      if re_flip.search(line):
+        resid = line.split(":")[1]
+        #reduce has slightly different outputs using chains versus segid
+        if len(resid) == 15: #chain
+          chain_id = resid[0:2].strip()
+          segid = None
+          if (len(chain_id) == 0):
+            chain_id = ' '
+          resid_less_chain = resid[2:]
+        elif len(resid) == 17: #segid
+          #self.results = []
+          #return
+          chain_id = None
+          segid = resid[0:4].strip()
+          #chain_id = resid[0:4].strip()
+          resid_less_chain = resid[4:]
+        else:
+          raise Sorry("unexpected length of residue identifier in reduce USER MODs.")
+        resname = resid_less_chain[5:8]
+
+        assert (resname in ["ASN", "GLN", "HIS"])
+        flip = nqh_flip(
+          chain_id=chain_id,
+          segid=segid,
+          resseq=resid_less_chain[0:4].strip(),
+          icode= resid_less_chain[4:5],
+          altloc=resid_less_chain[12:13],
+          resname=resname,
+          outlier=True)
+        flip.set_coordinates_from_hierarchy(pdb_hierarchy)
+        self.results.append(flip)
+        self.n_outliers += 1
+
+  def show(self, out=sys.stdout, prefix=""):
+    if (self.n_outliers == 0):
+      print(prefix+"No backwards Asn/Gln/His sidechains found.", file=out)
+    else :
+      for flip in self.results :
+        print(prefix+flip.as_string(), file=out)

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -65,7 +65,6 @@ class clashscore2(validation):
       force_unique_chain_ids=False,
       time_limit=120,
       b_factor_cutoff=None,
-      save_modified_hierarchy=False,
       verbose=False,
       do_flips=False,
       out=sys.stdout):
@@ -135,7 +134,6 @@ class clashscore2(validation):
       occ_max = flex.max(r.atoms().extract_occ())
       input_str = r.as_pdb_string()
       self.probe_clashscore_manager = probe_clashscore_manager(
-        h_pdb_string=input_str,
         nuclear=nuclear,
         fast=self.fast,
         condensed_probe=self.condensed_probe,
@@ -145,9 +143,6 @@ class clashscore2(validation):
         verbose=verbose,
         model_id=model.id)
       self.probe_clashscore_manager.run_probe_clashscore(input_str)
-      if (save_modified_hierarchy):
-        self.pdb_hierarchy = iotbx.pdb.input(
-          pdb_string=self.probe_clashscore_manager.h_pdb_string).construct_hierarchy()
 
       self.clash_dict[model.id] = self.probe_clashscore_manager.clashscore
       self.clash_dict_b_cutoff[model.id] = self.probe_clashscore_manager.\
@@ -308,7 +303,6 @@ class raw_probe_line_info(probe_line_info):
 
 class probe_clashscore_manager(object):
   def __init__(self,
-               h_pdb_string,
                fast = False,
                condensed_probe=False,
                nuclear=False,
@@ -321,7 +315,6 @@ class probe_clashscore_manager(object):
     Calculate probe (MolProbity) clashscore
 
     Args:
-      h_pdb_string (str): PDB string that contains hydrogen atoms
       nuclear (bool): When True use nuclear cloud x-H distances and vdW radii,
         otherwise use electron cloud x-H distances and vdW radii
       largest_occupancy (int)
@@ -374,9 +367,6 @@ class probe_clashscore_manager(object):
       self.probe_atom_b_factor = \
         '%s -q -mc -het -dumpatominfo %s' % (probe_command, nuclear_flag) +\
           ' "blt%d ogt%d not water" -' % (blt, ogt)
-
-    self.h_pdb_string = h_pdb_string
-    #self.run_probe_clashscore(self.h_pdb_string)
 
   def put_group_into_dict(self, line_info, clash_hash, hbond_hash):
     key = line_info.targAtom+line_info.srcAtom

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -105,8 +105,16 @@ class clashscore2(validation):
       do_flips = do_flips,
       log=out)
 
+    # First we must rebuild the model from the new hierarchy so that the copy can succeed.
     # Make a copy of the original model to use for submodel processing, we'll trim atoms out
     # of it for each submodel.
+    data_manager_model = mmtbx.model.manager(
+      model_input       = None,
+      pdb_hierarchy     = data_manager_model.get_hierarchy(),
+      stop_for_unknowns = False,
+      crystal_symmetry  = data_manager_model.crystal_symmetry(),
+      restraint_objects = None,
+      log               = None)
     original_model = data_manager_model.deep_copy()
 
     pdb_hierarchy = data_manager_model.get_hierarchy()
@@ -116,12 +124,12 @@ class clashscore2(validation):
     for i_mod, model in enumerate(pdb_hierarchy.models()):
 
       # Select only the current submodel from the hierarchy
-      submodule = original_model.deep_copy()
-      remove_models_except_index(submodule, i_mod)
+      submodel = original_model.deep_copy()
+      remove_models_except_index(submodel, i_mod)
 
-      # @todo
+      # Construct a hierarchy for the current submodel
       r = iotbx.pdb.hierarchy.root()
-      mdc = model.detached_copy()
+      mdc = submodel.get_hierarchy().models()[0].detached_copy()
       r.append_model(mdc)
 
       occ_max = flex.max(r.atoms().extract_occ())

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -109,6 +109,7 @@ class clashscore2(validation):
     # of it for each submodel.
     original_model = data_manager_model.deep_copy()
 
+    pdb_hierarchy = data_manager_model.get_hierarchy()
     n_models = len(pdb_hierarchy.models())
     use_segids = utils.use_segids_in_place_of_chainids(
                    hierarchy=pdb_hierarchy)


### PR DESCRIPTION
Adds a clashcore2 program that mirrors the clashscore program but it uses mmtbx.reduce2 and mmtbx.probe2 rather than phenix.reduce and phenix.probe.

It takes the same command-line programs as the original except for time_limit and it also supports probe PHIL parameters.