### PR TITLE
Probe2 json

### DIFF
--- a/mmtbx/model/model.py
+++ b/mmtbx/model/model.py
@@ -2046,7 +2046,7 @@ class manager(object):
     # Reason: contents of model and _model_input can get out of sync any time.
     self._model_input = None
     self._processed_pdb_file = None
-    # Order of calling this matetrs!
+    # Order of calling this matters!
     self.link_records_in_pdb_format = link_record_output(acp)
 
   def has_atoms_in_special_positions(self, selection, log=None):

--- a/mmtbx/programs/probe2.py
+++ b/mmtbx/programs/probe2.py
@@ -29,7 +29,7 @@ from iotbx.pdb import common_residue_names_get_class
 # @todo See if we can remove the shift and box once reduce_hydrogen is complete
 from cctbx.maptbx.box import shift_and_box_model
 
-version = "4.8.0"
+version = "4.9.0"
 
 master_phil_str = '''
 profile = False
@@ -1898,12 +1898,13 @@ Note:
     p.pdb_interpretation.allow_polymer_cross_special_position=True
     p.pdb_interpretation.clash_guard.nonbonded_distance_threshold=None
     p.pdb_interpretation.proceed_with_excessive_length_bonds=True
+    p.pdb_interpretation.disable_uc_volume_vs_n_atoms_check=True
     # We need to turn this on because without it the interpretation is
     # renaming atoms to be more correct.  Unfortunately, this causes the
     # dot names to no longer match the input file.
     p.pdb_interpretation.flip_symmetric_amino_acids=False
     try:
-      self.model.process(make_restraints=True, pdb_interpretation_params=p, logger=self.logger) # make restraints
+      self.model.process(make_restraints=True, pdb_interpretation_params=p) # make restraints
       geometry = self.model.get_restraints_manager().geometry
       sites_cart = self.model.get_sites_cart() # cartesian coordinates
       bondProxies, asu = \

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -36,7 +36,7 @@ import tempfile
 from iotbx.data_manager import DataManager
 import csv
 
-version = "2.6.0"
+version = "2.7.0"
 
 master_phil_str = '''
 approach = *add remove
@@ -1186,9 +1186,7 @@ NOTES:
 
     # Fix up bogus unit cell when it occurs by checking crystal symmetry.
     # @todo reduce_hydrogens.py:run() says: TODO temporary fix until the code is moved to model class
-    cs = self.model.crystal_symmetry()
-    if (cs is None) or (cs.unit_cell() is None):
-      self.model = shift_and_box_model(model = self.model, shift_model=False)
+    self.model = shift_and_box_model(model = self.model, shift_model=False)
 
     # If we've been asked to only to a single model index from the file, strip the model down to
     # only that index.


### PR DESCRIPTION
Fixes some bugs in probe2 so that it can load more files, and prints more robust errors when it fails.
Adds the ability to export a JSON format to probe2 with the same data as the raw format but also able to handle CIF files.