### PR TITLE
Refactor pydiscamb interface

### DIFF
--- a/cctbx/miller/__init__.py
+++ b/cctbx/miller/__init__.py
@@ -1585,7 +1585,8 @@ class set(crystal.symmetry):
                                         u_base=None,
                                         b_base=None,
                                         wing_cutoff=None,
-                                        exp_table_one_over_step_size=None):
+                                        exp_table_one_over_step_size=None,
+                                        extra_params=None):
     """
     Calculate structure factors for an :py:class:`cctbx.xray.structure` object
     corresponding to the current set of Miller indices.  Can use either FFT
@@ -1613,7 +1614,8 @@ class set(crystal.symmetry):
       exp_table_one_over_step_size=exp_table_one_over_step_size)(
         xray_structure=xray_structure,
         miller_set=self,
-        algorithm=algorithm)
+        algorithm=algorithm,
+        extra_params=extra_params)
 
   def amplitude_normalisations(self, asu_contents, wilson_plot):
     """ A miller.array whose data N(h) are the normalisations to convert
@@ -1648,7 +1650,8 @@ class set(crystal.symmetry):
         u_base=None,
         b_base=None,
         wing_cutoff=None,
-        exp_table_one_over_step_size=None):
+        exp_table_one_over_step_size=None,
+        extra_params=None):
     return self.f_obs_minus_f_calc(
       f_obs_factor=f_obs_factor,
       f_calc=self.structure_factors_from_scatterers(
@@ -1659,7 +1662,8 @@ class set(crystal.symmetry):
         u_base=u_base,
         b_base=b_base,
         wing_cutoff=wing_cutoff,
-        exp_table_one_over_step_size=exp_table_one_over_step_size).f_calc())
+        exp_table_one_over_step_size=exp_table_one_over_step_size,
+        extra_params=extra_params).f_calc())
 
   def setup_binner(self, d_max=0, d_min=0,
                    auto_binning=False,

--- a/cctbx/xray/structure.py
+++ b/cctbx/xray/structure.py
@@ -1381,7 +1381,8 @@ class structure(crystal.special_position_settings):
                               quality_factor=None,
                               u_base=None,
                               b_base=None,
-                              wing_cutoff=None):
+                              wing_cutoff=None,
+                              extra_params=None):
     """
     Calculate structure factors for the current scatterers using either direct
     summation or FFT method; by default the appropriate method will be guessed
@@ -1410,6 +1411,8 @@ class structure(crystal.special_position_settings):
     :param wing_cutoff: is how far away from atomic center you sample density
       around atom
     :type wing_cutoff: float
+    :param extra_params: Additional parameters passed to the structure factor calculation algorithm
+    :type extra_params: libtbx.phil.scope_extract
 
     :returns: a custom Python object (exact type depends on method used), from
       which f_calc() may be called
@@ -1436,7 +1439,8 @@ class structure(crystal.special_position_settings):
       wing_cutoff=wing_cutoff)(
         xray_structure=self,
         miller_set=miller_set,
-        algorithm=algorithm)
+        algorithm=algorithm,
+        extra_params=extra_params)
 
   def as_py_code(self, indent=""):
     """eval(self.as_py_code()) is similar (but sometimes not identical)

--- a/cctbx/xray/structure_factors/__init__.py
+++ b/cctbx/xray/structure_factors/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 from cctbx.xray.structure_factors.misc import *
+from cctbx.xray.structure_factors.algorithm import *
 from cctbx.xray.structure_factors.gradient_flags import *
 from cctbx.xray.structure_factors.from_scatterers import *
 from cctbx.xray.structure_factors.gradients import *

--- a/cctbx/xray/structure_factors/algorithm.py
+++ b/cctbx/xray/structure_factors/algorithm.py
@@ -9,7 +9,7 @@ from cctbx.xray.structure_factors.gradients_direct \
   import gradients_direct
 from cctbx.xray.structure_factors.gradients_fft \
   import gradients_fft
-
+from cctbx.xray.structure_factors.misc import pydiscamb_is_installed
 
 Algorithm = namedtuple(
     "Algorithm",
@@ -32,14 +32,11 @@ algorithms = {
     )
 }
 
-# discamb
-try:
-    from pydiscamb.cctbx_interface import from_scatterers_taam, gradients_taam
-    algorithms["taam"] = Algorithm(
-        "taam",
-        "Transferrable Aspherical Atom Model",
-        from_scatterers_taam,
-        gradients_taam
-    )
-except ImportError:
-    pass
+if pydiscamb_is_installed:
+  from pydiscamb.cctbx_interface import from_scatterers_taam, gradients_taam
+  algorithms["taam"] = Algorithm(
+    "taam",
+    "Transferrable Aspherical Atom Model",
+    from_scatterers_taam,
+    gradients_taam
+  )

