### PR TITLE
Niggli reduction c++

### DIFF
--- a/cctbx/regression/tst_krivy_gruber.py
+++ b/cctbx/regression/tst_krivy_gruber.py
@@ -117,7 +117,8 @@ def do_reduce(inp):
   if (relative_epsilon is None):
     assert check_is_niggli_cell(red_cell).itva_is_niggli_cell()
   # Cross-check: verify C++ niggli_reduction gives identical results to Python.
-  cpp_red = inp.niggli_reduction(relative_epsilon=relative_epsilon or 1.e-5)
+  cpp_red = inp.niggli_reduction(
+    relative_epsilon=1.e-5 if relative_epsilon is None else relative_epsilon)
   assert cpp_red.as_unit_cell().is_similar_to(red_cell), \
     "C++ niggli cell differs from Python: %s vs %s" % (
       cpp_red.as_unit_cell(), red_cell)

--- a/cctbx/regression/tst_krivy_gruber.py
+++ b/cctbx/regression/tst_krivy_gruber.py
@@ -116,6 +116,15 @@ def do_reduce(inp):
   assert inp.change_basis(red.r_inv().elems).is_similar_to(red_cell)
   if (relative_epsilon is None):
     assert check_is_niggli_cell(red_cell).itva_is_niggli_cell()
+  # Cross-check: verify C++ niggli_reduction gives identical results to Python.
+  cpp_red = inp.niggli_reduction(relative_epsilon=relative_epsilon or 1.e-5)
+  assert cpp_red.as_unit_cell().is_similar_to(red_cell), \
+    "C++ niggli cell differs from Python: %s vs %s" % (
+      cpp_red.as_unit_cell(), red_cell)
+  assert cpp_red.r_inv().elems == red.r_inv().elems, \
+    "C++ r_inv differs from Python: %s vs %s" % (
+      cpp_red.r_inv().elems, red.r_inv().elems)
+  assert inp.change_basis(cpp_red.r_inv().elems).is_similar_to(red_cell)
   time_gruber_1973.start()
   gruber_reduction = gruber_1973.reduction(
     inp, relative_epsilon=relative_epsilon)

