### PR TITLE
Fix MPI on XFEL CI for psana

### DIFF
--- a/.azure-pipelines/xfel/conda-linux.yml
+++ b/.azure-pipelines/xfel/conda-linux.yml
@@ -73,6 +73,11 @@ jobs:
     displayName: Install dependencies for CentOS
     condition: eq('${{ parameters.distribution }}', 'centos')
 
+  - script: |
+      yum install -y ucx
+    displayName: Add libucx for Rocky Linux
+    condition: eq('${{ parameters.distribution }}', 'rockylinux')
+
   - bash: |
       echo "##vso[task.setvariable variable=LC_ALL]C.utf8"
     displayName: Setup locale for CentOS 8

--- a/.azure-pipelines/xfel/conda-linux.yml
+++ b/.azure-pipelines/xfel/conda-linux.yml
@@ -64,8 +64,9 @@ jobs:
   - script: |
       /tmp/docker exec -t -u 0 ci-container \
       sh -c "yum install -y sudo"
-    displayName: Set up sudo for CentOS
-    condition: eq('${{ parameters.distribution }}', 'centos')
+    displayName: Set up sudo for CentOS and Rocky Linux
+    condition: or(eq('${{ parameters.distribution }}', 'centos'),
+                  eq('${{ parameters.distribution }}', 'rockylinux'))
 
   - script: |
       sudo yum groupinstall -y 'Development Tools'
@@ -74,7 +75,7 @@ jobs:
     condition: eq('${{ parameters.distribution }}', 'centos')
 
   - script: |
-      yum install -y ucx
+      sudo yum install -y ucx
     displayName: Add libucx for Rocky Linux
     condition: eq('${{ parameters.distribution }}', 'rockylinux')
 

--- a/.azure-pipelines/xfel/unix-psana-build.yml
+++ b/.azure-pipelines/xfel/unix-psana-build.yml
@@ -68,6 +68,9 @@ steps:
     source $(Pipeline.Workspace)/miniforge/etc/profile.d/conda.sh
     conda activate psana_env
     cd $(Pipeline.Workspace)
+    pushd modules/xfel_regression/test/util
+    sed -i 's/mpirun/mpiexec/' tst_mpi_abort.py
+    popd
     source ./build/setpaths.sh
     mkdir tests
     cd tests

--- a/.azure-pipelines/xfel/unix-psana-build.yml
+++ b/.azure-pipelines/xfel/unix-psana-build.yml
@@ -41,6 +41,8 @@ steps:
 - script: |
     set -xe
     bash $(Pipeline.Workspace)/miniforge/Miniforge3-$(CONDA)-x86_64.sh -b -u -p $(Pipeline.Workspace)/miniforge
+    # psana1 needs some discontinued packages
+    echo "restore_free_channel: true" > $(Pipeline.Workspace)/miniforge/.condarc
   displayName: Install miniforge
 
 - script: |
@@ -49,7 +51,6 @@ steps:
     conda env create -f $(Pipeline.Workspace)/modules/cctbx_project/xfel/conda_envs/psana_environment.yml python=$(PYTHON_FULL_VERSION)
     conda install -y -c conda-forge --no-deps -n psana_env junit-xml
     conda install -y -c conda-forge cmake pandas distro -n psana_env
-    conda list -n psana_env
   displayName: Create conda environment
   retryCountOnTaskFailure: 3
 
@@ -67,9 +68,6 @@ steps:
     source $(Pipeline.Workspace)/miniforge/etc/profile.d/conda.sh
     conda activate psana_env
     cd $(Pipeline.Workspace)
-    pushd modules/xfel_regression/test/util
-    sed -i 's/mpirun/mpiexec/' tst_mpi_abort.py
-    popd
     source ./build/setpaths.sh
     mkdir tests
     cd tests

--- a/.azure-pipelines/xfel/unix-psana-build.yml
+++ b/.azure-pipelines/xfel/unix-psana-build.yml
@@ -41,8 +41,6 @@ steps:
 - script: |
     set -xe
     bash $(Pipeline.Workspace)/miniforge/Miniforge3-$(CONDA)-x86_64.sh -b -u -p $(Pipeline.Workspace)/miniforge
-    # psana1 needs some discontinued packages
-    echo "restore_free_channel: true" > $(Pipeline.Workspace)/miniforge/.condarc
   displayName: Install miniforge
 
 - script: |

--- a/.azure-pipelines/xfel/unix-psana-build.yml
+++ b/.azure-pipelines/xfel/unix-psana-build.yml
@@ -51,6 +51,7 @@ steps:
     conda env create -f $(Pipeline.Workspace)/modules/cctbx_project/xfel/conda_envs/psana_environment.yml python=$(PYTHON_FULL_VERSION)
     conda install -y -c conda-forge --no-deps -n psana_env junit-xml
     conda install -y -c conda-forge cmake pandas distro -n psana_env
+    conda list -n psana_env
   displayName: Create conda environment
   retryCountOnTaskFailure: 3
 

--- a/xfel/conda_envs/README.md
+++ b/xfel/conda_envs/README.md
@@ -67,6 +67,12 @@ $ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base \
   --nproc=10 --python=39 --no-boost-src build
 ```
 
+## MPI support
+
+MPI functionality can be sensitive to the details of the system configuration. In one minimal setup (Azure CI on Rocky Linux)
+we had to add `ucx` via either YUM or Conda for full MPI function. For a particular cluster environment you may have to consult
+a local expert.
+
 ## LCLS environment
 
 For LCLS data, when not on the main LCLS servers, additional environment variables are needed so psana can find the XTC streams are stored. Given a folder named `$WORKING`, the XTC streams should be in `$WORKING/<endstation>/<experiment>/xtc`. If the data is older than run 21 (spring 2022), `$WORKING/lcls/ExpNameDb` should exist, with the file `experiment-db.dat`. That file will have entries like `280 CXI cxi78513` to map the numbers in the XTC streams to experiment names. Newer data doesn't need this. Given this folder structure, export these environment variables:


### PR DESCRIPTION
Observed some flaky behavior ("Missing hostname or invalid host/port description in business card") with mpirun in Rocky Linux on Azure. Apparently fixed by installing ucx.