### PR TITLE
Make `mpi_helper`'s method non-rooted if `root=None` 

### DIFF
--- a/libtbx/mpi4py.py
+++ b/libtbx/mpi4py.py
@@ -60,6 +60,8 @@ class mpiCommEmulator(object):
       counter += count
   def allgather(self, sendobj):
     return [sendobj]
+  def Allgatherv(self, sendbuf, recvbuf):
+    return self.Gatherv(sendbuf, recvbuf)
   def Abort(self,errorcode=0):
     import sys
     sys.exit()

--- a/xfel/merging/application/errors/error_modifier_mm24.py
+++ b/xfel/merging/application/errors/error_modifier_mm24.py
@@ -146,19 +146,15 @@ class error_modifier_mm24(worker):
   def calculate_intensity_bin_limits(self):
     '''Calculate the intensity bins between the 0.5 and 99.5 percentiles'''
     all_biased_means = self.mpi_helper.gather_variable_length_numpy_arrays(
-      np.array(self.refl_biased_means, dtype=float), root=0, dtype=float
+      np.array(self.refl_biased_means, dtype=float), root=None, dtype=float
       )
-    if self.mpi_helper.rank == 0:
-      all_biased_means = np.sort(all_biased_means)
-      lower_percentile = 0.005
-      upper_percentile = 0.995
-      n = all_biased_means.size
-      lower = all_biased_means[int(lower_percentile * n)]
-      upper = all_biased_means[int(upper_percentile * n)]
-      self.intensity_bin_limits = np.linspace(lower, upper, self.number_of_intensity_bins + 1)
-    else:
-      self.intensity_bin_limits = np.empty(self.number_of_intensity_bins + 1)
-    self.mpi_helper.comm.Bcast(self.intensity_bin_limits, root=0)
+    all_biased_means = np.sort(all_biased_means)
+    lower_percentile = 0.005
+    upper_percentile = 0.995
+    n = all_biased_means.size
+    lower = all_biased_means[int(lower_percentile * n)]
+    upper = all_biased_means[int(upper_percentile * n)]
+    self.intensity_bin_limits = np.linspace(lower, upper, self.number_of_intensity_bins + 1)
 
   def distribute_differences_over_intensity_bins(self):
     self.intensity_bins = [flex.reflection_table() for i in range(self.number_of_intensity_bins)]

--- a/xfel/merging/application/filter/global_filter.py
+++ b/xfel/merging/application/filter/global_filter.py
@@ -92,16 +92,16 @@ class GlobalFilter(worker):
     te = sum(self.expt_filter_reasons.values())
     tr = sum(self.refl_filter_reasons.values())
     self.logger.log(FilterReasons.report_line('TOTAL', te, tr))
+    all_expt_filter_reasons = self.mpi_helper.count(self.expt_filter_reasons)
+    all_refl_filter_reasons = self.mpi_helper.count(self.refl_filter_reasons)
     if self.mpi_helper.rank == 0:
       self.logger.main_log('Experiments/reflections filtered due to:')
-      expt_filter_reasons = self.mpi_helper.count(self.expt_filter_reasons)
-      refl_filter_reasons = self.mpi_helper.count(self.refl_filter_reasons)
-      for r in uniques(expt_filter_reasons, refl_filter_reasons):
-        te = expt_filter_reasons[r]
-        tr = refl_filter_reasons[r]
+      for r in uniques(all_expt_filter_reasons, all_refl_filter_reasons):
+        te = all_expt_filter_reasons[r]
+        tr = all_refl_filter_reasons[r]
         self.logger.main_log(FilterReasons.report_line(r.value, te, tr))
-      te = sum(expt_filter_reasons.values())
-      tr = sum(refl_filter_reasons.values())
+      te = sum(all_expt_filter_reasons.values())
+      tr = sum(all_refl_filter_reasons.values())
       self.logger.main_log(FilterReasons.report_line('TOTAL', te, tr))
 
   def run(self, experiments, reflections):