--- a/cctbx/xray/structure_factors/algorithm.py
+++ b/cctbx/xray/structure_factors/algorithm.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import, division, print_function
+from collections import namedtuple
+
+from cctbx.xray.structure_factors.from_scatterers_direct \
+  import from_scatterers_direct
+from cctbx.xray.structure_factors.from_scatterers_fft \
+  import from_scatterers_fft
+from cctbx.xray.structure_factors.gradients_direct \
+  import gradients_direct
+from cctbx.xray.structure_factors.gradients_fft \
+  import gradients_fft
+
+
+Algorithm = namedtuple(
+    "Algorithm",
+    ["name", "desc", "from_scatterers", "gradients"]
+)
+
+
+algorithms = {
+    "direct" : Algorithm(
+        "direct",
+        "Direct Summation",
+        from_scatterers_direct,
+        gradients_direct
+    ),
+    "fft" : Algorithm(
+        "fft",
+        "FFT Approximation",
+        from_scatterers_fft,
+        gradients_fft
+    )
+}
+
+# discamb
+try:
+    from pydiscamb.cctbx_interface import from_scatterers_taam, gradients_taam
+    algorithms["taam"] = Algorithm(
+        "taam",
+        "Transferrable Aspherical Atom Model",
+        from_scatterers_taam,
+        gradients_taam
+    )
+except ImportError:
+    pass

--- a/cctbx/xray/structure_factors/from_scatterers.py
+++ b/cctbx/xray/structure_factors/from_scatterers.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import, division, print_function
 # -*- coding: utf-8 -*-
 from cctbx.xray.structure_factors.manager import manager
-from cctbx.xray.structure_factors.from_scatterers_direct \
-  import from_scatterers_direct
-from cctbx.xray.structure_factors.from_scatterers_fft \
-  import from_scatterers_fft
+from cctbx.xray.structure_factors.algorithm import algorithms
 
 class from_scatterers(manager):
   """ Factory class for structure factor evaluations """
@@ -31,8 +28,9 @@ class from_scatterers(manager):
       or the best suited of the two of them when C{algorithm} is None
       providing the evaluated structure factors as C{e.f_calc()}
     """
-    assert algorithm in ("direct", "fft", None)
+    assert algorithm in algorithms.keys() or algorithm is None
     if (algorithm is None):
+      algorithm = "fft"
       n_scatterers = xray_structure.scatterers().size()
       n_miller_indices = miller_set.indices().size()
       if (not self.have_good_timing_estimates()):
@@ -44,8 +42,7 @@ class from_scatterers(manager):
         if (   self.estimate_time_direct(n_scatterers * n_miller_indices)
             <= self.estimate_time_fft(n_scatterers, n_miller_indices)):
           algorithm = "direct"
-    if (algorithm == "direct"): f = from_scatterers_direct
-    else:                       f = from_scatterers_fft
+    f = algorithms[algorithm].from_scatterers
     return f(
       manager=self,
       xray_structure=xray_structure,

--- a/cctbx/xray/structure_factors/from_scatterers.py
+++ b/cctbx/xray/structure_factors/from_scatterers.py
@@ -8,7 +8,8 @@ class from_scatterers(manager):
 
   def __call__(self, xray_structure,
                      miller_set,
-                     algorithm=None):
+                     algorithm=None,
+                     extra_params=None):
     """Evaluate structure factors and return the result
 
     :type xray_structure: cctbx.xray.structure
@@ -47,4 +48,5 @@ class from_scatterers(manager):
       manager=self,
       xray_structure=xray_structure,
       miller_set=miller_set,
-      algorithm=algorithm) # passing algorithm allows f to decide on CPU/GPU implementation
+      algorithm=algorithm, # passing algorithm allows f to decide on CPU/GPU implementation
+      extra_params=extra_params)

--- a/cctbx/xray/structure_factors/from_scatterers_direct.py
+++ b/cctbx/xray/structure_factors/from_scatterers_direct.py
@@ -13,7 +13,8 @@ class from_scatterers_direct(managed_calculation_base):
                      miller_set,
                      manager=None,
                      cos_sin_table=False,
