### PR TITLE
Replace (unmaintained) orderedset with ordered_set

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -2114,13 +2114,13 @@ class PhaserBuilder(CCIBuilder):
       self.skip_base = "hdf5,lz4_plugin,py2app,wxpython,docutils,pyopengl,pillow,tiff," + \
         "cairo,fonts,render,fontconfig,pixman,png,sphinx,freetype,gtk,matplotlib," + \
         "cython,h5py,gettext,numpy,pythonextra,pytest,junitxml,libsvm,pyrtf,six,send2trash," + \
-         "jinja2,orderedset,tabulate,scipy,scikit_learn,biopython,expat,glib,mrcfile"
+         "jinja2,ordered_set,tabulate,scipy,scikit_learn,biopython,expat,glib,mrcfile"
     else:
       self.skip_base = ','.join(self.skip_base.split(',') + ['hdf5','lz4_plugin','py2app',
          'wxpython','docutils','pyopengl','pillow','tiff','cairo','fonts','pyrtf','six','send2trash',
          'fontconfig','render','pixman','png','sphinx','freetype','gtk', 'matplotlib',
          'cython', 'h5py', 'gettext', 'numpy', 'pythonextra', 'pytest', 'junitxml','libsvm',
-         'jinja2', 'orderedset', 'tabulate', 'scipy', 'scikit_learn', 'biopython',
+         'jinja2', 'ordered_set', 'tabulate', 'scipy', 'scikit_learn', 'biopython',
          'expat', 'glib', 'mrcfile'
          ])
     super(PhaserBuilder, self).add_base(

--- a/libtbx/auto_build/install_base_packages.py
+++ b/libtbx/auto_build/install_base_packages.py
@@ -280,7 +280,7 @@ class installer(object):
     if options.dials:
       options.build_gui = True
       options.build_all = True
-      packages += ['pillow', 'jinja2', 'orderedset', 'scipy', 'scikit_learn', 'tqdm', 'msgpack']
+      packages += ['pillow', 'jinja2', 'ordered_set', 'scipy', 'scikit_learn', 'tqdm', 'msgpack']
     if options.xia2:
       options.build_gui = True
       options.build_all = True
@@ -727,7 +727,7 @@ Installation of Python packages may fail.
       'misc',
       'lz4_plugin',
       'jinja2',
-      'orderedset',
+      'ordered_set',
       'tqdm',
       'tabulate',
       'psutil',
@@ -1165,8 +1165,8 @@ _replace_sysconfig_paths(build_time_vars)
 
   def build_orderedset(self):
     self.build_python_module_pip(
-      'orderedset', package_version=ORDEREDSET_VERSION,
-      confirm_import_module='orderedset')
+      'ordered_set', package_version=ORDEREDSET_VERSION,
+      confirm_import_module='ordered_set')
 
   def build_tqdm(self):
     self.build_python_module_pip('tqdm', package_version=TQDM_VERSION)

--- a/xfel/conda_envs/psana_environment.yml
+++ b/xfel/conda_envs/psana_environment.yml
@@ -56,7 +56,7 @@ dependencies:
  - msgpack-python
  - msgpack-c
  - msgpack-cxx
- - orderedset
+ - ordered_set
  - python-blosc
  - scikit-learn
  - tqdm

--- a/xfel/merging/application/input/file_lister.py
+++ b/xfel/merging/application/input/file_lister.py
@@ -6,7 +6,7 @@ import os
 from six.moves import UserDict
 
 import numpy as np
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 
 
 class StemLocator(UserDict):

--- a/xfel/merging/application/modify/aux_cosym.py
+++ b/xfel/merging/application/modify/aux_cosym.py
@@ -6,7 +6,7 @@ from cctbx import sgtbx, miller
 from libtbx import easy_mp, Auto
 from scipy import sparse
 import numpy as np
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 import copy
 
 # Specialization, run only a subset of cosym steps and include plot


### PR DESCRIPTION
Hi, it seems that the orderedset module is abandoned by its author, and it started failing; in particular with Python 3.13 as discovered in Debian, but see also https://github.com/simonpercivall/orderedset/issues/36

There's an API-compatible replacement called ordered_set, see https://github.com/rspeer/ordered-set

This patch replaces the one with the other. It's already been used as part of the Debian packaging of cctbx with no influence on the build or the testsuite. I suggest applying it to upstream cctbx.