--- a/cctbx/regression/tst_niggli_reduction_cpp.py
+++ b/cctbx/regression/tst_niggli_reduction_cpp.py
@@ -1,0 +1,272 @@
+"""Comprehensive comparison of C++ niggli_reduction vs Python krivy_gruber_1976.
+
+Verifies that every public method on the C++ result (via
+cpp_niggli_reduction_result) matches the Python reference implementation
+for a wide range of unit cells.
+"""
+from __future__ import absolute_import, division, print_function
+from cctbx.uctbx import krivy_gruber_1976
+from cctbx.uctbx.reduction_base import iteration_limit_exceeded
+from cctbx import uctbx
+from libtbx.test_utils import Exception_expected
+import sys
+
+def ucgmx(gruber_matrix):
+  (a,b,c,d,e,f) = gruber_matrix
+  return uctbx.unit_cell(metrical_matrix=(a,b,c,f/2.,e/2.,d/2.))
+
+def compare_reductions(unit_cell, relative_epsilon=None):
+  """Compare all public methods between Python and C++ niggli reduction."""
+  py_red = krivy_gruber_1976.reduction(
+    unit_cell, relative_epsilon=relative_epsilon)
+  cpp_red = unit_cell.niggli_reduction(relative_epsilon=relative_epsilon)
+
+  # Reduced cell (exact: both construct unit_cell from identical G6 values
+  # via the same C++ unit_cell(metrical_matrix=...) constructor)
+  assert cpp_red.as_unit_cell().parameters() == \
+    py_red.as_unit_cell().parameters(), \
+    "as_unit_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.as_unit_cell().parameters(), py_red.as_unit_cell().parameters())
+
+  # Change-of-basis matrix (exact integer comparison)
+  assert cpp_red.r_inv().elems == py_red.r_inv().elems, \
+    "r_inv() mismatch: C++ %s vs Python %s" % (
+      cpp_red.r_inv().elems, py_red.r_inv().elems)
+
+  # Iteration count
+  assert cpp_red.n_iterations() == py_red.n_iterations(), \
+    "n_iterations() mismatch: C++ %d vs Python %d" % (
+      cpp_red.n_iterations(), py_red.n_iterations())
+
+  # Analysis methods from gruber_parameterization
+  assert cpp_red.is_niggli_cell() == py_red.is_niggli_cell(), \
+    "is_niggli_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.is_niggli_cell(), py_red.is_niggli_cell())
+
+  assert cpp_red.is_buerger_cell() == py_red.is_buerger_cell(), \
+    "is_buerger_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.is_buerger_cell(), py_red.is_buerger_cell())
+
+  assert cpp_red.type() == py_red.type(), \
+    "type() mismatch: C++ %s vs Python %s" % (
+      cpp_red.type(), py_red.type())
+
+  assert cpp_red.meets_main_conditions() == py_red.meets_main_conditions(), \
+    "meets_main_conditions() mismatch: C++ %s vs Python %s" % (
+      cpp_red.meets_main_conditions(), py_red.meets_main_conditions())
+
+  # change_of_basis_op
+  cpp_cbop = cpp_red.change_of_basis_op()
+  py_cbop = py_red.change_of_basis_op()
+  assert cpp_cbop.c().r().as_double() == py_cbop.c().r().as_double(), \
+    "change_of_basis_op() rotation mismatch: C++ %s vs Python %s" % (
+      cpp_cbop.c().r().as_double(), py_cbop.c().r().as_double())
+  assert cpp_cbop.c().t().as_double() == py_cbop.c().t().as_double(), \
+    "change_of_basis_op() translation mismatch: C++ %s vs Python %s" % (
+      cpp_cbop.c().t().as_double(), py_cbop.c().t().as_double())
+
+  # Verify the change_of_basis_op actually works (tolerance-based because
+  # change_basis reconstructs the cell through a different arithmetic path)
+  assert unit_cell.change_basis(cpp_cbop).is_similar_to(
+    cpp_red.as_unit_cell()), \
+    "change_of_basis_op does not transform to reduced cell"
+
+def exercise_textbook_examples():
+  # Gruber 1973 example
+  cells = [
+    ucgmx((4,136,76,-155,-31,44)),   # start
+    ucgmx((4,16,16,-16,-1,-3)),      # buerger
+    ucgmx((4,16,16,16,3,4)),         # niggli (already reduced)
+  ]
+  for uc in cells:
+    compare_reductions(uc)
+
+  # Krivy-Gruber 1976 example
+  cells = [
+    ucgmx((9,27,4,-5,-4,-22)),       # start
+    ucgmx((4,9,9,-8,-1,-4)),         # intermediate buerger
+    ucgmx((4,9,9,9,1,4)),            # intermediate buerger
+    ucgmx((4,9,9,9,3,4)),            # niggli (already reduced)
+  ]
+  for uc in cells:
+    compare_reductions(uc)
+
+def exercise_problem_parameters():
+  problem_parameters = (
+    (13.892443989449804, 13.892443989449804, 14.7648230602334,
+     61.936000954634402, 61.936000954634402, 88.515487291567879),
+    (10.0, 10.0, 20.0,
+     90.0, 45.0, 120.0),
+    (10.0, 20.0, 30.0,
+     120.0, 60.0, 120.0),
+    (10.816653826391969, 13.820274961085254, 13.820274961085254,
+     60.0, 66.962544368849834, 66.962544368849834),
+    (10.148891565092219, 13.379088160259652, 13.379088160259652,
+     107.33461190548745, 107.94415159713115, 109.72759194290299),
+    (19.798989873223331, 231.21851136965654, 14.352700094407323,
+     133.37207519042573, 92.016673840743408, 134.55815348093702),
+    (10.392304845413264, 13.19090595827292, 13.19090595827292,
+     112.64730819498385, 104.36056979415913, 106.96527532101391),
+    (16.046806535881213, 13.341664064126334, 197.64614845728718,
+     153.28759931491018, 114.05435960569044, 92.543256980798247),
+    (10.488088481701515, 13.820274961085254, 13.820274961085254,
+     109.9226012907464, 104.00699650533103, 110.31922490992999),
+    (10.04987562112089, 13.19090595827292, 13.19090595827292,
+     118.05419482122835, 97.404049814230376, 106.92070123011929),
+    (10.04987562112089, 13.45362404707371, 13.45362404707371,
+     109.02416163919622, 105.88181549565937, 109.44017310001107),
+    (11.357816691600547, 13.638181696985853, 13.638181696985855,
+     115.81608733396159, 104.29612977641231, 104.29612977641233),
+    (11.832159566199232, 13.784048752090222, 13.784048752090222,
+     110.67521616123457, 104.95317005195066, 110.01926787579129))
+  for parameters in problem_parameters:
+    compare_reductions(uctbx.unit_cell(parameters))
+
+def compare_reductions_with_limit(unit_cell, iteration_limit,
+                                  relative_epsilon=None):
+  """Like compare_reductions but with an explicit iteration_limit."""
+  py_red = krivy_gruber_1976.reduction(
+    unit_cell, relative_epsilon=relative_epsilon,
+    iteration_limit=iteration_limit)
+  cpp_red = unit_cell.niggli_reduction(
+    relative_epsilon=relative_epsilon, iteration_limit=iteration_limit)
+
+  assert cpp_red.as_unit_cell().parameters() == \
+    py_red.as_unit_cell().parameters(), \
+    "as_unit_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.as_unit_cell().parameters(), py_red.as_unit_cell().parameters())
+  assert cpp_red.r_inv().elems == py_red.r_inv().elems, \
+    "r_inv() mismatch: C++ %s vs Python %s" % (
+      cpp_red.r_inv().elems, py_red.r_inv().elems)
+  assert cpp_red.n_iterations() == py_red.n_iterations(), \
+    "n_iterations() mismatch: C++ %d vs Python %d" % (
+      cpp_red.n_iterations(), py_red.n_iterations())
+  assert cpp_red.is_niggli_cell() == py_red.is_niggli_cell(), \
+    "is_niggli_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.is_niggli_cell(), py_red.is_niggli_cell())
+  assert cpp_red.type() == py_red.type(), \
+    "type() mismatch: C++ %s vs Python %s" % (
+      cpp_red.type(), py_red.type())
+
+def exercise_extreme():
+  uc = uctbx.unit_cell((
+    69.059014477286041, 48.674386086971339, 0.0048194797114296736,
+    89.995145576185806, 89.999840576946085, 99.484656090034875))
+  compare_reductions(uc)
+  # This cell requires a high iteration limit (>1000)
+  uc = uctbx.unit_cell((
+    80.816186392181365, 81.021289502648813, 140.6784408482614,
+    29.932540128999769, 89.92047105556459, 119.85301114570319))
+  compare_reductions_with_limit(uc, iteration_limit=10000)
+
+def exercise_real_world_examples():
+  uc = uctbx.unit_cell((
+    12.7366, 29.2300, 5.0242,
+    94.6570, 100.8630, 99.7561))
+  compare_reductions(uc)
+  uc = uctbx.unit_cell((
+    12.7806, 12.7366, 29.457,
+    103.42, 103.57, 22.71))
+  compare_reductions(uc)
+
+def exercise_grid():
+  # Same angle set as tst_krivy_gruber.py (non-quick mode).
+  n_tested = 0
+  for a in (10, 20, 30):
+    for b in (10, 20, 30):
+      for c in (10, 20, 30):
+        for alpha in (10, 30, 45, 60, 90, 120, 150, 170):
+          for beta in (10, 30, 45, 60, 90, 120, 150, 170):
+            for gamma in (10, 30, 45, 60, 90, 120, 150, 170):
+              try:
+                uc = uctbx.unit_cell((a,b,c,alpha,beta,gamma))
+              except Exception:
+                continue
+              if uc.volume() < a*b*c/1000.:
+                continue
+              compare_reductions(uc)
+              n_tested += 1
+  assert n_tested > 1000, "Too few grid cells tested: %d" % n_tested
+
+def exercise_bravais_plus():
+  # Same space-group/cell combinations as tst_krivy_gruber.exercise_bravais_plus().
+  from cctbx import sgtbx
+  for pg in ("1", "2", "2 2", "4", "3*", "6", "2 2 3"):
+    for z in "PABCIRF":
+      sgi = sgtbx.space_group_info("Hall: %s %s" % (z, pg))
+      r_inv = sgi.group().z2p_op().c_inv().r()
+      uc = sgi.any_compatible_unit_cell(volume=100).change_basis(
+        r_inv.num(), r_inv.den())
+      compare_reductions(uc)
+
+def exercise_gruber_types():
+  # Same 28 Gruber types as tst_krivy_gruber.exercise_gruber_types(),
+  # 10 random trials each.  Seed is fixed for reproducibility.
+  from cctbx.uctbx import gruber_1973_table_1
+  from cctbx.regression.tst_krivy_gruber import random_gruber_matrix
+  import random
+  random.seed(0)
+  type_conditions = gruber_1973_table_1.get_type_conditions()
+  for k in range(1, 29):
+    tc = type_conditions[k]
+    for _ in range(10):
+      compare_reductions(ucgmx(random_gruber_matrix(tc)))
+
+def exercise_iteration_limit():
+  uc = ucgmx((4,16,16,-16,-1,-3))  # buerger cell, needs several iterations
+  # Python raises iteration_limit_exceeded
+  try:
+    krivy_gruber_1976.reduction(uc, iteration_limit=1)
+  except iteration_limit_exceeded:
+    pass
+  else:
+    raise Exception_expected
+  # C++ should also raise iteration_limit_exceeded
+  try:
+    uc.niggli_reduction(iteration_limit=1)
+  except iteration_limit_exceeded:
+    pass
+  else:
+    raise Exception_expected
+
+def exercise_a3_a4_zero_component():
+  """Targeted test for the zero-component edge case in do_a3_a4.
+
+  A cell with alpha=beta=90 yields xi=eta=0 and zeta > 0 in G6.
+  In sign_counts() this gives pos=1, nonneg=3 (pos != nonneg, pos%2 == 1),
+  triggering the extra negate_column branch in the all-negative/mixed case.
+  """
+  uc = uctbx.unit_cell((10, 20, 30, 90, 90, 120))
+  compare_reductions(uc)
+  cpp_red = uc.niggli_reduction()
+  assert cpp_red.is_niggli_cell(), \
+    "Reduced cell is not Niggli: %s" % str(cpp_red.as_gruber_matrix())
+
+def exercise_zero_epsilon():
+  cells = [
+    ucgmx((4,136,76,-155,-31,44)),
+    ucgmx((4,16,16,16,3,4)),
+    ucgmx((9,27,4,-5,-4,-22)),
+    uctbx.unit_cell((10, 20, 30, 90, 90, 90)),
+    uctbx.unit_cell((12.7366, 29.2300, 5.0242, 94.6570, 100.8630, 99.7561)),
+    uctbx.unit_cell((13.892443989449804, 13.892443989449804, 14.7648230602334,
+      61.936000954634402, 61.936000954634402, 88.515487291567879)),
+  ]
+  for uc in cells:
+    compare_reductions(uc, relative_epsilon=0)
+
+def exercise():
+  exercise_textbook_examples()
+  exercise_problem_parameters()
+  exercise_extreme()
+  exercise_real_world_examples()
+  exercise_grid()
+  exercise_bravais_plus()
+  exercise_gruber_types()
+  exercise_iteration_limit()
+  exercise_a3_a4_zero_component()
+  exercise_zero_epsilon()
+  print("OK")
+
+if (__name__ == "__main__"):
+  exercise()

