### PR TITLE
Reduce2 skip bad atoms

### DIFF
--- a/mmtbx/probe/Helpers.py
+++ b/mmtbx/probe/Helpers.py
@@ -468,20 +468,16 @@ def getExtraAtomInfo(model, bondedNeighborLists, useNeutronDistances = False, pr
               else:
                 fullName = (chain.id + ' ' + a.parent().resname.strip() + ' ' +
                   str(a.parent().parent().resseq_as_int()) + ' ' + a.name.strip())
-                #raise Sorry("Unrecognized specific H bond type for "+fullName+", got "+hb_type+"\n")
-                warnings += ("Unrecognized specific H bond type for "+fullName+", got "+hb_type+
-                             ": keeping default values\n")
+                warnings += ("Warning: Unrecognized specific H bond type for "+fullName+", got "+hb_type+
+                             ": keeping default value\n")
                 extras.setMappingFor(a, extra)
 
             except Exception as e:
               fullName = (chain.id + ' ' + a.parent().resname.strip() + ' ' +
                 str(a.parent().parent().resseq_as_int()) + ' ' + a.name.strip())
-              #raise Sorry("Could not find atom info for "+fullName+
-              #  " (perhaps interpretation was not run on the model?)\n"+
-              #  "  Exception: "+str(e))
-              warnings += ("Could not find atom info for "+fullName+
-                " (perhaps interpretation was not run on the model?): "+
-                "  Exception: "+str(e)+": keeping default values\n")
+              warnings += ("Warning: Could not find atom info for "+fullName+
+                " (perhaps interpretation was not run on the model?):"+
+                " keeping some default values\n")
               extras.setMappingFor(a, extra)
 
   return getExtraAtomInfoReturn(extras, warnings)

--- a/mmtbx/probe/Helpers.py
+++ b/mmtbx/probe/Helpers.py
@@ -379,85 +379,88 @@ def getExtraAtomInfo(model, bondedNeighborLists, useNeutronDistances = False, pr
           for a in ag.atoms():
             extra = probeExt.ExtraAtomInfo()
             try:
+              # Get the first non-blank character of the alternate for this atom.
+              # If there is none, set the value to the empty string.  If there is, set
+              # it to a string with just that character.
+              alt = a.parent().altloc.strip()
+              extra.altLoc = alt
+
+              extra.charge = probeExt.atom_charge(a)
+
+              # For ions, the Richardsons determined in discussion with
+              # Michael Prisant that we want to use the ionic radius rather than the
+              # larger radius for all purposes.
+              # @todo Once the CCTBX radius determination discussion and upgrade is
+              # complete (ongoing as of March 2022), this check might be removed
+              # and we'll just use the CCTBX radius.
+              extra.isIon = a.element_is_ion()
+              if extra.isIon:
+                extra.vdwRadius = model.get_specific_ion_radius(a.i_seq)
+                warnings += ("Using ionic radius for "+a.name.strip()+": "+str(extra.vdwRadius)+
+                              " (rather than "+
+                              str(model.get_specific_vdw_radius(a.i_seq, False))+
+                              ")\n")
+              else:
+                extra.vdwRadius = model.get_specific_vdw_radius(a.i_seq, False)
+
+              # Mark aromatic ring N and C atoms as acceptors as a hack to enable the
+              # ring itself to behave as an acceptor.
+              # @todo Remove this once we have a better way to model the ring itself
+              # as an acceptor, perhaps making it a cylinder or a sphere in the center
+              # of the ring.
+              if a.element in ['C','N']:
+                if AtomTypes.IsAromaticAcceptor(ag.resname, a.name):
+                  extra.isAcceptor = True
+                  warnings += "Marking "+a.name.strip()+" as an aromatic-ring acceptor\n"
+
+              # Mark Nitrogens that do not have an attached Hydrogen as acceptors.
+              # We only do this in HET atoms because CCTBX routines seem to be working
+              # properly in standard residues.
+              # We determine whether it is in a het atom by seeing if the residue name
+              # is in the amino-acid mapping structure.
+              if not a.parent().resname in iotbx.pdb.amino_acid_codes.one_letter_given_three_letter:
+                if a.element == 'N':
+                  # See if the atom has no Hydrogens covalently bonded to it.
+                  found = False
+                  for n in bondedNeighborLists[a]:
+                    if n.element_is_hydrogen():
+                      found = True
+                      break
+                  if not found and not extra.isAcceptor:
+                    extra.isAcceptor = True
+                    warnings += "Marking "+a.parent().resname.strip()+" "+a.name.strip()+" as a non-Hydrogen HET acceptor\n"
+
+              # Mark all Carbonyl's with the Probe radius while the Richardsons and
+              # the CCTBX decide how to handle this.
+              # @todo After 2021, see if the CCTBX has the same values (1.65 and 1.80)
+              # for Carbonyls and remove this if so.  It needs to stay with these values
+              # to avoid spurious collisions per experiments run by the Richardsons in
+              # September 2021.
+              if (a.name.strip().upper() == 'C'
+                  or AtomTypes.IsSpecialAminoAcidCarbonyl(a.parent().resname.strip().upper(),
+                      a.name.upper()) ):
+                expected = 1.65
+                if extra.vdwRadius != expected:
+                  warnings += ("Overriding radius for "+a.name.strip()+": "+str(expected)+
+                                " (was "+str(extra.vdwRadius)+")\n")
+                  extra.vdwRadius = expected
+
+              # If we've been asked to ensure polar hydrogen radius, do so here.
+              if probePhil.set_polar_hydrogen_radius and isPolarHydrogen(a, bondedNeighborLists):
+                if extra.vdwRadius != 1.05:
+                  warnings += ("Overriding radius for "+a.name.strip()+": 1.05 (was "+
+                                str(extra.vdwRadius)+")\n")
+                  extra.vdwRadius = 1.05
+
+              # Find the hydrogen-bond type for this atom.
+              # Do this after the above checks because it can fail for unknown HETs and we want to have
+              # filled in the rest of the information first.
               hb_type = model.get_specific_h_bond_type(a.i_seq)
               if hb_type in ['A', 'B', 'D', 'N', 'H']: #isinstance(hb_type, str):
                 if hb_type == "A" or hb_type == "B":
                   extra.isAcceptor = True
                 if hb_type == "D" or hb_type == "B":
                   extra.isDonor = True
-
-                # Get the first non-blank character of the alternate for this atom.
-                # If there is none, set the value to the empty string.  If there is, set
-                # it to a string with just that character.
-                alt = a.parent().altloc.strip()
-                extra.altLoc = alt
-
-                extra.charge = probeExt.atom_charge(a)
-
-                # For ions, the Richardsons determined in discussion with
-                # Michael Prisant that we want to use the ionic radius rather than the
-                # larger radius for all purposes.
-                # @todo Once the CCTBX radius determination discussion and upgrade is
-                # complete (ongoing as of March 2022), this check might be removed
-                # and we'll just use the CCTBX radius.
-                extra.isIon = a.element_is_ion()
-                if extra.isIon:
-                  extra.vdwRadius = model.get_specific_ion_radius(a.i_seq)
-                  warnings += ("Using ionic radius for "+a.name.strip()+": "+str(extra.vdwRadius)+
-                               " (rather than "+
-                               str(model.get_specific_vdw_radius(a.i_seq, False))+
-                               ")\n")
-                else:
-                  extra.vdwRadius = model.get_specific_vdw_radius(a.i_seq, False)
-
-                # Mark aromatic ring N and C atoms as acceptors as a hack to enable the
-                # ring itself to behave as an acceptor.
-                # @todo Remove this once we have a better way to model the ring itself
-                # as an acceptor, perhaps making it a cylinder or a sphere in the center
-                # of the ring.
-                if a.element in ['C','N']:
-                  if AtomTypes.IsAromaticAcceptor(ag.resname, a.name):
-                    extra.isAcceptor = True
-                    warnings += "Marking "+a.name.strip()+" as an aromatic-ring acceptor\n"
-
-                # Mark Nitrogens that do not have an attached Hydrogen as acceptors.
-                # We only do this in HET atoms because CCTBX routines seem to be working
-                # properly in standard residues.
-                # We determine whether it is in a het atom by seeing if the residue name
-                # is in the amino-acid mapping structure.
-                if not a.parent().resname in iotbx.pdb.amino_acid_codes.one_letter_given_three_letter:
-                  if a.element == 'N':
-                    # See if the atom has no Hydrogens covalently bonded to it.
-                    found = False
-                    for n in bondedNeighborLists[a]:
-                      if n.element_is_hydrogen():
-                        found = True
-                        break
-                    if not found and not extra.isAcceptor:
-                      extra.isAcceptor = True
-                      warnings += "Marking "+a.parent().resname.strip()+" "+a.name.strip()+" as a non-Hydrogen HET acceptor\n"
-
-                # Mark all Carbonyl's with the Probe radius while the Richardsons and
-                # the CCTBX decide how to handle this.
-                # @todo After 2021, see if the CCTBX has the same values (1.65 and 1.80)
-                # for Carbonyls and remove this if so.  It needs to stay with these values
-                # to avoid spurious collisions per experiments run by the Richardsons in
-                # September 2021.
-                if (a.name.strip().upper() == 'C'
-                    or AtomTypes.IsSpecialAminoAcidCarbonyl(a.parent().resname.strip().upper(),
-                        a.name.upper()) ):
-                  expected = 1.65
-                  if extra.vdwRadius != expected:
-                    warnings += ("Overriding radius for "+a.name.strip()+": "+str(expected)+
-                                 " (was "+str(extra.vdwRadius)+")\n")
-                    extra.vdwRadius = expected
-
-                # If we've been asked to ensure polar hydrogen radius, do so here.
-                if probePhil.set_polar_hydrogen_radius and isPolarHydrogen(a, bondedNeighborLists):
-                  if extra.vdwRadius != 1.05:
-                    warnings += ("Overriding radius for "+a.name.strip()+": 1.05 (was "+
-                                 str(extra.vdwRadius)+")\n")
-                    extra.vdwRadius = 1.05
 
                 extras.setMappingFor(a, extra)
 

--- a/mmtbx/probe/Helpers.py
+++ b/mmtbx/probe/Helpers.py
@@ -465,14 +465,21 @@ def getExtraAtomInfo(model, bondedNeighborLists, useNeutronDistances = False, pr
               else:
                 fullName = (chain.id + ' ' + a.parent().resname.strip() + ' ' +
                   str(a.parent().parent().resseq_as_int()) + ' ' + a.name.strip())
-                raise Sorry("Unrecognized specific H bond type for "+fullName+", got "+hb_type+"\n")
+                #raise Sorry("Unrecognized specific H bond type for "+fullName+", got "+hb_type+"\n")
+                warnings += ("Unrecognized specific H bond type for "+fullName+", got "+hb_type+
+                             ": keeping default values\n")
+                extras.setMappingFor(a, extra)
 
             except Exception as e:
               fullName = (chain.id + ' ' + a.parent().resname.strip() + ' ' +
                 str(a.parent().parent().resseq_as_int()) + ' ' + a.name.strip())
-              raise Sorry("Could not find atom info for "+fullName+
-                " (perhaps interpretation was not run on the model?)\n"+
-                "  Exception: "+str(e))
+              #raise Sorry("Could not find atom info for "+fullName+
+              #  " (perhaps interpretation was not run on the model?)\n"+
+              #  "  Exception: "+str(e))
+              warnings += ("Could not find atom info for "+fullName+
+                " (perhaps interpretation was not run on the model?): "+
+                "  Exception: "+str(e)+": keeping default values\n")
+              extras.setMappingFor(a, extra)
 
   return getExtraAtomInfoReturn(extras, warnings)
 

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -1040,7 +1040,7 @@ NOTES:
       use_neutron_distances=self.params.use_neutron_distances,
       n_terminal_charge=self.params.n_terminal_charge,
       exclude_water=True,
-      stop_for_unknowns=False,
+      stop_for_unknowns=self.params.stop_on_any_missing_hydrogen,
       keep_existing_H=self.params.keep_existing_H
     )
     reduce_add_h_obj.run()
@@ -1079,7 +1079,7 @@ NOTES:
     # by Hydrogen placement will have flipped them, so we don't need to do it again.
     p.pdb_interpretation.flip_symmetric_amino_acids=False
     #p.pdb_interpretation.sort_atoms=True
-    self.model.set_stop_for_unknowns(False)
+    self.model.set_stop_for_unknowns(self.params.stop_on_any_missing_hydrogen)
     self.model.process(make_restraints=make_restraints, pdb_interpretation_params=p)
 
 # ------------------------------------------------------------------------------
@@ -1222,7 +1222,7 @@ NOTES:
     # Use model function to set crystal symmetry if necessary 2025-03-19 TT
     self.model.add_crystal_symmetry_if_necessary()
     if self.data_manager.has_restraints():
-      self.model.set_stop_for_unknowns(False)
+      self.model.set_stop_for_unknowns(self.params.stop_on_any_missing_hydrogen)
       self.model.process(make_restraints=False)
 
     # If we've been asked to only to a single model index from the file, strip the model down to

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -1277,6 +1277,9 @@ NOTES:
         fillAtomDump = self.params.output.print_atom_info)
       doneOpt = time.time()
       warnings = opt.getWarnings()
+      # Find the lines from warnings that start with "Warning: " and
+      # concatenate them into a single string.
+      warnings = '\n'.join([line for line in warnings.split('\n') if line.startswith('Warning:')])
       if len(warnings) > 0:
         print('\nWarnings during optimization:\n'+warnings, file=self.logger)
       outString += opt.getInfo()

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -1276,6 +1276,9 @@ NOTES:
         cliqueOutlineFileName=self.params.output.clique_outline_file_name,
         fillAtomDump = self.params.output.print_atom_info)
       doneOpt = time.time()
