### PR TITLE
In cftbx, handle more recent versions of INTEGRATE.HKL

### DIFF
--- a/rstbx/cftbx/coordinate_frame_helpers.py
+++ b/rstbx/cftbx/coordinate_frame_helpers.py
@@ -306,6 +306,10 @@ def import_xds_integrate_hkl(integrate_hkl_file):
         if record.startswith('!ORGX='):
             ox = float(record.split()[1])
             oy = float(record.split()[3])
+            try:
+                distance = float(record.split()[5])
+            except IndexError: # Older versions of this file do not contain distance on this line.
+                pass
             continue
         if record.startswith('!STARTING_FRAME'):
             starting_frame = int(record.split()[-1])


### PR DESCRIPTION
Current versions of XDS produce an `INTEGRATE.HKL` with this line:

```
!ORGX=   1202.11  ORGY=   1213.24  DETECTOR_DISTANCE=   213.027
```

whereas old versions had these items on separate lines:
```
!ORGX=   1202.11  ORGY=   1213.24
!DETECTOR_DISTANCE=   213.027
```
This PR updates cftbx to handle both the new and old cases, without it an assertion is raised due to the detector distance not being found.