### PR TITLE
XFEL GUI updates

### DIFF
--- a/libtbx/__init__.py
+++ b/libtbx/__init__.py
@@ -68,6 +68,9 @@ class AutoType(object):
 
 Auto = AutoType()
 
+class mpi_import_guard:
+  disable_mpi = False
+
 class slots_getstate_setstate(object):
   """
   Implements getstate and setstate for classes with __slots__ defined. Allows an

--- a/libtbx/mpi4py.py
+++ b/libtbx/mpi4py.py
@@ -67,13 +67,23 @@ class mpiCommEmulator(object):
 
 mpiEmulator.COMM_WORLD = mpiCommEmulator()
 
+class MpiDisabledError(Exception):
+  pass
+
 try:
+  import libtbx
+  if libtbx.mpi_import_guard.disable_mpi:
+    raise MpiDisabledError
   from mpi4py import MPI
   using_mpi = True
 except ImportError:
   print ("\nWarning: could not import mpi4py. Running as a single process.\n")
   MPI = mpiEmulator()
   using_mpi = False
+except MpiDisabledError:
+  MPI = mpiEmulator()
+  using_mpi = False
+
 
 def mpi_abort_on_exception(func):
   """

--- a/prime/command_line/mpi_run.py
+++ b/prime/command_line/mpi_run.py
@@ -3,7 +3,7 @@
 Find initial scaling factors for all integration results
 """
 from __future__ import absolute_import, division, print_function
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 import sys, os
 from prime.postrefine.mod_input import process_input, read_pickles
 from prime.postrefine.mod_util import intensities_scaler

--- a/prime/command_line/mpi_scale.py
+++ b/prime/command_line/mpi_scale.py
@@ -3,7 +3,7 @@
 Find initial scaling factors for all integration results
 """
 from __future__ import absolute_import, division, print_function
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 import sys, os
 from prime.postrefine.mod_input import process_input, read_pickles
 from prime.postrefine.mod_util import intensities_scaler