--- a/xfel/merging/application/mpi_helper.py
+++ b/xfel/merging/application/mpi_helper.py
@@ -32,7 +32,11 @@ def adaptive_collective(rooted_variant, non_rooted_variant):
   `allgather` if root is None, and gather (with an appropriate root) otherwise.
   """
   def adaptive_collective_dispatcher(*args, **kwargs):
-    collective = non_rooted_variant if kwargs['root'] is None else rooted_variant
+    if (root := kwargs.pop('root', 0)) is None:
+      collective = non_rooted_variant
+    else:  # if root is an integer
+      collective = rooted_variant
+      kwargs['root'] = root
     return collective(*args, **kwargs)
   yield adaptive_collective_dispatcher
 

--- a/xfel/merging/application/mpi_helper.py
+++ b/xfel/merging/application/mpi_helper.py
@@ -112,7 +112,7 @@ class mpi_helper(object):
   def gather_variable_length_numpy_arrays(self, send_arrays, root=0, dtype=float):
     with adaptive_collective(self.comm.gather, self.comm.allgather) as gather:
       lengths = gather(send_arrays.size, root=root)
-    gathered_arrays = np.empty(np.sum(lengths), dtype=dtype) if lengths else None
+    gathered_array = np.empty(np.sum(lengths), dtype=dtype) if lengths else None
     with adaptive_collective(self.comm.Gatherv, self.comm.Allgatherv) as gather_v:
-      gather_v(sendbuf=send_arrays, recvbuf=(gathered_arrays, lengths), root=root)
-    return gathered_arrays
+      gather_v(sendbuf=send_arrays, recvbuf=(gathered_array, lengths), root=root)
+    return gathered_array

--- a/xfel/merging/application/mpi_helper.py
+++ b/xfel/merging/application/mpi_helper.py
@@ -3,7 +3,7 @@ from collections import Counter
 from contextlib import contextmanager
 from libtbx.mpi4py import MPI
 import numpy as np
-from dials.array_family import flex
+
 
 import sys
 def system_exception_handler(exception_type, value, traceback):

--- a/xfel/merging/application/mpi_helper.py
+++ b/xfel/merging/application/mpi_helper.py
@@ -26,7 +26,11 @@ sys.excepthook = system_exception_handler
 
 @contextmanager
 def adaptive_collective(rooted_variant, non_rooted_variant):
-  """Declare and switch from rooted to non-rooted collective if root is None"""
+  """
+  Declare and switch from rooted to non-rooted collective if root is None.
+  Statement `with adaptive_collective(gather, allgather) as gather:` will yield
+  `allgather` if root is None, and gather (with an appropriate root) otherwise.
+  """
   def adaptive_collective_dispatcher(*args, **kwargs):
     collective = non_rooted_variant if kwargs['root'] is None else rooted_variant
     return collective(*args, **kwargs)

--- a/xfel/merging/application/mpi_helper.py
+++ b/xfel/merging/application/mpi_helper.py
@@ -32,7 +32,8 @@ def adaptive_collective(rooted_variant, non_rooted_variant):
   `allgather` if root is None, and gather (with an appropriate root) otherwise.
   """
   def adaptive_collective_dispatcher(*args, **kwargs):
-    if (root := kwargs.pop('root', 0)) is None:
+    root = kwargs.pop('root', 0)
+    if root is None:
       collective = non_rooted_variant
     else:  # if root is an integer
       collective = rooted_variant

--- a/xfel/merging/application/mpi_helper.py
+++ b/xfel/merging/application/mpi_helper.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 from collections import Counter
+from contextlib import contextmanager
 from libtbx.mpi4py import MPI
 import numpy as np
 from dials.array_family import flex
@@ -23,6 +24,15 @@ def system_exception_handler(exception_type, value, traceback):
 sys.excepthook = system_exception_handler
 
 
+@contextmanager
+def adaptive_collective(rooted_variant, non_rooted_variant):
+  """Declare and switch from rooted to non-rooted collective if root is None"""
+  def adaptive_collective_dispatcher(*args, **kwargs):
+    collective = non_rooted_variant if kwargs['root'] is None else rooted_variant
+    return collective(*args, **kwargs)
+  yield adaptive_collective_dispatcher
+
+
 class mpi_helper(object):
   def __init__(self):
     self.MPI = MPI