--- a/cctbx/regression/tst_niggli_reduction_cpp.py
+++ b/cctbx/regression/tst_niggli_reduction_cpp.py
@@ -9,7 +9,6 @@ from cctbx.uctbx import krivy_gruber_1976
 from cctbx.uctbx.reduction_base import iteration_limit_exceeded
 from cctbx import uctbx
 from libtbx.test_utils import Exception_expected
-import sys
 
 def ucgmx(gruber_matrix):
   (a,b,c,d,e,f) = gruber_matrix

--- a/cctbx/run_tests.py
+++ b/cctbx/run_tests.py
@@ -57,6 +57,7 @@ tst_list = [
   "$D/adp_restraints/tst_ext.py",
   "$D/regression/tst_math_module.py",
   ["$D/regression/tst_krivy_gruber.py", "--Quick"],
+  "$D/regression/tst_niggli_reduction_cpp.py",
   "$D/regression/tst_sgtbx.py",
   "$D/regression/tst_itvb_2001_table_a1427_hall_symbols.py",
   "$D/regression/tst_space_group_type_tidy_cb_op_t.py",

--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -194,16 +194,20 @@ class _():
     from cctbx_uctbx_ext import niggli_reduction as _c_niggli_reduction
     from cctbx.uctbx.reduction_base import iteration_limit_exceeded
     from cctbx.uctbx.reduction_base import cpp_niggli_reduction_result
+    from cctbx.uctbx.reduction_base import NIGGLI_DEFAULT_RELATIVE_EPSILON
+    from cctbx.uctbx.reduction_base import NIGGLI_DEFAULT_ITERATION_LIMIT
     if relative_epsilon is None:
-      relative_epsilon = 1.e-5
+      relative_epsilon = NIGGLI_DEFAULT_RELATIVE_EPSILON
     if iteration_limit is None:
-      iteration_limit = 1000
+      iteration_limit = NIGGLI_DEFAULT_ITERATION_LIMIT
     try:
       impl = _c_niggli_reduction(self, relative_epsilon, iteration_limit)
     except RuntimeError as e:
-      raise iteration_limit_exceeded(str(e))
+      if "Niggli reduction iteration limit exceeded" not in str(e):
+        raise
+      raise iteration_limit_exceeded(str(e)) from e
     return cpp_niggli_reduction_result(
-      impl.as_unit_cell(), relative_epsilon,
+      impl.as_unit_cell(), self, relative_epsilon,
       impl.r_inv_as_tuple(), impl.n_iterations(),
       impl.gruber_parameters())
 

--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -193,7 +193,7 @@ class _():
   def niggli_reduction(self, relative_epsilon=None, iteration_limit=None):
     from cctbx_uctbx_ext import niggli_reduction as _c_niggli_reduction
     from cctbx.uctbx.reduction_base import iteration_limit_exceeded
-    from cctbx import sgtbx
+    from cctbx.uctbx.reduction_base import cpp_niggli_reduction_result
     if relative_epsilon is None:
       relative_epsilon = 1.e-5
     if iteration_limit is None:
@@ -202,22 +202,9 @@ class _():
       impl = _c_niggli_reduction(self, relative_epsilon, iteration_limit)
     except RuntimeError as e:
       raise iteration_limit_exceeded(str(e))
-
-    class _result(object):
-      def __init__(self, impl):
-        self._impl = impl
-      def r_inv(self):
-        return matrix.sqr(self._impl.r_inv_as_tuple())
-      def n_iterations(self):
-        return self._impl.n_iterations()
-      def as_unit_cell(self):
-        return self._impl.as_unit_cell()
-      def change_of_basis_op(self):
-        return sgtbx.change_of_basis_op(
-          sgtbx.rt_mx(sgtbx.rot_mx(
-            self._impl.r_inv_as_tuple(), 1))).inverse()
-
-    return _result(impl)
+    return cpp_niggli_reduction_result(
+      impl.as_unit_cell(), relative_epsilon,
+      impl.r_inv_as_tuple(), impl.n_iterations())
 
   def niggli_cell(self,
         relative_epsilon=None,

--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -194,20 +194,19 @@ class _():
     from cctbx_uctbx_ext import niggli_reduction as _c_niggli_reduction
     from cctbx.uctbx.reduction_base import iteration_limit_exceeded
     from cctbx.uctbx.reduction_base import cpp_niggli_reduction_result
-    from cctbx.uctbx.reduction_base import NIGGLI_DEFAULT_RELATIVE_EPSILON
-    from cctbx.uctbx.reduction_base import NIGGLI_DEFAULT_ITERATION_LIMIT
-    if relative_epsilon is None:
-      relative_epsilon = NIGGLI_DEFAULT_RELATIVE_EPSILON
-    if iteration_limit is None:
-      iteration_limit = NIGGLI_DEFAULT_ITERATION_LIMIT
+    kwargs = {}
+    if relative_epsilon is not None:
+      kwargs['relative_epsilon'] = relative_epsilon
+    if iteration_limit is not None:
+      kwargs['iteration_limit'] = iteration_limit
     try:
-      impl = _c_niggli_reduction(self, relative_epsilon, iteration_limit)
+      impl = _c_niggli_reduction(self, **kwargs)
     except RuntimeError as e:
       if "Niggli reduction iteration limit exceeded" not in str(e):
         raise
       raise iteration_limit_exceeded(str(e)) from e
     return cpp_niggli_reduction_result(
-      impl.as_unit_cell(), self, relative_epsilon,
+      impl.as_unit_cell(), impl.epsilon(),
       impl.r_inv_as_tuple(), impl.n_iterations(),
       impl.gruber_parameters())
 

--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -191,8 +191,33 @@ class _():
     return gruber_parameterization(self, relative_epsilon).is_niggli_cell()
 
   def niggli_reduction(self, relative_epsilon=None, iteration_limit=None):
-    from cctbx.uctbx import krivy_gruber_1976
-    return krivy_gruber_1976.reduction(self, relative_epsilon, iteration_limit)
+    from cctbx_uctbx_ext import niggli_reduction as _c_niggli_reduction
+    from cctbx.uctbx.reduction_base import iteration_limit_exceeded
+    from cctbx import sgtbx
+    if relative_epsilon is None:
+      relative_epsilon = 1.e-5
+    if iteration_limit is None:
+      iteration_limit = 1000
+    try:
+      impl = _c_niggli_reduction(self, relative_epsilon, iteration_limit)
+    except RuntimeError as e:
+      raise iteration_limit_exceeded(str(e))
+
+    class _result(object):
+      def __init__(self, impl):
+        self._impl = impl
+      def r_inv(self):
+        return matrix.sqr(self._impl.r_inv_as_tuple())
+      def n_iterations(self):
+        return self._impl.n_iterations()
+      def as_unit_cell(self):
+        return self._impl.as_unit_cell()
+      def change_of_basis_op(self):
+        return sgtbx.change_of_basis_op(
+          sgtbx.rt_mx(sgtbx.rot_mx(
+            self._impl.r_inv_as_tuple(), 1))).inverse()
+
+    return _result(impl)
 
   def niggli_cell(self,
         relative_epsilon=None,

--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -204,7 +204,8 @@ class _():
       raise iteration_limit_exceeded(str(e))
     return cpp_niggli_reduction_result(
       impl.as_unit_cell(), relative_epsilon,
-      impl.r_inv_as_tuple(), impl.n_iterations())
+      impl.r_inv_as_tuple(), impl.n_iterations(),
+      impl.gruber_parameters())
 
   def niggli_cell(self,
         relative_epsilon=None,

--- a/cctbx/uctbx/boost_python/SConscript
+++ b/cctbx/uctbx/boost_python/SConscript
@@ -3,4 +3,4 @@ env = env_cctbx_boost_python_ext.Clone()
 env.Prepend(LIBS=["cctbx"])
 env.SharedLibrary(
   target="#lib/cctbx_uctbx_ext",
-  source=["uctbx_ext.cpp", "fast_minimum_reduction.cpp"])
+  source=["uctbx_ext.cpp", "fast_minimum_reduction.cpp", "niggli_reduction.cpp"])

--- a/cctbx/uctbx/boost_python/niggli_reduction.cpp
+++ b/cctbx/uctbx/boost_python/niggli_reduction.cpp
@@ -22,6 +22,16 @@ namespace {
         m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8]);
     }
 