-                     algorithm="direct"):
+                     algorithm="direct",
+                     extra_params=None):
     """Evaluate structure factors via direct calculations
 
     :type xray_structure: cctbx.xray.structure

--- a/cctbx/xray/structure_factors/from_scatterers_fft.py
+++ b/cctbx/xray/structure_factors/from_scatterers_fft.py
@@ -13,7 +13,8 @@ class from_scatterers_fft(managed_calculation_base):
   def __init__(self, manager,
                      xray_structure,
                      miller_set,
-                     algorithm="fft"):
+                     algorithm="fft",
+                     extra_params=None):
     scattering_type_registry = xray_structure.scattering_type_registry()
     if (len(scattering_type_registry.unassigned_types()) > 0):
       self.show_unknown_scatterers(registry = scattering_type_registry)

--- a/cctbx/xray/structure_factors/gradients.py
+++ b/cctbx/xray/structure_factors/gradients.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, division, print_function
 from cctbx.xray.structure_factors.manager import manager
-from cctbx.xray.structure_factors.gradients_direct \
-  import gradients_direct
-from cctbx.xray.structure_factors.gradients_fft \
-  import gradients_fft
+from cctbx.xray.structure_factors.algorithm import algorithms
 
 class gradients(manager):
   """ Factory class for structure factor derivatives evaluation """
@@ -43,8 +40,9 @@ class gradients(manager):
         gradients as C{e.packed()}
 
     """
-    assert algorithm in ("direct", "fft", None)
+    assert algorithm in algorithms.items() or algorithm is None
     if (algorithm is None):
+      algorithm = "fft"
       n_scatterers = xray_structure.scatterers().size()
       n_miller_indices = miller_set.indices().size()
       if (not self.have_good_timing_estimates()):
@@ -55,8 +53,7 @@ class gradients(manager):
         if (   self.estimate_time_direct(n_scatterers * n_miller_indices)
             <= self.estimate_time_fft(n_scatterers, n_miller_indices)):
           algorithm = "direct"
-    if (algorithm == "direct"): f = gradients_direct
-    else:                       f = gradients_fft
+    f = algorithms[algorithm].gradients
     return f(
       manager=self,
       xray_structure=xray_structure,

--- a/cctbx/xray/structure_factors/gradients.py
+++ b/cctbx/xray/structure_factors/gradients.py
@@ -10,7 +10,8 @@ class gradients(manager):
                      miller_set,
                      d_target_d_f_calc,
                      n_parameters,
-                     algorithm=None):
+                     algorithm=None,
+                     extra_params=None):
     """
     Evaluate structure factors derivatives and return the result
 
@@ -60,4 +61,5 @@ class gradients(manager):
       u_iso_refinable_params=u_iso_refinable_params,
       miller_set=miller_set,
       d_target_d_f_calc=d_target_d_f_calc,
-      n_parameters=n_parameters)
+      n_parameters=n_parameters,
+      extra_params=extra_params)

--- a/cctbx/xray/structure_factors/gradients.py
+++ b/cctbx/xray/structure_factors/gradients.py
@@ -40,7 +40,7 @@ class gradients(manager):
         gradients as C{e.packed()}
 
     """
-    assert algorithm in algorithms.items() or algorithm is None
+    assert algorithm in algorithms.keys() or algorithm is None
     if (algorithm is None):
       algorithm = "fft"
       n_scatterers = xray_structure.scatterers().size()

--- a/cctbx/xray/structure_factors/gradients_direct.py
+++ b/cctbx/xray/structure_factors/gradients_direct.py
@@ -15,7 +15,8 @@ class gradients_direct(gradients_base):
                      d_target_d_f_calc,
                      n_parameters,
                      manager=None,
-                     cos_sin_table=False):
+                     cos_sin_table=False,
+                     extra_params=None):
     time_all = user_plus_sys_time()
     gradients_base.__init__(self,
       manager, xray_structure, miller_set, algorithm="direct")

--- a/cctbx/xray/structure_factors/gradients_fft.py
+++ b/cctbx/xray/structure_factors/gradients_fft.py
@@ -17,7 +17,8 @@ class gradients_fft(gradients_base):
                      u_iso_refinable_params,
                      miller_set,
                      d_target_d_f_calc,
-                     n_parameters):
+                     n_parameters,
+                     extra_params=None):
     time_all = time_apply_u_extra = user_plus_sys_time()
     gradients_base.__init__(self,
       manager, xray_structure, miller_set, algorithm="fft")

--- a/cctbx/xray/structure_factors/manager.py
+++ b/cctbx/xray/structure_factors/manager.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 from cctbx.xray.structure_factors.misc import quality_factor_from_any
+from cctbx.xray.structure_factors.algorithm import algorithms
 from cctbx.xray import ext
 from cctbx import maptbx
 from cctbx import crystal
@@ -251,7 +252,7 @@ class managed_calculation_base(object):
     if (manager is not None):
       assert xray_structure.unit_cell().is_similar_to(manager.unit_cell())
       assert xray_structure.space_group() == manager.space_group()
-    assert algorithm in ["direct", "fft"]
+    assert algorithm in algorithms.keys()
 
   def manager(self):
     return self._manager