@@ -43,8 +53,9 @@ class mpi_helper(object):
     Example: (a1,a2,a3) + (b1, b2, b3) = (a1+b1, a2+b2, a3+b3)
     """
     flex_type = flex_type if flex_type is not None else type(flex_array)
-    list_of_all_flex_arrays = self.comm.gather(flex_array, root=root)
-    if self.rank != root:
+    with adaptive_collective(self.comm.gather, self.comm.allgather) as gather:
+      list_of_all_flex_arrays = gather(flex_array, root=root)
+    if list_of_all_flex_arrays is None:
       return None
     cumulative = flex_type(flex_array.size(), 0)
     for flex_array in list_of_all_flex_arrays:
@@ -58,8 +69,9 @@ class mpi_helper(object):
     Example: (a1,a2,a3) + (b1, b2, b3) = (a1, a2, a3, b1, b2, b3)
     """
     flex_type = flex_type if flex_type is not None else type(flex_array)
-    list_of_all_flex_arrays = self.comm.gather(flex_array, root=root)
-    if self.rank != root:
+    with adaptive_collective(self.comm.gather, self.comm.allgather) as gather:
+      list_of_all_flex_arrays = gather(flex_array, root=root)
+    if list_of_all_flex_arrays is None:
       return None
     aggregate = flex_type()
     for flex_array in list_of_all_flex_arrays:
@@ -72,15 +84,17 @@ class mpi_helper(object):
     Return total `Counter` of occurrences of each element in data across ranks.
     Example: (a1, a1, a2) + (a1, a2, a3) = {a1: 3, a2: 2, a1: 1}
     """
-    counters = self.comm.gather(Counter(data), root=root)
-    return sum(counters, Counter()) if self.rank == root else None
+    with adaptive_collective(self.comm.gather, self.comm.allgather) as gather:
+      counters = gather(Counter(data), root=root)
+    return sum(counters, Counter()) if counters is not None else None
 
   def sum(self, data, root=0):
     """
     Sum values of data across all ranks.
     Example: a1 + a2 + a3 = a1+a2+a3
     """
-    return self.comm.reduce(data, self.MPI.SUM, root=root)
+    with adaptive_collective(self.comm.reduce, self.comm.allreduce) as reduce:
+      return reduce(data, self.MPI.SUM, root=root)
 
   def set_error(self, description):
     self.error = (self.rank, description)
@@ -96,10 +110,9 @@ class mpi_helper(object):
       self.comm.Abort(1)
 
   def gather_variable_length_numpy_arrays(self, send_arrays, root=0, dtype=float):
-    lengths = self.comm.gather(send_arrays.size, root=root)
-    if self.rank == root:
-      gathered_arrays = np.empty(np.sum(lengths), dtype=dtype)
-    else:
-      gathered_arrays = None
-    self.comm.Gatherv(sendbuf=send_arrays, recvbuf=(gathered_arrays, lengths), root=root)
+    with adaptive_collective(self.comm.gather, self.comm.allgather) as gather:
+      lengths = gather(send_arrays.size, root=root)
+    gathered_arrays = np.empty(np.sum(lengths), dtype=dtype) if lengths else None
+    with adaptive_collective(self.comm.Gatherv, self.comm.Allgatherv) as gather_v:
+      gather_v(sendbuf=send_arrays, recvbuf=(gathered_arrays, lengths), root=root)
     return gathered_arrays

--- a/xfel/merging/application/statistics/beam_statistics.py
+++ b/xfel/merging/application/statistics/beam_statistics.py
@@ -14,17 +14,10 @@ class beam_statistics(worker):
     self.logger.log_step_time("BEAM_STATISTICS")
     f_wavelengths = flex.double([b.get_wavelength() for b in experiments.beams()])
 
-    flex_all_wavelengths = self.mpi_helper.aggregate_flex(f_wavelengths, flex.double)
-
+    flex_all_wavelengths = self.mpi_helper.aggregate_flex(f_wavelengths, flex.double, root=None)
+    average_wavelength = flex.mean(flex_all_wavelengths)
     if self.mpi_helper.rank == 0:
-      average_wavelength = flex.mean(flex_all_wavelengths)
       self.logger.main_log("Wavelength: %f"%average_wavelength)
-    else:
-      average_wavelength = None
-
-    self.logger.log_step_time("BROADCAST_WAVELENGTH")
-    average_wavelength = self.mpi_helper.comm.bcast(average_wavelength, root = 0)
-    self.logger.log_step_time("BROADCAST_WAVELENGTH", True)
 
     # save the average wavelength to the phil parameters
     if self.mpi_helper.rank == 0:

--- a/xfel/merging/application/statistics/unit_cell_statistics.py
+++ b/xfel/merging/application/statistics/unit_cell_statistics.py
@@ -49,13 +49,13 @@ class unit_cell_distribution(object):
     self.uc_gamma_values.append(gamma)
 
   def collect_from_all_ranks(self):
-    self.all_uc_a_values = self.mpi_helper.aggregate_flex(self.uc_a_values, flex.double)
-    self.all_uc_b_values = self.mpi_helper.aggregate_flex(self.uc_b_values, flex.double)
-    self.all_uc_c_values = self.mpi_helper.aggregate_flex(self.uc_c_values, flex.double)
+    self.all_uc_a_values = self.mpi_helper.aggregate_flex(self.uc_a_values, flex.double, root=None)
+    self.all_uc_b_values = self.mpi_helper.aggregate_flex(self.uc_b_values, flex.double, root=None)
+    self.all_uc_c_values = self.mpi_helper.aggregate_flex(self.uc_c_values, flex.double, root=None)
 
-    self.all_uc_alpha_values  = self.mpi_helper.aggregate_flex(self.uc_alpha_values, flex.double)
-    self.all_uc_beta_values   = self.mpi_helper.aggregate_flex(self.uc_beta_values, flex.double)
-    self.all_uc_gamma_values  = self.mpi_helper.aggregate_flex(self.uc_gamma_values, flex.double)
+    self.all_uc_alpha_values  = self.mpi_helper.aggregate_flex(self.uc_alpha_values, flex.double, root=None)
+    self.all_uc_beta_values   = self.mpi_helper.aggregate_flex(self.uc_beta_values, flex.double, root=None)
+    self.all_uc_gamma_values  = self.mpi_helper.aggregate_flex(self.uc_gamma_values, flex.double, root=None)
 
   def is_valid(self):
     return len(self.all_uc_a_values) > 0 and len(self.all_uc_b_values) > 0 and len(self.all_uc_c_values) > 0 and \
@@ -129,14 +129,10 @@ class unit_cell_statistics(worker):
     ucd.collect_from_all_ranks()
 
     average_unit_cell = None
-    if self.mpi_helper.rank == 0:
-      if ucd.is_valid():
+    if ucd.is_valid():
+      if self.mpi_helper.rank == 0:
         ucd.show_histograms()
-        average_unit_cell = ucd.get_average_cell()
-
-    self.logger.log_step_time("BROADCAST_UNIT_CELL")
-    average_unit_cell = self.mpi_helper.comm.bcast(average_unit_cell, root = 0)
-    self.logger.log_step_time("BROADCAST_UNIT_CELL", True)
+      average_unit_cell = ucd.get_average_cell()
 
     # save the average unit cell to the phil parameters
     if self.mpi_helper.rank == 0:


### PR DESCRIPTION
A common pattern in multiprocessing is to collect data on the root (typically rank 0), process it there, and broadcast it back to other ranks. However, the better practice is typically to use a non-rooted operation: pass the inputs between all ranks and perform calculations independently on each. This removes the need for a second communication (broadcast) and improves code readability.

Non-rooted approach is inferior only in these rare cases where the cost of the switching to non-rooted operation is much larger than the cost of the secondary broadcast. Non-rooted approach might potentially also cause issues with memory consumption if the input or temporary objects (created when analyzing input) are very volumous.

In xfel, communicating between ranks can be done using the `mpi_helper` class, whose methods alias more complex operations to improve readability and remove repetition. Currently all of the `mpi_helper` methods are rooted, forcing one to copy or rewrite them whenever an non-rooted collective is more desired.

This patch slightly modifies all `mpi_helper` methods, allowing them to use non-rooted mpi4py collectives. Whenever their keyword argument `root` (default `0`) is set to `None` instead of an integer, the methods will use a non-rooted collective instead of the collective variant. This will produce identical output on all ranks, removing need for some follow-up broadcasts and allowing for cleaner and potentially faster code.

Following the update, I have also modified three (cctbx_project) instances where `mpi_helper` methods were used and could be changed to utilize non-rooted collective variants to potentially speed up the execution. Each was done in a separate commit to revert if change is not desired. The change will also positively affect code in other repositories utilizing the `mpi_helper`. 