### PR TITLE
New cctbx.xfel.merge worker for computing and filtering on ΔCC½

### DIFF
--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -639,6 +639,18 @@ statistics {
       .help = As an example, could be intensity from *sf.cif
       .help = Specifically this is a tag searched for in the array name, could be 'tensity' from 'intensity'
   }
+  deltaccint
+    .help = Parameters used when computing ΔCC½ (aka ΔCC internal), a means of filtering out lattices that
+    .help = degrade the overall CC½. Uses the σ-τ method from Assmann 2016. Enable by adding the deltaccint
+    .help = worker after the group worker.
+  {
+    iqr_ratio = 10
+      .type = float
+      .help = If ΔCC½ filter is enabled, first compute CC½ when removing every image one at a time, then compute
+      .help = the IQR of these CC½s.  Remove all lattices whose contribution degrades CC½ by more than
+      .help = IQR * iqr_ratio. You can discover a good IQR by running the program once, examining the log file
+      .help = where possible values are listed, and running it again with the best value.
+  }
   predictions_to_edge {
     apply = False
       .type = bool

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -641,15 +641,15 @@ statistics {
   }
   deltaccint
     .help = Parameters used when computing ΔCC½ (aka ΔCC internal), a means of filtering out lattices that
-    .help = degrade the overall CC½. Uses the σ-τ method from Assmann 2016. Enable by adding the deltaccint
-    .help = worker after the group worker.
+    .help = degrade the overall CC½. Uses the σ-τ method from Assmann 2016 to avoid splitting the data into
+    .help = odd/even datasets. Enable by adding the deltaccint worker after the group worker.
   {
     iqr_ratio = 10
       .type = float
-      .help = If ΔCC½ filter is enabled, first compute CC½ when removing every image one at a time, then compute
-      .help = the IQR of these CC½s.  Remove all lattices whose contribution degrades CC½ by more than
-      .help = IQR * iqr_ratio. You can discover a good IQR by running the program once, examining the log file
-      .help = where possible values are listed, and running it again with the best value.
+      .help = If the ΔCC½ filter is enabled, first compute CC½ when removing every image one at a time, then
+      .help = compute the IQR of these CC½s. Remove all lattices whose contribution degrades CC½ by more than
+      .help = IQR * iqr_ratio above the median. You can discover a good IQR by running the program once,
+      .help = examining the log file where possible values are listed, and running it again with the best value.
   }
   predictions_to_edge {
     apply = False

--- a/xfel/merging/application/statistics/deltaccint.py
+++ b/xfel/merging/application/statistics/deltaccint.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 from six.moves import range
 from dxtbx import flumpy
 from dials.array_family import flex
+import itertools
 import numpy as np
 from scitbx.math import five_number_summary
 from xfel.merging.application.reflection_table_utils import reflection_table_utils
@@ -28,16 +29,7 @@ class deltaccint(worker):
       if len(set(refls['id'])) >= min_mult:
         filtered.extend(refls)
 
-    # Get list of all experiment identifiers
-    expt_ids = comm.gather(filtered.experiment_identifiers().values(), 0)
-    if self.mpi_helper.rank == 0:
-      all_expt_ids = flex.std_string()
-      for expt_ids_ in expt_ids:
-        all_expt_ids.extend(expt_ids_)
-      expt_ids = list(set(all_expt_ids))
-    else:
-      expt_ids = None
-    all_expt_ids = comm.bcast(expt_ids, 0)
+    all_expt_ids = list(sorted(set(itertools.chain.from_iterable(comm.allgather(filtered.experiment_identifiers().values())))))
     all_expts_map = dict(zip(all_expt_ids, range(len(all_expt_ids))))
 
     if self.mpi_helper.rank == 0:

--- a/xfel/merging/application/statistics/deltaccint.py
+++ b/xfel/merging/application/statistics/deltaccint.py
@@ -163,7 +163,7 @@ class deltaccint(worker):
       self.logger.main_log("")
 
       if self.params.statistics.deltaccint.iqr_ratio:
-        cut = med + iqr * self.params.statistics.deltaccint.iqr_ratio
+        cut = q3 + iqr * self.params.statistics.deltaccint.iqr_ratio
         sel = data > cut
         worst_expts_ = flex.std_string(all_expt_ids).select(sel)
 

--- a/xfel/merging/application/statistics/deltaccint.py
+++ b/xfel/merging/application/statistics/deltaccint.py
@@ -30,7 +30,7 @@ class deltaccint(worker):
         filtered.extend(refls)
 
     all_expt_ids = list(sorted(set(itertools.chain.from_iterable(comm.allgather(filtered.experiment_identifiers().values())))))
-    all_expts_map = dict(zip(all_expt_ids, range(len(all_expt_ids))))
+    all_expts_map = {v: k for k, v in enumerate(all_expt_ids)}
 
     if self.mpi_helper.rank == 0:
       self.logger.main_log("Beginning ΔCC½ analysis (σ-τ method from Assmann 2016)")
@@ -47,7 +47,7 @@ class deltaccint(worker):
 
     hkl_set = [hkl for hkl in list(set(filtered['miller_index_asymmetric'])) if hkl in hkl_resolution_bins]
     n_hkl = len(hkl_set)
-    hkl_map = dict(zip(hkl_set, range(n_hkl)))
+    hkl_map = {v: k for k, v in enumerate(hkl_set)}
 
     expt_map = filtered.experiment_identifiers()
 
@@ -85,7 +85,7 @@ class deltaccint(worker):
         mean_intensity = merged[expt_idx,hkl_idx]
         diff_sq_[expt_idx] -= (intensity[i] - mean_intensity)**2
 
-      variance[:,hkl_idx] = diff_sq_ / n[:,hkl_idx]
+      variance[:,hkl_idx] = diff_sq_ / (n[:,hkl_idx]-1)
 
     # N expts (all ranks) x N bins
     n_bins = resolution_binner.n_bins_used()
@@ -128,7 +128,7 @@ class deltaccint(worker):
 
     # Report
     if self.mpi_helper.rank == 0:
-      sigma_sq_y = total_diff_sq_sum / all_i_n
+      sigma_sq_y = total_diff_sq_sum / (all_i_n-1)
       sigma_sq_e = total_var_sums / total_i_n
       deltaccint_st = (sigma_sq_y - (0.5 * sigma_sq_e)) / (sigma_sq_y + sigma_sq_e)
 

--- a/xfel/merging/application/statistics/deltaccint.py
+++ b/xfel/merging/application/statistics/deltaccint.py
@@ -1,0 +1,190 @@
+from __future__ import absolute_import, division, print_function
+from six.moves import range
+from dxtbx import flumpy
+from dials.array_family import flex
+import numpy as np
+from scitbx.math import five_number_summary
+from xfel.merging.application.reflection_table_utils import reflection_table_utils
+from xfel.merging.application.worker import worker
+
+
+class deltaccint(worker):
+  '''Calculates ΔCC½ using the σ-τ method from Assmann 2016'''
+
+  def __repr__(self):
+    return 'ΔCC½ statistics (σ-τ method)'
+
+  def run(self, experiments, reflections):
+    self.logger.log_step_time("STATISTICS_DELTA_CCINT")
+
+    comm = self.mpi_helper.comm
+    MPI = self.mpi_helper.MPI
+
+    assert experiments == None, "Must be run after the group worker"
+    # need at least 3 reflections to keep multiplicty > 2 when removing an image
+    filtered = flex.reflection_table()
+    min_mult = max(3, self.params.merging.minimum_multiplicity)
+    for refls in reflection_table_utils.get_next_hkl_reflection_table(reflections=reflections):
+      if len(set(refls['id'])) >= min_mult:
+        filtered.extend(refls)
+
+    # Get list of all experiment identifiers
+    expt_ids = comm.gather(filtered.experiment_identifiers().values(), 0)
+    if self.mpi_helper.rank == 0:
+      all_expt_ids = flex.std_string()
+      for expt_ids_ in expt_ids:
+        all_expt_ids.extend(expt_ids_)
+      expt_ids = list(set(all_expt_ids))
+    else:
+      expt_ids = None
+    all_expt_ids = comm.bcast(expt_ids, 0)
+    all_expts_map = dict(zip(all_expt_ids, range(len(all_expt_ids))))
+
+    if self.mpi_helper.rank == 0:
+      self.logger.main_log("Beginning ΔCC½ analysis (σ-τ method from Assmann 2016)")
+      self.logger.main_log("Removing reflections with less than %d measurements"%min_mult)
+      self.logger.main_log("N experiments after filtering: %d"%len(all_expt_ids))
+      self.logger.main_log("")
+
+    # We need to compute
+    # 1) variance of the average intensities -> compute averages of all intensities and then compute variance per bin
+    # 2) average variance of the intensities -> compute variances of all intensities and then compute average per bin
+
+    resolution_binner = self.params.statistics.resolution_binner
+    hkl_resolution_bins = self.params.statistics.hkl_resolution_bins
+
+    hkl_set = [hkl for hkl in list(set(filtered['miller_index_asymmetric'])) if hkl in hkl_resolution_bins]
+    n_hkl = len(hkl_set)
+    hkl_map = dict(zip(hkl_set, range(n_hkl)))
+
+    expt_map = filtered.experiment_identifiers()
+
+    # N expts (all ranks) x N hkl (this rank)
+    sums     = np.zeros((len(all_expt_ids), n_hkl), float)
+    n        = np.zeros((len(all_expt_ids), n_hkl), int)
+    merged   = np.zeros((len(all_expt_ids), n_hkl), float)
+    variance = np.zeros((len(all_expt_ids), n_hkl), float)
+
+    for refls in reflection_table_utils.get_next_hkl_reflection_table(reflections=filtered):
+      hkl = refls['miller_index_asymmetric'][0]
+      if hkl not in hkl_map: continue
+      hkl_idx = hkl_map[hkl]
+      intensity = flumpy.to_numpy(refls['intensity.sum.value'])
+
+      # set the sum and n for all expts for this hkl
+      sums[:,hkl_idx] = np.sum(intensity)
+      n   [:,hkl_idx] = len(refls)
+
+      # For each reflection, subtract it off the experiment it came from, leaving it for the rest of the experiments
+      for i in range(len(refls)):
+        expt_idx = all_expts_map[expt_map[refls['id'][i]]]
+        sums[expt_idx,hkl_idx] -= intensity[i]
+        n   [expt_idx,hkl_idx] -= 1
+      merged[:,hkl_idx] = sums[:,hkl_idx]/n[:,hkl_idx]
+
+      # compute variance for each hkl (less the intensity from each experiment)
+      diff_sq_ = np.zeros(len(all_expt_ids))
+      for expt_idx in range(len(all_expt_ids)):
+        mean_intensity = merged[expt_idx,hkl_idx]
+        diff_sq_[expt_idx] = np.sum((intensity-mean_intensity)**2)
+
+      for i in range(len(refls)):
+        expt_idx = all_expts_map[expt_map[refls['id'][i]]]
+        mean_intensity = merged[expt_idx,hkl_idx]
+        diff_sq_[expt_idx] -= (intensity[i] - mean_intensity)**2
+
+      variance[:,hkl_idx] = diff_sq_ / n[:,hkl_idx]
+
+    # N expts (all ranks) x N bins
+    n_bins = resolution_binner.n_bins_used()
+    all_i_sums   = np.zeros((len(all_expt_ids), n_bins), float) # sum of the averaged intensities
+    all_i_n      = np.zeros((len(all_expt_ids), n_bins), int)   # count of the averaged intensities
+    all_var_sums = np.zeros((len(all_expt_ids), n_bins), float) # sums of the variances of the intensities
+
+    # Sum up and reduce the bins
+    for hkl in hkl_set:
+      bin_idx = hkl_resolution_bins[hkl] - 1
+      all_i_sums  [:,bin_idx] += merged[:,hkl_map[hkl]]
+      all_i_n     [:,bin_idx] += 1
+      all_var_sums[:,bin_idx] += variance[:,hkl_map[hkl]]
+
+    total_i_sums   = comm.reduce(all_i_sums,   MPI.SUM, 0)
+    total_i_n      = comm.reduce(all_i_n,      MPI.SUM, 0)
+    total_var_sums = comm.reduce(all_var_sums, MPI.SUM, 0)
+
+    # Broadcast the average intensities
+    if self.mpi_helper.rank == 0:
+      total_i_average_ = total_i_sums / total_i_n
+    else:
+      total_i_average_ = None
+    total_i_average = comm.bcast(total_i_average_, 0)
+
+    # Compute the variance of the average intensities
+    # First, the numerator, the difference between each hkl and the average for that hkl's bin (ommiting each experiment once)
+    diff_sq = np.zeros(merged.shape, float)
+    for hkl in hkl_set:
+      diff_sq[:,hkl_map[hkl]] = (merged[:,hkl_map[hkl]] - total_i_average[:,hkl_resolution_bins[hkl]-1]) ** 2
+
+    # N expts (all ranks) x N bins
+    diff_sq_sum = np.zeros(all_i_sums.shape, float)
+
+    # Complete the numerator for this rank
+    for hkl in hkl_set:
+      diff_sq_sum[:,hkl_resolution_bins[hkl]-1] += diff_sq[:,hkl_map[hkl]]
+
+    total_diff_sq_sum = comm.reduce(diff_sq_sum, MPI.SUM, 0)
+
+    # Report
+    if self.mpi_helper.rank == 0:
+      sigma_sq_y = total_diff_sq_sum / all_i_n
+      sigma_sq_e = total_var_sums / total_i_n
+      deltaccint_st = (sigma_sq_y - (0.5 * sigma_sq_e)) / (sigma_sq_y + sigma_sq_e)
+
+      data = flex.double(np.mean(deltaccint_st, axis=1)) * 100
+      sorted_data = data.select(flex.sort_permutation(data))
+
+      mini, q1, med, q3, maxi = five_number_summary(data)
+      self.logger.main_log("Five number summary")
+      self.logger.main_log("% 8.4f%% min"%mini)
+      self.logger.main_log("% 8.4f%% q1"%q1)
+      self.logger.main_log("% 8.4f%% median"%med)
+      self.logger.main_log("% 8.4f%% q3"%q3)
+      self.logger.main_log("% 8.4f%% max"%maxi)
+      self.logger.main_log("")
+
+      n_worst = min(len(data), 30)
+      worst = sorted_data[-n_worst:]
+      iqr = q3-q1
+
+      self.logger.main_log("Showing ΔCC½ of the worst %d lattices and IQR ratio needed to remove them"%n_worst)
+      self.logger.main_log(" ΔCC½ (%) IQR ratio Lattices removed")
+      for i in range(len(worst)):
+        self.logger.main_log("% 8.4f % 10.1f %d"%(worst[i], (worst[i]-med)/iqr, n_worst-i))
+      self.logger.main_log("")
+
+      if self.params.statistics.deltaccint.iqr_ratio:
+        cut = med + iqr * self.params.statistics.deltaccint.iqr_ratio
+        sel = data > cut
+        worst_expts_ = flex.std_string(all_expt_ids).select(sel)
+
+        self.logger.main_log("Removing %d experiments out of %d using IQR ratio %.1f"%(len(worst_expts_), len(all_expt_ids), self.params.statistics.deltaccint.iqr_ratio))
+
+    # Broadcast the worst experiments to cut
+    else:
+      worst_expts_ = None
+
+    if self.params.statistics.deltaccint.iqr_ratio:
+      worst_expts = comm.bcast(worst_expts_, 0)
+      self.logger.log("Starting number of reflections: %d"%len(reflections))
+      self.logger.log("Reflections after filtering by minimum multiplicity of %d: %d"%(min_mult, len(filtered)))
+      reflections.remove_on_experiment_identifiers(worst_expts)
+      reflections.reset_ids()
+      self.logger.log("Reflections after filtering by ΔCC½: %d"%len(reflections))
+
+    self.logger.log_step_time("STATISTICS_DELTA_CCINT", True)
+
+    return experiments, reflections
+
+if __name__ == '__main__':
+  from xfel.merging.application.worker import exercise_worker
+  exercise_worker(deltaccint)

--- a/xfel/merging/application/statistics/factory.py
+++ b/xfel/merging/application/statistics/factory.py
@@ -3,6 +3,7 @@ from xfel.merging.application.statistics.unit_cell_statistics import unit_cell_s
 from xfel.merging.application.statistics.beam_statistics import beam_statistics
 from xfel.merging.application.statistics.intensity_resolution_statistics import intensity_resolution_statistics
 from xfel.merging.application.statistics.intensity_resolution_statistics_cxi import intensity_resolution_statistics_cxi
+from xfel.merging.application.statistics.deltaccint import deltaccint
 from xfel.merging.application.statistics.experiment_resolution_statistics import experiment_resolution_statistics
 from xfel.merging.application.statistics.intensity_histogram import intensity_histogram
 from xfel.merging.application.worker import factory as factory_base
@@ -27,4 +28,6 @@ class factory(factory_base):
         return [intensity_resolution_statistics_cxi(params, mpi_helper, mpi_logger)]
       elif info_count > 1 and additional_info[1] == 'histogram':
         return [intensity_histogram(params, mpi_helper, mpi_logger)]
+    elif additional_info[0] == 'deltaccint':
+      return [deltaccint(params, mpi_helper, mpi_logger)]
 


### PR DESCRIPTION
This is a means of filtering out lattices that degrade the overall CC½. Uses the σ-τ method from [Assmann 2016](https://journals.iucr.org/j/issues/2016/03/00/zw5005/#FD4) to avoid splitting the data into odd/even datasets. Enable by adding the deltaccint worker after the group worker.

Includes parameter iqr_ratio = 10. If the ΔCC½ filter is enabled, first compute CC½ when removing every image one at a time, then compute the IQR of these CC½s.  Remove all lattices whose contribution degrades CC½ by more than IQR * iqr_ratio above the median. You can discover a good IQR by running the program once, examining the log file where possible values are listed, and running it again with the best value.

Implementation heavily uses MPI for fast computation of ΔCC½ on thousands of images.  Current run time with this version is ~5 minutes for 8.8k images.

Example output in the log for a PSII dataset:

```
STEP 11: ΔCC½ statistics (σ-τ method)
Beginning ΔCC½ analysis (σ-τ method from Assmann 2016)
Removing reflections with less than 3 measurements
N experiments after filtering: 8816

Five number summary
 91.3091% min
 91.3109% q1
 91.3111% median
 91.3114% q3
 91.4728% max

Showing ΔCC½ of the worst 30 lattices and IQR ratio needed to remove them
 ΔCC½ (%) IQR ratio Lattices removed
 91.3172       11.7 30
 91.3174       12.1 29
 91.3175       12.3 28
 91.3175       12.4 27
 91.3178       12.9 26
 91.3179       13.1 25
 91.3182       13.7 24
 91.3183       13.8 23
 91.3184       14.1 22
 91.3185       14.2 21
 91.3188       14.8 20
 91.3192       15.5 19
 91.3199       16.9 18
 91.3200       17.1 17
 91.3215       20.1 16
 91.3218       20.5 15
 91.3219       20.7 14
 91.3222       21.3 13
 91.3350       45.9 12
 91.3403       56.1 11
 91.3403       56.2 10
 91.3404       56.3 9
 91.3407       56.9 8
 91.3408       57.1 7
 91.3409       57.3 6
 91.3410       57.6 5
 91.3413       58.1 4
 91.3414       58.2 3
 91.3649      103.5 2
 91.4728      311.1 1

Removing 29 experiments out of 8816 using IQR ratio 12.0
```
