### PR TITLE
Don't `self.params.input.path = None` after `list_input_pairs` on rank0

### DIFF
--- a/xfel/merging/application/input/file_loader.py
+++ b/xfel/merging/application/input/file_loader.py
@@ -115,7 +115,6 @@ class simple_file_loader(worker):
     if self.mpi_helper.rank == 0:
       file_list = list_input_pairs(self.params)
       self.logger.log("Built an input list of %d json/pickle file pairs"%(len(file_list)))
-      self.params.input.path = None # Rank 0 has already parsed the input parameters
 
       # optionally write a file list mapping to disk, useful in post processing if save_experiments_and_reflections=True
       file_id_from_names = None


### PR DESCRIPTION
This PR removes line `self.params.input.path = None # Rank 0 has already parsed the input parameters` from `xfel/merging/application/input/file_loader.py`. With this change phil parameter `input.path` should be accessible for rank 0 for all downstream workers.

I looked at the code and this change should not affect any existing functionality; however, since theoretically it can indirectly affect all `cctbx.xfel.merge` workers, I am running it via PR to make sure it passes all tests first.