### PR TITLE
`xfel.merge`: import from `dials.algorithms.symmetry` not `dials.command_line.symmetry`

### DIFF
--- a/xfel/merging/application/modify/aux_cosym.py
+++ b/xfel/merging/application/modify/aux_cosym.py
@@ -174,7 +174,7 @@ class CosymAnalysis(BaseClass):
 from dials.command_line.cosym import logger
 from dials.command_line.cosym import cosym as dials_cl_cosym_wrapper
 from dials.util.exclude_images import get_selection_for_valid_image_ranges
-from dials.command_line.symmetry import (
+from dials.algorithms.symmetry import (
     apply_change_of_basis_ops,
     change_of_basis_ops_to_minimum_cell,
     eliminate_sys_absent,


### PR DESCRIPTION
Following code location move in dials/dials#3013