### PR TITLE
Fixed out of memory error in cctbx.xfel.merge's isolation forest filter.

### DIFF
--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -375,7 +375,7 @@ select
     contamination_upper = 0.0001
       .type = float
       .help = Fraction of upper tail reflections that are outliers
-    n_estimators = 1000
+    n_estimators = 100
       .type = int
       .help = Number of decision trees in random forest model
     sampling_fraction = 0.1


### PR DESCRIPTION
The isolation forest filter was having an out of memory error. The random forest models were very large. I set the number of estimators to 1,000 initially in development because it gave smooth decision boundaries. I reset this to 100 (sklearn's default). The problem was when the root rank communicated the models to the other ranks, the communication packet was just too large. I also changed from a comm.bcast to sending the model individually to the other ranks. I have found this to help with out of memory issues during mpi communications in the past.