+    // Return the 6 reduced G6 Gruber parameters (A, B, C, xi, eta, zeta)
+    // as a Python tuple, avoiding metrical matrix round-trip drift.
+    static boost::python::tuple
+    gruber_parameters(w_t const& self)
+    {
+      return boost::python::make_tuple(
+        self.A(), self.B(), self.C(),
+        self.xi(), self.eta(), self.zeta());
+    }
+
     static void
     wrap()
     {
@@ -35,6 +45,7 @@ namespace {
           arg("iteration_limit")=1000)))
         .def("r_inv", &w_t::r_inv, ccr())
         .def("r_inv_as_tuple", r_inv_as_tuple)
+        .def("gruber_parameters", gruber_parameters)
         .def("n_iterations", &w_t::n_iterations)
         .def("as_unit_cell", &w_t::as_unit_cell)
       ;

--- a/cctbx/uctbx/boost_python/niggli_reduction.cpp
+++ b/cctbx/uctbx/boost_python/niggli_reduction.cpp
@@ -1,0 +1,51 @@
+#include <boost/python/class.hpp>
+#include <boost/python/args.hpp>
+#include <boost/python/tuple.hpp>
+#include <boost/python/return_value_policy.hpp>
+#include <boost/python/copy_const_reference.hpp>
+#include <cctbx/uctbx/niggli_reduction.h>
+
+namespace cctbx { namespace uctbx { namespace boost_python {
+namespace {
+
+  struct niggli_reduction_wrappers
+  {
+    typedef niggli_reduction w_t;
+
+    // Return the 9 elements of r_inv as a Python tuple for use with
+    // sgtbx.rot_mx(elems, den) in Python.
+    static boost::python::tuple
+    r_inv_as_tuple(w_t const& self)
+    {
+      scitbx::mat3<int> const& m = self.r_inv();
+      return boost::python::make_tuple(
+        m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8]);
+    }
+
+    static void
+    wrap()
+    {
+      using namespace boost::python;
+      typedef return_value_policy<copy_const_reference> ccr;
+      class_<w_t>("niggli_reduction", no_init)
+        .def(init<unit_cell const&,
+                  optional<double, int> >((
+          arg("unit_cell"),
+          arg("relative_epsilon")=1.e-5,
+          arg("iteration_limit")=1000)))
+        .def("r_inv", &w_t::r_inv, ccr())
+        .def("r_inv_as_tuple", r_inv_as_tuple)
+        .def("n_iterations", &w_t::n_iterations)
+        .def("as_unit_cell", &w_t::as_unit_cell)
+      ;
+    }
+  };
+
+} // namespace <anonymous>
+
+  void wrap_niggli_reduction()
+  {
+    niggli_reduction_wrappers::wrap();
+  }
+
+}}} // namespace cctbx::uctbx::boost_python

--- a/cctbx/uctbx/boost_python/niggli_reduction.cpp
+++ b/cctbx/uctbx/boost_python/niggli_reduction.cpp
@@ -47,6 +47,7 @@ namespace {
         .def("r_inv_as_tuple", r_inv_as_tuple)
         .def("gruber_parameters", gruber_parameters)
         .def("n_iterations", &w_t::n_iterations)
+        .def("epsilon", &w_t::epsilon)
         .def("as_unit_cell", &w_t::as_unit_cell)
       ;
     }

