### PR TITLE
Stop attempting "legacy editable" installs

### DIFF
--- a/.azure-pipelines/xfel/unix-conda-build.yml
+++ b/.azure-pipelines/xfel/unix-conda-build.yml
@@ -105,8 +105,6 @@ steps:
     conda activate $(PYTHON_VERSION)
     cd $(Pipeline.Workspace)
     source ./build/setpaths.sh
-    pip install -e `libtbx.find_in_repositories dxtbx` # temporary workaround
-    pip install -e `libtbx.find_in_repositories dials` # temporary workaround
     mkdir tests
     cd tests
     libtbx.configure xfel_regression LS49 ls49_big_data

--- a/.azure-pipelines/xfel/unix-psana-build.yml
+++ b/.azure-pipelines/xfel/unix-psana-build.yml
@@ -69,8 +69,6 @@ steps:
     conda activate psana_env
     cd $(Pipeline.Workspace)
     source ./build/setpaths.sh
-    pip install -e `libtbx.find_in_repositories dxtbx` # temporary workaround
-    pip install -e `libtbx.find_in_repositories dials` # temporary workaround
     mkdir tests
     cd tests
     libtbx.configure xfel_regression

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -2185,19 +2185,8 @@ selfx:
       for path in self.pythonpath:
         sys.path.insert(0, abs(path))
 
-      # Some libtbx_refresh scripts do a `pip install --editable`. The default
-      # behavior was changed in setuptools 64 and currently we expect the old
-      # behavior. See: https://github.com/pypa/setuptools/pull/3265
-      sef_previous = os.environ.get('SETUPTOOLS_ENABLE_FEATURES')
-      os.environ['SETUPTOOLS_ENABLE_FEATURES'] = 'legacy_editable'
-
       for module in self.module_list:
         module.process_libtbx_refresh_py()
-
-      if sef_previous is not None:
-          os.environ['SETUPTOOLS_ENABLE_FEATURES'] = sef_previous
-      else:
-          os.environ.pop('SETUPTOOLS_ENABLE_FEATURES')
 
       self.write_python_and_show_path_duplicates()
       self.process_exe()

--- a/libtbx/env_config.py
+++ b/libtbx/env_config.py
@@ -2185,8 +2185,19 @@ selfx:
       for path in self.pythonpath:
         sys.path.insert(0, abs(path))
 
+      # Some libtbx_refresh scripts do a `pip install --editable`. The default
+      # behavior was changed in setuptools 64 and currently we expect the old
+      # behavior. See: https://github.com/pypa/setuptools/pull/3265
+      sef_previous = os.environ.get('SETUPTOOLS_ENABLE_FEATURES')
+      os.environ['SETUPTOOLS_ENABLE_FEATURES'] = 'legacy_editable'
+
       for module in self.module_list:
         module.process_libtbx_refresh_py()
+
+      if sef_previous is not None:
+          os.environ['SETUPTOOLS_ENABLE_FEATURES'] = sef_previous
+      else:
+          os.environ.pop('SETUPTOOLS_ENABLE_FEATURES')
 
       self.write_python_and_show_path_duplicates()
       self.process_exe()


### PR DESCRIPTION
Legacy-editable mode was removed in pypa/setuptools#4953, this env
variable no longer does anything. We accommodate the new behavior in
cctbx/dxtbx#807 and dials/dials#2906.