+      warnings = opt.getWarnings()
+      if len(warnings) > 0:
+        print('\nWarnings during optimization:\n'+warnings, file=self.logger)
       outString += opt.getInfo()
       outString += 'Time to Add Hydrogen = {:.3f} sec'.format(doneAdd-startAdd)+'\n'
       outString += 'Time to Optimize = {:.3f} sec'.format(doneOpt-startOpt)+'\n'

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -34,7 +34,7 @@ import copy
 from iotbx.data_manager import DataManager
 import csv
 
-version = "2.12.0"
+version = "2.13.0"
 
 master_phil_str = '''
 approach = *add remove
@@ -1079,6 +1079,7 @@ NOTES:
     # by Hydrogen placement will have flipped them, so we don't need to do it again.
     p.pdb_interpretation.flip_symmetric_amino_acids=False
     #p.pdb_interpretation.sort_atoms=True
+    self.model.set_stop_for_unknowns(False)
     self.model.process(make_restraints=make_restraints, pdb_interpretation_params=p)
 
 # ------------------------------------------------------------------------------

--- a/mmtbx/reduce/Optimizers.py
+++ b/mmtbx/reduce/Optimizers.py
@@ -243,6 +243,7 @@ class Optimizer(object):
     ################################################################################
     # Initialize internal variables.
     self._infoString = ""
+    self._warningString = ""
     self._atomDump = ""
     self._waterOccCutoff = 0.66 # @todo Make this a parameter, -WaterOCCcutoff param in reduce
     self._waterBCutoff = 40.0   # @todo Make this a parameter, -WaterBcutoff param in reduce
@@ -278,6 +279,7 @@ class Optimizer(object):
     self._extraAtomInfo = ret.extraAtomInfo
     self._infoString += ret.warnings
     self._infoString += _ReportTiming(self._verbosity, "get extra atom info")
+    self._warningString += ret.warnings
 
     ################################################################################
     # Run optimization for every desired conformer and every desired model, calling
@@ -756,6 +758,18 @@ class Optimizer(object):
     """
     ret = self._infoString
     self._infoString = ""
+    return ret
+
+  def getWarnings(self):
+    """
+      Returns warnings that the user may care about regarding the processing.
+      :return: the information so far collected in the string.  Calling this method also clears
+      the information, so that later calls will not repeat it.
+      If the object was constructed with fillAtomDump = False, then the atom dump will always be
+      empty.
+    """
+    ret = self._warningString
+    self._warningString = ""
     return ret
 
   def getAtomDump(self):


### PR DESCRIPTION
Has reduce2 continuing to run with default values for atoms whose hydrogen-bonding status or other characteristics cannot be determined (unknown HET groups). This enables reduce2 to run on a wider range of models with the goal of running on all models in the PDB and corner cases.

Prints all of the warnings on the console and the description output with Warning: prefixed to indicate the problems to the person running it.