@@ -265,6 +266,4 @@ class managed_calculation_base(object):
   def algorithm(self, verbose=False):
     if (not verbose):
       return self._algorithm
-    if (self._algorithm == "direct"):
-      return "Direct Summation"
-    return "FFT Approximation"
+    return algorithms[self._algorithm].desc

--- a/cctbx/xray/structure_factors/manager.py
+++ b/cctbx/xray/structure_factors/manager.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 from cctbx.xray.structure_factors.misc import quality_factor_from_any
-from cctbx.xray.structure_factors.algorithm import algorithms
 from cctbx.xray import ext
 from cctbx import maptbx
 from cctbx import crystal
@@ -252,7 +251,10 @@ class managed_calculation_base(object):
     if (manager is not None):
       assert xray_structure.unit_cell().is_similar_to(manager.unit_cell())
       assert xray_structure.space_group() == manager.space_group()
+
+    from cctbx.xray.structure_factors.algorithm import algorithms
     assert algorithm in algorithms.keys()
+
 
   def manager(self):
     return self._manager
@@ -266,4 +268,5 @@ class managed_calculation_base(object):
   def algorithm(self, verbose=False):
     if (not verbose):
       return self._algorithm
+    from cctbx.xray.structure_factors.algorithm import algorithms
     return algorithms[self._algorithm].desc

--- a/cctbx/xray/structure_factors/misc.py
+++ b/cctbx/xray/structure_factors/misc.py
@@ -32,4 +32,3 @@ try:
   del __pydiscamb
 except ImportError:
   pydiscamb_is_installed = False
-pydiscamb_is_installed = True

--- a/cctbx/xray/structure_factors/misc.py
+++ b/cctbx/xray/structure_factors/misc.py
@@ -23,3 +23,13 @@ expensive_function_call_message = (
     "Programming problem: Calling this function is expensive."
   + " Please assign the result to an intermediate variable.")
 
+
+# Check if pydiscamb is installed
+try:
+  # prefix to avoid including in structure_factors import
+  import pydiscamb as __pydiscamb
+  pydiscamb_is_installed = True
+  del __pydiscamb
+except ImportError:
+  pydiscamb_is_installed = False
+pydiscamb_is_installed = True

--- a/mmtbx/__init__.py
+++ b/mmtbx/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from libtbx.utils import Sorry
 from libtbx.version import get_version
-from scitbx.array_family import flex
 
 __version__ = get_version()
 

--- a/mmtbx/__init__.py
+++ b/mmtbx/__init__.py
@@ -303,35 +303,11 @@ class fmodels(object):
         self.target_work_xray_weighted = self.target_work_xray * wx
         self.gradient_xray = None
         if(compute_gradients):
-          # XXX discamb
-          if self.fmodels.fmodel_xray().is_taam():
-            #f0 = self.fmodels.fmodel_xray().xray_structure.scatterers()[0].flags
-            #if f0.grad_occupancy():
-            #gs = tfx_r.gradients_wrt_atomic_parameters()
-            #if   f0.grad_site():
-            #  sf = flex.vec3_double([g.site_derivatives for g in gs]).as_double()
-            #elif f0.grad_u_iso():
-            #  sf = flex.double([g.adp_derivatives[0] for g in gs])
-            if occupancy:
-              sel = flex.size_t()
-              scs = self.fmodels.fmodel_xray().xray_structure.scatterers()
-              sz = scs.size()
-              sf_ = flex.double(sz,0)
-              for i_seq, s in enumerate(scs):
-                if s.flags.grad_occupancy():
-                  sel.append(i_seq)
-              sf = tfx_r.gradients_wrt_atomic_parameters()
-              sf_ = sf_.set_selected(sel, sf)
-              sf = sf_
-            else:
-              sf = tfx_r.gradients_wrt_atomic_parameters()
-          # XXX discamb
+          if(occupancy):
+            sf = tfx_r.gradients_wrt_atomic_parameters(occupancy = occupancy)
           else:
-            if(occupancy):
-              sf = tfx_r.gradients_wrt_atomic_parameters(occupancy = occupancy)
-            else:
-              sf = tfx_r.gradients_wrt_atomic_parameters(
-                u_iso_refinable_params = u_iso_refinable_params).packed()
+            sf = tfx_r.gradients_wrt_atomic_parameters(
+              u_iso_refinable_params = u_iso_refinable_params).packed()
 
           self.gradient_xray = sf
           self.gradient_xray_weighted = sf * wx

--- a/mmtbx/f_model/f_model.py
+++ b/mmtbx/f_model/f_model.py
@@ -372,8 +372,6 @@ class manager(manager_mixin):
          scale_method="combo",
          origin=None,
          data_type=None):
