### PR TITLE
Make the mm24 algorithm default

### DIFF
--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -533,7 +533,7 @@ merging {
     .type = int(value_min=2)
     .help = If defined, merged structure factors not produced for the Miller indices below this threshold.
   error {
-    model = ha14 *ev11 mm24 errors_from_sample_residuals
+    model = ha14 ev11 *mm24 errors_from_sample_residuals
       .type = choice
       .multiple = False
       .help = ha14, formerly sdfac_auto, apply sdfac to each-image data assuming negative


### PR DESCRIPTION
This edit switches the default error model for reflection intensities from ev11 to mm24.