### PR TITLE
fit trusted range into int32

### DIFF
--- a/simtbx/nanoBragg/__init__.py
+++ b/simtbx/nanoBragg/__init__.py
@@ -238,7 +238,7 @@ class _():
                      'px_mm_strategy': {'type': 'SimplePxMmStrategy'},
                      'raw_image_offset': (0, 0),
                      'thickness': 0.00001,  # TODO
-                     'trusted_range': (-1e3, 1e10),  # TODO
+                     'trusted_range': (-1e3, 1e9),  # TODO
                      'type': ''}]}
     detector = DetectorFactory.from_dict(det_descr)
     return detector


### PR DESCRIPTION
See this test failure:
```
    Traceback (most recent call last):
      File "/__w/1/modules/cctbx_project/simtbx/nanoBragg/tst_gauss_argchk.py", line 234, in <module>
        SIM.to_nexus_nxmx("test_full_001.h5", intfile_scale=output_scale)
      File "/__w/1/modules/cctbx_project/simtbx/nanoBragg/__init__.py", line 368, in to_nexus_nxmx
        writer(imageset=self.imageset)
      File "/__w/1/modules/dxtbx/src/dxtbx/format/nxmx_writer.py", line 202, in __call__
        self.construct_detector()
      File "/__w/1/modules/dxtbx/src/dxtbx/format/nxmx_writer.py", line 424, in construct_detector
        det.create_dataset("saturation_value", (1,), data=[trusted_max], dtype="int32")
      File "/__w/1/miniforge/envs/py311/lib/python3.11/site-packages/h5py/_hl/group.py", line 186, in create_dataset
        dsid = dataset.make_new_dset(group, shape, dtype, data, name, **kwds)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/__w/1/miniforge/envs/py311/lib/python3.11/site-packages/h5py/_hl/dataset.py", line 48, in make_new_dset
        data = array_for_new_object(data, specified_dtype=dtype)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/__w/1/miniforge/envs/py311/lib/python3.11/site-packages/h5py/_hl/base.py", line 121, in array_for_new_object
        data = np.asarray(data, order="C", dtype=as_dtype)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    OverflowError: Python integer 10000000000 out of bounds for int32
```

I don't see why it has ever been possible to write a default NanoBragg detector to nxmx, because the max trusted value has always been 1e10 and this `saturation_value` entry has always had dtype int32. It looks like 1e10 was a bit of a placeholder anyway, so I hope this change is of no consequence.