-    self.pydiscamb = None       # XXX discamb
-    self.discamb_wrapper = None # XXX discamb
     self._origin = origin
     self._data_type = data_type
     self.russ = None
@@ -539,21 +537,6 @@ class manager(manager_mixin):
         indices = twin_mi,
         crystal_symmetry = miller_array.crystal_symmetry())
     return result
-
-  def _set_taam_and_compute_f_calc(self, xray_structure):     # XXX discamb
-    assert xray_structure is not None                         # XXX discamb
-    if self.pydiscamb is None:                                # XXX discamb
-      import pydiscamb                                        # XXX discamb
-      self.pydiscamb = pydiscamb                              # XXX discamb
-    self.discamb_wrapper =  self.pydiscamb.DiscambWrapper(
-      xray_structure,
-      method = self.pydiscamb.FCalcMethod.TAAM)               # XXX discamb
-    self.discamb_wrapper.set_indices(self.f_obs().indices())  # XXX discamb
-    data = flex.complex_double(self.discamb_wrapper.f_calc()) # XXX discamb
-    return self.f_obs().array(data = data)                    # XXX discamb
-
-  def is_taam(self):            # XXX discamb
-    return self.sfg_params.taam # XXX discamb
 
   def compute_f_calc(self, miller_array = None, xray_structure=None):
     xrs = xray_structure

--- a/mmtbx/f_model/f_model.py
+++ b/mmtbx/f_model/f_model.py
@@ -162,8 +162,8 @@ sf_and_grads_accuracy_master_params = iotbx.phil.parse("""\
     .type = float
   exp_table_one_over_step_size = None
     .type = float
-  taam
-    .help = Transferrable Aspherical Atom Model (TAAM)-specific parameters
+  extra
+    .help = Extra parameters for additional algorithms, e.g. TAAM using DiSCaMB
   {
   }
 """)
@@ -171,7 +171,7 @@ sf_and_grads_accuracy_master_params = iotbx.phil.parse("""\
 if cctbx.xray.structure_factors.pydiscamb_is_installed:
   sf_and_grads_accuracy_master_params.adopt_scope(
     iotbx.phil.parse(
-      "taam  { include scope pydiscamb.cctbx_interface.taam_master_params }",
+      "extra  { discamb { include scope pydiscamb.cctbx_interface.pydiscamb_master_params } }",
       process_includes=True,
     )
   )
@@ -519,8 +519,7 @@ class manager(manager_mixin):
          b_base                       = self.sfg_params.b_base,
          wing_cutoff                  = self.sfg_params.wing_cutoff,
          exp_table_one_over_step_size =
-                                  self.sfg_params.exp_table_one_over_step_size,
-         extra_params=self.sfg_params.taam)
+                                  self.sfg_params.exp_table_one_over_step_size)
     return self._structure_factor_gradients_w
 
   structure_factor_gradients_w = property(_get_structure_factor_gradients_w)
@@ -555,7 +554,7 @@ class manager(manager_mixin):
       b_base                       = p.b_base,
       wing_cutoff                  = p.wing_cutoff,
       exp_table_one_over_step_size = p.exp_table_one_over_step_size,
-      extra_params = p.taam
+      extra_params = p.extra
       )
     m = manager.manager()
     return manager.f_calc()

--- a/mmtbx/f_model/f_model.py
+++ b/mmtbx/f_model/f_model.py
@@ -171,7 +171,7 @@ sf_and_grads_accuracy_master_params = iotbx.phil.parse("""\
 if cctbx.xray.structure_factors.pydiscamb_is_installed:
   sf_and_grads_accuracy_master_params.adopt_scope(
     iotbx.phil.parse(
-      "taam  { include scope pydiscamb.cctbx_interface.taam_master_params }", 
+      "taam  { include scope pydiscamb.cctbx_interface.taam_master_params }",
       process_includes=True,
     )
   )

--- a/mmtbx/f_model/f_model.py
+++ b/mmtbx/f_model/f_model.py
@@ -146,7 +146,7 @@ class manager_mixin(object):
       .gradients_wrt_atomic_parameters(**keyword_args)
 
 sf_and_grads_accuracy_master_params = iotbx.phil.parse("""\
-  algorithm = *fft direct
+  algorithm = *fft direct taam
     .type = choice
   cos_sin_table = False
     .type = bool
@@ -162,10 +162,19 @@ sf_and_grads_accuracy_master_params = iotbx.phil.parse("""\
     .type = float
   exp_table_one_over_step_size = None
     .type = float
-  taam = False
-    .type = bool
-    .help = Use aspherical form-factors (TAAM=Transferable Aspherical Atom Model)
+  taam
+    .help = Transferrable Aspherical Atom Model (TAAM)-specific parameters
+  {
+  }
 """)
+
+if cctbx.xray.structure_factors.pydiscamb_is_installed:
+  sf_and_grads_accuracy_master_params.adopt_scope(
+    iotbx.phil.parse(
+      "taam  { include scope pydiscamb.cctbx_interface.taam_master_params }", 
+      process_includes=True,
+    )
+  )
 
 alpha_beta_master_params = iotbx.phil.parse("""\
   include scope mmtbx.max_lik.maxlik.alpha_beta_params
@@ -512,7 +521,8 @@ class manager(manager_mixin):
          b_base                       = self.sfg_params.b_base,
          wing_cutoff                  = self.sfg_params.wing_cutoff,
          exp_table_one_over_step_size =
-                                  self.sfg_params.exp_table_one_over_step_size)
+                                  self.sfg_params.exp_table_one_over_step_size,
+         extra_params=self.sfg_params.taam)
     return self._structure_factor_gradients_w
 
   structure_factor_gradients_w = property(_get_structure_factor_gradients_w)
