### PR TITLE
Predict more spots on stills, gather more signal.

### DIFF
--- a/xfel/merging/application/integrate/integrate.py
+++ b/xfel/merging/application/integrate/integrate.py
@@ -47,6 +47,14 @@ class integrate(worker):
     for expt_id, expt in enumerate(experiments):
       assert len(expt.imageset.paths()) == 1 and len(expt.imageset) == 1
       self.logger.log("Starting integration experiment %d"%expt_id)
+      if self.params.integration.recruitment.expand_nave_parameters: # NKS request predictions on larger envelope
+        eta = expt.crystal.get_half_mosaicity_deg()
+        deff = expt.crystal.get_domain_size_ang()
+        factor = self.params.integration.recruitment.expansion_factor
+        expt.crystal.set_domain_size_ang(deff/factor)
+        expt.crystal.set_half_mosaicity_deg(eta*factor)
+        self.logger.log("Expand focus experiment, half_mosaicity_deg=%8f-->%8f domain_size_ang=%.0f-->%.0f"%(
+          eta,expt.crystal.get_half_mosaicity_deg(),deff,expt.crystal.get_domain_size_ang()))
       refls = reflections.select(reflections['id'] == expt_id)
       if expt.imageset.paths()[0] != current_imageset_path:
         current_imageset_path = expt.imageset.paths()[0]
@@ -63,6 +71,40 @@ class integrate(worker):
       except RuntimeError:
         self.logger.log("Error integrating expt %d"%expt_id)
         continue
+
+      if self.params.integration.recruitment.expand_nave_parameters: # NKS Nave params on I/sigma spots, reapply envelope
+        import math
+        d_spacing = expt.crystal.get_unit_cell().d(integrated["miller_index"])
+        isigma3 = (integrated["intensity.sum.value"]/flex.sqrt(integrated["intensity.sum.variance"])
+                   )>self.params.integration.recruitment.significance_cutoff
+        from serialtbx.mono_simulation.max_like import minimizer
+        try:
+          M = minimizer(
+                d_i=d_spacing.select(isigma3),
+                psi_i=integrated['delpsical.rad'].select(isigma3),
+                eta_rad=(math.pi/180.) * (2.*expt.crystal.get_half_mosaicity_deg()),
+                Deff=expt.crystal.get_domain_size_ang(),
+          )
+          new_half_mosaicity_deg = M.x[1] * 180.0 / (2.0 * math.pi)
+          new_domain_size_ang = 2.0 / M.x[0]
+          self.logger.log("  Refit Nave on 3 sigma, half_mosaicity_deg=%8f domain_size_ang=%.0f"%(
+          new_half_mosaicity_deg,new_domain_size_ang))
+          expt.crystal.set_half_mosaicity_deg(new_half_mosaicity_deg)
+          expt.crystal.set_domain_size_ang(new_domain_size_ang)
+          permitted_psi_envelope_rad = ((d_spacing/new_domain_size_ang) + (new_half_mosaicity_deg * math.pi/180.))
+          accepted = flex.abs(integrated['delpsical.rad']) <= permitted_psi_envelope_rad
+          integrated = integrated.select(accepted)
+
+        except Exception as e:
+          self.logger.log("Recovering "+str(e))
+          expt.crystal.set_domain_size_ang(deff)
+          expt.crystal.set_half_mosaicity_deg(eta)
+          integrated = processor.integrate(experiments[expt_id:expt_id+1], refls)
+          try:
+            integrated = processor.integrate(experiments[expt_id:expt_id+1], refls)
+          except RuntimeError:
+            self.logger.log("Error integrating expt %d"%expt_id)
+            continue
 
       all_integrated_expts.append(expt)
       if all_integrated_refls:

--- a/xfel/merging/command_line/mpi_integrate.py
+++ b/xfel/merging/command_line/mpi_integrate.py
@@ -53,6 +53,20 @@ integrate_phil_str = '''
         .help = "Override the panel trusted range (underload and saturation) during integration."
         .short_caption = "Panel trusted range"
     }
+    recruitment {
+      expand_nave_parameters = False
+        .type = bool
+        .help = For stills integration, post time-dependent re-refinement,
+        .help = Expand the Nave-parameter envelope used to predict spots, in order to capture more signal.
+      expansion_factor = 2.0
+        .type = float
+        .help = apply this expansion of the current trumpet plot, note that the stills_process application
+        .help = already encodes an expansion-factor of 1.4 at the indexing step, this is on top of that.
+      significance_cutoff = 2.0
+        .type = float
+        .help = Once the expanded predictions are integrated, re-determine the Nave parameters, but instead of
+        .help = fitting on spotfinder spots, fit on integrated I/sigma spots with this cutoff.
+    }
   }
 
   output {


### PR DESCRIPTION
For stills integration, after the time-dependent ensemble refinement, we reintegrate the data in the cctbx.xfel.mpi_integrate program.  Here, allow the option of expanding the Nave-parameter envelope that is used to predict spots, in order to capture more signal. Dramatically increase the overall multiplicity, possibly by a factor of 1.5. Use this phil parameter to activate this feature:
integration.recruitment.expand_nave_parameters=True

XFEL group is invited to compare before/after merging logs on Perlmutter:
cd /global/cfs/cdirs/lcls/sauter/LY99/mfx101080424/redoscamerge
vimdiff 42915231/*main* 44977789/*main*