### PR TITLE
Don't use cxx11

### DIFF
--- a/libtbx/auto_build/bootstrap.py
+++ b/libtbx/auto_build/bootstrap.py
@@ -2291,9 +2291,8 @@ class DIALSBuilder(CCIBuilder):
 
   def get_libtbx_configure(self):
     configlst = super(DIALSBuilder, self).get_libtbx_configure()
-    if self.python != "27":
-      # Do not enable C++11 for Python 2.7 builds, cf. https://github.com/cctbx/cctbx_project/pull/497
-      configlst.append('--enable_cxx11')
+    if '--enable_cxx11' in configlst: configlst.remove('--enable_cxx11')
+    configlst.append('--cxxstd=c++14')
     return configlst
 
 class LABELITBuilder(CCIBuilder):


### PR DESCRIPTION
This fix:
1. Removes the `--enable_cxx11` flag
2. Ensures that `--cxxstd=c++14` is set

It follows similar patterns in the `bootstap.py` file. This is necessary to make the `alcc-recipes` deployment on Perlmutter work after the most recent compiler toolchain update (which also replaces the boost install with conda forge's boost).

Before merging, we might want to discuss if this is the best way to implement "a non-ancient c++ standard". E.g.:
1. Do we want to enable even more recent C++ versions? (E.g. let the user specify the C++ standard and just ensure that it's "at least C++14")
2. Do we want to remove the `--enable_cxx11` flag alltogether?

Anyone on Perlmutter, please give https://github.com/JBlaschke/alcc-recipes/blob/master/cctbx/setup_perlmutter_new.sh a try to see if it also works for you.