### PR TITLE
XFEL GUI: support psana2 in joint refinement

### DIFF
--- a/xfel/merging/application/balance/load_balancer.py
+++ b/xfel/merging/application/balance/load_balancer.py
@@ -35,6 +35,8 @@ class load_balancer(worker):
     else:
       expt_counts_by_rank = None
 
+    if not self.check_psana2(): return experiments, reflections
+
     if self.params.input.parallel_file_load.balance == "global1":
       new_experiments, new_reflections = self.distribute_over_ranks_shuffle(experiments, reflections, self.mpi_helper.comm, self.mpi_helper.size)
     elif self.params.input.parallel_file_load.balance == "global2":
@@ -53,7 +55,7 @@ class load_balancer(worker):
 
     # Do we have any data?
     from xfel.merging.application.utils.data_counter import data_counter
-    data_counter(self.params).count(new_experiments, new_reflections)
+    data_counter(self.params, mpi_helper = self.mpi_helper, mpi_logger = self.logger).count(new_experiments, new_reflections)
 
     return new_experiments, new_reflections
 

--- a/xfel/merging/application/input/file_loader.py
+++ b/xfel/merging/application/input/file_loader.py
@@ -111,6 +111,8 @@ class simple_file_loader(worker):
       starting_refls_count = len(all_reflections)
     self.logger.log("Initial number of experiments: %d; Initial number of reflections: %d"%(starting_expts_count, starting_refls_count))
 
+    if not self.check_psana2(): return all_experiments, all_reflections
+
     # Generate and send a list of file paths to each worker
     if self.mpi_helper.rank == 0:
       file_list = list_input_pairs(self.params)
@@ -208,7 +210,7 @@ class simple_file_loader(worker):
 
     # Do we have any data?
     from xfel.merging.application.utils.data_counter import data_counter
-    data_counter(self.params).count(all_experiments, all_reflections)
+    data_counter(self.params, mpi_helper = self.mpi_helper, mpi_logger = self.logger).count(all_experiments, all_reflections)
     return all_experiments, all_reflections
 
   def prune_reflection_table_keys(self, reflections):

--- a/xfel/merging/application/integrate/integrate.py
+++ b/xfel/merging/application/integrate/integrate.py
@@ -34,6 +34,16 @@ class integrate(worker):
     all_integrated_refls = None
     current_imageset = None
     current_imageset_path = None
+
+    if self.params.mp.psana2_mode:
+      self.check_psana2(split_comm=False)
+      paths_ = list(set([p for iset in experiments.imagesets() for p in iset.paths()]))
+      paths = list(set([p for plist in self.mpi_helper.comm.allgather(paths_) for p in plist]))
+      assert len(paths) == 1
+
+      current_imageset_path = paths[0]
+      current_imageset = ImageSetFactory.make_imageset([current_imageset_path])
+
     for expt_id, expt in enumerate(experiments):
       assert len(expt.imageset.paths()) == 1 and len(expt.imageset) == 1
       self.logger.log("Starting integration experiment %d"%expt_id)

--- a/xfel/merging/application/mpi_helper.py
+++ b/xfel/merging/application/mpi_helper.py
@@ -53,8 +53,9 @@ class mpi_helper(object):
   def time(self):
     return self.MPI.Wtime()
 
-  def finalize(self):
-    self.MPI.Finalize()
+  def finalize(self, mpi_finalize = True):
+    if mpi_finalize:
+      self.MPI.Finalize()
 
   def cumulative_flex(self, flex_array, flex_type=None, root=0):
     """

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -109,6 +109,9 @@ mp {
       .type = bool
       .help = Enable code profiling. Use (for example) runsnake to visualize processing performance
   }
+  psana2_mode = False
+    .type = bool
+    .help = Needed when using the integrate worker with psana2/XTC2 data
 }
 """
 

--- a/xfel/merging/command_line/merge.py
+++ b/xfel/merging/command_line/merge.py
@@ -47,7 +47,7 @@ class Script(object):
     self.mpi_logger = mpi_logger()
 
   def __del__(self):
-    self.mpi_helper.finalize()
+    self.mpi_helper.finalize(mpi_finalize = not self.params.mp.psana2_mode)
 
   def parse_input(self, args=None):
     '''Parse input at rank 0 and broadcast the input parameters and options to all ranks'''

--- a/xfel/ui/db/job.py
+++ b/xfel/ui/db/job.py
@@ -627,6 +627,12 @@ class EnsembleRefinementJob(Job):
     path = get_run_path(self.app.params.output_folder, self.trial, self.rungroup, self.run, self.task)
     os.mkdir(path)
 
+    if self.app.params.facility.name == 'lcls':
+      import psana
+      psana2_mode = getattr(psana, 'xtc_version', None) == 2
+    else:
+      psana2_mode = False
+
     arguments = """
     mp.queue={}
     mp.nnodes={}
@@ -658,6 +664,7 @@ class EnsembleRefinementJob(Job):
     striping.dry_run=True
     striping.output_folder={}
     reintegration.integration.lookup.mask={}
+    reintegration.mp.psana2_mode={}
     mp.local.include_mp_in_command=False
     """.format(self.app.params.mp.queue if len(self.app.params.mp.queue) > 0 else None,
                self.app.params.mp.nnodes_tder or self.app.params.mp.nnodes,
@@ -685,6 +692,7 @@ class EnsembleRefinementJob(Job):
                target_phil_path,
                path,
                self.rungroup.untrusted_pixel_mask_path,
+               psana2_mode,
                ).split('\n')
     arguments = [arg.strip() for arg in arguments]
 


### PR DESCRIPTION
Psana2 uses MPI ranks 0 and 1, so this PR adds a new parameter, mp.psana2_mode=False, that when True, accounts for those ranks not being available.  This is only relevant for mpi_integrate, which is used during time dependent ensemble refinement.

The PR splits the MPI communicator in two, isolating ranks 0 and 1 during the input and balance steps, then brings them back for the integrate step.  Since psana2 needs to start on all ranks, the imageset path is broadcast to all ranks and loaded, but only used on ranks 2+.