@@ -552,10 +562,6 @@ class manager(manager_mixin):
     p = self.sfg_params
     if(miller_array.indices().size()==0):
       raise RuntimeError("Empty miller_array.")
-
-    if self.sfg_params.taam:                                         # XXX discamb
-      return self._set_taam_and_compute_f_calc(xray_structure = xrs) # XXX discamb
-
     manager = miller_array.structure_factors_from_scatterers(
       xray_structure               = xrs,
       algorithm                    = p.algorithm,
@@ -565,7 +571,9 @@ class manager(manager_mixin):
       u_base                       = p.u_base,
       b_base                       = p.b_base,
       wing_cutoff                  = p.wing_cutoff,
-      exp_table_one_over_step_size = p.exp_table_one_over_step_size)
+      exp_table_one_over_step_size = p.exp_table_one_over_step_size,
+      extra_params = p.taam
+      )
     m = manager.manager()
     return manager.f_calc()
 

--- a/mmtbx/refinement/anomalous_scatterer_groups.py
+++ b/mmtbx/refinement/anomalous_scatterer_groups.py
@@ -75,7 +75,8 @@ class minimizer(object):
       xray_structure=fmodel.xray_structure,
       n_parameters=0,
       miller_set=d_target_d_f_calc,
-      algorithm=fmodel.sfg_params.algorithm)
+      algorithm=fmodel.sfg_params.algorithm,
+      extra_params=fmodel.sfg_params.extra)
     d_t_d_fp = sfg.d_target_d_fp()
     d_t_d_fdp = sfg.d_target_d_fdp()
     del sfg

--- a/mmtbx/refinement/data.py
+++ b/mmtbx/refinement/data.py
@@ -77,30 +77,13 @@ class fs(object):
       return self.tg.gradients_wrt_atomic_parameters().packed()
       assert 0
     else:
-      if not self.fmodel.is_taam(): # XXX discamb
-        if not self.sites_cart:
-          g = self.tg.gradients_wrt_atomic_parameters().packed()
-          result = flex.double(self.size, 0)
-          result.set_selected(self.selection, g)
-          return result
-        else:
-          g = self.tg.d_target_d_site_cart()
-          result = flex.vec3_double(self.size, [0,0,0])
-          result.set_selected(self.selection, g)
-          return result.as_double()
-      else:                                                                 # XXX discamb
-        d_target_d_fcalc = self.tg.d_target_d_f_calc_work()                 # XXX discamb
-        self.fmodel.discamb_wrapper.set_indices(d_target_d_fcalc.indices()) # XXX discamb
-        gradients = self.fmodel.discamb_wrapper.d_target_d_params(          # XXX discamb
-          list(d_target_d_fcalc.data()))                                    # XXX discamb
-        if self.sites_cart:                                                            # XXX discamb
-          return flex.vec3_double([g.site_derivatives for g in gradients]).as_double() # XXX discamb
-        elif self.u_iso:                                                               # XXX discamb
-          g = flex.double([g.adp_derivatives[0] for g in gradients])                   # XXX discamb
-          result = flex.double(self.size, 0)                                           # XXX discamb
-          result.set_selected(self.selection, g)                                       # XXX discamb
-          return result.as_double()                                                    # XXX discamb
-        elif self.occupancy:                                                           # XXX discamb
-          assert 0                                                                     # XXX discamb
-          #return flex.double([g.occupancy_derivatives for g in gradients])            # XXX discamb
-        else: assert 0                                                                 # XXX discamb
+      if not self.sites_cart:
+        g = self.tg.gradients_wrt_atomic_parameters().packed()
+        result = flex.double(self.size, 0)
+        result.set_selected(self.selection, g)
+        return result
+      else:
+        g = self.tg.d_target_d_site_cart()
+        result = flex.vec3_double(self.size, [0,0,0])
+        result.set_selected(self.selection, g)
+        return result.as_double()

