### PR TITLE
Fix MySQL 9 compatibility in cctbx.xfel

### DIFF
--- a/xfel/conda_envs/psana_environment.yml
+++ b/xfel/conda_envs/psana_environment.yml
@@ -76,7 +76,7 @@ dependencies:
  - PyRTF
 
  # xfel gui
- - mysql=8
+ - mysql
  - mysqlclient
  - pydrive2
 

--- a/xfel/ui/db/schema.sql
+++ b/xfel/ui/db/schema.sql
@@ -14,7 +14,7 @@ SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';
 -- -----------------------------------------------------
 -- Schema mydb
 -- -----------------------------------------------------
-CREATE SCHEMA IF NOT EXISTS `mydb` DEFAULT CHARACTER SET utf8 ;
+CREATE SCHEMA IF NOT EXISTS `mydb` DEFAULT CHARACTER SET utf8mb4 ;
 USE `mydb` ;
 
 -- -----------------------------------------------------
@@ -170,6 +170,7 @@ CREATE TABLE IF NOT EXISTS `mydb`.`event` (
   `two_theta_low` DOUBLE NULL,
   `two_theta_high` DOUBLE NULL,
   PRIMARY KEY (`id`, `run_id`, `trial_id`, `rungroup_id`),
+  UNIQUE INDEX `id_run_id_UNIQUE` (`id` ASC, `run_id` ASC),
   INDEX `fk_event_run1_idx` (`run_id` ASC),
   INDEX `fk_event_trial1_idx` (`trial_id` ASC),
   INDEX `fk_event_rungroup1_idx` (`rungroup_id` ASC),
@@ -199,6 +200,7 @@ CREATE TABLE IF NOT EXISTS `mydb`.`isoform` (
   `name` VARCHAR(45) NOT NULL,
   `trial_id` INT NOT NULL,
   PRIMARY KEY (`id`, `trial_id`),
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC),
   INDEX `fk_isoform_trial1_idx` (`trial_id` ASC),
   CONSTRAINT `fk_isoform_trial1`
     FOREIGN KEY (`trial_id`)
@@ -261,6 +263,7 @@ CREATE TABLE IF NOT EXISTS `mydb`.`bin` (
   `total_hkl` INT NULL,
   `cell_id` INT NOT NULL,
   PRIMARY KEY (`id`, `cell_id`),
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC),
   INDEX `fk_bin_cell1_idx` (`cell_id` ASC),
   CONSTRAINT `fk_bin_cell1`
     FOREIGN KEY (`cell_id`)
@@ -289,6 +292,7 @@ CREATE TABLE IF NOT EXISTS `mydb`.`crystal` (
   `ewald_proximal_volume` DOUBLE NULL,
   `cell_id` INT NOT NULL,
   PRIMARY KEY (`id`, `cell_id`),
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC),
   INDEX `fk_crystal_cell1_idx` (`cell_id` ASC),
   CONSTRAINT `fk_crystal_cell1`
     FOREIGN KEY (`cell_id`)
@@ -492,6 +496,7 @@ CREATE TABLE IF NOT EXISTS `mydb`.`dataset_version` (
   `dataset_id` INT NOT NULL,
   `version` INT NOT NULL,
   PRIMARY KEY (`id`, `dataset_id`),
+  UNIQUE INDEX `id_UNIQUE` (`id` ASC),
   INDEX `fk_dataset_version_dataset1_idx` (`dataset_id` ASC),
   CONSTRAINT `fk_dataset_version_dataset1`
     FOREIGN KEY (`dataset_id`)

--- a/xfel/xpp/experiment_schema.sql
+++ b/xfel/xpp/experiment_schema.sql
@@ -14,7 +14,7 @@ SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';
 -- -----------------------------------------------------
 -- Schema mydb
 -- -----------------------------------------------------
-CREATE SCHEMA IF NOT EXISTS `mydb` DEFAULT CHARACTER SET utf8 ;
+CREATE SCHEMA IF NOT EXISTS `mydb` DEFAULT CHARACTER SET utf8mb4 ;
 USE `mydb` ;
 
 -- -----------------------------------------------------
@@ -147,6 +147,7 @@ CREATE TABLE IF NOT EXISTS `mydb`.`hkls` (
   `l` INT NOT NULL,
   `isoforms_isoform_id` INT NOT NULL,
   PRIMARY KEY (`hkl_id`, `isoforms_isoform_id`),
+  UNIQUE INDEX `hkl_id_UNIQUE` (`hkl_id` ASC),
   INDEX `fk_hkls_isoforms1_idx` (`isoforms_isoform_id` ASC),
   CONSTRAINT `fk_hkls_isoforms1`
     FOREIGN KEY (`isoforms_isoform_id`)
@@ -192,6 +193,7 @@ CREATE TABLE IF NOT EXISTS `mydb`.`frames` (
   `isoforms_isoform_id` INT NOT NULL,
   `runs_run_id` INT NOT NULL,
   PRIMARY KEY (`frame_id`, `rungroups_id`, `trials_id`, `isoforms_isoform_id`, `runs_run_id`),
+  UNIQUE INDEX `frame_id_rungroups_trials_UNIQUE` (`frame_id` ASC, `rungroups_id` ASC, `trials_id` ASC),
   INDEX `fk_frames_rungroups1_idx` (`rungroups_id` ASC),
   INDEX `fk_frames_trials1_idx` (`trials_id` ASC),
   INDEX `fk_frames_isoforms1_idx` (`isoforms_isoform_id` ASC),


### PR DESCRIPTION
MySQL 9 removed the default_authentication_plugin server variable, the SUPER privilege, and deprecated symbolic-links, breaking cctbx.xfel.ui_server database initialization. MySQL 9 also enforces stricter foreign key validation, requiring explicit unique indexes on referenced columns that are a subset of a composite primary key.

- Remove symbolic-links and default_authentication_plugin from my.cnf template (unnecessary since MySQL 8.0, unknown variable in MySQL 9)
- Add version-aware privilege grant: GRANT SYSTEM_VARIABLES_ADMIN for MySQL 9+, UPDATE mysql.user Super_Priv for MySQL 8
- Add UNIQUE INDEX to tables with composite PKs referenced by FKs: isoform, event, bin, crystal, dataset_version (schema.sql) and hkls, frames (experiment_schema.sql)
- Update schema charset from utf8 to utf8mb4
- Unpin mysql=8 in psana_environment.yml