### PR TITLE
Computing the length of the crystal box by subtracting its two ends a…

### DIFF
--- a/cctbx/maptbx/box.py
+++ b/cctbx/maptbx/box.py
@@ -1334,9 +1334,10 @@ def shift_and_box_model(model = None,
     sites_cart=sites_cart-col(sites_cart.min())+col(
       (box_cushion,box_cushion,box_cushion))
 
+  box_start=col(sites_cart.min())-col((box_cushion,box_cushion,box_cushion))
   box_end=col(sites_cart.max())+col((box_cushion,box_cushion,box_cushion))
   if not crystal_symmetry:
-    a,b,c=box_end
+    a,b,c = box_end - box_start
     crystal_symmetry=crystal.symmetry((a,b,c, 90,90,90),1)
   phc = ph.deep_copy()
   phc.atoms().set_xyz(sites_cart)


### PR DESCRIPTION
…nd adding cushion on each end rather than by assuming that the origin is zero or cushion above zero.  This makes the box side lengths always positive even when all atoms are on the negative side of one of the axes and the shift_model parameter to shift_and_box_model is False