--- a/mmtbx/refinement/targets.py
+++ b/mmtbx/refinement/targets.py
@@ -306,21 +306,13 @@ class target_result_mixin(object):
         miller_set=d_target_d_f_calc,
         algorithm=manager.sfg_params.algorithm).d_target_d_occupancy()
     else:
-      # XXX discamb
-      if manager.is_taam(): # XXX discamb
-        #manager.discamb_wrapper.set_indices(d_target_d_f_calc.indices())
-        #result = manager.discamb_wrapper.d_target_d_params(
-        #  list(d_target_d_f_calc.data()))
-         result = manager.discamb_wrapper.d_target_d_params(d_target_d_f_calc)
-      # XXX discamb
-      else:
-        result = manager.structure_factor_gradients_w(
-          u_iso_refinable_params=u_iso_refinable_params,
-          d_target_d_f_calc=d_target_d_f_calc.data(),
-          xray_structure=xray_structure,
-          n_parameters=xray_structure.n_parameters(),
-          miller_set=d_target_d_f_calc,
-          algorithm=manager.sfg_params.algorithm)
+      result = manager.structure_factor_gradients_w(
+        u_iso_refinable_params=u_iso_refinable_params,
+        d_target_d_f_calc=d_target_d_f_calc.data(),
+        xray_structure=xray_structure,
+        n_parameters=xray_structure.n_parameters(),
+        miller_set=d_target_d_f_calc,
+        algorithm=manager.sfg_params.algorithm)
     time_gradients_wrt_atomic_parameters += timer.elapsed()
     return result
 

--- a/mmtbx/refinement/targets.py
+++ b/mmtbx/refinement/targets.py
@@ -288,7 +288,8 @@ class target_result_mixin(object):
         xray_structure=xray_structure,
         n_parameters=0,
         miller_set=d_target_d_f_calc,
-        algorithm=manager.sfg_params.algorithm).d_target_d_u_cart()
+        algorithm=manager.sfg_params.algorithm,
+        extra_params=manager.sfg_params.extra).d_target_d_u_cart()
     elif(u_iso):
       result = manager.structure_factor_gradients_w(
         u_iso_refinable_params=None,
@@ -296,7 +297,8 @@ class target_result_mixin(object):
         xray_structure=xray_structure,
         n_parameters=0,
         miller_set=d_target_d_f_calc,
-        algorithm=manager.sfg_params.algorithm).d_target_d_u_iso()
+        algorithm=manager.sfg_params.algorithm,
+        extra_params=manager.sfg_params.extra).d_target_d_u_iso()
     elif(occupancy):
       result = manager.structure_factor_gradients_w(
         u_iso_refinable_params=None,
@@ -304,7 +306,8 @@ class target_result_mixin(object):
         xray_structure=xray_structure,
         n_parameters=0,
         miller_set=d_target_d_f_calc,
-        algorithm=manager.sfg_params.algorithm).d_target_d_occupancy()
+        algorithm=manager.sfg_params.algorithm,
+        extra_params=manager.sfg_params.extra).d_target_d_occupancy()
     else:
       result = manager.structure_factor_gradients_w(
         u_iso_refinable_params=u_iso_refinable_params,
@@ -312,7 +315,8 @@ class target_result_mixin(object):
         xray_structure=xray_structure,
         n_parameters=xray_structure.n_parameters(),
         miller_set=d_target_d_f_calc,
-        algorithm=manager.sfg_params.algorithm)
+        algorithm=manager.sfg_params.algorithm,
+        extra_params=manager.sfg_params.extra)
     time_gradients_wrt_atomic_parameters += timer.elapsed()
     return result
 

--- a/mmtbx/refinement/weights.py
+++ b/mmtbx/refinement/weights.py
@@ -159,7 +159,6 @@ class adp_gradients(object):
                      iso_restraints,
                      shake):
     fmodel_dc = fmodel.deep_copy()
-    if fmodel_dc.is_taam(): fmodel_dc.sfg_params.taam=False # XXX discamb
     xray_structure = fmodel_dc.xray_structure
     sel_i = model.refinement_flags.adp_individual_iso
     sel_a = model.refinement_flags.adp_individual_aniso
@@ -242,7 +241,6 @@ class site_gradients(object):
                      gradient_filtering = False,
                      log=None):
     fmodel_dc = fmodel.deep_copy()