--- a/simtbx/command_line/errors.py
+++ b/simtbx/command_line/errors.py
@@ -10,7 +10,7 @@ parser.add_argument("outdir", type=str, help="output folder where integration ta
 parser.add_argument("--ndev", type=int, default=1, help="number of gpu devices")
 args = parser.parse_args()
 
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 COMM = MPI.COMM_WORLD
 
 import os

--- a/simtbx/command_line/estimate_Ncells_Eta.py
+++ b/simtbx/command_line/estimate_Ncells_Eta.py
@@ -17,7 +17,7 @@ parser.add_argument("--EtaMin", type=float, default=1e-3, help="If estimated Eta
 #parser.add_argument("--njobs", type=int, default=5, help="number of jobs (only runs on single node, no MPI)")
 parser.add_argument("--plot", action="store_true", help="show a histogram at the end")
 args = parser.parse_args()
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 COMM = MPI.COMM_WORLD
 #from joblib import Parallel, delayed
 import json

--- a/simtbx/command_line/integrate.py
+++ b/simtbx/command_line/integrate.py
@@ -21,7 +21,7 @@ parser.add_argument("--scanWeakFracs", action="store_true", help="optionally sto
 
 args = parser.parse_args()
 
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 COMM = MPI.COMM_WORLD
 
 import logging

--- a/xfel/amo/pnccd_ana/mpi_fxs_bg.py
+++ b/xfel/amo/pnccd_ana/mpi_fxs_bg.py
@@ -17,7 +17,7 @@ plt.ion()
 #times. Here ignoring those errors.
 np.seterr(divide='ignore', invalid='ignore')
 
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 size = comm.Get_size()
@@ -141,7 +141,7 @@ def compute_bg(argv=None) :
     argv = sys.argv[1:]
 
   try:
-     from mpi4py import MPI
+     from libtbx.mpi4py import MPI
   except ImportError:
      raise Sorry("MPI not found")
 

--- a/xfel/amo/pnccd_ana/mpi_fxs_c2.py
+++ b/xfel/amo/pnccd_ana/mpi_fxs_c2.py
@@ -18,7 +18,7 @@ plt.ion()
 #times. Here ignoring those errors.
 np.seterr(divide='ignore', invalid='ignore')
 
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 size = comm.Get_size()
@@ -148,7 +148,7 @@ def compute_c2(argv=None) :
      argv = sys.argv[1:]
 
   try:
-     from mpi4py import MPI
+     from libtbx.mpi4py import MPI
   except ImportError:
      raise Sorry("MPI not found")
 

--- a/xfel/amo/pnccd_ana/mpi_fxs_calib.py
+++ b/xfel/amo/pnccd_ana/mpi_fxs_calib.py
@@ -16,7 +16,7 @@ plt.ion()
 #times. Here ignoring those errors.
 np.seterr(divide='ignore', invalid='ignore')
 
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 size = comm.Get_size()
@@ -135,7 +135,7 @@ def compute_calib(argv=None) :
     argv = sys.argv[1:]
 
   try:
-     from mpi4py import MPI
+     from libtbx.mpi4py import MPI
   except ImportError:
      raise Sorry("MPI not found")
 

--- a/xfel/amo/pnccd_ana/mpi_fxs_index.py
+++ b/xfel/amo/pnccd_ana/mpi_fxs_index.py
@@ -17,7 +17,7 @@ plt.ion()
 #times. Here ignoring those errors.
 np.seterr(divide='ignore', invalid='ignore')
 
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 size = comm.Get_size()
@@ -136,7 +136,7 @@ def compute_index(argv=None) :
     argv = sys.argv[1:]
 
   try:
-     from mpi4py import MPI
+     from libtbx.mpi4py import MPI
   except ImportError:
      raise Sorry("MPI not found")
 

--- a/xfel/amo/pnccd_ana/mpi_fxs_launch.py
+++ b/xfel/amo/pnccd_ana/mpi_fxs_launch.py
@@ -77,7 +77,7 @@ def launch(argv=None) :
      argv = sys.argv[1:]
 
   try:
-     from mpi4py import MPI
+     from libtbx.mpi4py import MPI
   except ImportError:
      raise Sorry("MPI not found")
 

--- a/xfel/amo/pnccd_ana/mpi_fxs_mask.py
+++ b/xfel/amo/pnccd_ana/mpi_fxs_mask.py
@@ -18,7 +18,7 @@ plt.ion()
 #times. Here ignoring those errors.
 np.seterr(divide='ignore', invalid='ignore')
 
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 size = comm.Get_size()
@@ -140,7 +140,7 @@ def compute_mask(argv=None) :
     argv = sys.argv[1:]
 
   try:
-     from mpi4py import MPI
+     from libtbx.mpi4py import MPI
   except ImportError:
      raise Sorry("MPI not found")
 

--- a/xfel/amo/pnccd_ana/pnccd_hit.py
+++ b/xfel/amo/pnccd_ana/pnccd_hit.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 import numpy as np
-from mpi4py import MPI
+from libtbx.mpi4py import MPI
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 size = comm.Get_size()

--- a/xfel/command_line/FEE_average_plot.py
+++ b/xfel/command_line/FEE_average_plot.py
@@ -92,7 +92,7 @@ def run(args):
   ds = DataSource(dataset_name)
   src = Source('DetInfo(%s)'%params.input.address)
   # set up multiprocessing with MPI
-  from mpi4py import MPI
+  from libtbx.mpi4py import MPI
   comm = MPI.COMM_WORLD
   rank = comm.Get_rank() # each process in MPI has a unique id, 0-indexed
   size = comm.Get_size() # size: number of processes running in this job

--- a/xfel/command_line/cxi_xtc_process.py
+++ b/xfel/command_line/cxi_xtc_process.py
@@ -137,7 +137,7 @@ class Script(object):
     print("Processing run %d of experiment %s using config file %s"%(params.input.run_num, params.input.experiment, params.input.cfg))
 
     if params.mp.method == "mpi":
-      from mpi4py import MPI
+      from libtbx.mpi4py import MPI
       comm = MPI.COMM_WORLD
       rank = comm.Get_rank() # each process in MPI has a unique id, 0-indexed
       size = comm.Get_size() # size: number of processes running in this job

--- a/xfel/command_line/mpi_average.py
+++ b/xfel/command_line/mpi_average.py
@@ -22,7 +22,7 @@ def average(argv=None):
     argv = sys.argv[1:]
 
   try:
-    from mpi4py import MPI
+    from libtbx.mpi4py import MPI
   except ImportError:
     raise Sorry("MPI not found")
 

--- a/xfel/command_line/upload_mtz.py
+++ b/xfel/command_line/upload_mtz.py
@@ -6,7 +6,6 @@ from dials.util import Sorry
 import os, sys
 import re
 import fcntl
-import time
 
 
 help_message = """

--- a/xfel/command_line/upload_mtz.py
+++ b/xfel/command_line/upload_mtz.py
@@ -5,6 +5,8 @@ from libtbx.phil import parse
 from dials.util import Sorry
 import os, sys
 import re
+import fcntl
+import time
 
 
 help_message = """
@@ -71,6 +73,21 @@ def _get_log_fname(mtz_fname):
   assert len(hit.groups()) == 1
   return hit.groups()[0] + '_main.log'
 
+class Locker:
+  """ See https://stackoverflow.com/a/60214222
+  """
+  def __enter__(self):
+    try:
+      self.fp = open(os.path.expanduser('~/.upload_mtz.lock'), 'wb')
+    except FileNotFoundError:
+      self.fp = None
+    if self.fp is not None:
+      fcntl.flock(self.fp.fileno(), fcntl.LOCK_EX)
+  def __exit__(self, *args, **kwargs):
+    if self.fp is not None:
+      fcntl.flock(self.fp.fileno(), fcntl.LOCK_UN)
+      self.fp.close()
+
 class pydrive2_interface:
   """
   Wrapper for uploading versioned mtzs and logs using Pydrive2. Constructed from
@@ -92,26 +109,29 @@ class pydrive2_interface:
     self.drive = GoogleDrive(gauth)
     self.top_folder_id = folder_id
 
+
+
   def _fetch_or_create_folder(self, fname, parent_id):
-    query = {
-        "q": "'{}' in parents and title='{}'".format(parent_id, fname),
-        "supportsTeamDrives": "true",
-        "includeItemsFromAllDrives": "true",
-        "corpora": "allDrives"
-    }
-    hits = self.drive.ListFile(query).GetList()
-    if hits:
-      assert len(hits)==1
-      return hits[0]['id']
-    else:
+    with Locker():
       query = {
-        "title": fname,
-        "mimeType": "application/vnd.google-apps.folder",
-        "parents": [{"kind": "drive#fileLink", "id": parent_id}]
+          "q": "'{}' in parents and title='{}'".format(parent_id, fname),
+          "supportsTeamDrives": "true",
+          "includeItemsFromAllDrives": "true",
+          "corpora": "allDrives"
       }
-      f = self.drive.CreateFile(query)
-      f.Upload()
-      return f['id']
+      hits = self.drive.ListFile(query).GetList()
+      if hits:
+        assert len(hits)==1
+        return hits[0]['id']
+      else:
+        query = {
+          "title": fname,
+          "mimeType": "application/vnd.google-apps.folder",
+          "parents": [{"kind": "drive#fileLink", "id": parent_id}]
+        }
+        f = self.drive.CreateFile(query)
+        f.Upload()
+        return f['id']
 
   def _upload_detail(self, file_path, parent_id):
     title = os.path.split(file_path)[1]

--- a/xfel/command_line/xfel_process.py
+++ b/xfel/command_line/xfel_process.py
@@ -3,6 +3,7 @@
 # LIBTBX_SET_DISPATCHER_NAME cctbx.xfel.process
 
 from __future__ import absolute_import, division, print_function
+from libtbx.mpi4py import mpi_abort_on_exception
 
 help_message = '''
 
@@ -84,6 +85,12 @@ class Script(DialsScript):
       phil=phil_scope,
       epilog=help_message
       )
+
+  @mpi_abort_on_exception
+  def run(self):
+    super().run()
+
+
 
 if __name__ == '__main__':
   import dials.command_line.stills_process

--- a/xfel/command_line/xtc_dump.py
+++ b/xfel/command_line/xtc_dump.py
@@ -156,7 +156,7 @@ class Script(object):
     self.params = params
     self.options = options
 
-    from mpi4py import MPI
+    from libtbx.mpi4py import MPI
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank() # each process in MPI has a unique id, 0-indexed
     size = comm.Get_size() # size: number of processes running in this job

--- a/xfel/command_line/xtc_process.py
+++ b/xfel/command_line/xtc_process.py
@@ -615,7 +615,7 @@ class InMemScript(DialsProcessScript, DialsProcessorWithLogging):
     self.options = options
 
     if params.mp.method == "mpi":
-      from mpi4py import MPI
+      from libtbx.mpi4py import MPI
       comm = MPI.COMM_WORLD
       rank = comm.Get_rank() # each process in MPI has a unique id, 0-indexed
       size = comm.Get_size() # size: number of processes running in this job

--- a/xfel/conda_envs/psana_environment.yml
+++ b/xfel/conda_envs/psana_environment.yml
@@ -76,6 +76,7 @@ dependencies:
  # xfel gui
  - mysql
  - mysqlclient
+ - pydrive2
 
  # Avoid numpy 1.21.[01234]
  # See https://github.com/cctbx/cctbx_project/issues/627

--- a/xfel/cxi/cspad_ana/mod_event_code.py
+++ b/xfel/cxi/cspad_ana/mod_event_code.py
@@ -50,7 +50,7 @@ class mod_event_code(object):
         self.size = int(os.environ['SGE_TASK_LAST']) - int(os.environ['SGE_TASK_FIRST']) + 1
     else:
       try:
-        from mpi4py import MPI
+        from libtbx.mpi4py import MPI
       except ImportError:
         self.rank = 0
         self.size = 1

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -687,7 +687,7 @@ lunus {
 
 diffbragg_phil = """
 diffBragg {
-  include scope simtbx.command_line.hopper.phil_scope
+  include scope simtbx.diffBragg.phil.phil_scope
 }
 """
 

--- a/xfel/small_cell/command_line/small_cell_index.py
+++ b/xfel/small_cell/command_line/small_cell_index.py
@@ -118,7 +118,7 @@ def run(argv=None):
       files = os.listdir(path)
 
       try:
-        from mpi4py import MPI
+        from libtbx.mpi4py import MPI
         comm = MPI.COMM_WORLD
         rank = comm.Get_rank()
         size = comm.Get_size()

--- a/xfel/ui/command_line/xfel_gui_launch.py
+++ b/xfel/ui/command_line/xfel_gui_launch.py
@@ -14,6 +14,9 @@ import wx, sys
 import matplotlib as mp
 mp.use('PS')
 
+import libtbx
+libtbx.mpi_import_guard.disable_mpi = True
+
 from xfel.ui.components.xfel_gui_init import MainWindow
 from xfel.ui.components.xfel_gui_dialogs import SettingsDialog
 from xfel.ui import load_cached_settings, save_cached_settings

--- a/xfel/ui/command_line/xfel_gui_launch.py
+++ b/xfel/ui/command_line/xfel_gui_launch.py
@@ -16,14 +16,14 @@ mp.use('PS')
 
 from xfel.ui.components.xfel_gui_init import MainWindow
 from xfel.ui.components.xfel_gui_dialogs import SettingsDialog
-from xfel.ui import save_cached_settings
+from xfel.ui import load_cached_settings, save_cached_settings
 
 class MainApp(wx.App):
   ''' App for the main GUI window  '''
 
   def OnInit(self):
-
-    self.frame = MainWindow(None, -1, title='CCTBX.XFEL')
+    params = load_cached_settings()
+    self.frame = MainWindow(None, -1, title='CCTBX.XFEL', params=params)
 
     # select primary display and center on that
     self.frame.SetSize((800, -1))
@@ -33,11 +33,11 @@ class MainApp(wx.App):
     self.frame.Center()
 
     # Start with login dialog before opening main window
-    self.login = SettingsDialog(self.frame, self.frame.params)
+    self.login = SettingsDialog(self.frame, params=params)
     self.login.SetTitle('CCTBX.XFEL Login')
     self.login.Center()
     if (self.login.ShowModal() == wx.ID_OK):
-      save_cached_settings(self.frame.params)
+      save_cached_settings(params)
       if self.frame.connect_to_db(drop_tables=self.login.drop_tables):
         self.exp_tag = '| {}'.format(self.login.db_cred.ctr.GetValue())
         self.exp = '| {}'.format(self.login.experiment.ctr.GetValue())
@@ -48,6 +48,7 @@ class MainApp(wx.App):
         #self.frame.start_run_sentinel()
         #self.frame.start_job_monitor()
         #self.frame.start_prg_sentinel()
+        self.frame.run_window.show_hide_tabs()
         return True
       else:
         return False

--- a/xfel/ui/command_line/xfel_gui_launch.py
+++ b/xfel/ui/command_line/xfel_gui_launch.py
@@ -14,8 +14,6 @@ import wx, sys
 import matplotlib as mp
 mp.use('PS')
 
-import libtbx
-libtbx.mpi_import_guard.disable_mpi = True
 
 from xfel.ui.components.xfel_gui_init import MainWindow
 from xfel.ui.components.xfel_gui_dialogs import SettingsDialog
@@ -59,6 +57,9 @@ class MainApp(wx.App):
       return False
 
 def run(args):
+  import libtbx
+  libtbx.mpi_import_guard.disable_mpi = True
+
   if '-h' in args or '--help' in args or '-c' in args:
     from xfel.ui import master_phil_str
     from libtbx.phil import parse

--- a/xfel/ui/components/ebeam_plotter.py
+++ b/xfel/ui/components/ebeam_plotter.py
@@ -45,14 +45,22 @@ def compare_ebeams_with_fees(locfiles, runs=None, plot=True, use_figure=None, ma
     if len(ebeams_eV) == 0:
       print("No events found with both FEE and eBeam")
       return None, None
-    if plot:
-      ax.hist(ebeams_eV, alpha=0.5, bins=40, label=f'run {runs[i]} ebeams ({int(eeV)} eV)')
-      ax.hist(fee_coms_eV, alpha=0.5, bins=40, label=f'run {runs[i]} FEE COMs ({int(feV)} eV)')
+    fee_coms_eV = np.array(fee_coms_eV)
+    ebeam_eV = np.array(ebeams_eV)
+    fee_coms_wav = np.array(fee_coms_wav)
+    ebeams_wav = np.array(ebeams_wav)
 
-    diffs_eV = np.array(fee_coms_eV) - np.array(ebeams_eV)
+    diffs_eV = fee_coms_eV - ebeam_eV
     ebeam_eV_offsets.append(sum(diffs_eV)/len(diffs_eV))
-    diffs_wav = np.array(fee_coms_wav) - np.array(ebeams_wav)
+    diffs_wav = fee_coms_wav - ebeams_wav
     ebeam_wav_offsets.append(sum(diffs_wav)/len(diffs_wav))
+
+    mean_fee_eV = np.mean(fee_coms_eV)
+    mean_ebeam_eV = np.mean(ebeam_eV)
+
+    if plot:
+      ax.hist(ebeams_eV, alpha=0.5, bins=40, label=f'run {runs[i]} ebeams ({int(mean_ebeam_eV)} eV)')
+      ax.hist(fee_coms_eV, alpha=0.5, bins=40, label=f'run {runs[i]} FEE COMs ({int(mean_fee_eV)} eV)')
 
   if plot:
     ax.legend()

--- a/xfel/ui/components/ebeam_plotter.py
+++ b/xfel/ui/components/ebeam_plotter.py
@@ -42,6 +42,9 @@ def compare_ebeams_with_fees(locfiles, runs=None, plot=True, use_figure=None, ma
       ebeams_eV.append(eeV:=ENERGY_CONV/ewav)
       print(f'{i}: {int(feV)} eV FEE / {int(eeV)} eV Ebeam')
 
+    if len(ebeams_eV) == 0:
+      print("No events found with both FEE and eBeam")
+      return None, None
     if plot:
       ax.hist(ebeams_eV, alpha=0.5, bins=40, label=f'run {runs[i]} ebeams ({int(eeV)} eV)')
       ax.hist(fee_coms_eV, alpha=0.5, bins=40, label=f'run {runs[i]} FEE COMs ({int(feV)} eV)')

--- a/xfel/ui/components/run_stats_plotter.py
+++ b/xfel/ui/components/run_stats_plotter.py
@@ -305,17 +305,6 @@ def plot_run_stats(stats,
   if title is not None:
     plt.title(title)
   if interactive:
-    def onclick(event):
-      ts = event.xdata
-      if ts is None: return
-      diffs = flex.abs(t - ts)
-      ts = t[flex.first_index(diffs, flex.min(diffs))]
-      print(get_paths_from_timestamps([ts], tag="shot", ext=ext)[0])
-
-    if hasattr(f, '_cid'):
-      f.canvas.mpl_disconnect(f._cid)
-    f._cid = f.canvas.mpl_connect('button_press_event', onclick)
-
     if not figure:
       plt.show()
   else:
@@ -361,7 +350,7 @@ def plot_multirun_stats(runs,
     if len(r[0]) > 0:
       if compress_runs:
         tslice = r[0] - r[0][0] + offset
-        offset += (r[0][-1] - r[0][0] + 1/120.)
+        offset += (r[0][-1] - r[0][0] + 1)
       else:
         tslice = r[0]
       last_end = r[0][-1]

--- a/xfel/ui/components/xfel_gui_dialogs.py
+++ b/xfel/ui/components/xfel_gui_dialogs.py
@@ -52,6 +52,11 @@ class EdListCtrl(wx.ListCtrl, TextEditMixin):
     TextEditMixin.__init__(self)
     self.curRow = -1
 
+  def OnLeftDown(self, evt=None):
+    try:
+      return super(EdListCtrl, self).OnLeftDown(evt)
+    except wx._core.wxAssertionError:
+      pass
 
 class BaseDialog(wx.Dialog):
   def __init__(self, parent,

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -1633,7 +1633,8 @@ class MainWindow(wx.Frame):
   def onQuit(self, e):
     self.stop_sentinels()
     save_cached_settings(self.params)
-    if self.run_window.runstats_tab.sf_frame is not None:
+    # wx windows resolve to False if closed
+    if self.run_window.runstats_tab.sf_frame:
       self.run_window.runstats_tab.sf_frame.Close()
     self.Destroy()
 
@@ -3065,7 +3066,7 @@ class RunStatsTab(SpotfinderTab):
     from dials.command_line.image_viewer import phil_scope
     from dials.util.image_viewer.spotfinder_frame import SpotFrame, chooser_wrapper
     from dxtbx.model.experiment_list import ExperimentListFactory
-    if tab.sf_frame is None:
+    if not tab.sf_frame: # if closed, wx windows resolve to False
       expts = ExperimentListFactory.from_filenames([locator_path], load_models=False)
       tab.sf_frame = SpotFrame(tab.main, params=phil_scope.extract(), experiments=[expts], reflections=[])
       tab.sf_frame.SetSize((1024, 780))

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -3033,6 +3033,8 @@ class RunStatsTab(SpotfinderTab):
     if event.canvas.toolbar.mode: return
     if event.xdata is None: return
     tab = event.canvas.GetParent().GetParent().GetParent()
+    params = tab.main.params
+    if params.facility.name != 'lcls': return
     all_stats = tab.main.runstats_sentinel.stats
     if not all_stats:
       return
@@ -3059,7 +3061,6 @@ class RunStatsTab(SpotfinderTab):
         break
     assert found_it, run_number
 
-    params = tab.main.params
     locator_path = os.path.join(params.output_folder, "r%04d"%int(run_number), \
                                 "%03d_rg%03d"%(trial.trial, rg.id), 'data.loc')
 

--- a/xfel/ui/db/job.py
+++ b/xfel/ui/db/job.py
@@ -1060,9 +1060,10 @@ def submit_all_jobs(app):
             print ("Task %s waiting on job %d (%s) for trial %d, rungroup %d, run %s, task %d" % \
               (next_task.type, submitted_job.id, submitted_job.status, trial.trial, rungroup.id, run.run, next_task.id))
             break
-          if submitted_job.status not in ["DONE", "EXIT"]:
-            print ("Task %s cannot start due to unexpected status for job %d (%s) for trial %d, rungroup %d, run %s, task %d" % \
-              (next_task.type, submitted_job.id, submitted_job.status, trial.trial, rungroup.id, run.run, next_task.id))
+          if submitted_job.status not in ["DONE"]:
+            if submitted_job.status != "EXIT":
+              print ("Task %s cannot start due to unexpected status for job %d (%s) for trial %d, rungroup %d, run %s, task %d" % \
+                (next_task.type, submitted_job.id, submitted_job.status, trial.trial, rungroup.id, run.run, next_task.id))
             break
           if submitted_job.status in ("SUBMIT_FAIL", "DELETED") and job.task and job.task.type == "ensemble_refinement":
             break # XXX need a better way to indicate that a job has failed and shouldn't go through the pipeline due to no data

--- a/xfel/ui/db/xfel_db.py
+++ b/xfel/ui/db/xfel_db.py
@@ -21,6 +21,8 @@ from six.moves import zip
 
 from xfel.command_line.experiment_manager import initialize as initialize_base
 
+CACHED_CONNECT_TIMEOUT = 300
+
 class initialize(initialize_base):
   expected_tables = ["run", "job", "rungroup", "trial", "tag", "run_tag", "event", "trial_rungroup",
                      "imageset", "imageset_event", "beam", "detector", "experiment",
@@ -293,6 +295,7 @@ class db_application(object):
   def __init__(self, params, cache_connection = True, mode = 'execute'):
     self.params = params
     self.dbobj = None
+    self.dbobj_refreshed_time = None
     self.cache_connection = cache_connection
     self.query_count = 0
     self.mode = mode
@@ -326,8 +329,12 @@ class db_application(object):
         # https://stackoverflow.com/questions/1617637/pythons-mysqldb-not-getting-updated-row
         if not commit: # connection caching is not attempted if commit=False
           dbobj = get_db_connection(self.params, autocommit=False)
-        elif self.dbobj is None:
+        elif (
+            self.dbobj is None
+            or time.time() - self.dbobj_refreshed_time > CACHED_CONNECT_TIMEOUT
+        ):
           dbobj = get_db_connection(self.params, autocommit=True)
+          self.dbobj_refreshed_time = time.time()
           if self.cache_connection:
             self.dbobj = dbobj
         else:


### PR DESCRIPTION
Series of updates from most recent beamtime:

- Switch extant usage of mpi4py to libtbx.mpi4py
- Refresh cached database connection after 5 minutes
- add pydrive2 to psana_environment
- XFEL GUI: only move on to next task if the previous one is in the DONE state
- XFEL GUI: more tweaks for energy tab
- Prevent duplicate gdrive uploads
- Improve mpi safety
- only disable mpi if the gui actually runs
- XFEL GUI: energy tab, label eBeam using average
- XFEL GUI: open image viewer when clicking on a dot

Note 1f4c25c9b89b92aba5873d3f5d37ebaf5c749328 switches over to using libtbx.mpi4py everywhere in cctbx, including simtbx.