--- a/cctbx/uctbx/boost_python/uctbx_ext.cpp
+++ b/cctbx/uctbx/boost_python/uctbx_ext.cpp
@@ -17,6 +17,7 @@
 namespace cctbx { namespace uctbx { namespace boost_python {
 
   void wrap_fast_minimum_reduction();
+  void wrap_niggli_reduction();
 
 namespace {
 
@@ -390,6 +391,7 @@ namespace {
 
     unit_cell_wrappers::wrap();
     wrap_fast_minimum_reduction();
+    wrap_niggli_reduction();
 
     def("fractional_unit_shifts", fractional_unit_shifts_d, (
       arg("distance_frac")));

--- a/cctbx/uctbx/niggli_reduction.h
+++ b/cctbx/uctbx/niggli_reduction.h
@@ -1,0 +1,242 @@
+#ifndef CCTBX_UCTBX_NIGGLI_REDUCTION_H
+#define CCTBX_UCTBX_NIGGLI_REDUCTION_H
+
+#include <cctbx/uctbx.h>
+#include <cctbx/error.h>
+#include <scitbx/mat3.h>
+#include <cmath>
+#include <algorithm>
+
+namespace cctbx { namespace uctbx {
+
+  class error_niggli_iteration_limit_exceeded : public error
+  {
+    public:
+      error_niggli_iteration_limit_exceeded()
+      :
+        error("Niggli reduction iteration limit exceeded.")
+      {}
+  };
+
+  //! C++ implementation of the Krivy-Gruber (1976) Niggli reduction.
+  /*!
+   * Implements the algorithm of Krivy & Gruber (1976) Acta Cryst. A32, 297-298.
+   * Operates on the G6 Gruber parameterization:
+   *   A = a.a,  B = b.b,  C = c.c
+   *   xi = 2(b.c),  eta = 2(a.c),  zeta = 2(a.b)
+   *
+   * The accumulated change-of-basis matrix r_inv is stored as a 3x3 integer
+   * matrix (denominator = 1, entries are 0 or +/-1) in the same convention as
+   * fast_minimum_reduction::r_inv() and reduction_base._r_inv.
+   *
+   * Based on the algorithm in gemmi::GruberVector (cellred.hpp), ported to
+   * cctbx to remove the gemmi external dependency.
+   */
+  class niggli_reduction
+  {
+    public:
+      niggli_reduction(
+        uctbx::unit_cell const& unit_cell,
+        double relative_epsilon=1.e-5,
+        int iteration_limit=1000)
+      :
+        n_iterations_(0),
+        iteration_limit_(iteration_limit),
+        r_inv_(1,0,0, 0,1,0, 0,0,1)
+      {
+        // Initialize G6 from the metrical matrix.
+        // metrical_matrix() returns sym_mat3 with indices:
+        //   [0]=a*a, [1]=b*b, [2]=c*c, [3]=a*b, [4]=a*c, [5]=b*c
+        scitbx::sym_mat3<double> const& m = unit_cell.metrical_matrix();
+        A_    = m[0];
+        B_    = m[1];
+        C_    = m[2];
+        xi_   = 2.0 * m[5];  // 2*(b.c)
+        eta_  = 2.0 * m[4];  // 2*(a.c)
+        zeta_ = 2.0 * m[3];  // 2*(a.b)
+        epsilon_ = std::pow(unit_cell.volume(), 1.0/3.0) * relative_epsilon;
+
+        // Main reduction loop: normalize then apply one Niggli step.
+        for (;;) {
+          normalize();
+          if (++n_iterations_ == iteration_limit_) {
+            throw error_niggli_iteration_limit_exceeded();
+          }
+          if (niggli_step()) {
+            break;
+          }
+        }
+      }
+
+      scitbx::mat3<int> const& r_inv() const { return r_inv_; }
+
+      int n_iterations() const { return n_iterations_; }
+
+      uctbx::unit_cell as_unit_cell() const
+      {
+        // as_sym_mat3 convention: (A, B, C, zeta/2, eta/2, xi/2)
+        // which maps to metrical matrix (a*a, b*b, c*c, a*b, a*c, b*c)
+        scitbx::sym_mat3<double> mm(A_, B_, C_, zeta_/2, eta_/2, xi_/2);
+        return uctbx::unit_cell(mm);
+      }
+
+    protected:
+
+      // --- Column operations on r_inv_ ---
+      // Columns correspond to basis vectors; all reduction steps are
+      // column operations on the change-of-basis matrix.
+
+      void swap_columns_and_negate(int ci, int cj)
+      {
+        for (int row = 0; row < 3; row++) {
+          std::swap(r_inv_[row*3+ci], r_inv_[row*3+cj]);
+        }
+        for (int k = 0; k < 9; k++) {
+          r_inv_[k] = -r_inv_[k];
+        }
+      }
+
+      void negate_column(int ci)
+      {
+        for (int row = 0; row < 3; row++) {
+          r_inv_[row*3+ci] = -r_inv_[row*3+ci];
+        }
+      }
+
+      void add_column(int src, int dst, int sign)
+      {
+        for (int row = 0; row < 3; row++) {
+          r_inv_[row*3+dst] += sign * r_inv_[row*3+src];
+        }
+      }
+
+      // --- Epsilon-based comparisons ---
+
+      bool eps_lt(double x, double y) const { return x < y - epsilon_; }
+      bool eps_gt(double x, double y) const { return eps_lt(y, x); }
+      bool eps_eq(double x, double y) const
+      {
+        return !eps_lt(x, y) && !eps_lt(y, x);
+      }
+
+      // --- N1 sorting step (used inside normalize) ---
+
+      void do_step_N1()
+      {
+        if (eps_gt(A_, B_) ||
+            (eps_eq(A_, B_) && eps_gt(std::abs(xi_), std::abs(eta_)))) {
+          std::swap(A_, B_);
+          std::swap(xi_, eta_);
+          swap_columns_and_negate(0, 1);
+        }
+      }
+
+      // --- normalize(): Algorithm N from Gruber (1973) ---
+      // Sorts A <= B <= C with tie-breaking on |xi|, |eta|, |zeta|,
+      // then enforces consistent signs on xi, eta, zeta.
+
+      void normalize()
+      {
+        // N1: sort A <= B
+        do_step_N1();
+
+        // N2: sort B <= C (then re-apply N1 since B may have decreased)
+        if (eps_gt(B_, C_) ||
+            (eps_eq(B_, C_) && eps_gt(std::abs(eta_), std::abs(zeta_)))) {
+          std::swap(B_, C_);
+          std::swap(eta_, zeta_);
+          swap_columns_and_negate(1, 2);
+          do_step_N1();
+        }
+
+        // N3: enforce consistent sign convention for xi, eta, zeta.
+        // Target: all three values have the same sign.
+        // sgn=+1 if exactly an odd number are strictly positive (all zeros ignored),
+        //        AND there are no zero-valued components.
+        // sgn=-1 otherwise (make all non-positive).
+        int pos   = (xi_ > epsilon_)    + (eta_ > epsilon_)    + (zeta_ > epsilon_);
+        int nonneg = (xi_ >= -epsilon_) + (eta_ >= -epsilon_) + (zeta_ >= -epsilon_);
+        double sgn = (pos == nonneg && pos % 2 == 1) ? 1.0 : -1.0;
+
+        // Negate columns whose value has the wrong sign.
+        if (sgn * xi_   < -epsilon_) negate_column(0);
+        if (sgn * eta_  < -epsilon_) negate_column(1);
+        if (sgn * zeta_ < -epsilon_) negate_column(2);
+
+        // Special case: if there is a zero component and we are in the odd-positive
+        // case, negate one more column to keep the product of all signs consistent.
+        if (pos != nonneg && pos % 2 == 1) {
+          negate_column(
+            std::fabs(zeta_) <= epsilon_ ? 2 :
+            std::fabs(eta_)  <= epsilon_ ? 1 : 0);
+        }
+
+        // Apply the target sign to the scalar values.
+        xi_   = std::copysign(xi_,   sgn);
+        eta_  = std::copysign(eta_,  sgn);
+        zeta_ = std::copysign(zeta_, sgn);
+      }
+
+      // --- niggli_step(): Steps A5-A8 from Krivy & Gruber (1976) ---
+      // Must be called after normalize(). Returns true if the cell is already
+      // Niggli-reduced (no step was needed).
+
+      bool niggli_step()
+      {
+        // Step 5: reduce |xi| w.r.t. B
+        if (eps_gt(std::abs(xi_), B_) ||
+            (xi_ >= B_ - epsilon_ && eps_lt(2*eta_, zeta_)) ||
+            (xi_ <= -(B_ - epsilon_) && eps_lt(zeta_, 0.0))) {
+          double s = xi_ >= 0 ? 1.0 : -1.0;
+          C_   += B_ - xi_ * s;
+          eta_ -= zeta_ * s;
+          xi_  -= 2 * B_ * s;
+          add_column(1, 2, -(int)s);
+          return false;
+        }
+        // Step 6: reduce |eta| w.r.t. A
+        if (eps_gt(std::abs(eta_), A_) ||
+            (eta_ >= A_ - epsilon_ && eps_lt(2*xi_, zeta_)) ||
+            (eta_ <= -(A_ - epsilon_) && eps_lt(zeta_, 0.0))) {
+          double s = eta_ >= 0 ? 1.0 : -1.0;
+          C_   += A_ - eta_ * s;
+          xi_  -= zeta_ * s;
+          eta_ -= 2 * A_ * s;
+          add_column(0, 2, -(int)s);
+          return false;
+        }
+        // Step 7: reduce |zeta| w.r.t. A
+        if (eps_gt(std::abs(zeta_), A_) ||
+            (zeta_ >= A_ - epsilon_ && eps_lt(2*xi_, eta_)) ||
+            (zeta_ <= -(A_ - epsilon_) && eps_lt(eta_, 0.0))) {
+          double s = zeta_ >= 0 ? 1.0 : -1.0;
+          B_    += A_ - zeta_ * s;
+          xi_   -= eta_ * s;
+          zeta_ -= 2 * A_ * s;
+          add_column(0, 1, -(int)s);
+          return false;
+        }
+        // Step 8: mixed condition
+        if (eps_lt(xi_ + eta_ + zeta_ + A_ + B_, 0.0) ||
+            (eps_eq(xi_ + eta_ + zeta_ + A_ + B_, 0.0) &&
+             eps_gt(2*(A_ + eta_) + zeta_, 0.0))) {
+          C_   += A_ + B_ + xi_ + eta_ + zeta_;
+          xi_  += 2*B_ + zeta_;
+          eta_ += 2*A_ + zeta_;
+          add_column(0, 2, 1);
+          add_column(1, 2, 1);
+          return false;
+        }
+        return true;  // already Niggli-reduced
+      }
+
+      double A_, B_, C_, xi_, eta_, zeta_;
+      double epsilon_;
+      int n_iterations_;
+      int iteration_limit_;
+      scitbx::mat3<int> r_inv_;
+  };
+
+}} // namespace cctbx::uctbx
+
+#endif // CCTBX_UCTBX_NIGGLI_REDUCTION_H

--- a/cctbx/uctbx/niggli_reduction.h
+++ b/cctbx/uctbx/niggli_reduction.h
@@ -76,6 +76,8 @@ namespace cctbx { namespace uctbx {
 
       int n_iterations() const { return n_iterations_; }
 
+      double epsilon() const { return epsilon_; }
+
       //! Direct access to the reduced G6 Gruber parameters.
       double A()    const { return A_; }
       double B()    const { return B_; }

--- a/cctbx/uctbx/niggli_reduction.h
+++ b/cctbx/uctbx/niggli_reduction.h
@@ -1,3 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Derived from gemmi::GruberVector in include/gemmi/cellred.hpp
+// Copyright 2017-2024 Global Phasing Ltd.  MPL-2.0.
+
 #ifndef CCTBX_UCTBX_NIGGLI_REDUCTION_H
 #define CCTBX_UCTBX_NIGGLI_REDUCTION_H
 
@@ -192,7 +199,7 @@ namespace cctbx { namespace uctbx {
         if (sgn * eta_  < -epsilon_) negate_column(1);
         if (sgn * zeta_ < -epsilon_) negate_column(2);
 
-        // Edge case: zero-valued component in the all-positive branch requires
+        // Edge case: zero-valued component in the all-negative branch requires
         // one extra negation to maintain the correct sign product
         // (mirrors Python n3_false_action's f[z]=-1 adjustment).
         if (pos != nonneg && pos % 2 == 1) {

--- a/cctbx/uctbx/niggli_reduction.h
+++ b/cctbx/uctbx/niggli_reduction.h
@@ -69,6 +69,14 @@ namespace cctbx { namespace uctbx {
 
       int n_iterations() const { return n_iterations_; }
 
+      //! Direct access to the reduced G6 Gruber parameters.
+      double A()    const { return A_; }
+      double B()    const { return B_; }
+      double C()    const { return C_; }
+      double xi()   const { return xi_; }
+      double eta()  const { return eta_; }
+      double zeta() const { return zeta_; }
+
       uctbx::unit_cell as_unit_cell() const
       {
         // as_sym_mat3 convention: (A, B, C, zeta/2, eta/2, xi/2)

--- a/cctbx/uctbx/niggli_reduction.h
+++ b/cctbx/uctbx/niggli_reduction.h
@@ -25,9 +25,14 @@ namespace cctbx { namespace uctbx {
    *   A = a.a,  B = b.b,  C = c.c
    *   xi = 2(b.c),  eta = 2(a.c),  zeta = 2(a.b)
    *
+   * The main loop mirrors the Python krivy_gruber_1976.reduction.step() function
+   * exactly: A1 (N1 sort), A2 (N2 sort, restart if fired), A3/A4 (N3 sign,
+   * always), A5-A8 (reduction, restart if fired).  n_iterations() counts
+   * individual actions (cb_update calls) to match the Python implementation.
+   *
    * The accumulated change-of-basis matrix r_inv is stored as a 3x3 integer
-   * matrix (denominator = 1, entries are 0 or +/-1) in the same convention as
-   * fast_minimum_reduction::r_inv() and reduction_base._r_inv.
+   * matrix (denominator = 1) in the same convention as fast_minimum_reduction
+   * and reduction_base._r_inv.
    *
    * Based on the algorithm in gemmi::GruberVector (cellred.hpp), ported to
    * cctbx to remove the gemmi external dependency.
@@ -56,16 +61,8 @@ namespace cctbx { namespace uctbx {
         zeta_ = 2.0 * m[3];  // 2*(a.b)
         epsilon_ = std::pow(unit_cell.volume(), 1.0/3.0) * relative_epsilon;
 
-        // Main reduction loop: normalize then apply one Niggli step.
-        for (;;) {
-          normalize();
-          if (++n_iterations_ == iteration_limit_) {
-            throw error_niggli_iteration_limit_exceeded();
-          }
-          if (niggli_step()) {
-            break;
-          }
-        }
+        // Main reduction loop, matching Python's: while (self.step()): pass
+        while (step()) {}
       }
 
       scitbx::mat3<int> const& r_inv() const { return r_inv_; }
@@ -119,71 +116,93 @@ namespace cctbx { namespace uctbx {
         return !eps_lt(x, y) && !eps_lt(y, x);
       }
 
-      // --- N1 sorting step (used inside normalize) ---
+      // --- Iteration counter (mirrors Python cb_update) ---
+      // Called once per action, checks limit before incrementing.
 
-      void do_step_N1()
+      void cb_update()
+      {
+        if (n_iterations_ == iteration_limit_) {
+          throw error_niggli_iteration_limit_exceeded();
+        }
+        n_iterations_++;
+      }
+
+      // --- Individual action methods (A1-A8 = N1, N2, N3, A5-A8) ---
+      // Each mirrors the corresponding Python action method.
+
+      // A1: N1 sort (A <= B).  Returns true if the swap was applied.
+      bool do_a1()
       {
         if (eps_gt(A_, B_) ||
             (eps_eq(A_, B_) && eps_gt(std::abs(xi_), std::abs(eta_)))) {
           std::swap(A_, B_);
           std::swap(xi_, eta_);
           swap_columns_and_negate(0, 1);
+          cb_update();
+          return true;
         }
+        return false;
       }
 
-      // --- normalize(): Algorithm N from Gruber (1973) ---
-      // Sorts A <= B <= C with tie-breaking on |xi|, |eta|, |zeta|,
-      // then enforces consistent signs on xi, eta, zeta.
-
-      void normalize()
+      // A2: N2 sort (B <= C).  Returns true if the swap was applied.
+      bool do_a2()
       {
-        // N1: sort A <= B
-        do_step_N1();
-
-        // N2: sort B <= C (then re-apply N1 since B may have decreased)
         if (eps_gt(B_, C_) ||
             (eps_eq(B_, C_) && eps_gt(std::abs(eta_), std::abs(zeta_)))) {
           std::swap(B_, C_);
           std::swap(eta_, zeta_);
           swap_columns_and_negate(1, 2);
-          do_step_N1();
+          cb_update();
+          return true;
         }
+        return false;
+      }
 
-        // N3: enforce consistent sign convention for xi, eta, zeta.
-        // Target: all three values have the same sign.
-        // sgn=+1 if exactly an odd number are strictly positive (all zeros ignored),
-        //        AND there are no zero-valued components.
-        // sgn=-1 otherwise (make all non-positive).
-        int pos   = (xi_ > epsilon_)    + (eta_ > epsilon_)    + (zeta_ > epsilon_);
-        int nonneg = (xi_ >= -epsilon_) + (eta_ >= -epsilon_) + (zeta_ >= -epsilon_);
+      // Helper: classify xi_/eta_/zeta_ signs.
+      // n_positive: number strictly greater than +epsilon
+      // n_nonneg:   number greater than -epsilon (i.e., >= 0 within tolerance)
+      void sign_counts(int& n_positive, int& n_nonneg) const
+      {
+        n_positive = (xi_   >  epsilon_) + (eta_  >  epsilon_) + (zeta_ >  epsilon_);
+        n_nonneg   = (xi_   > -epsilon_) + (eta_  > -epsilon_) + (zeta_ > -epsilon_);
+      }
+
+      // A3/A4: N3 sign normalization.  Always applied (always calls cb_update).
+      // Mirrors Python n3_true_action (def_gt_0=true) and n3_false_action (false).
+      void do_a3_a4()
+      {
+        int pos, nonneg;
+        sign_counts(pos, nonneg);
+
+        // Target sign: +1 if all-positive case (def_gt_0), -1 otherwise.
+        // def_gt_0 <==> n_positive==3 OR (n_zero==0 AND n_positive==1)
+        //           <==> pos==nonneg AND pos%2==1
         double sgn = (pos == nonneg && pos % 2 == 1) ? 1.0 : -1.0;
 
-        // Negate columns whose value has the wrong sign.
+        // Negate columns whose current sign opposes the target.
         if (sgn * xi_   < -epsilon_) negate_column(0);
         if (sgn * eta_  < -epsilon_) negate_column(1);
         if (sgn * zeta_ < -epsilon_) negate_column(2);
 
-        // Special case: if there is a zero component and we are in the odd-positive
-        // case, negate one more column to keep the product of all signs consistent.
+        // Edge case: zero-valued component in the all-positive branch requires
+        // one extra negation to maintain the correct sign product
+        // (mirrors Python n3_false_action's f[z]=-1 adjustment).
         if (pos != nonneg && pos % 2 == 1) {
           negate_column(
             std::fabs(zeta_) <= epsilon_ ? 2 :
             std::fabs(eta_)  <= epsilon_ ? 1 : 0);
         }
 
-        // Apply the target sign to the scalar values.
         xi_   = std::copysign(xi_,   sgn);
         eta_  = std::copysign(eta_,  sgn);
         zeta_ = std::copysign(zeta_, sgn);
+
+        cb_update();  // ONE action regardless of how many columns were negated
       }
 
-      // --- niggli_step(): Steps A5-A8 from Krivy & Gruber (1976) ---
-      // Must be called after normalize(). Returns true if the cell is already
-      // Niggli-reduced (no step was needed).
-
-      bool niggli_step()
+      // A5: reduce |xi| w.r.t. B.  Returns true if the step was applied.
+      bool do_a5()
       {
-        // Step 5: reduce |xi| w.r.t. B
         if (eps_gt(std::abs(xi_), B_) ||
             (xi_ >= B_ - epsilon_ && eps_lt(2*eta_, zeta_)) ||
             (xi_ <= -(B_ - epsilon_) && eps_lt(zeta_, 0.0))) {
@@ -192,9 +211,15 @@ namespace cctbx { namespace uctbx {
           eta_ -= zeta_ * s;
           xi_  -= 2 * B_ * s;
           add_column(1, 2, -(int)s);
-          return false;
+          cb_update();
+          return true;
         }
-        // Step 6: reduce |eta| w.r.t. A
+        return false;
+      }
+
+      // A6: reduce |eta| w.r.t. A.  Returns true if the step was applied.
+      bool do_a6()
+      {
         if (eps_gt(std::abs(eta_), A_) ||
             (eta_ >= A_ - epsilon_ && eps_lt(2*xi_, zeta_)) ||
             (eta_ <= -(A_ - epsilon_) && eps_lt(zeta_, 0.0))) {
@@ -203,9 +228,15 @@ namespace cctbx { namespace uctbx {
           xi_  -= zeta_ * s;
           eta_ -= 2 * A_ * s;
           add_column(0, 2, -(int)s);
-          return false;
+          cb_update();
+          return true;
         }
-        // Step 7: reduce |zeta| w.r.t. A
+        return false;
+      }
+
+      // A7: reduce |zeta| w.r.t. A.  Returns true if the step was applied.
+      bool do_a7()
+      {
         if (eps_gt(std::abs(zeta_), A_) ||
             (zeta_ >= A_ - epsilon_ && eps_lt(2*xi_, eta_)) ||
             (zeta_ <= -(A_ - epsilon_) && eps_lt(eta_, 0.0))) {
@@ -214,9 +245,15 @@ namespace cctbx { namespace uctbx {
           xi_   -= eta_ * s;
           zeta_ -= 2 * A_ * s;
           add_column(0, 1, -(int)s);
-          return false;
+          cb_update();
+          return true;
         }
-        // Step 8: mixed condition
+        return false;
+      }
+
+      // A8: mixed condition.  Returns true if the step was applied.
+      bool do_a8()
+      {
         if (eps_lt(xi_ + eta_ + zeta_ + A_ + B_, 0.0) ||
             (eps_eq(xi_ + eta_ + zeta_ + A_ + B_, 0.0) &&
              eps_gt(2*(A_ + eta_) + zeta_, 0.0))) {
@@ -225,9 +262,30 @@ namespace cctbx { namespace uctbx {
           eta_ += 2*A_ + zeta_;
           add_column(0, 2, 1);
           add_column(1, 2, 1);
-          return false;
+          cb_update();  // ONE action for the two add_column calls (mirrors Python)
+          return true;
         }
-        return true;  // already Niggli-reduced
+        return false;
+      }
+
+      // --- Main step function ---
+      // Mirrors Python krivy_gruber_1976.reduction.step() exactly:
+      //   A1 (optional N1 sort)
+      //   A2 (N2 sort, restart if fired)
+      //   A3/A4 (N3 sign, always)
+      //   A5-A8 (reduction, restart if fired)
+      //   return false when nothing triggered a restart
+
+      bool step()
+      {
+        do_a1();                    // A1: N1 sort (optional, no restart)
+        if (do_a2()) return true;   // A2: N2 sort (restart if fired)
+        do_a3_a4();                 // A3/A4: sign normalization (always)
+        if (do_a5()) return true;   // A5
+        if (do_a6()) return true;   // A6
+        if (do_a7()) return true;   // A7
+        if (do_a8()) return true;   // A8
+        return false;               // done
       }
 
       double A_, B_, C_, xi_, eta_, zeta_;

--- a/cctbx/uctbx/reduction_base.py
+++ b/cctbx/uctbx/reduction_base.py
@@ -114,6 +114,30 @@ class gruber_parameterization(object):
 
 class iteration_limit_exceeded(RuntimeError): pass
 
+class cpp_niggli_reduction_result(gruber_parameterization):
+  """Result wrapper for C++ niggli_reduction.
+
+  Inherits all analysis methods from gruber_parameterization
+  (is_niggli_cell, is_buerger_cell, type, meets_main_conditions, etc.)
+  and adds r_inv, n_iterations, and change_of_basis_op from the C++ result.
+  """
+
+  def __init__(self, reduced_cell, relative_epsilon, r_inv_elems, n_iterations):
+    gruber_parameterization.__init__(self, reduced_cell, relative_epsilon)
+    self._r_inv = matrix.sqr(r_inv_elems)
+    self._n_iterations = n_iterations
+
+  def r_inv(self):
+    return self._r_inv
+
+  def n_iterations(self):
+    return self._n_iterations
+
+  def change_of_basis_op(self):
+    from cctbx import sgtbx
+    return sgtbx.change_of_basis_op(
+      sgtbx.rt_mx(sgtbx.rot_mx(self._r_inv.elems, 1))).inverse()
+
 class reduction_base(gruber_parameterization):
 
   def __init__(self, unit_cell, relative_epsilon, iteration_limit):

--- a/cctbx/uctbx/reduction_base.py
+++ b/cctbx/uctbx/reduction_base.py
@@ -3,6 +3,14 @@ from cctbx import uctbx
 from scitbx import matrix
 from six.moves import zip
 
+# Defaults shared by the C++ wrapper (cctbx/uctbx/__init__.py) and the
+# Python reduction classes.  Update all three sites if these change:
+#   1. Here (authoritative Python values)
+#   2. cctbx/uctbx/__init__.py (niggli_reduction method)
+#   3. cctbx/uctbx/niggli_reduction.h (C++ default args — C++-only API)
+NIGGLI_DEFAULT_RELATIVE_EPSILON = 1.e-5
+NIGGLI_DEFAULT_ITERATION_LIMIT  = 1000
+
 class gruber_parameterization(object):
 
   def __init__(self, unit_cell, relative_epsilon=None):
@@ -125,12 +133,14 @@ class cpp_niggli_reduction_result(gruber_parameterization):
   from the unit_cell metrical matrix round-trip (G6 -> cell params -> G6).
   """
 
-  def __init__(self, reduced_cell, relative_epsilon, r_inv_elems, n_iterations,
-               gruber_parameters):
+  def __init__(self, reduced_cell, input_cell, relative_epsilon,
+               r_inv_elems, n_iterations, gruber_parameters):
     # Set G6 values directly from C++ instead of calling
-    # gruber_parameterization.__init__ which round-trips through unit_cell
+    # gruber_parameterization.__init__, which round-trips through unit_cell.
+    # Epsilon is computed from the INPUT cell volume, matching the C++ algorithm
+    # and gruber_parameterization (not the reduced cell, which differs in volume).
     self.a, self.b, self.c, self.d, self.e, self.f = gruber_parameters
-    self.epsilon = reduced_cell.volume()**(1/3.) * relative_epsilon
+    self.epsilon = input_cell.volume()**(1/3.) * relative_epsilon
     self._r_inv = matrix.sqr(r_inv_elems)
     self._n_iterations = n_iterations
 

--- a/cctbx/uctbx/reduction_base.py
+++ b/cctbx/uctbx/reduction_base.py
@@ -3,14 +3,6 @@ from cctbx import uctbx
 from scitbx import matrix
 from six.moves import zip
 
-# Defaults shared by the C++ wrapper (cctbx/uctbx/__init__.py) and the
-# Python reduction classes.  Update all three sites if these change:
-#   1. Here (authoritative Python values)
-#   2. cctbx/uctbx/__init__.py (niggli_reduction method)
-#   3. cctbx/uctbx/niggli_reduction.h (C++ default args — C++-only API)
-NIGGLI_DEFAULT_RELATIVE_EPSILON = 1.e-5
-NIGGLI_DEFAULT_ITERATION_LIMIT  = 1000
-
 class gruber_parameterization(object):
 
   def __init__(self, unit_cell, relative_epsilon=None):
@@ -133,14 +125,14 @@ class cpp_niggli_reduction_result(gruber_parameterization):
   from the unit_cell metrical matrix round-trip (G6 -> cell params -> G6).
   """
 
-  def __init__(self, reduced_cell, input_cell, relative_epsilon,
-               r_inv_elems, n_iterations, gruber_parameters):
+  def __init__(self, reduced_cell, epsilon, r_inv_elems, n_iterations,
+               gruber_parameters):
     # Set G6 values directly from C++ instead of calling
     # gruber_parameterization.__init__, which round-trips through unit_cell.
-    # Epsilon is computed from the INPUT cell volume, matching the C++ algorithm
-    # and gruber_parameterization (not the reduced cell, which differs in volume).
+    # Epsilon comes directly from the C++ reduction (computed from the input
+    # cell volume), so it matches exactly what the algorithm used.
     self.a, self.b, self.c, self.d, self.e, self.f = gruber_parameters
-    self.epsilon = input_cell.volume()**(1/3.) * relative_epsilon
+    self.epsilon = epsilon
     self._r_inv = matrix.sqr(r_inv_elems)
     self._n_iterations = n_iterations
 

--- a/cctbx/uctbx/reduction_base.py
+++ b/cctbx/uctbx/reduction_base.py
@@ -120,10 +120,17 @@ class cpp_niggli_reduction_result(gruber_parameterization):
   Inherits all analysis methods from gruber_parameterization
   (is_niggli_cell, is_buerger_cell, type, meets_main_conditions, etc.)
   and adds r_inv, n_iterations, and change_of_basis_op from the C++ result.
+
+  G6 parameters are set directly from C++ to avoid floating-point drift
+  from the unit_cell metrical matrix round-trip (G6 -> cell params -> G6).
   """
 
-  def __init__(self, reduced_cell, relative_epsilon, r_inv_elems, n_iterations):
-    gruber_parameterization.__init__(self, reduced_cell, relative_epsilon)
+  def __init__(self, reduced_cell, relative_epsilon, r_inv_elems, n_iterations,
+               gruber_parameters):
+    # Set G6 values directly from C++ instead of calling
+    # gruber_parameterization.__init__ which round-trips through unit_cell
+    self.a, self.b, self.c, self.d, self.e, self.f = gruber_parameters
+    self.epsilon = reduced_cell.volume()**(1/3.) * relative_epsilon
     self._r_inv = matrix.sqr(r_inv_elems)
     self._n_iterations = n_iterations
 


### PR DESCRIPTION
This PR replaces the existing Niggli reduction with a c++ implementation. It was copied from the Gemmi implementation and edited to match differences in how cctbx counted iterations. The testing was edited to cross-check the new c++ implementation with the existing python implementation. 

During serial data reduction, when multiple lattices are present on an image, indexing is performed by repetitive indexing attempts with subsampled observations. Profiling showed the existing Niggli Reduction contributed a significant amount of execution time. The c++ reduces the fraction of time in the Niggli reduction from 27.4%  to 4% in a test case.