-    if fmodel_dc.is_taam(): fmodel_dc.sfg_params.taam=False # XXX discamb
     xray_structure = fmodel_dc.xray_structure
     sel_si  = model.refinement_flags.sites_individual
     sel_sta = model.refinement_flags.sites_torsion_angles

--- a/mmtbx/twinning/twin_f_model.py
+++ b/mmtbx/twinning/twin_f_model.py
@@ -1002,7 +1002,7 @@ the percentage of R-free reflections).
         wing_cutoff                  = self.sfg_params.wing_cutoff,
         exp_table_one_over_step_size =
                         self.sfg_params.exp_table_one_over_step_size,
-        extra_params                 = self.sfg_params.taam
+        extra_params                 = self.sfg_params.extra
       )
     else:
       tmp = self.miller_set.structure_factors_from_scatterers(
@@ -1103,7 +1103,7 @@ the percentage of R-free reflections).
            wing_cutoff                  = self.sfg_params.wing_cutoff,
            exp_table_one_over_step_size =
                            self.sfg_params.exp_table_one_over_step_size,
-           extra_params                 = self.sfg_params.taam).f_calc()
+           extra_params                 = self.sfg_params.extra).f_calc()
        else:
          f_calc = self.miller_set.structure_factors_from_scatterers(
            xray_structure = self.xray_structure).f_calc()

--- a/mmtbx/twinning/twin_f_model.py
+++ b/mmtbx/twinning/twin_f_model.py
@@ -1001,7 +1001,8 @@ the percentage of R-free reflections).
         b_base                       = self.sfg_params.b_base,
         wing_cutoff                  = self.sfg_params.wing_cutoff,
         exp_table_one_over_step_size =
-                        self.sfg_params.exp_table_one_over_step_size
+                        self.sfg_params.exp_table_one_over_step_size,
+        extra_params                 = self.sfg_params.taam
       )
     else:
       tmp = self.miller_set.structure_factors_from_scatterers(
@@ -1101,7 +1102,8 @@ the percentage of R-free reflections).
            b_base                       = self.sfg_params.b_base,
            wing_cutoff                  = self.sfg_params.wing_cutoff,
            exp_table_one_over_step_size =
-                           self.sfg_params.exp_table_one_over_step_size).f_calc()
+                           self.sfg_params.exp_table_one_over_step_size,
+           extra_params                 = self.sfg_params.taam).f_calc()
        else:
          f_calc = self.miller_set.structure_factors_from_scatterers(
            xray_structure = self.xray_structure).f_calc()

--- a/mmtbx/utils/__init__.py
+++ b/mmtbx/utils/__init__.py
@@ -1252,7 +1252,7 @@ class fmodel_from_xray_structure(object):
          b_base                       = sfga.b_base,
          wing_cutoff                  = sfga.wing_cutoff,
          exp_table_one_over_step_size = sfga.exp_table_one_over_step_size,
-         extra_params                 = sfga.taam
+         extra_params                 = sfga.extra
          ).f_calc()
       lr = None
       try: lr = params.low_resolution

--- a/mmtbx/utils/__init__.py
+++ b/mmtbx/utils/__init__.py
@@ -1251,7 +1251,8 @@ class fmodel_from_xray_structure(object):
          u_base                       = sfga.u_base,
          b_base                       = sfga.b_base,
          wing_cutoff                  = sfga.wing_cutoff,
-         exp_table_one_over_step_size = sfga.exp_table_one_over_step_size
+         exp_table_one_over_step_size = sfga.exp_table_one_over_step_size,
+         extra_params                 = sfga.taam
          ).f_calc()
       lr = None
       try: lr = params.low_resolution


### PR DESCRIPTION
Hello!

This PR aims to make use of the existing structure factor + gradient framework in cctbx when using TAAM with pydiscamb.

I refactored the algorithm selection slightly, and added TAAM as an option. Currently, the actual implementation is in pydiscamb: https://github.com/viljarjf/pyDiSCaMB/blob/main/pydiscamb/cctbx_interface.py
I would like some input on this solution, if maybe the `gradients_taam` and `from_scatterers_taam` classes should be in cctbx and the results classes in pydiscamb?
The runtime measurement still needs to be added to the taam classes, regardless.

Extra parameters can be passed to DiSCaMB by means of a phil scope. I put this in pydiscamb, to more easily support / update the options if and when they change in DiSCaMB. The `extra`-scope is meant to allow for other algorithms in the future, with a `discamb` subscope defined in pydiscamb. Here, I also have the option to add more parameter sets for other available calculators in DiSCaMB.

Happy for any input on this! I have not been able to test this much, as I'm having difficulties properly installing cctbx.