### PR TITLE
xcif parser now wired to the iotbx.cif.reader 

### DIFF
--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -127,6 +127,13 @@ jobs:
           ls ./modules
           df -h
 
+      - name: Skip build cache, if requested
+        if: contains(github.event.head_commit.message, '[skip cache]')
+        run: |
+          set -xe
+          rm -fr ./build
+          ls
+
       - name: Run bootstrap.py
         run: |
           set -xe
@@ -273,6 +280,13 @@ jobs:
         shell: cmd
         run: |
           del /S /Q .\build\lib\_pycbf.pyd 2> nul
+
+      - name: Skip build cache, if requested
+        if: contains(github.event.head_commit.message, '[skip cache]')
+        shell: cmd
+        run: |
+          rmdir /s /q .\build
+          dir
 
       - name: Run bootstrap.py
         shell: cmd

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ mmtbx/suitename/assist/
 mmtbx/suitename/*.show.txt
 
 *sublime*
+
+# Local Claude AI guidance files (not for shared use)
+CLAUDE.md
+*/CLAUDE.md

--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -26,6 +26,7 @@ from libtbx.utils import flat_list
 from libtbx.utils import detect_binary_file
 from libtbx import smart_open
 
+import os
 import sys
 
 distances_as_cif_loop = geometry.distances_as_cif_loop
@@ -42,21 +43,22 @@ DEFAULT_ENGINE = "ucif"
 _VALID_ENGINES = ("ucif", "xcif")
 
 
-def _drive_builder_from_xcif(builder, input_string, strict):
-  """Parse input_string with xcif and drive the given cif_model_builder-style
-  builder via its callback methods (add_data_block / add_data_item / add_loop /
-  start_save_frame / end_save_frame).
+_XCIF_COMPRESSED_SUFFIXES = (".gz", ".Z", ".bz2")
 
-  Returns a (possibly empty) list of error message strings. xcif throws on
-  first parse error rather than accumulating, so the list has at most one
-  entry. When it does, the builder is left with whatever state it had
-  before the throw — which is nothing, since xcif_ext.parse runs to
-  completion before the walker touches the builder.
 
-  strict=False relaxes two things: pair items appearing before the first
-  data_ block are attached to an implicit 'global_' block; and explicit
-  'global_' block headers (STAR/DDL2 convention, used by the cctbx
-  monomer library) are accepted. strict=True rejects both.
+def _xcif_can_use_parse_file(file_path):
+  """True when file_path is safe to hand to xcif_ext.parse_file (which
+  memory-maps). False for compressed files; smart_open handles those,
+  parse_file does not."""
+  if file_path is None:
+    return False
+  return not file_path.endswith(_XCIF_COMPRESSED_SUFFIXES)
+
+
+def _walk_xcif_doc(builder, doc):
+  """Drive `builder` (a cif_model_builder-style object with
+  add_data_block / add_data_item / add_loop / start_save_frame /
+  end_save_frame) from an already-parsed xcif Document.
 
   The xcif C++ parser stores block and save-frame names with the data_/save_
   prefix stripped; the builder's strip-before-first-underscore logic
@@ -64,15 +66,6 @@ def _drive_builder_from_xcif(builder, input_string, strict):
   tokens, so we prepend the prefix back.
   """
   import xcif_ext
-  try:
-    doc = xcif_ext.parse(input_string, strict=strict)
-  except (ValueError, RuntimeError) as e:
-    # xcif raises ValueError for std::invalid_argument (explicit translator)
-    # and RuntimeError for CifError (inherits std::runtime_error, default
-    # boost.python translation). Return the message so the caller can
-    # either surface it as CifParserError or stash it for error_count().
-    return [str(e)]
-
   # Use the enum values from xcif_ext directly — no ABI drift.
   # int(...) because bp::enum_ wraps values in a Python type;
   # the tuple comparisons below want plain ints.
@@ -119,6 +112,45 @@ def _drive_builder_from_xcif(builder, input_string, strict):
         builder.end_save_frame()
       else:
         _emit_pair_or_loop(kind, idx, pair_tags, pair_values, loops)
+
+
+def _drive_builder_from_xcif(builder, input_string, strict):
+  """Parse input_string with xcif and drive the given builder.
+
+  Returns a (possibly empty) list of error message strings. xcif throws on
+  first parse error rather than accumulating, so the list has at most one
+  entry. When it does, the builder is left with whatever state it had
+  before the throw — which is nothing, since xcif_ext.parse runs to
+  completion before the walker touches the builder.
+
+  strict=False relaxes two things: pair items appearing before the first
+  data_ block are attached to an implicit 'global_' block; and explicit
+  'global_' block headers (STAR/DDL2 convention, used by the cctbx
+  monomer library) are accepted. strict=True rejects both.
+  """
+  import xcif_ext
+  try:
+    doc = xcif_ext.parse(input_string, strict=strict)
+  except (ValueError, RuntimeError) as e:
+    # xcif raises ValueError for std::invalid_argument (explicit translator)
+    # and RuntimeError for CifError (inherits std::runtime_error, default
+    # boost.python translation). Return the message so the caller can
+    # either surface it as CifParserError or stash it for error_count().
+    return [str(e)]
+  _walk_xcif_doc(builder, doc)
+  return []
+
+
+def _drive_builder_from_xcif_file(builder, file_path, strict):
+  """Like _drive_builder_from_xcif but dispatches to xcif_ext.parse_file
+  (memory-mapped, zero-copy). Avoids allocating a Python string copy of
+  the file contents when the caller supplied a plain uncompressed path."""
+  import xcif_ext
+  try:
+    doc = xcif_ext.parse_file(file_path, strict=strict)
+  except (ValueError, RuntimeError) as e:
+    return [str(e)]
+  _walk_xcif_doc(builder, doc)
   return []
 
 
@@ -146,6 +178,24 @@ class reader(object):
     else: assert cif_object is None
     self.builder = builder
     self.original_arrays = None
+    self._xcif_errors = []
+    self.parser = None
+    # Fast path: xcif + plain uncompressed file_path -> memory-mapped
+    # parse_file, skipping the Python-string copy of the whole file.
+    # file_object= callers always go through the read-into-string path
+    # because there is no file descriptor to hand to mmap.
+    if (engine == "xcif"
+        and file_object is None
+        and file_path is not None
+        and _xcif_can_use_parse_file(file_path)):
+      resolved = os.path.expanduser(file_path)
+      if detect_binary_file.from_initial_block(resolved):
+        raise CifParserError("Binary file detected, aborting parsing.")
+      self._xcif_errors = _drive_builder_from_xcif_file(
+        self.builder, resolved, strict)
+      if raise_if_errors and self._xcif_errors:
+        raise CifParserError(self._xcif_errors[0])
+      return
     if file_path is not None:
       file_object = smart_open.for_reading(file_path)
     else:
@@ -159,11 +209,9 @@ class reader(object):
       len(input_string), binary_detector.monitor_initial)
     if binary_detector.is_binary_file(block=input_string):
       raise CifParserError("Binary file detected, aborting parsing.")
-    self._xcif_errors = []
     if engine == "xcif":
       self._xcif_errors = _drive_builder_from_xcif(
         self.builder, input_string, strict)
-      self.parser = None
       if raise_if_errors and self._xcif_errors:
         raise CifParserError(self._xcif_errors[0])
     else:

--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -38,7 +38,16 @@ class CifParserError(Sorry):
 
 
 # Parser engine selection.
-# Callers can override per-instance via the engine= kwarg on reader.__init__.
+#
+# "ucif" is the historical ANTLR-generated parser that has shipped with
+# iotbx.cif since 2011; it is the default for backward compatibility.
+# "xcif" is a newer hand-written C++ parser in cctbx_project/xcif that
+# is API-compatible through the iotbx.cif.reader adapter but materially
+# faster on large files (memory-mapped zero-copy parse_file path).
+#
+# Callers can override per-instance via the engine= kwarg on
+# reader.__init__. DEFAULT_ENGINE is read at construction time; changing
+# it at runtime affects only subsequent reader() calls.
 DEFAULT_ENGINE = "ucif"
 _VALID_ENGINES = ("ucif", "xcif")
 
@@ -155,6 +164,81 @@ def _drive_builder_from_xcif_file(builder, file_path, strict):
 
 
 class reader(object):
+  """Parse a CIF / mmCIF input and populate an iotbx.cif.model tree.
+
+  Accepts input via exactly one of file_path, file_object, or
+  input_string. Parsing is delegated to a selected engine (see
+  engine= below). On success, model() returns the populated
+  iotbx.cif.model.cif tree. On error, the behavior depends on the
+  raise_if_errors flag and the selected engine (see engine= for the
+  divergence).
+
+  Arguments
+  ---------
+  file_path : str or None
+      Path to a CIF file on disk. Handles .gz / .Z / .bz2 via
+      smart_open. Mutually exclusive with file_object / input_string.
+  file_object : file-like or None
+      Readable stream containing CIF text. Read to EOF. Mutually
+      exclusive with file_path / input_string.
+  input_string : str or None
+      CIF text already in memory. Mutually exclusive with the above.
+  cif_object : iotbx.cif.model.cif or None
+      Pre-existing model to append into. Mutually exclusive with
+      builder.
+  builder : object or None
+      Custom builder receiving parse callbacks. Must implement
+      add_data_block(heading), add_data_item(tag, value),
+      add_loop(header, data), start_save_frame(heading), and
+      end_save_frame(). IMPORTANT: heading strings are passed WITH
+      the "data_" / "save_" prefix intact (e.g. "data_foo",
+      "save_bar"); the default cif_model_builder strips the prefix
+      at the first underscore, so a third-party builder that
+      string-compares the full token needs to account for the
+      prefix. Mutually exclusive with cif_object.
+  raise_if_errors : bool, default True
+      If True, raise CifParserError on the first parse error. If
+      False, collect errors (see error_count() / show_errors()) and
+      leave whatever model state the engine produced accessible via
+      model(). See engine= for the partial-model divergence.
+  strict : bool, default True
+      If False, accept STAR/DDL2 global_ blocks and content
+      appearing before the first data_ block (attached to an
+      implicit global_ block). Required for the cctbx monomer
+      library.
+  engine : {"ucif", "xcif", None}, default None
+      Selects the underlying parser implementation. None means
+      DEFAULT_ENGINE. Behavioral differences that matter for
+      callers:
+        * Error messages. xcif prefixes diagnostics with
+          "<source>:line:col: "; ucif emits bare messages. Code
+          that greps CifParserError strings must handle both.
+        * Partial-model-on-error (raise_if_errors=False). ucif
+          continues past the first error, accumulates multiple
+          diagnostics, and yields a partial model with blocks
+          parsed before the fault populated. xcif stops at the
+          first CifError and yields an EMPTY model with exactly
+          one diagnostic. Callers that salvage partial state from
+          malformed files must use engine="ucif".
+        * Source order. Both engines preserve pair/loop/save-frame
+          source order within a block (str(model) output matches).
+        * File path fast-path. engine="xcif" with file_path set
+          and an uncompressed extension dispatches to a
+          memory-mapped C++ parser, skipping the Python-string
+          copy of the file. Compressed files (.gz/.Z/.bz2) and
+          file_object= inputs fall back to the read-into-string
+          path.
+
+  Attributes
+  ----------
+  engine : str
+      The engine actually used for this parse (never None after
+      __init__).
+  file_path : str or None
+      As passed in.
+  builder : object
+      The builder that received callbacks.
+  """
 
   def __init__(self,
                file_path=None,

--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -42,10 +42,21 @@ DEFAULT_ENGINE = "ucif"
 _VALID_ENGINES = ("ucif", "xcif")
 
 
-def _drive_builder_from_xcif(builder, input_string):
+def _drive_builder_from_xcif(builder, input_string, strict):
   """Parse input_string with xcif and drive the given cif_model_builder-style
   builder via its callback methods (add_data_block / add_data_item / add_loop /
   start_save_frame / end_save_frame).
+
+  Returns a (possibly empty) list of error message strings. xcif throws on
+  first parse error rather than accumulating, so the list has at most one
+  entry. When it does, the builder is left with whatever state it had
+  before the throw — which is nothing, since xcif_ext.parse runs to
+  completion before the walker touches the builder.
+
+  strict=False relaxes two things: pair items appearing before the first
+  data_ block are attached to an implicit 'global_' block; and explicit
+  'global_' block headers (STAR/DDL2 convention, used by the cctbx
+  monomer library) are accepted. strict=True rejects both.
 
   The xcif C++ parser stores block and save-frame names with the data_/save_
   prefix stripped; the builder's strip-before-first-underscore logic
@@ -54,13 +65,13 @@ def _drive_builder_from_xcif(builder, input_string):
   """
   import xcif_ext
   try:
-    doc = xcif_ext.parse(input_string)
+    doc = xcif_ext.parse(input_string, strict=strict)
   except (ValueError, RuntimeError) as e:
     # xcif raises ValueError for std::invalid_argument (explicit translator)
     # and RuntimeError for CifError (inherits std::runtime_error, default
-    # boost.python translation). Both become CifParserError so callers'
-    # existing except-CifParserError clauses keep working.
-    raise CifParserError(str(e))
+    # boost.python translation). Return the message so the caller can
+    # either surface it as CifParserError or stash it for error_count().
+    return [str(e)]
 
   def _drive_block_body(xblock):
     # Pair items first, then loops. Source-order interleave is not preserved
@@ -77,14 +88,18 @@ def _drive_builder_from_xcif(builder, input_string):
     xblock = doc[i]
     name = xblock.name
     if name.lower() == "global_":
-      builder.add_data_block("global_")
-    else:
-      builder.add_data_block("data_" + name)
+      # Match ucif: global_ blocks are ignored in non-strict mode
+      # (ucif/cif.g:167). Content is accepted syntactically but not
+      # stored in the model. Synthesised global_ blocks from leading
+      # pairs (strict=false, no explicit header) are also dropped.
+      continue
+    builder.add_data_block("data_" + name)
     _drive_block_body(xblock)
     for sf in xblock.save_frames:
       builder.start_save_frame("save_" + sf.name)
       _drive_block_body(sf)
       builder.end_save_frame()
+  return []
 
 
 class reader(object):
@@ -124,9 +139,13 @@ class reader(object):
       raise ValueError(
         "engine must be one of %s, got %r" % (_VALID_ENGINES, engine))
     self.engine = engine
+    self._xcif_errors = []
     if engine == "xcif":
-      _drive_builder_from_xcif(self.builder, input_string)
+      self._xcif_errors = _drive_builder_from_xcif(
+        self.builder, input_string, strict)
       self.parser = None
+      if raise_if_errors and self._xcif_errors:
+        raise CifParserError(self._xcif_errors[0])
     else:
       self.parser = ext.fast_reader(builder, input_string, file_path, strict)
       if raise_if_errors and len(self.parser.lexer_errors()):
@@ -139,13 +158,15 @@ class reader(object):
 
   def error_count(self):
     if self.parser is None:
-      return 0
+      return len(self._xcif_errors)
     return self.parser.lexer_errors().size()\
            + self.parser.parser_errors().size()
 
   def show_errors(self, max_errors=50, out=None):
     if out is None: out = sys.stdout
     if self.parser is None:
+      for msg in self._xcif_errors[:max_errors]:
+        print(msg, file=out)
       return
     for msg in self.parser.lexer_errors()[:max_errors]:
       print(msg, file=out)

--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -35,6 +35,58 @@ class CifParserError(Sorry):
   __orig_module__ = __module__
   __module__ = Exception.__module__
 
+
+# Parser engine selection.
+# Callers can override per-instance via the engine= kwarg on reader.__init__.
+DEFAULT_ENGINE = "ucif"
+_VALID_ENGINES = ("ucif", "xcif")
+
+
+def _drive_builder_from_xcif(builder, input_string):
+  """Parse input_string with xcif and drive the given cif_model_builder-style
+  builder via its callback methods (add_data_block / add_data_item / add_loop /
+  start_save_frame / end_save_frame).
+
+  The xcif C++ parser stores block and save-frame names with the data_/save_
+  prefix stripped; the builder's strip-before-first-underscore logic
+  (iotbx/cif/builders.py add_data_block / start_save_frame) expects raw
+  tokens, so we prepend the prefix back.
+  """
+  import xcif_ext
+  try:
+    doc = xcif_ext.parse(input_string)
+  except (ValueError, RuntimeError) as e:
+    # xcif raises ValueError for std::invalid_argument (explicit translator)
+    # and RuntimeError for CifError (inherits std::runtime_error, default
+    # boost.python translation). Both become CifParserError so callers'
+    # existing except-CifParserError clauses keep working.
+    raise CifParserError(str(e))
+
+  def _drive_block_body(xblock):
+    # Pair items first, then loops. Source-order interleave is not preserved
+    # by xcif (pairs_ and loops_ are separate vectors in xcif::Block); if
+    # downstream .show() output diffs become a problem, revisit here.
+    for tag, val in zip(xblock.pair_tags, xblock.pair_values):
+      builder.add_data_item(tag, val)
+    for xloop in xblock.loops:
+      tags = list(xloop.tags)
+      columns = [xloop.column_as_flex_string(t) for t in tags]
+      builder.add_loop(tags, columns)
+
+  for i in range(len(doc)):
+    xblock = doc[i]
+    name = xblock.name
+    if name.lower() == "global_":
+      builder.add_data_block("global_")
+    else:
+      builder.add_data_block("data_" + name)
+    _drive_block_body(xblock)
+    for sf in xblock.save_frames:
+      builder.start_save_frame("save_" + sf.name)
+      _drive_block_body(sf)
+      builder.end_save_frame()
+
+
 class reader(object):
 
   def __init__(self,
@@ -44,7 +96,8 @@ class reader(object):
                cif_object=None,
                builder=None,
                raise_if_errors=True,
-               strict=True):
+               strict=True,
+               engine=None):
     assert [file_path, file_object, input_string].count(None) == 2
     self.file_path = file_path
     if builder is None:
@@ -65,21 +118,35 @@ class reader(object):
       len(input_string), binary_detector.monitor_initial)
     if binary_detector.is_binary_file(block=input_string):
       raise CifParserError("Binary file detected, aborting parsing.")
-    self.parser = ext.fast_reader(builder, input_string, file_path, strict)
-    if raise_if_errors and len(self.parser.lexer_errors()):
-      raise CifParserError(self.parser.lexer_errors()[0])
-    if raise_if_errors and len(self.parser.parser_errors()):
-      raise CifParserError(self.parser.parser_errors()[0])
+    if engine is None:
+      engine = DEFAULT_ENGINE
+    if engine not in _VALID_ENGINES:
+      raise ValueError(
+        "engine must be one of %s, got %r" % (_VALID_ENGINES, engine))
+    self.engine = engine
+    if engine == "xcif":
+      _drive_builder_from_xcif(self.builder, input_string)
+      self.parser = None
+    else:
+      self.parser = ext.fast_reader(builder, input_string, file_path, strict)
+      if raise_if_errors and len(self.parser.lexer_errors()):
+        raise CifParserError(self.parser.lexer_errors()[0])
+      if raise_if_errors and len(self.parser.parser_errors()):
+        raise CifParserError(self.parser.parser_errors()[0])
 
   def model(self):
     return self.builder.model()
 
   def error_count(self):
+    if self.parser is None:
+      return 0
     return self.parser.lexer_errors().size()\
            + self.parser.parser_errors().size()
 
   def show_errors(self, max_errors=50, out=None):
     if out is None: out = sys.stdout
+    if self.parser is None:
+      return
     for msg in self.parser.lexer_errors()[:max_errors]:
       print(msg, file=out)
     for msg in self.parser.parser_errors()[:max_errors]:

--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -73,16 +73,24 @@ def _drive_builder_from_xcif(builder, input_string, strict):
     # either surface it as CifParserError or stash it for error_count().
     return [str(e)]
 
-  def _drive_block_body(xblock):
-    # Pair items first, then loops. Source-order interleave is not preserved
-    # by xcif (pairs_ and loops_ are separate vectors in xcif::Block); if
-    # downstream .show() output diffs become a problem, revisit here.
-    for tag, val in zip(xblock.pair_tags, xblock.pair_values):
-      builder.add_data_item(tag, val)
-    for xloop in xblock.loops:
+  # Use the enum values from xcif_ext directly — no ABI drift.
+  # int(...) because bp::enum_ wraps values in a Python type;
+  # the tuple comparisons below want plain ints.
+  ENTRY_PAIR = int(xcif_ext.EntryKind.PAIR)
+  ENTRY_LOOP = int(xcif_ext.EntryKind.LOOP)
+  ENTRY_SAVE_FRAME = int(xcif_ext.EntryKind.SAVE_FRAME)
+
+  def _emit_pair_or_loop(kind, idx, pair_tags, pair_values, loops):
+    if kind == ENTRY_PAIR:
+      builder.add_data_item(pair_tags[idx], pair_values[idx])
+    elif kind == ENTRY_LOOP:
+      xloop = loops[idx]
       tags = list(xloop.tags)
       columns = [xloop.column_as_flex_string(t) for t in tags]
       builder.add_loop(tags, columns)
+    # Unknown kinds are silently skipped — preserves forward-compat
+    # if xcif ever adds a new EntryKind and consumers upgrade the
+    # walker later.
 
   for i in range(len(doc)):
     xblock = doc[i]
@@ -90,15 +98,27 @@ def _drive_builder_from_xcif(builder, input_string, strict):
     if name.lower() == "global_":
       # Match ucif: global_ blocks are ignored in non-strict mode
       # (ucif/cif.g:167). Content is accepted syntactically but not
-      # stored in the model. Synthesised global_ blocks from leading
-      # pairs (strict=false, no explicit header) are also dropped.
+      # stored in the model.
       continue
     builder.add_data_block("data_" + name)
-    _drive_block_body(xblock)
-    for sf in xblock.save_frames:
-      builder.start_save_frame("save_" + sf.name)
-      _drive_block_body(sf)
-      builder.end_save_frame()
+    pair_tags = list(xblock.pair_tags)
+    pair_values = list(xblock.pair_values)
+    loops = list(xblock.loops)
+    save_frames = list(xblock.save_frames)
+    for kind, idx in xblock.source_order:
+      if kind == ENTRY_SAVE_FRAME:
+        sf = save_frames[idx]
+        builder.start_save_frame("save_" + sf.name)
+        sf_pair_tags = list(sf.pair_tags)
+        sf_pair_values = list(sf.pair_values)
+        sf_loops = list(sf.loops)
+        for sub_kind, sub_idx in sf.source_order:
+          _emit_pair_or_loop(sub_kind, sub_idx,
+                             sf_pair_tags, sf_pair_values, sf_loops)
+          # Nested save frames are rejected by the parser.
+        builder.end_save_frame()
+      else:
+        _emit_pair_or_loop(kind, idx, pair_tags, pair_values, loops)
   return []
 
 

--- a/iotbx/cif/__init__.py
+++ b/iotbx/cif/__init__.py
@@ -134,6 +134,12 @@ class reader(object):
                strict=True,
                engine=None):
     assert [file_path, file_object, input_string].count(None) == 2
+    if engine is None:
+      engine = DEFAULT_ENGINE
+    if engine not in _VALID_ENGINES:
+      raise ValueError(
+        "engine must be one of %s, got %r" % (_VALID_ENGINES, engine))
+    self.engine = engine
     self.file_path = file_path
     if builder is None:
       builder = builders.cif_model_builder(cif_object)
@@ -153,12 +159,6 @@ class reader(object):
       len(input_string), binary_detector.monitor_initial)
     if binary_detector.is_binary_file(block=input_string):
       raise CifParserError("Binary file detected, aborting parsing.")
-    if engine is None:
-      engine = DEFAULT_ENGINE
-    if engine not in _VALID_ENGINES:
-      raise ValueError(
-        "engine must be one of %s, got %r" % (_VALID_ENGINES, engine))
-    self.engine = engine
     self._xcif_errors = []
     if engine == "xcif":
       self._xcif_errors = _drive_builder_from_xcif(

--- a/iotbx/cif/tests/tst_model_builder.py
+++ b/iotbx/cif/tests/tst_model_builder.py
@@ -28,7 +28,19 @@ loop_
   try:
     r = iotbx.cif.reader(input_string=cif_txt_1+cif_txt_2)
   except Sorry as e:
-    assert not show_diff(str(e), "Loop containing tags _geom_bond_atom_site_label_1, _geom_bond_atom_site_label_2, _geom_bond_distance, _geom_bond_site_symmetry_2 appears repeated")
+    # Both wordings are accepted so the test stays valid regardless of
+    # which parser iotbx.cif.reader uses underneath:
+    # - ucif raises at cif_model_builder.add_loop time with the full
+    #   tag list;
+    # - xcif raises at parse time when the second loop's first tag is
+    #   seen as a duplicate. xcif messages are prefixed "<source>:line:col: ".
+    accepted = (
+      "Loop containing tags _geom_bond_atom_site_label_1, _geom_bond_atom_site_label_2, _geom_bond_distance, _geom_bond_site_symmetry_2 appears repeated",
+      "duplicate tag '_geom_bond_atom_site_label_1'",
+    )
+    err = str(e)
+    assert any(err == m or err.endswith(": " + m) for m in accepted), \
+      "got: %r" % err
   else:
     assert 0, "Sorry must be raised above."
 
@@ -53,7 +65,16 @@ loop_
   try:
     r = iotbx.cif.reader(input_string=cif_txt_1)
   except Sorry as e:
-    assert not show_diff(str(e), "Loop containing tags _atom_site_label, _atom_site_U_iso_or_equiv appears repeated")
+    # See test_repeated_loop_1 for the rationale on accepting both
+    # wordings. xcif catches the duplicate at parse time when the
+    # second loop redeclares `_atom_site_label`.
+    accepted = (
+      "Loop containing tags _atom_site_label, _atom_site_U_iso_or_equiv appears repeated",
+      "duplicate tag '_atom_site_label'",
+    )
+    err = str(e)
+    assert any(err == m or err.endswith(": " + m) for m in accepted), \
+      "got: %r" % err
   else:
     assert 0, "Sorry must be raised above."
 
@@ -97,7 +118,18 @@ _diffrn_ambient_temperature 300
   try:
     r = iotbx.cif.reader(input_string=cif_txt_1)
   except Sorry as e:
-    assert not show_diff(str(e), "Data item _diffrn_ambient_temperature received multiple values")
+    # Both wordings accepted:
+    # - ucif raises at cif_model_builder.add_data_item when the tag
+    #   repeats within a block;
+    # - xcif raises at parse time when parse_pair sees the duplicate
+    #   tag. xcif messages are prefixed "<source>:line:col: ".
+    accepted = (
+      "Data item _diffrn_ambient_temperature received multiple values",
+      "duplicate tag '_diffrn_ambient_temperature'",
+    )
+    err = str(e)
+    assert any(err == m or err.endswith(": " + m) for m in accepted), \
+      "got: %r" % err
   else:
     assert 0, "Sorry must be raised above."
 

--- a/iotbx/pdb/tst_pdb.py
+++ b/iotbx/pdb/tst_pdb.py
@@ -714,8 +714,18 @@ ATOM  60  CA . VAL  C   26  ?  -12.16900  22.54800  -4.78000  1.000   8.45988  C
   try: pdb_inp = pdb.input(file_name=f.name, source_info=None)
   except iotbx.cif.CifParserError as e:
     err_message = str(e)
-    assert err_message == \
-           "Wrong number of data items for loop containing _atom_site.group_PDB"
+    # Both wordings accepted so the test stays valid regardless of
+    # which parser iotbx.cif.reader uses underneath. Both messages
+    # name the offending loop's first tag so users can grep for it.
+    # - ucif raises at model-build time;
+    # - xcif raises at parse time and prefixes "<source>:line:col: ".
+    accepted = (
+      "Wrong number of data items for loop containing _atom_site.group_PDB",
+      "loop containing tag '_atom_site.group_PDB' has 57 values, "
+        "not a multiple of its 18 tags",
+    )
+    assert any(err_message == m or err_message.endswith(": " + m)
+               for m in accepted), "got: %r" % err_message
   else: raise Exception_expected
 
 def exercise_extract_authors():

--- a/xcif/SConscript
+++ b/xcif/SConscript
@@ -92,6 +92,10 @@ if not libtbx.env.module_is_installed("xcif"):
     source="regression/cpp/tst_quoted_string_delimiter.cpp")
 
   env_xcif_cpp_tests.Program(
+    target="regression/cpp/tst_semicolon_field_strict",
+    source="regression/cpp/tst_semicolon_field_strict.cpp")
+
+  env_xcif_cpp_tests.Program(
     target="regression/cpp/tst_thread_safety",
     source="regression/cpp/tst_thread_safety.cpp")
 

--- a/xcif/SConscript
+++ b/xcif/SConscript
@@ -88,6 +88,10 @@ if not libtbx.env.module_is_installed("xcif"):
     source="regression/cpp/tst_non_strict_mode.cpp")
 
   env_xcif_cpp_tests.Program(
+    target="regression/cpp/tst_quoted_string_delimiter",
+    source="regression/cpp/tst_quoted_string_delimiter.cpp")
+
+  env_xcif_cpp_tests.Program(
     target="regression/cpp/tst_thread_safety",
     source="regression/cpp/tst_thread_safety.cpp")
 

--- a/xcif/SConscript
+++ b/xcif/SConscript
@@ -84,6 +84,10 @@ if not libtbx.env.module_is_installed("xcif"):
     source="regression/cpp/example_parse.cpp")
 
   env_xcif_cpp_tests.Program(
+    target="regression/cpp/tst_non_strict_mode",
+    source="regression/cpp/tst_non_strict_mode.cpp")
+
+  env_xcif_cpp_tests.Program(
     target="regression/cpp/tst_thread_safety",
     source="regression/cpp/tst_thread_safety.cpp")
 

--- a/xcif/data_model.cpp
+++ b/xcif/data_model.cpp
@@ -210,6 +210,9 @@ private:
           advance();
           if (!parse_content(sf, true))
             error("unclosed save frame");
+          blk.source_order_.push_back(
+            std::make_pair(Block::ENTRY_SAVE_FRAME,
+                           blk.save_frames_.size() - 1));
           break;
         }
         case TOKEN_SAVE_END:
@@ -239,6 +242,8 @@ private:
     string_view val = sv();
     blk.pairs_.push_back(std::make_pair(tag, val));
     blk.pair_index_[tag] = blk.pairs_.size() - 1;
+    blk.source_order_.push_back(
+      std::make_pair(Block::ENTRY_PAIR, blk.pairs_.size() - 1));
     advance();
   }
 
@@ -279,6 +284,8 @@ private:
     for (std::size_t i = 0; i < lp.tags_.size(); ++i)
       blk.loop_tag_index_[lp.tags_[i]] = li;
     blk.loops_.push_back(std::move(lp));
+    blk.source_order_.push_back(
+      std::make_pair(Block::ENTRY_LOOP, blk.loops_.size() - 1));
   }
 };
 

--- a/xcif/data_model.cpp
+++ b/xcif/data_model.cpp
@@ -101,28 +101,69 @@ namespace detail {
 
 class Parser {
 public:
-  Parser(const char* data, std::size_t len, const char* src)
-    : tok_(data, len, src), source_(src) { advance(); }
+  Parser(const char* data, std::size_t len, const char* src,
+         bool strict = true)
+    : tok_(data, len, src), source_(src), strict_(strict) { advance(); }
 
   void run(Document& doc) {
     while (cur_.type != TOKEN_EOF) {
       if (cur_.type == TOKEN_BLOCK_HEADER) {
         doc.blocks_.push_back(Block());
         Block& blk = doc.blocks_.back();
-        blk.name_ = string_view(cur_.ptr + 5, cur_.len - 5);
+        // Two kinds of TOKEN_BLOCK_HEADER tokens come from the tokenizer:
+        //   "data_X"  (any length >=5) — block name is X
+        //   "global_" (exactly 7 chars) — block name is the full "global_"
+        // For "global_", point the string_view at a static literal so the
+        // name survives Document copies/moves and matches the non-strict
+        // synthesized block's storage strategy.
+        if (cur_.len == 7 &&
+            (cur_.ptr[0] == 'g' || cur_.ptr[0] == 'G')) {
+          static const char kGlobalName[] = "global_";
+          blk.name_ = string_view(kGlobalName, 7);
+        } else {
+          blk.name_ = string_view(cur_.ptr + 5, cur_.len - 5);
+        }
         doc.block_index_[blk.name_] = doc.blocks_.size() - 1;
         advance();
         parse_content(blk, false);
+      } else if (!strict_) {
+        // Non-strict: accumulate pre-block-header content into an
+        // implicit block named "global_". Created on demand; reused if
+        // content appears both before any data_ block and again between
+        // two data_ blocks (rare but legal under ucif-compat semantics).
+        Block& global_blk = find_or_create_global_block(doc);
+        parse_content(global_blk, false);
       } else {
         error("data outside of a data block");
       }
     }
   }
 
+  Block& find_or_create_global_block(Document& doc) {
+    // The name "global_" lives in static storage so the string_view has
+    // stable backing regardless of how the Document is copied or moved.
+    // (Storing it in a std::string member of Document triggers SSO: the
+    // string's buffer moves with the object, dangling any string_view
+    // into it.)
+    static const char kGlobalName[] = "global_";
+    static const std::size_t kGlobalLen = sizeof(kGlobalName) - 1;
+    string_view name(kGlobalName, kGlobalLen);
+    ci_map<std::size_t>::iterator it = doc.block_index_.find(name);
+    if (it != doc.block_index_.end()) {
+      return doc.blocks_[it->second];
+    }
+    doc.blocks_.push_back(Block());
+    Block& blk = doc.blocks_.back();
+    blk.name_ = name;
+    doc.block_index_[name] = doc.blocks_.size() - 1;
+    return blk;
+  }
+
 private:
   Tokenizer tok_;
   Token cur_;
   std::string source_;
+  bool strict_;
 
   void advance() { cur_ = tok_.next(); }
 
@@ -227,18 +268,21 @@ private:
 
 // ── parse() ────────────────────────────────────────────────────────
 
-Document parse(const char* data, std::size_t length, const char* source) {
+Document parse(const char* data, std::size_t length, const char* source,
+               bool strict) {
   Document doc;
   doc.owned_buf_.assign(data, data + length);
-  detail::Parser parser(doc.owned_buf_.data(), doc.owned_buf_.size(), source);
+  detail::Parser parser(doc.owned_buf_.data(), doc.owned_buf_.size(),
+                        source, strict);
   parser.run(doc);
   return doc;
 }
 
-Document parse_file(const char* path) {
+Document parse_file(const char* path, bool strict) {
   Document doc;
   doc.mapped_file_ = MappedFile(path);
-  detail::Parser parser(doc.mapped_file_.data(), doc.mapped_file_.size(), path);
+  detail::Parser parser(doc.mapped_file_.data(), doc.mapped_file_.size(),
+                        path, strict);
   parser.run(doc);
   return doc;
 }

--- a/xcif/data_model.cpp
+++ b/xcif/data_model.cpp
@@ -108,16 +108,24 @@ public:
   void run(Document& doc) {
     while (cur_.type != TOKEN_EOF) {
       if (cur_.type == TOKEN_BLOCK_HEADER) {
-        doc.blocks_.push_back(Block());
-        Block& blk = doc.blocks_.back();
         // Two kinds of TOKEN_BLOCK_HEADER tokens come from the tokenizer:
         //   "data_X"  (any length >=5) — block name is X
-        //   "global_" (exactly 7 chars) — block name is the full "global_"
-        // For "global_", point the string_view at a static literal so the
-        // name survives Document copies/moves and matches the non-strict
-        // synthesized block's storage strategy.
-        if (cur_.len == 7 &&
-            (cur_.ptr[0] == 'g' || cur_.ptr[0] == 'G')) {
+        //   "global_" (exactly 7 chars) — a STAR/DDL2 reserved block.
+        // CIF 1.1 strict does not allow `global_`; it's a non-strict
+        // relaxation (the cctbx monomer library uses it and loads with
+        // strict=false).
+        bool is_global = (cur_.len == 7 &&
+            (cur_.ptr[0] == 'g' || cur_.ptr[0] == 'G'));
+        if (is_global && strict_) {
+          error("global_ block is not allowed in strict mode "
+                "(use strict=false to accept STAR/DDL2 files)");
+        }
+        doc.blocks_.push_back(Block());
+        Block& blk = doc.blocks_.back();
+        if (is_global) {
+          // Point at a static literal so the name survives Document
+          // copies/moves and matches the non-strict synthesised block's
+          // storage strategy.
           static const char kGlobalName[] = "global_";
           blk.name_ = string_view(kGlobalName, 7);
         } else {

--- a/xcif/data_model.cpp
+++ b/xcif/data_model.cpp
@@ -262,8 +262,18 @@ private:
       lp.values_.push_back(sv());
       advance();
     }
-    if (!lp.values_.empty() && lp.values_.size() % lp.tags_.size() != 0)
-      error("loop value count is not a multiple of tag count");
+    if (!lp.values_.empty() && lp.values_.size() % lp.tags_.size() != 0) {
+      // Include the first tag name and actual counts — the user can
+      // then grep a large file for the offending loop, and the counts
+      // make the shape of the mismatch obvious.
+      std::ostringstream msg;
+      msg << "loop containing tag '"
+          << std::string(lp.tags_[0].data(), lp.tags_[0].size())
+          << "' has " << lp.values_.size()
+          << " values, not a multiple of its "
+          << lp.tags_.size() << " tags";
+      error(msg.str());
+    }
     // Register loop tags in block index
     std::size_t li = blk.loops_.size();
     for (std::size_t i = 0; i < lp.tags_.size(); ++i)

--- a/xcif/include/xcif/data_model.h
+++ b/xcif/include/xcif/data_model.h
@@ -127,8 +127,8 @@ public:
 
 private:
   friend class detail::Parser;
-  friend Document parse(const char*, std::size_t, const char*);
-  friend Document parse_file(const char*);
+  friend Document parse(const char*, std::size_t, const char*, bool);
+  friend Document parse_file(const char*, bool);
   std::vector<char> owned_buf_;
   MappedFile mapped_file_;
   std::vector<Block> blocks_;
@@ -137,17 +137,23 @@ private:
 
 // ── Free functions ─────────────────────────────────────────────────
 
+// When strict=false, content (pair items, loops) appearing before the
+// first data_ block is attached to an implicit block named "global_"
+// instead of raising "data outside of a data block". Matches ucif's
+// non-strict behavior. Everything inside a data_ block is unaffected.
 Document parse(const char* data, std::size_t length,
-               const char* source = "<input>");
+               const char* source = "<input>",
+               bool strict = true);
 
 inline Document parse(const char* data,
-                      const char* source = "<input>") {
-  return parse(data, std::strlen(data), source);
+                      const char* source = "<input>",
+                      bool strict = true) {
+  return parse(data, std::strlen(data), source, strict);
 }
 
 // Zero-copy file parse: memory-maps the file and parses directly
 // from mapped memory without copying the buffer.
-Document parse_file(const char* path);
+Document parse_file(const char* path, bool strict = true);
 
 } // namespace xcif
 #endif // XCIF_DATA_MODEL_H

--- a/xcif/include/xcif/data_model.h
+++ b/xcif/include/xcif/data_model.h
@@ -93,6 +93,17 @@ private:
 
 class Block {
 public:
+  enum EntryKind { ENTRY_PAIR = 0, ENTRY_LOOP = 1, ENTRY_SAVE_FRAME = 2 };
+
+  // Ordered (kind, index) log of pair / loop / save-frame entries in
+  // the order they appeared in the source. kind values are EntryKind;
+  // index points into pairs_, loops_, or save_frames_ respectively.
+  // Consumers that need to serialise or walk the block in source
+  // order should iterate source_order() instead of pairs() + loops()
+  // separately.
+  const std::vector<std::pair<EntryKind, std::size_t>>&
+  source_order() const { return source_order_; }
+
   string_view name() const { return name_; }
   bool has_tag(const string_view& tag) const {
     return pair_index_.find(tag) != pair_index_.end();
@@ -115,6 +126,7 @@ private:
   ci_map<std::size_t> loop_tag_index_;
   std::vector<Block> save_frames_;
   ci_map<std::size_t> save_frame_index_;
+  std::vector<std::pair<EntryKind, std::size_t>> source_order_;
 };
 
 // ── Document ───────────────────────────────────────────────────────

--- a/xcif/include/xcif/string_view.h
+++ b/xcif/include/xcif/string_view.h
@@ -47,8 +47,8 @@ public:
   const_iterator end()   const { return ptr_ + len_; }
 
   // Modifiers
-  void remove_prefix(size_type n) { ptr_ += n; len_ -= n; }
-  void remove_suffix(size_type n) { len_ -= n; }
+  void remove_prefix(size_type n) { assert(n <= len_); ptr_ += n; len_ -= n; }
+  void remove_suffix(size_type n) { assert(n <= len_); len_ -= n; }
 
   // Operations
   string_view substr(size_type pos, size_type count = npos) const {

--- a/xcif/include/xcif/string_view.h
+++ b/xcif/include/xcif/string_view.h
@@ -14,6 +14,7 @@ namespace xcif { using string_view = std::string_view; }
 #else // C++14 implementation
 
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <ostream>
 #include <string>
@@ -38,8 +39,8 @@ public:
   size_type   length() const { return len_; }
   bool        empty()  const { return len_ == 0; }
   char operator[](size_type i) const { return ptr_[i]; }
-  char front() const { return ptr_[0]; }
-  char back()  const { return ptr_[len_ - 1]; }
+  char front() const { assert(!empty()); return ptr_[0]; }
+  char back()  const { assert(!empty()); return ptr_[len_ - 1]; }
 
   // Iterators
   const_iterator begin() const { return ptr_; }

--- a/xcif/numeric.cpp
+++ b/xcif/numeric.cpp
@@ -3,7 +3,17 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <locale.h>
 #include <stdexcept>
+
+namespace {
+// strtod is locale-sensitive (decimal separator varies).  Use strtod_l with
+// a fixed C locale so that CIF's mandatory '.' separator always works.
+locale_t xcif_c_locale() {
+  static locale_t loc = ::newlocale(LC_ALL_MASK, "C", (locale_t)0);
+  return loc;
+}
+} // namespace
 
 namespace xcif {
 
@@ -31,7 +41,7 @@ double as_double(const string_view& sv) {
   buf[parse_len] = '\0';
 
   char* end;
-  double val = std::strtod(buf, &end);
+  double val = ::strtod_l(buf, &end, xcif_c_locale());
   if (end == buf) return XCIF_NAN;
   return val;
 }
@@ -83,7 +93,7 @@ std::pair<double, double> as_double_with_su(const string_view& sv) {
   buf[val_len] = '\0';
 
   char* end;
-  double value = std::strtod(buf, &end);
+  double value = ::strtod_l(buf, &end, xcif_c_locale());
   if (end == buf)
     return std::make_pair(XCIF_NAN, 0.0);
 

--- a/xcif/numeric.cpp
+++ b/xcif/numeric.cpp
@@ -42,25 +42,21 @@ int as_int(const string_view& sv) {
   if (sv.empty())
     throw std::invalid_argument("as_int: empty string");
 
-  const char* p = sv.data();
-  std::size_t len = sv.size();
-  std::size_t i = 0;
-  bool neg = false;
+  char buf[32];
+  if (sv.size() >= sizeof(buf))
+    throw std::invalid_argument("as_int: value too long");
+  std::memcpy(buf, sv.data(), sv.size());
+  buf[sv.size()] = '\0';
 
-  if (p[0] == '-')      { neg = true; ++i; }
-  else if (p[0] == '+') { ++i; }
-
-  if (i == len)
-    throw std::invalid_argument("as_int: no digits");
-
-  int result = 0;
-  for (; i < len; ++i) {
-    char c = p[i];
-    if (c < '0' || c > '9')
-      throw std::invalid_argument("as_int: non-digit character");
-    result = result * 10 + (c - '0');
-  }
-  return neg ? -result : result;
+  char* end;
+  errno = 0;
+  long val = std::strtol(buf, &end, 10);
+  if (end == buf || *end != '\0')
+    throw std::invalid_argument("as_int: non-digit character");
+  if (errno == ERANGE || val > std::numeric_limits<int>::max()
+                      || val < std::numeric_limits<int>::min())
+    throw std::overflow_error("as_int: value out of range");
+  return static_cast<int>(val);
 }
 
 // ── as_double_with_su ──────────────────────────────────────────────

--- a/xcif/numeric.cpp
+++ b/xcif/numeric.cpp
@@ -6,14 +6,24 @@
 #include <locale.h>
 #include <stdexcept>
 
+// strtod is locale-sensitive (decimal separator varies).  Use a C-locale
+// strtod wrapper so that CIF's mandatory '.' separator always works.
+// POSIX provides strtod_l / newlocale; MSVC provides _strtod_l / _create_locale.
+#ifdef _WIN32
 namespace {
-// strtod is locale-sensitive (decimal separator varies).  Use strtod_l with
-// a fixed C locale so that CIF's mandatory '.' separator always works.
-locale_t xcif_c_locale() {
-  static locale_t loc = ::newlocale(LC_ALL_MASK, "C", (locale_t)0);
-  return loc;
+static double xcif_strtod_c(const char* buf, char** end) {
+  static _locale_t s_loc = _create_locale(LC_ALL, "C");
+  return _strtod_l(buf, end, s_loc);
 }
 } // namespace
+#else
+namespace {
+static double xcif_strtod_c(const char* buf, char** end) {
+  static locale_t s_loc = ::newlocale(LC_ALL_MASK, "C", (locale_t)0);
+  return ::strtod_l(buf, end, s_loc);
+}
+} // namespace
+#endif
 
 namespace xcif {
 
@@ -41,7 +51,7 @@ double as_double(const string_view& sv) {
   buf[parse_len] = '\0';
 
   char* end;
-  double val = ::strtod_l(buf, &end, xcif_c_locale());
+  double val = xcif_strtod_c(buf, &end);
   if (end == buf) return XCIF_NAN;
   return val;
 }
@@ -93,7 +103,7 @@ std::pair<double, double> as_double_with_su(const string_view& sv) {
   buf[val_len] = '\0';
 
   char* end;
-  double value = ::strtod_l(buf, &end, xcif_c_locale());
+  double value = xcif_strtod_c(buf, &end);
   if (end == buf)
     return std::make_pair(XCIF_NAN, 0.0);
 

--- a/xcif/regression/cpp/tst_data_model.cpp
+++ b/xcif/regression/cpp/tst_data_model.cpp
@@ -321,6 +321,49 @@ void test_block_name_preserves_original_case() {
   CHECK_EQ(doc[0].name(), "MyProtein");
 }
 
+void test_block_source_order() {
+  Document doc = parse(
+    "data_t\n"
+    "_a 1\n"
+    "loop_ _x _y 1 2\n"
+    "_b 2\n",
+    "<test>");
+  const Block& blk = doc[0];
+  const auto& order = blk.source_order();
+  CHECK_EQ(order.size(), 3u);
+  CHECK_EQ(order[0].first, Block::ENTRY_PAIR);
+  CHECK_EQ(order[0].second, 0u);
+  CHECK_EQ(order[1].first, Block::ENTRY_LOOP);
+  CHECK_EQ(order[1].second, 0u);
+  CHECK_EQ(order[2].first, Block::ENTRY_PAIR);
+  CHECK_EQ(order[2].second, 1u);
+}
+
+void test_block_source_order_with_save_frame() {
+  Document doc = parse(
+    "data_t\n"
+    "_a 1\n"
+    "save_s1\n"
+    "_inside 2\n"
+    "save_\n"
+    "loop_ _x _y 1 2\n",
+    "<test>");
+  const Block& blk = doc[0];
+  const auto& order = blk.source_order();
+  CHECK_EQ(order.size(), 3u);
+  CHECK_EQ(order[0].first, Block::ENTRY_PAIR);
+  CHECK_EQ(order[0].second, 0u);
+  CHECK_EQ(order[1].first, Block::ENTRY_SAVE_FRAME);
+  CHECK_EQ(order[1].second, 0u);
+  CHECK_EQ(order[2].first, Block::ENTRY_LOOP);
+  CHECK_EQ(order[2].second, 0u);
+  // Save frame's own source_order should contain its pair item.
+  const Block& sf = blk.save_frames()[0];
+  const auto& sf_order = sf.source_order();
+  CHECK_EQ(sf_order.size(), 1u);
+  CHECK_EQ(sf_order[0].first, Block::ENTRY_PAIR);
+}
+
 // ─── run_all_tests ─────────────────────────────────────────────────
 
 void run_all_tests() {
@@ -369,6 +412,8 @@ void run_all_tests() {
 
   // §6 Misc
   test_block_name_preserves_original_case();
+  test_block_source_order();
+  test_block_source_order_with_save_frame();
 }
 
 XCIF_TEST_MAIN()

--- a/xcif/regression/cpp/tst_error_handling.cpp
+++ b/xcif/regression/cpp/tst_error_handling.cpp
@@ -160,11 +160,11 @@ void test_unterminated_quoted_string_graceful() {
   CHECK(doc[0].has_tag(string_view("_a")));
 }
 
-void test_unclosed_semicolon_field_graceful() {
-  // Missing closing ';': tokenizer returns partial content and parse succeeds.
-  Document doc = parse("data_t\n_a\n;line one\nline two\n");
-  CHECK_EQ(doc.size(), 1u);
-  CHECK(doc[0].has_tag(string_view("_a")));
+void test_unclosed_semicolon_field_raises() {
+  // CIF 1.1 §2.2.7.4: semicolon text field must be closed by `;` at
+  // column 1 of a new line. EOF before that is a syntax error.
+  // (Was previously "graceful"; tightened to match spec + ucif.)
+  CHECK(parse_throws("data_t\n_a\n;line one\nline two\n", "semicolon"));
 }
 
 // ─── run_all_tests ─────────────────────────────────────────────────
@@ -197,7 +197,7 @@ void run_all_tests() {
   test_comment_only_no_error();
   test_whitespace_only_no_error();
   test_unterminated_quoted_string_graceful();
-  test_unclosed_semicolon_field_graceful();
+  test_unclosed_semicolon_field_raises();
 }
 
 XCIF_TEST_MAIN()

--- a/xcif/regression/cpp/tst_error_handling.cpp
+++ b/xcif/regression/cpp/tst_error_handling.cpp
@@ -153,6 +153,20 @@ void test_whitespace_only_no_error() {
   CHECK_EQ(doc.size(), 0u);
 }
 
+void test_unterminated_quoted_string_graceful() {
+  // Missing closing quote: tokenizer returns partial content and parse succeeds.
+  Document doc = parse("data_t\n_a 'hello");
+  CHECK_EQ(doc.size(), 1u);
+  CHECK(doc[0].has_tag(string_view("_a")));
+}
+
+void test_unclosed_semicolon_field_graceful() {
+  // Missing closing ';': tokenizer returns partial content and parse succeeds.
+  Document doc = parse("data_t\n_a\n;line one\nline two\n");
+  CHECK_EQ(doc.size(), 1u);
+  CHECK(doc[0].has_tag(string_view("_a")));
+}
+
 // ─── run_all_tests ─────────────────────────────────────────────────
 
 void run_all_tests() {
@@ -182,6 +196,8 @@ void run_all_tests() {
   test_empty_input_no_error();
   test_comment_only_no_error();
   test_whitespace_only_no_error();
+  test_unterminated_quoted_string_graceful();
+  test_unclosed_semicolon_field_graceful();
 }
 
 XCIF_TEST_MAIN()

--- a/xcif/regression/cpp/tst_error_handling.cpp
+++ b/xcif/regression/cpp/tst_error_handling.cpp
@@ -71,11 +71,18 @@ void test_loop_no_tags() {
 }
 
 void test_loop_values_not_multiple_of_tags() {
-  // 2 tags but 3 values
+  // 2 tags but 3 values. The error message must name the offending
+  // loop's first tag so users can grep for it in large files, and
+  // include the actual counts so the user understands the shape.
   CHECK(parse_throws(
-    "data_t\nloop_\n_a\n_b\n1 2 3\n",
-    "multiple"
-  ));
+    "data_t\nloop_\n_alpha\n_beta\n1 2 3\n",
+    "_alpha"));
+  CHECK(parse_throws(
+    "data_t\nloop_\n_alpha\n_beta\n1 2 3\n",
+    "3 values"));
+  CHECK(parse_throws(
+    "data_t\nloop_\n_alpha\n_beta\n1 2 3\n",
+    "2 tags"));
 }
 
 // ─── §2  Duplicate detection ───────────────────────────────────────

--- a/xcif/regression/cpp/tst_error_handling.cpp
+++ b/xcif/regression/cpp/tst_error_handling.cpp
@@ -153,16 +153,20 @@ void test_whitespace_only_no_error() {
   CHECK_EQ(doc.size(), 0u);
 }
 
-void test_unterminated_quoted_string_graceful() {
-  // Missing closing quote: tokenizer returns partial content and parse succeeds.
-  Document doc = parse("data_t\n_a 'hello");
-  CHECK_EQ(doc.size(), 1u);
-  CHECK(doc[0].has_tag(string_view("_a")));
+void test_unterminated_quoted_string_raises() {
+  // CIF 1.1 grammar requires a matching closing delimiter for a
+  // quoted string; EOF before the close is a syntax error.
+  // (See https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax.)
+  // Was previously "graceful"; tightened to match spec + ucif.
+  CHECK(parse_throws("data_t\n_a 'hello", "unterminated"));
+  CHECK(parse_throws("data_t\n_a \"hello", "unterminated"));
 }
 
 void test_unclosed_semicolon_field_raises() {
-  // CIF 1.1 §2.2.7.4: semicolon text field must be closed by `;` at
-  // column 1 of a new line. EOF before that is a syntax error.
+  // CIF 1.1 syntax spec paragraph 17
+  // (https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax):
+  // a semicolon text field is closed by `;` as the first character of
+  // a line. EOF before that is a syntax error.
   // (Was previously "graceful"; tightened to match spec + ucif.)
   CHECK(parse_throws("data_t\n_a\n;line one\nline two\n", "semicolon"));
 }
@@ -196,7 +200,7 @@ void run_all_tests() {
   test_empty_input_no_error();
   test_comment_only_no_error();
   test_whitespace_only_no_error();
-  test_unterminated_quoted_string_graceful();
+  test_unterminated_quoted_string_raises();
   test_unclosed_semicolon_field_raises();
 }
 

--- a/xcif/regression/cpp/tst_error_handling.cpp
+++ b/xcif/regression/cpp/tst_error_handling.cpp
@@ -169,6 +169,36 @@ void test_unterminated_quoted_string_raises() {
   CHECK(parse_throws("data_t\n_a \"hello", "unterminated"));
 }
 
+void test_dos_eof_marker_accepted_at_end() {
+  // Legacy DOS end-of-file marker (0x1A) commonly appended by SHELX
+  // and other tools to `.hkl` / `.cif` files. CIF 1.1 doesn't list
+  // it in the character set, but ucif ignores it and real files
+  // contain it. xcif must treat it as EOF, not as a stray value
+  // that bumps the loop's value count.
+  const char src[] =
+    "data_t\n"
+    "loop_\n_a\n_b\n1 2\n3 4\n"
+    "\x1A\n";
+  Document doc = parse(src, sizeof(src) - 1);
+  CHECK_EQ(doc.size(), 1u);
+  const Loop* lp = doc[0].find_loop(string_view("_a"));
+  CHECK(lp != 0);
+  if (lp) CHECK_EQ(lp->length(), 2u);
+}
+
+void test_dos_eof_marker_mid_stream_is_eof() {
+  // If 0x1A appears mid-stream (followed by more content), treat it
+  // as EOF and ignore everything after — matches DOS-era semantics.
+  const char src[] = "data_t\n_a 1\n\x1A\n_b 2\n";
+  Document doc = parse(src, sizeof(src) - 1);
+  CHECK_EQ(doc.size(), 1u);
+  CHECK_EQ(std::string(doc[0].find_value(string_view("_a")).data(),
+                       doc[0].find_value(string_view("_a")).size()),
+           std::string("1"));
+  // _b never appeared — it's past the DOS-EOF
+  CHECK(!doc[0].has_tag(string_view("_b")));
+}
+
 void test_unclosed_semicolon_field_raises() {
   // CIF 1.1 syntax spec paragraph 17
   // (https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax):
@@ -208,6 +238,8 @@ void run_all_tests() {
   test_comment_only_no_error();
   test_whitespace_only_no_error();
   test_unterminated_quoted_string_raises();
+  test_dos_eof_marker_accepted_at_end();
+  test_dos_eof_marker_mid_stream_is_eof();
   test_unclosed_semicolon_field_raises();
 }
 

--- a/xcif/regression/cpp/tst_non_strict_mode.cpp
+++ b/xcif/regression/cpp/tst_non_strict_mode.cpp
@@ -139,14 +139,23 @@ void test_non_strict_find_block_by_global_name() {
   if (g) CHECK_EQ(sv_to_string(g->name()), std::string("global_"));
 }
 
-// ─── Explicit global_ header (CIF 1.1 reserved block type) ────────
-// Separate from non-strict synthesis: `global_` appears as its own
-// line and the tokenizer must recognize it as a block header, not a
-// value. Case is insensitive. This is the form used by cctbx's
-// monomer library (mon_lib_list.cif and friends).
+// ─── Explicit global_ header (reserved STAR/DDL2 block type) ──────
+// CIF 1.1 strict does not allow `global_`; ucif treats it as a
+// non-strict-only relaxation. xcif matches: strict mode rejects,
+// non-strict mode accepts. The cctbx monomer library (mon_lib_list.cif
+// and friends) uses `global_` and loads with strict=false.
 
-void test_explicit_global_header_strict() {
-  Document doc = parse("global_\n_a 1\n_b 2\n");
+void test_explicit_global_header_rejected_in_strict() {
+  try {
+    parse("global_\n_a 1\n_b 2\n");
+    CHECK(false /* should have thrown */);
+  } catch (const CifError& e) {
+    CHECK(std::string(e.what()).find("global_") != std::string::npos);
+  }
+}
+
+void test_explicit_global_header_non_strict() {
+  Document doc = parse("global_\n_a 1\n_b 2\n", "<test>", /*strict=*/false);
   CHECK_EQ(doc.size(), 1u);
   CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
   CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_a"))),
@@ -156,7 +165,8 @@ void test_explicit_global_header_strict() {
 }
 
 void test_explicit_global_followed_by_data_block() {
-  Document doc = parse("global_\n_a 1\ndata_foo\n_x 1\n");
+  Document doc = parse("global_\n_a 1\ndata_foo\n_x 1\n",
+                       "<test>", /*strict=*/false);
   CHECK_EQ(doc.size(), 2u);
   CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
   CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_a"))),
@@ -165,7 +175,7 @@ void test_explicit_global_followed_by_data_block() {
 }
 
 void test_explicit_global_case_insensitive() {
-  Document doc = parse("GLOBAL_\n_a 1\n");
+  Document doc = parse("GLOBAL_\n_a 1\n", "<test>", /*strict=*/false);
   CHECK_EQ(doc.size(), 1u);
   const Block* g = doc.find_block(string_view("global_"));
   CHECK(g != 0);
@@ -182,7 +192,7 @@ void test_monomer_library_header_with_explicit_global() {
     "loop_\n"
     "_chem_comp.id\n"
     "ALA\n";
-  Document doc = parse(src, "<monomer>");  // strict=true — no relaxation needed
+  Document doc = parse(src, "<monomer>", /*strict=*/false);
   CHECK_EQ(doc.size(), 2u);
   CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
   CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_lib_version"))),
@@ -205,7 +215,8 @@ void run_all_tests() {
   test_non_strict_only_data_block_unchanged();
   test_non_strict_find_block_by_global_name();
 
-  test_explicit_global_header_strict();
+  test_explicit_global_header_rejected_in_strict();
+  test_explicit_global_header_non_strict();
   test_explicit_global_followed_by_data_block();
   test_explicit_global_case_insensitive();
   test_monomer_library_header_with_explicit_global();

--- a/xcif/regression/cpp/tst_non_strict_mode.cpp
+++ b/xcif/regression/cpp/tst_non_strict_mode.cpp
@@ -1,0 +1,214 @@
+// cctbx_project/xcif/regression/cpp/tst_non_strict_mode.cpp
+//
+// Tests for xcif::parse(..., strict=false).
+//
+// Motivating case: the cctbx monomer library files start with
+//   _lib_update       15/04/05
+//   # ---   LIST OF MONOMERS ---
+//   data_comp_list
+//   ...
+// i.e. pair items appear before the first data_ block. ucif accepts this
+// silently when strict=false; xcif rejected it with a "data outside of a
+// data block" error. Non-strict mode synthesizes an implicit "global_"
+// block to hold any leading / interleaved content.
+
+#include <xcif/data_model.h>
+#include "test_utils.h"
+#include <string>
+
+using namespace xcif;
+
+static std::string sv_to_string(const string_view& sv) {
+  return std::string(sv.data(), sv.size());
+}
+
+// ─── Strict mode unchanged ─────────────────────────────────────────
+
+void test_strict_rejects_leading_pair() {
+  try {
+    parse("_a 1\ndata_foo\n_x 1\n");
+    CHECK(false /* should have thrown */);
+  } catch (const CifError&) {
+    // expected
+  }
+}
+
+void test_default_is_strict() {
+  // No strict arg — must still error as before.
+  try {
+    parse("_a 1\n");
+    CHECK(false /* should have thrown */);
+  } catch (const CifError& e) {
+    CHECK(std::string(e.what()).find("outside") != std::string::npos);
+  }
+}
+
+void test_strict_true_rejects_leading_pair() {
+  // Explicit strict=true.
+  try {
+    parse("_a 1\n", "<test>", /*strict=*/true);
+    CHECK(false /* should have thrown */);
+  } catch (const CifError&) {
+    // expected
+  }
+}
+
+// ─── Non-strict: synthesize global_ block ─────────────────────────
+
+void test_non_strict_leading_pair_then_data_block() {
+  Document doc = parse(
+    "_a 1\ndata_foo\n_x 1\n",
+    "<test>",
+    /*strict=*/false);
+  CHECK_EQ(doc.size(), 2u);
+  CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
+  CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_a"))),
+           std::string("1"));
+  CHECK_EQ(sv_to_string(doc[1].name()), std::string("foo"));
+  CHECK_EQ(sv_to_string(doc[1].find_value(string_view("_x"))),
+           std::string("1"));
+}
+
+void test_non_strict_only_leading_pairs() {
+  Document doc = parse("_a 1\n_b 2\n", "<test>", false);
+  CHECK_EQ(doc.size(), 1u);
+  CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
+  CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_a"))),
+           std::string("1"));
+  CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_b"))),
+           std::string("2"));
+}
+
+void test_non_strict_monomer_library_header_pattern() {
+  const char* src =
+    "_lib_update       15/04/05\n"
+    "# ------------------------------------------------\n"
+    "#\n"
+    "# ---   LIST OF MONOMERS ---\n"
+    "#\n"
+    "data_comp_list\n"
+    "loop_\n"
+    "_chem_comp.id\n"
+    "ALA\n"
+    "GLY\n";
+  Document doc = parse(src, "<monomer>", false);
+  CHECK_EQ(doc.size(), 2u);
+  CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
+  CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_lib_update"))),
+           std::string("15/04/05"));
+  CHECK_EQ(sv_to_string(doc[1].name()), std::string("comp_list"));
+  const Loop* lp = doc[1].find_loop(string_view("_chem_comp.id"));
+  CHECK(lp != 0);
+  if (lp) CHECK_EQ(lp->length(), 2u);
+}
+
+void test_non_strict_leading_loop() {
+  const char* src =
+    "loop_\n"
+    "_a\n"
+    "_b\n"
+    "1 2\n"
+    "3 4\n";
+  Document doc = parse(src, "<test>", false);
+  CHECK_EQ(doc.size(), 1u);
+  CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
+  const Loop* lp = doc[0].find_loop(string_view("_a"));
+  CHECK(lp != 0);
+  if (lp) {
+    CHECK_EQ(lp->length(), 2u);
+    CHECK_EQ(lp->width(), 2u);
+  }
+}
+
+void test_non_strict_empty_input() {
+  Document doc = parse("", "<test>", false);
+  CHECK_EQ(doc.size(), 0u);
+}
+
+void test_non_strict_only_data_block_unchanged() {
+  // If there's no leading content, non-strict should behave like strict.
+  Document doc = parse("data_foo\n_x 1\n", "<test>", false);
+  CHECK_EQ(doc.size(), 1u);
+  CHECK_EQ(sv_to_string(doc[0].name()), std::string("foo"));
+}
+
+void test_non_strict_find_block_by_global_name() {
+  Document doc = parse("_a 1\ndata_foo\n", "<test>", false);
+  const Block* g = doc.find_block(string_view("global_"));
+  CHECK(g != 0);
+  if (g) CHECK_EQ(sv_to_string(g->name()), std::string("global_"));
+}
+
+// ─── Explicit global_ header (CIF 1.1 reserved block type) ────────
+// Separate from non-strict synthesis: `global_` appears as its own
+// line and the tokenizer must recognize it as a block header, not a
+// value. Case is insensitive. This is the form used by cctbx's
+// monomer library (mon_lib_list.cif and friends).
+
+void test_explicit_global_header_strict() {
+  Document doc = parse("global_\n_a 1\n_b 2\n");
+  CHECK_EQ(doc.size(), 1u);
+  CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
+  CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_a"))),
+           std::string("1"));
+  CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_b"))),
+           std::string("2"));
+}
+
+void test_explicit_global_followed_by_data_block() {
+  Document doc = parse("global_\n_a 1\ndata_foo\n_x 1\n");
+  CHECK_EQ(doc.size(), 2u);
+  CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
+  CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_a"))),
+           std::string("1"));
+  CHECK_EQ(sv_to_string(doc[1].name()), std::string("foo"));
+}
+
+void test_explicit_global_case_insensitive() {
+  Document doc = parse("GLOBAL_\n_a 1\n");
+  CHECK_EQ(doc.size(), 1u);
+  const Block* g = doc.find_block(string_view("global_"));
+  CHECK(g != 0);
+}
+
+void test_monomer_library_header_with_explicit_global() {
+  const char* src =
+    "global_\n"
+    "_lib_name         mon_lib\n"
+    "_lib_version      4.11\n"
+    "_lib_update       15/04/05\n"
+    "# -----------------------------------------------\n"
+    "data_comp_list\n"
+    "loop_\n"
+    "_chem_comp.id\n"
+    "ALA\n";
+  Document doc = parse(src, "<monomer>");  // strict=true — no relaxation needed
+  CHECK_EQ(doc.size(), 2u);
+  CHECK_EQ(sv_to_string(doc[0].name()), std::string("global_"));
+  CHECK_EQ(sv_to_string(doc[0].find_value(string_view("_lib_version"))),
+           std::string("4.11"));
+  CHECK_EQ(sv_to_string(doc[1].name()), std::string("comp_list"));
+}
+
+// ─── run_all_tests ─────────────────────────────────────────────────
+
+void run_all_tests() {
+  test_strict_rejects_leading_pair();
+  test_default_is_strict();
+  test_strict_true_rejects_leading_pair();
+
+  test_non_strict_leading_pair_then_data_block();
+  test_non_strict_only_leading_pairs();
+  test_non_strict_monomer_library_header_pattern();
+  test_non_strict_leading_loop();
+  test_non_strict_empty_input();
+  test_non_strict_only_data_block_unchanged();
+  test_non_strict_find_block_by_global_name();
+
+  test_explicit_global_header_strict();
+  test_explicit_global_followed_by_data_block();
+  test_explicit_global_case_insensitive();
+  test_monomer_library_header_with_explicit_global();
+}
+
+XCIF_TEST_MAIN()

--- a/xcif/regression/cpp/tst_numeric.cpp
+++ b/xcif/regression/cpp/tst_numeric.cpp
@@ -129,6 +129,28 @@ void test_int_leading_plus() {
   CHECK_EQ(as_int("+5"), 5);
 }
 
+void test_int_max() {
+  CHECK_EQ(as_int("2147483647"), std::numeric_limits<int>::max());
+}
+
+void test_int_min() {
+  CHECK_EQ(as_int("-2147483648"), std::numeric_limits<int>::min());
+}
+
+void test_int_overflow_pos() {
+  bool caught = false;
+  try { as_int("2147483648"); }
+  catch (const std::overflow_error&) { caught = true; }
+  CHECK(caught);
+}
+
+void test_int_overflow_neg() {
+  bool caught = false;
+  try { as_int("-2147483649"); }
+  catch (const std::overflow_error&) { caught = true; }
+  CHECK(caught);
+}
+
 // ─── §5  as_double_with_su ──────────────────────────────────────────
 
 void test_su_none() {
@@ -165,6 +187,13 @@ void test_su_single_decimal() {
   std::pair<double, double> r = as_double_with_su("1.0(1)");
   CHECK(approx_eq(r.first, 1.0));
   CHECK(approx_eq(r.second, 0.1));
+}
+
+void test_su_with_exponent() {
+  // "1.5e+3(2)": 1 decimal digit before 'e', so su = 2/10 = 0.2; value = 1500
+  std::pair<double, double> r = as_double_with_su("1.5e+3(2)");
+  CHECK(approx_eq(r.first, 1500.0));
+  CHECK(approx_eq(r.second, 0.2));
 }
 
 void test_su_unknown_returns_nan() {
@@ -237,6 +266,10 @@ void run_all_tests() {
   test_int_zero();
   test_int_large();
   test_int_leading_plus();
+  test_int_max();
+  test_int_min();
+  test_int_overflow_pos();
+  test_int_overflow_neg();
 
   // §5 as_double_with_su
   test_su_none();
@@ -245,6 +278,7 @@ void run_all_tests() {
   test_su_integer();
   test_su_many_decimals();
   test_su_single_decimal();
+  test_su_with_exponent();
   test_su_unknown_returns_nan();
 
   // §6 Predicates

--- a/xcif/regression/cpp/tst_numeric.cpp
+++ b/xcif/regression/cpp/tst_numeric.cpp
@@ -202,6 +202,28 @@ void test_su_unknown_returns_nan() {
   CHECK(approx_eq(r.second, 0.0));
 }
 
+// ─── §5b as_double / as_double_with_su — boundary / malformed input ──
+
+void test_double_long_value_nan() {
+  // Values with ≥32 chars before '(' exceed the stack buffer → NaN
+  CHECK(std::isnan(as_double("1.23456789012345678901234567890123")));
+}
+
+void test_su_missing_close_paren() {
+  // "1.5(" has no closing ')' → su = 0.0 (graceful)
+  std::pair<double, double> r = as_double_with_su("1.5(");
+  CHECK(approx_eq(r.first, 1.5));
+  CHECK(approx_eq(r.second, 0.0));
+}
+
+void test_su_nonnumeric_in_su_content() {
+  // Non-digit chars in su content are skipped; digits are accumulated.
+  // "1.5(3a5)": su_int = 35, decimals = 1, su = 3.5
+  std::pair<double, double> r = as_double_with_su("1.5(3a5)");
+  CHECK(approx_eq(r.first, 1.5));
+  CHECK(approx_eq(r.second, 3.5));
+}
+
 // ─── §6  Predicates ─────────────────────────────────────────────────
 
 void test_is_unknown_dot() {
@@ -280,6 +302,11 @@ void run_all_tests() {
   test_su_single_decimal();
   test_su_with_exponent();
   test_su_unknown_returns_nan();
+
+  // §5b as_double/as_double_with_su — boundary / malformed
+  test_double_long_value_nan();
+  test_su_missing_close_paren();
+  test_su_nonnumeric_in_su_content();
 
   // §6 Predicates
   test_is_unknown_dot();

--- a/xcif/regression/cpp/tst_quoted_string_delimiter.cpp
+++ b/xcif/regression/cpp/tst_quoted_string_delimiter.cpp
@@ -1,0 +1,146 @@
+// cctbx_project/xcif/regression/cpp/tst_quoted_string_delimiter.cpp
+//
+// CIF 1.1 requires that the closing delimiter of a quoted string
+// (' for single, " for double) is only treated as a close when it is
+// followed by whitespace or end-of-input. An embedded delimiter
+// followed by a non-whitespace character is part of the string.
+//
+// Motivating case — cctbx monomer library, mon_lib_list.cif line 1688:
+//   'N-METHYL-PYRIDOXAL-5'-PHOSPHATE     '
+// The inner `'` is followed by `-`, so the string runs to the outer
+// closing `'` which is followed by a space.
+
+#include <xcif/data_model.h>
+#include <xcif/tokenizer.h>
+#include "test_utils.h"
+#include <cstring>
+#include <string>
+
+using namespace xcif;
+
+static std::string sv_to_string(const string_view& sv) {
+  return std::string(sv.data(), sv.size());
+}
+
+// Tokenize once and return the Nth value token (0-indexed).
+static std::string nth_value(const char* input, std::size_t n) {
+  Tokenizer tok(input, std::strlen(input), "<test>");
+  std::size_t seen = 0;
+  while (true) {
+    Token t = tok.next();
+    if (t.type == TOKEN_EOF) break;
+    if (t.type == TOKEN_VALUE) {
+      if (seen == n) return std::string(t.ptr, t.len);
+      ++seen;
+    }
+  }
+  return std::string("<not found>");
+}
+
+// ─── Existing behaviour still works ────────────────────────────────
+
+void test_plain_single_quoted() {
+  CHECK_EQ(nth_value("_a 'hello'\n", 0), std::string("hello"));
+}
+
+void test_plain_double_quoted() {
+  CHECK_EQ(nth_value("_a \"hello\"\n", 0), std::string("hello"));
+}
+
+void test_empty_single_quoted() {
+  CHECK_EQ(nth_value("_a '' \n", 0), std::string(""));
+}
+
+// ─── Embedded delimiter (CIF 1.1 spec requirement) ────────────────
+
+void test_apostrophe_followed_by_dash_is_embedded() {
+  // `5'-PHOSPHATE` — apostrophe followed by `-`, not whitespace.
+  CHECK_EQ(nth_value("_a 'N-METHYL-PYRIDOXAL-5'-PHOSPHATE'\n", 0),
+           std::string("N-METHYL-PYRIDOXAL-5'-PHOSPHATE"));
+}
+
+void test_apostrophe_followed_by_letter_is_embedded() {
+  CHECK_EQ(nth_value("_a 'it's fine'\n", 0),
+           std::string("it's fine"));
+}
+
+void test_double_quote_followed_by_letter_is_embedded() {
+  // Same rule applies to double-quoted strings.
+  // Note the absence of a space between the inner `"` and `once` —
+  // a space there would close the string (CIF 1.1 2.2.7.3).
+  CHECK_EQ(nth_value("_a \"say \"hi\"once\"\n", 0),
+           std::string("say \"hi\"once"));
+}
+
+void test_multiple_embedded_apostrophes() {
+  CHECK_EQ(nth_value("_a 'don't can't won't' \n", 0),
+           std::string("don't can't won't"));
+}
+
+// ─── Closing rules — whitespace / EOL / tab ───────────────────────
+
+void test_apostrophe_at_end_of_line_closes() {
+  // Closing `'` followed by newline is a terminator.
+  CHECK_EQ(nth_value("_a 'hello'\n_b 1\n", 0), std::string("hello"));
+}
+
+void test_apostrophe_followed_by_tab_closes() {
+  CHECK_EQ(nth_value("_a 'hello'\t2\n", 0), std::string("hello"));
+}
+
+void test_apostrophe_at_end_of_input_closes() {
+  // No character after the closing `'`.
+  CHECK_EQ(nth_value("_a 'hello'", 0), std::string("hello"));
+}
+
+// ─── Monomer library real-world case ──────────────────────────────
+
+void test_monomer_library_apostrophe_row() {
+  // Parse a compact loop row like the one at mon_lib_list.cif:1688.
+  const char* src =
+    "data_t\n"
+    "loop_\n"
+    "_chem_comp.id\n"
+    "_chem_comp.three_letter_code\n"
+    "_chem_comp.name\n"
+    "_chem_comp.group\n"
+    "_chem_comp.number_atoms_all\n"
+    "_chem_comp.number_atoms_nh\n"
+    "_chem_comp.desc_level\n"
+    "MPL      .   'N-METHYL-PYRIDOXAL-5'-PHOSPHATE     ' non-polymer  28  17 M\n";
+  Document doc = parse(src);
+  CHECK_EQ(doc.size(), 1u);
+  const Loop* lp = doc[0].find_loop(string_view("_chem_comp.id"));
+  CHECK(lp != 0);
+  if (!lp) return;
+  CHECK_EQ(lp->length(), 1u);
+  CHECK_EQ(lp->width(), 7u);
+  // Column 2 (0-indexed) is the name with embedded apostrophe.
+  CHECK_EQ(sv_to_string(lp->value(0, 2)),
+           std::string("N-METHYL-PYRIDOXAL-5'-PHOSPHATE     "));
+  // Surrounding columns must be unaffected.
+  CHECK_EQ(sv_to_string(lp->value(0, 0)), std::string("MPL"));
+  CHECK_EQ(sv_to_string(lp->value(0, 3)), std::string("non-polymer"));
+  CHECK_EQ(sv_to_string(lp->value(0, 6)), std::string("M"));
+}
+
+// ─── run_all_tests ─────────────────────────────────────────────────
+
+void run_all_tests() {
+  test_plain_single_quoted();
+  test_plain_double_quoted();
+  test_empty_single_quoted();
+
+  test_apostrophe_followed_by_dash_is_embedded();
+  test_apostrophe_followed_by_letter_is_embedded();
+  test_double_quote_followed_by_letter_is_embedded();
+  test_multiple_embedded_apostrophes();
+
+  test_apostrophe_at_end_of_line_closes();
+  test_apostrophe_followed_by_tab_closes();
+  test_apostrophe_at_end_of_input_closes();
+
+  test_monomer_library_apostrophe_row();
+}
+
+XCIF_TEST_MAIN()

--- a/xcif/regression/cpp/tst_quoted_string_delimiter.cpp
+++ b/xcif/regression/cpp/tst_quoted_string_delimiter.cpp
@@ -1,9 +1,11 @@
 // cctbx_project/xcif/regression/cpp/tst_quoted_string_delimiter.cpp
 //
-// CIF 1.1 requires that the closing delimiter of a quoted string
-// (' for single, " for double) is only treated as a close when it is
-// followed by whitespace or end-of-input. An embedded delimiter
-// followed by a non-whitespace character is part of the string.
+// CIF 1.1 syntax spec, paragraph 15
+// (https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax):
+// a quote-delimited character string may contain instances of the
+// delimiter (' for single, " for double) provided they are not
+// followed by whitespace. The closing delimiter is only recognised
+// as such when it is followed by whitespace or end-of-input.
 //
 // Motivating case — cctbx monomer library, mon_lib_list.cif line 1688:
 //   'N-METHYL-PYRIDOXAL-5'-PHOSPHATE     '
@@ -65,9 +67,9 @@ void test_apostrophe_followed_by_letter_is_embedded() {
 }
 
 void test_double_quote_followed_by_letter_is_embedded() {
-  // Same rule applies to double-quoted strings.
+  // Same rule applies to double-quoted strings (paragraph 15).
   // Note the absence of a space between the inner `"` and `once` —
-  // a space there would close the string (CIF 1.1 2.2.7.3).
+  // a space there would close the string.
   CHECK_EQ(nth_value("_a \"say \"hi\"once\"\n", 0),
            std::string("say \"hi\"once"));
 }

--- a/xcif/regression/cpp/tst_semicolon_field_strict.cpp
+++ b/xcif/regression/cpp/tst_semicolon_field_strict.cpp
@@ -1,0 +1,107 @@
+// cctbx_project/xcif/regression/cpp/tst_semicolon_field_strict.cpp
+//
+// CIF 1.1 §2.2.7.4: a semicolon text field must be terminated by `;`
+// appearing as the first character of a line. An unterminated field
+// (EOF before the closing `;` at column 1, or only a mid-line `;`) is
+// a syntax error.
+//
+// xcif previously returned a partial TOKEN_VALUE and let the parse
+// succeed, silently accepting content that has no closing delimiter.
+// That hid real malformations in user files. This test fixture
+// asserts the parser now raises CifError for each malformed shape.
+
+#include <xcif/data_model.h>
+#include "test_utils.h"
+#include <string>
+
+using namespace xcif;
+
+static bool parse_throws(const char* input, const char* expected_substr) {
+  try {
+    parse(input);
+    return false;
+  } catch (const CifError& e) {
+    if (expected_substr == nullptr) return true;
+    std::string msg = e.what();
+    if (msg.find(expected_substr) == std::string::npos) {
+      fprintf(stderr, "  Expected substring '%s' in error:\n  '%s'\n",
+              expected_substr, msg.c_str());
+      return false;
+    }
+    return true;
+  } catch (const std::exception& e) {
+    fprintf(stderr, "  Wrong exception type: %s\n", e.what());
+    return false;
+  }
+}
+
+// ─── Unterminated fields are errors ───────────────────────────────
+
+void test_semicolon_field_eof_before_close() {
+  // Opens at col 1 but never closes.
+  CHECK(parse_throws("data_t\n_a\n;line one\nline two\n",
+                     "semicolon"));
+}
+
+void test_semicolon_field_with_mid_line_semicolon() {
+  // The trailing `;` is at end-of-line, not column 1 — must not close.
+  // This is the shape used by tst_lex_parse_build.py::bad_semicolon_text_field.
+  const char* src =
+    "data_sucrose\n"
+    "_a 1\n"
+    "_exptl_absorpt_process_details\n"
+    ";\n"
+    "Final HKLF 4 output contains 64446 reflections, Rint = 0.0650\n"
+    " (47528 with I > 3sig(I), Rint = 0.0624);\n";
+  CHECK(parse_throws(src, "semicolon"));
+}
+
+void test_semicolon_field_eof_at_open_line() {
+  // File ends on the opening `;` line itself.
+  CHECK(parse_throws("data_t\n_a\n;no closing", "semicolon"));
+}
+
+// ─── Well-formed semicolon fields continue to parse ───────────────
+
+void test_semicolon_field_properly_closed_two_lines() {
+  Document doc = parse("data_t\n_a\n;hello\n;\n");
+  CHECK_EQ(doc.size(), 1u);
+  CHECK(doc[0].has_tag(string_view("_a")));
+  // Value is the body between the opening `;\n` and the closing `\n;`.
+  // Content begins immediately after the opening `;`, so includes an
+  // initial newline.
+  string_view v = doc[0].find_value(string_view("_a"));
+  CHECK_EQ(std::string(v.data(), v.size()), std::string("hello\n"));
+}
+
+void test_semicolon_field_multiline_closed() {
+  Document doc = parse(
+    "data_t\n"
+    "_a\n"
+    ";line one\n"
+    "line two\n"
+    "line three\n"
+    ";\n");
+  CHECK_EQ(doc.size(), 1u);
+  CHECK(doc[0].has_tag(string_view("_a")));
+}
+
+void test_semicolon_field_empty() {
+  // Immediate close on the next line.
+  Document doc = parse("data_t\n_a\n;\n;\n");
+  CHECK_EQ(doc.size(), 1u);
+  CHECK(doc[0].has_tag(string_view("_a")));
+}
+
+// ─── run_all_tests ─────────────────────────────────────────────────
+
+void run_all_tests() {
+  test_semicolon_field_eof_before_close();
+  test_semicolon_field_with_mid_line_semicolon();
+  test_semicolon_field_eof_at_open_line();
+  test_semicolon_field_properly_closed_two_lines();
+  test_semicolon_field_multiline_closed();
+  test_semicolon_field_empty();
+}
+
+XCIF_TEST_MAIN()

--- a/xcif/regression/cpp/tst_semicolon_field_strict.cpp
+++ b/xcif/regression/cpp/tst_semicolon_field_strict.cpp
@@ -1,9 +1,10 @@
 // cctbx_project/xcif/regression/cpp/tst_semicolon_field_strict.cpp
 //
-// CIF 1.1 §2.2.7.4: a semicolon text field must be terminated by `;`
-// appearing as the first character of a line. An unterminated field
-// (EOF before the closing `;` at column 1, or only a mid-line `;`) is
-// a syntax error.
+// CIF 1.1 syntax spec, paragraph 17
+// (https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax):
+// a semicolon text field is delimited by `;` appearing as the first
+// character of a line. An unterminated field (EOF before the closing
+// `;` at column 1, or only a mid-line `;`) is a syntax error.
 //
 // xcif previously returned a partial TOKEN_VALUE and let the parse
 // succeed, silently accepting content that has no closing delimiter.

--- a/xcif/regression/cpp/tst_tokenizer.cpp
+++ b/xcif/regression/cpp/tst_tokenizer.cpp
@@ -66,14 +66,12 @@ static void test_unquoted_value() {
 static void test_single_quoted_string() {
   xcif::Token t = second("_a 'hello world'");
   CHECK_EQ(t.type, xcif::TOKEN_VALUE);
-  std::cout << "Im'm in test singel quoted string\n";
   CHECK_EQ(t.as_str(), std::string("hello world"));
 }
 
 static void test_double_quoted_string() {
   xcif::Token t = second("_a \"hello world\"");
   CHECK_EQ(t.type, xcif::TOKEN_VALUE);
-  std::cout << "Im'm bla test 10 test_double_quoted_string\n";
   CHECK_EQ(t.as_str(), std::string("hello world"));
 }
 
@@ -82,7 +80,6 @@ static void test_semicolon_text_field() {
   const char* input = "_a\n;line one\nline two\n;\n";
   xcif::Token t = second(input);
   CHECK_EQ(t.type, xcif::TOKEN_VALUE);
-  std::cout << "Im'm bla test 325 test_semicolon_text_field\n";
   CHECK_EQ(t.as_str(), std::string("line one\nline two\n"));
 }
 

--- a/xcif/regression/cpp/tst_tokenizer.cpp
+++ b/xcif/regression/cpp/tst_tokenizer.cpp
@@ -305,6 +305,30 @@ static void test_loop_followed_by_tags_and_values() {
   CHECK_EQ(toks[3].type, xcif::TOKEN_VALUE);
 }
 
+static void test_unterminated_single_quote_returns_rest() {
+  // Unterminated single-quoted string: returns everything after the opening
+  // quote up to EOF as TOKEN_VALUE (graceful degradation, not an error).
+  xcif::Token t = second("_a 'hello world");
+  CHECK_EQ(t.type, xcif::TOKEN_VALUE);
+  CHECK_EQ(t.as_str(), std::string("hello world"));
+}
+
+static void test_unterminated_double_quote_returns_rest() {
+  xcif::Token t = second("_a \"hello world");
+  CHECK_EQ(t.type, xcif::TOKEN_VALUE);
+  CHECK_EQ(t.as_str(), std::string("hello world"));
+}
+
+static void test_null_byte_truncates_unquoted_token() {
+  // Null byte is not an ordinary character, so read_unquoted stops there.
+  const char input[] = {'_', 'a', ' ', 'v', 'a', 'l', '\0', 'u', 'e'};
+  xcif::Tokenizer tok(input, sizeof(input), "<test>");
+  tok.next(); // _a
+  xcif::Token t = tok.next();
+  CHECK_EQ(t.type, xcif::TOKEN_VALUE);
+  CHECK_EQ(t.as_str(), std::string("val"));
+}
+
 // ---------------------------------------------------------------------------
 // Test Registry
 // ---------------------------------------------------------------------------
@@ -373,6 +397,9 @@ static void run_all_tests() {
   test_multiple_blank_lines_ignored();
   test_consecutive_tags_and_values();
   test_loop_followed_by_tags_and_values();
+  test_unterminated_single_quote_returns_rest();
+  test_unterminated_double_quote_returns_rest();
+  test_null_byte_truncates_unquoted_token();
 }
 
 XCIF_TEST_MAIN()

--- a/xcif/regression/cpp/tst_tokenizer.cpp
+++ b/xcif/regression/cpp/tst_tokenizer.cpp
@@ -6,6 +6,7 @@
 
 #include "test_utils.h"
 #include "xcif/tokenizer.h"
+#include "xcif/data_model.h"  // xcif::CifError (thrown on malformed tokens)
 #include <cstring>
 #include <iostream>
 #include <string>
@@ -305,18 +306,32 @@ static void test_loop_followed_by_tags_and_values() {
   CHECK_EQ(toks[3].type, xcif::TOKEN_VALUE);
 }
 
-static void test_unterminated_single_quote_returns_rest() {
-  // Unterminated single-quoted string: returns everything after the opening
-  // quote up to EOF as TOKEN_VALUE (graceful degradation, not an error).
-  xcif::Token t = second("_a 'hello world");
-  CHECK_EQ(t.type, xcif::TOKEN_VALUE);
-  CHECK_EQ(t.as_str(), std::string("hello world"));
+static void test_unterminated_single_quote_raises() {
+  // CIF 1.1 grammar requires a matching closing delimiter for a
+  // quoted string (https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax);
+  // unterminated quoted strings are syntax errors.
+  // (Previously "returns rest"; tightened to match spec and ucif.)
+  const char* src = "_a 'hello world";
+  xcif::Tokenizer tok(src, std::strlen(src), "<test>");
+  (void)tok.next(); // _a
+  try {
+    (void)tok.next(); // should throw on the unterminated quote
+    CHECK(false /* expected CifError */);
+  } catch (const xcif::CifError&) {
+    // expected
+  }
 }
 
-static void test_unterminated_double_quote_returns_rest() {
-  xcif::Token t = second("_a \"hello world");
-  CHECK_EQ(t.type, xcif::TOKEN_VALUE);
-  CHECK_EQ(t.as_str(), std::string("hello world"));
+static void test_unterminated_double_quote_raises() {
+  const char* src = "_a \"hello world";
+  xcif::Tokenizer tok(src, std::strlen(src), "<test>");
+  (void)tok.next();
+  try {
+    (void)tok.next();
+    CHECK(false /* expected CifError */);
+  } catch (const xcif::CifError&) {
+    // expected
+  }
 }
 
 static void test_null_byte_truncates_unquoted_token() {
@@ -397,8 +412,8 @@ static void run_all_tests() {
   test_multiple_blank_lines_ignored();
   test_consecutive_tags_and_values();
   test_loop_followed_by_tags_and_values();
-  test_unterminated_single_quote_returns_rest();
-  test_unterminated_double_quote_returns_rest();
+  test_unterminated_single_quote_raises();
+  test_unterminated_double_quote_raises();
   test_null_byte_truncates_unquoted_token();
 }
 

--- a/xcif/regression/example.cif
+++ b/xcif/regression/example.cif
@@ -71,6 +71,24 @@ degradation.
 ;
 
 # --------------------------------------------------------------------------
+# Parent categories required by _atom_site child items (minimal stubs)
+# --------------------------------------------------------------------------
+loop_
+  _chem_comp.id
+  MET
+  GLN
+
+loop_
+  _entity.id
+  1
+
+loop_
+  _atom_type.symbol
+  N
+  C
+  O
+
+# --------------------------------------------------------------------------
 # Atom coordinate loop -10 atoms from the first two residues.
 # A loop_ block begins with the keyword `loop_`, followed by all column
 # tag names, followed by the data rows (column-major order, row by row).

--- a/xcif/regression/tst_api_compat.py
+++ b/xcif/regression/tst_api_compat.py
@@ -703,6 +703,37 @@ def exercise_output_example_cif():
       sx[:500], su[:500])
 
 
+def exercise_loop_category():
+  """Edge cases for the _loop_category() helper used by _loop_adapter."""
+  from xcif import _loop_category
+
+  # Empty list -> empty string
+  assert _loop_category([]) == "", \
+    "Expected '' for empty list, got '%s'" % _loop_category([])
+
+  # Single tag returned as-is (no trimming applied)
+  assert _loop_category(["_atom_site.id"]) == "_atom_site.id", \
+    "Single tag with dot: %s" % _loop_category(["_atom_site.id"])
+  assert _loop_category(["_single"]) == "_single", \
+    "Single tag no dot: %s" % _loop_category(["_single"])
+
+  # Multiple tags sharing a dot-separated category
+  r = _loop_category(["_atom_site.id", "_atom_site.x", "_atom_site.z"])
+  assert r == "_atom_site", \
+    "Dot-prefix: expected '_atom_site', got '%s'" % r
+
+  # Tags that share only the category name (diverge right after the dot)
+  # "_cell.length_a" vs "_cell.angle_alpha" → common prefix = "_cell." → "_cell"
+  r = _loop_category(["_cell.length_a", "_cell.angle_alpha"])
+  assert r == "_cell", "Expected '_cell', got '%s'" % r
+
+  # Multiple tags sharing only an underscore delimiter (no dot)
+  # "_refln_h", "_refln_k" → common prefix "_refln_" (ends with '_', kept)
+  r = _loop_category(["_refln_h", "_refln_k", "_refln_l"])
+  assert r.startswith("_refln"), \
+    "Underscore-prefix: expected '_refln...', got '%s'" % r
+
+
 if __name__ == "__main__":
   # C++ binding level tests
   exercise_block_names()
@@ -735,5 +766,7 @@ if __name__ == "__main__":
   exercise_output_quoted()
   exercise_output_nulls()
   exercise_output_example_cif()
+  # Internal helper
+  exercise_loop_category()
   print(format_cpu_times())
   print("OK")

--- a/xcif/regression/tst_bindings.py
+++ b/xcif/regression/tst_bindings.py
@@ -181,6 +181,23 @@ def exercise_flex_columns():
   assert math.isnan(x2[2]), "Expected NaN for '?'"
   assert approx_equal(x2[3], 3.0)
 
+  # column_as_flex_int raises ValueError when a cell contains '.' or '?'
+  cif_nullints = (
+    "data_nullints\n"
+    "loop_\n"
+    "_val.n\n"
+    "1\n"
+    ".\n"
+    "3\n"
+  )
+  doc3 = xcif_ext.parse(cif_nullints)
+  loop3 = doc3[0].find_loop("_val")
+  try:
+    loop3.column_as_flex_int("_val.n")
+    raise AssertionError("Expected ValueError for '.' in int column")
+  except ValueError:
+    pass
+
 def exercise_numeric():
   """Numeric conversion free functions."""
   import xcif_ext

--- a/xcif/regression/tst_example_parse.py
+++ b/xcif/regression/tst_example_parse.py
@@ -42,7 +42,7 @@ def exercise():
   # -----------------------------------------------------------------------
   assert "Blocks: 1" in out, "Expected 1 block"
   assert "Block: 1UBQ" in out, "Expected block name 1UBQ"
-  assert "Loops: 2" in out, "Expected 2 loops"
+  assert "Loops: 5" in out, "Expected 5 loops"
   assert "13 tags x 10 rows" in out, "Expected atom loop dimensions"
   assert "6 tags x 1 rows" in out, "Expected reflns loop dimensions"
 

--- a/xcif/regression/tst_example_tokenize.py
+++ b/xcif/regression/tst_example_tokenize.py
@@ -21,11 +21,11 @@ from libtbx.utils import format_cpu_times
 # Expected golden values — update here when example.cif is intentionally
 # changed, and document the reason in the commit message.
 # ---------------------------------------------------------------------------
-EXPECTED_TOTAL          = 204
-EXPECTED_TAG            = 42
-EXPECTED_VALUE          = 159
+EXPECTED_TOTAL          = 216
+EXPECTED_TAG            = 45
+EXPECTED_VALUE          = 165
 EXPECTED_BLOCK_HEADER   = 1
-EXPECTED_LOOP           = 2
+EXPECTED_LOOP           = 5
 
 def exercise():
   build_dir = libtbx.env.under_build("xcif")

--- a/xcif/regression/tst_iotbx_cif_reader_engine.py
+++ b/xcif/regression/tst_iotbx_cif_reader_engine.py
@@ -3,6 +3,8 @@
 Covers:
 - Unknown engine values are rejected with ValueError before any file I/O.
 - Known engines ("ucif", "xcif") are accepted.
+- engine="xcif" with file_path dispatches to xcif_ext.parse_file (zero-copy
+  mmap) rather than reading the whole file into a Python string.
 """
 from __future__ import absolute_import, division, print_function
 
@@ -10,6 +12,7 @@ import os
 import tempfile
 
 import iotbx.cif
+import xcif_ext
 
 
 def exercise_engine_validated_before_io():
@@ -47,9 +50,101 @@ def exercise_known_engines_accepted():
       "pair not parsed with engine=%s: got %r" % (engine, model["t"]["_k"])
 
 
+_SAMPLE_CIF = """\
+data_t
+_k v
+loop_
+_a.id
+_a.val
+ 1 x
+ 2 y
+"""
+
+
+def _write_sample(tmpdir):
+  p = os.path.join(tmpdir, "sample.cif")
+  with open(p, "w") as f:
+    f.write(_SAMPLE_CIF)
+  return p
+
+
+def exercise_file_path_uses_parse_file():
+  # Record which xcif_ext entry point the reader invokes.
+  real_parse = xcif_ext.parse
+  real_parse_file = xcif_ext.parse_file
+  calls = {"parse": 0, "parse_file": 0}
+
+  def _tracking_parse(text, **kw):
+    calls["parse"] += 1
+    return real_parse(text, **kw)
+
+  def _tracking_parse_file(path, **kw):
+    calls["parse_file"] += 1
+    return real_parse_file(path, **kw)
+
+  xcif_ext.parse = _tracking_parse
+  xcif_ext.parse_file = _tracking_parse_file
+  try:
+    tmpdir = tempfile.mkdtemp(prefix="xcif_reader_item5_")
+    try:
+      path = _write_sample(tmpdir)
+
+      # input_string + xcif: parse() is used, parse_file() is NOT.
+      iotbx.cif.reader(input_string=_SAMPLE_CIF, engine="xcif").model()
+      assert calls["parse"] == 1, \
+        "input_string path should call parse: %r" % calls
+      assert calls["parse_file"] == 0, \
+        "input_string path must NOT call parse_file: %r" % calls
+
+      # file_path + xcif: parse_file() is used, parse() is NOT.
+      calls["parse"] = 0
+      calls["parse_file"] = 0
+      iotbx.cif.reader(file_path=path, engine="xcif").model()
+      assert calls["parse_file"] == 1, \
+        "file_path path should call parse_file: %r" % calls
+      assert calls["parse"] == 0, \
+        "file_path path must NOT call parse (avoid Python-string copy): %r" % (
+          calls,)
+    finally:
+      import shutil
+      shutil.rmtree(tmpdir, ignore_errors=True)
+  finally:
+    xcif_ext.parse = real_parse
+    xcif_ext.parse_file = real_parse_file
+
+
+def exercise_file_path_matches_input_string():
+  tmpdir = tempfile.mkdtemp(prefix="xcif_reader_item5_")
+  try:
+    path = _write_sample(tmpdir)
+    m_str = iotbx.cif.reader(
+      input_string=_SAMPLE_CIF, engine="xcif").model()
+    m_file = iotbx.cif.reader(file_path=path, engine="xcif").model()
+    # Compare block set, pair items, loop tag+content.
+    assert list(m_str.keys()) == list(m_file.keys())
+    for name in m_str:
+      b_s = m_str[name]
+      b_f = m_file[name]
+      assert list(b_s._set) == list(b_f._set), \
+        "source-order drift between input_string and file_path"
+      assert dict(b_s._items) == dict(b_f._items)
+      assert set(b_s.loops.keys()) == set(b_f.loops.keys())
+      for ln in b_s.loops:
+        lp_s = b_s.loops[ln]
+        lp_f = b_f.loops[ln]
+        assert set(lp_s.keys()) == set(lp_f.keys())
+        for tag in lp_s.keys():
+          assert list(lp_s[tag]) == list(lp_f[tag])
+  finally:
+    import shutil
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def run():
   exercise_engine_validated_before_io()
   exercise_known_engines_accepted()
+  exercise_file_path_uses_parse_file()
+  exercise_file_path_matches_input_string()
   print("OK")
 
 

--- a/xcif/regression/tst_iotbx_cif_reader_engine.py
+++ b/xcif/regression/tst_iotbx_cif_reader_engine.py
@@ -1,0 +1,57 @@
+"""Tests for the engine= kwarg on iotbx.cif.reader.
+
+Covers:
+- Unknown engine values are rejected with ValueError before any file I/O.
+- Known engines ("ucif", "xcif") are accepted.
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+import tempfile
+
+import iotbx.cif
+
+
+def exercise_engine_validated_before_io():
+  # A bad engine value must be rejected before the reader touches the
+  # filesystem. Use a path that does not exist: if engine validation
+  # happens first we get ValueError from the engine check; if file I/O
+  # happens first we get an OSError/IOError/Sorry from smart_open.
+  bogus_path = os.path.join(
+    tempfile.gettempdir(),
+    "definitely_not_a_real_cif_file_%d.cif" % os.getpid())
+  # Make sure it really does not exist
+  if os.path.exists(bogus_path):
+    os.remove(bogus_path)
+  try:
+    iotbx.cif.reader(file_path=bogus_path, engine="not_a_real_engine")
+  except ValueError as e:
+    msg = str(e)
+    assert "engine" in msg, \
+      "expected engine-related ValueError, got: %s" % msg
+    return
+  except Exception as e:
+    raise AssertionError(
+      "engine validation should happen before file I/O; "
+      "got %s instead of ValueError: %s" % (type(e).__name__, e))
+  raise AssertionError("expected ValueError for bad engine, no exception raised")
+
+
+def exercise_known_engines_accepted():
+  input_string = "data_t\n_k v\n"
+  for engine in ("ucif", "xcif"):
+    reader = iotbx.cif.reader(input_string=input_string, engine=engine)
+    model = reader.model()
+    assert "t" in model, "block not parsed with engine=%s" % engine
+    assert model["t"]["_k"] == "v", \
+      "pair not parsed with engine=%s: got %r" % (engine, model["t"]["_k"])
+
+
+def run():
+  exercise_engine_validated_before_io()
+  exercise_known_engines_accepted()
+  print("OK")
+
+
+if __name__ == "__main__":
+  run()

--- a/xcif/regression/tst_iotbx_cif_reader_parity.py
+++ b/xcif/regression/tst_iotbx_cif_reader_parity.py
@@ -11,7 +11,6 @@ import os
 import sys
 
 import libtbx.load_env
-from libtbx.test_utils import show_diff
 import iotbx.cif
 
 

--- a/xcif/regression/tst_iotbx_cif_reader_parity.py
+++ b/xcif/regression/tst_iotbx_cif_reader_parity.py
@@ -1,0 +1,263 @@
+"""Parity test: iotbx.cif.reader with engine='ucif' vs engine='xcif'.
+
+Parses a corpus of CIF fixtures with both engines and asserts the resulting
+iotbx.cif.model.cif objects are structurally equivalent (pair items, loops,
+save frames). Order-insensitive at the block/loop level; order-preserving
+inside loop columns.
+"""
+from __future__ import absolute_import, division, print_function
+
+import os
+import sys
+
+import libtbx.load_env
+from libtbx.test_utils import show_diff
+import iotbx.cif
+
+
+# ---------------------------------------------------------------------------
+# Inline fixtures — cover corner cases the real files may not exercise.
+# ---------------------------------------------------------------------------
+
+CIF_SIMPLE_PAIRS = """\
+data_pairs_only
+_one 1
+_two 'two words'
+_three 3.14
+_four .
+_five ?
+"""
+
+CIF_LOOP_ONLY = """\
+data_loop_only
+loop_
+_atom.label
+_atom.x
+_atom.y
+_atom.z
+ A  1.0  2.0  3.0
+ B  4.0  5.0  6.0
+ C  7.0  8.0  9.0
+"""
+
+CIF_INTERLEAVED = """\
+data_interleaved
+_leading_key 'before loop'
+loop_
+_site.id
+_site.occ
+ 1  1.0
+ 2  0.5
+_trailing_key 'after loop'
+"""
+
+CIF_MULTIBLOCK = """\
+data_alpha
+_id alpha
+_flag y
+
+data_beta
+_id beta
+loop_
+_beta.i
+_beta.v
+ 1 one
+ 2 two
+"""
+
+CIF_SAVE_FRAMES = """\
+data_with_saves
+_top_level 'outer'
+save_frame1
+_inner.key1 value1
+_inner.key2 value2
+loop_
+_inner_loop.a
+_inner_loop.b
+ 1 x
+ 2 y
+save_
+
+save_frame2
+_other.key other_value
+save_
+"""
+
+CIF_UNDERSCORE_IN_NAME = """\
+data_foo_bar_baz
+_key val
+"""
+
+CIF_QUOTED_AND_SEMI = """\
+data_quotes
+_single_quoted 'with spaces'
+_double_quoted "also spaces"
+_semicolon_text
+;
+line one
+line two
+;
+_normal normal
+"""
+
+
+INLINE_FIXTURES = [
+  ("simple_pairs", CIF_SIMPLE_PAIRS),
+  ("loop_only", CIF_LOOP_ONLY),
+  ("interleaved", CIF_INTERLEAVED),
+  ("multiblock", CIF_MULTIBLOCK),
+  ("save_frames", CIF_SAVE_FRAMES),
+  ("underscore_in_name", CIF_UNDERSCORE_IN_NAME),
+  ("quoted_and_semi", CIF_QUOTED_AND_SEMI),
+]
+
+
+# ---------------------------------------------------------------------------
+# File fixtures from xcif/regression/
+# ---------------------------------------------------------------------------
+
+def _xcif_regression_dir():
+  path = libtbx.env.dist_path("xcif")
+  return os.path.join(path, "regression")
+
+def _file_fixtures():
+  d = _xcif_regression_dir()
+  out = []
+  for name in ("example.cif", "1yjp.cif", "1yjp-sf.cif"):
+    p = os.path.join(d, name)
+    if os.path.isfile(p):
+      out.append((name, p))
+  return out
+
+
+# ---------------------------------------------------------------------------
+# Structural comparator
+# ---------------------------------------------------------------------------
+
+def _fail(context, msg):
+  return "parity mismatch at %s: %s" % (context, msg)
+
+def _compare_loop(ctx, lp_u, lp_x):
+  tags_u = list(lp_u.keys())
+  tags_x = list(lp_x.keys())
+  # Tag set must match (order within a loop is observed but allow either
+  # engine to enumerate in a different cif_model_builder order — compare as
+  # set first, then per-tag column content).
+  if set(tags_u) != set(tags_x):
+    return _fail(ctx, "loop tags differ: ucif=%s xcif=%s" % (
+      sorted(tags_u), sorted(tags_x)))
+  for tag in tags_u:
+    col_u = list(lp_u[tag])
+    col_x = list(lp_x[tag])
+    if col_u != col_x:
+      return _fail(ctx + "/" + tag,
+                   "column differs: ucif[:5]=%s xcif[:5]=%s lengths=%d,%d" %
+                   (col_u[:5], col_x[:5], len(col_u), len(col_x)))
+  return None
+
+def _compare_block_like(ctx, blk_u, blk_x):
+  # Pair items
+  items_u = dict(blk_u._items)
+  items_x = dict(blk_x._items)
+  if set(items_u.keys()) != set(items_x.keys()):
+    only_u = set(items_u) - set(items_x)
+    only_x = set(items_x) - set(items_u)
+    return _fail(ctx, "pair keys differ: only-in-ucif=%s only-in-xcif=%s" % (
+      sorted(only_u), sorted(only_x)))
+  for k, v_u in items_u.items():
+    v_x = items_x[k]
+    if v_u != v_x:
+      return _fail(ctx + "/" + k,
+                   "pair value differs: ucif=%r xcif=%r" % (v_u, v_x))
+  # Loops
+  loops_u = blk_u.loops
+  loops_x = blk_x.loops
+  if set(loops_u.keys()) != set(loops_x.keys()):
+    only_u = set(loops_u) - set(loops_x)
+    only_x = set(loops_x) - set(loops_u)
+    return _fail(ctx, "loop names differ: only-in-ucif=%s only-in-xcif=%s" % (
+      sorted(only_u), sorted(only_x)))
+  for name in loops_u:
+    err = _compare_loop(ctx + "/loop:" + name, loops_u[name], loops_x[name])
+    if err: return err
+  return None
+
+def _compare_cif(ctx, cif_u, cif_x):
+  names_u = list(cif_u.keys())
+  names_x = list(cif_x.keys())
+  if set(names_u) != set(names_x):
+    only_u = set(names_u) - set(names_x)
+    only_x = set(names_x) - set(names_u)
+    return _fail(ctx, "block names differ: only-in-ucif=%s only-in-xcif=%s" %
+                 (sorted(only_u), sorted(only_x)))
+  for name in names_u:
+    blk_u = cif_u[name]
+    blk_x = cif_x[name]
+    err = _compare_block_like("%s/block:%s" % (ctx, name), blk_u, blk_x)
+    if err: return err
+    # Save frames (block has .saves, save does not)
+    saves_u = getattr(blk_u, "saves", {})
+    saves_x = getattr(blk_x, "saves", {})
+    if set(saves_u.keys()) != set(saves_x.keys()):
+      only_u = set(saves_u) - set(saves_x)
+      only_x = set(saves_x) - set(saves_u)
+      return _fail(
+        "%s/block:%s" % (ctx, name),
+        "save frames differ: only-in-ucif=%s only-in-xcif=%s" % (
+          sorted(only_u), sorted(only_x)))
+    for sf_name in saves_u:
+      err = _compare_block_like(
+        "%s/block:%s/save:%s" % (ctx, name, sf_name),
+        saves_u[sf_name], saves_x[sf_name])
+      if err: return err
+  return None
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def _parse_both(input_string=None, file_path=None):
+  if file_path is not None:
+    m_u = iotbx.cif.reader(file_path=file_path, engine="ucif").model()
+    m_x = iotbx.cif.reader(file_path=file_path, engine="xcif").model()
+  else:
+    m_u = iotbx.cif.reader(input_string=input_string, engine="ucif").model()
+    m_x = iotbx.cif.reader(input_string=input_string, engine="xcif").model()
+  return m_u, m_x
+
+def _run_case(label, *, input_string=None, file_path=None):
+  try:
+    m_u, m_x = _parse_both(input_string=input_string, file_path=file_path)
+  except Exception as e:
+    return "%s: parse raised: %s" % (label, e)
+  err = _compare_cif(label, m_u, m_x)
+  return err
+
+def run():
+  failures = []
+  for label, text in INLINE_FIXTURES:
+    err = _run_case(label, input_string=text)
+    if err:
+      failures.append(err)
+    else:
+      print("OK:", label)
+
+  for name, path in _file_fixtures():
+    err = _run_case("file:" + name, file_path=path)
+    if err:
+      failures.append(err)
+    else:
+      print("OK: file:" + name)
+
+  if failures:
+    print()
+    print("FAILURES:")
+    for f in failures:
+      print(" -", f)
+    sys.exit(1)
+  print()
+  print("OK all parity cases")
+
+if __name__ == "__main__":
+  run()

--- a/xcif/regression/tst_iotbx_cif_reader_parity.py
+++ b/xcif/regression/tst_iotbx_cif_reader_parity.py
@@ -47,7 +47,13 @@ _site.id
 _site.occ
  1  1.0
  2  0.5
-_trailing_key 'after loop'
+_middle_key 'between loops'
+loop_
+_other.id
+_other.val
+ 1  a
+ 2  b
+_trailing_key 'after loops'
 """
 
 CIF_MULTIBLOCK = """\
@@ -155,7 +161,18 @@ def _compare_loop(ctx, lp_u, lp_x):
   return None
 
 def _compare_block_like(ctx, blk_u, blk_x):
-  # Pair items
+  # Pair items + loop names: check ORDER first via block._set.
+  # _set is the OrderedSet that preserves source-order interleave
+  # across pair items and loops within a block; it drives
+  # str(model) / block.show() output. Comparing _items and .loops
+  # as separate dicts cannot catch pair/loop interleave mismatches.
+  set_u = list(blk_u._set)
+  set_x = list(blk_x._set)
+  if set_u != set_x:
+    return _fail(ctx,
+      "block key order differs (source-order mismatch):\n"
+      "  ucif=%s\n  xcif=%s" % (set_u, set_x))
+  # Pair items (content; order already verified via _set above)
   items_u = dict(blk_u._items)
   items_x = dict(blk_x._items)
   if set(items_u.keys()) != set(items_x.keys()):
@@ -168,7 +185,7 @@ def _compare_block_like(ctx, blk_u, blk_x):
     if v_u != v_x:
       return _fail(ctx + "/" + k,
                    "pair value differs: ucif=%r xcif=%r" % (v_u, v_x))
-  # Loops
+  # Loops (content)
   loops_u = blk_u.loops
   loops_x = blk_x.loops
   if set(loops_u.keys()) != set(loops_x.keys()):

--- a/xcif/regression/tst_non_strict_mode.py
+++ b/xcif/regression/tst_non_strict_mode.py
@@ -94,24 +94,36 @@ def test_non_strict_find_block_by_global_name():
   assert g.name == "global_"
 
 
-# ─── Explicit global_ block header (CIF 1.1 reserved) ─────────────
+# ─── Explicit global_ block header — strict rejects, non-strict OK ───
+# CIF 1.1 strict does not allow `global_`; ucif treats it as a
+# non-strict-only relaxation. xcif matches: strict mode rejects,
+# non-strict accepts. The cctbx monomer library (mon_lib_list.cif etc.)
+# uses `global_` and loads with strict=False.
 
-def test_explicit_global_header_strict():
-  doc = xcif_ext.parse("global_\n_a 1\n_b 2\n")
+def test_explicit_global_header_rejected_in_strict():
+  try:
+    xcif_ext.parse("global_\n_a 1\n_b 2\n")
+  except (RuntimeError, ValueError) as e:
+    assert "global_" in str(e), str(e)
+    return
+  raise AssertionError("strict mode should reject global_ header")
+
+def test_explicit_global_header_non_strict():
+  doc = xcif_ext.parse("global_\n_a 1\n_b 2\n", strict=False)
   assert len(doc) == 1
   assert doc[0].name == "global_"
   assert doc[0].find_value("_a") == "1"
   assert doc[0].find_value("_b") == "2"
 
 def test_explicit_global_followed_by_data_block():
-  doc = xcif_ext.parse("global_\n_a 1\ndata_foo\n_x 1\n")
+  doc = xcif_ext.parse("global_\n_a 1\ndata_foo\n_x 1\n", strict=False)
   assert len(doc) == 2
   assert doc[0].name == "global_"
   assert doc[0].find_value("_a") == "1"
   assert doc[1].name == "foo"
 
 def test_explicit_global_case_insensitive():
-  doc = xcif_ext.parse("GLOBAL_\n_a 1\n")
+  doc = xcif_ext.parse("GLOBAL_\n_a 1\n", strict=False)
   assert len(doc) == 1
   g = doc.find_block("global_")
   assert g is not None
@@ -128,7 +140,7 @@ def test_monomer_library_header_with_explicit_global():
     "_chem_comp.id\n"
     "ALA\n"
   )
-  doc = xcif_ext.parse(src)  # strict=True
+  doc = xcif_ext.parse(src, strict=False)
   assert len(doc) == 2
   assert doc[0].name == "global_"
   assert doc[0].find_value("_lib_version") == "4.11"
@@ -145,7 +157,8 @@ def run():
   test_non_strict_empty_input()
   test_non_strict_only_data_block_unchanged()
   test_non_strict_find_block_by_global_name()
-  test_explicit_global_header_strict()
+  test_explicit_global_header_rejected_in_strict()
+  test_explicit_global_header_non_strict()
   test_explicit_global_followed_by_data_block()
   test_explicit_global_case_insensitive()
   test_monomer_library_header_with_explicit_global()

--- a/xcif/regression/tst_non_strict_mode.py
+++ b/xcif/regression/tst_non_strict_mode.py
@@ -1,0 +1,156 @@
+"""Tests for xcif_ext.parse(..., strict=False) — synthesized global_ block
+for content before the first data_ block.
+
+Motivating case: the cctbx monomer library files start with pair items
+(e.g. _lib_update 15/04/05) before the first data_ block. ucif silently
+accepts this in non-strict mode; xcif must also, attaching the leading
+content to an implicit global_ block.
+"""
+from __future__ import absolute_import, division, print_function
+
+import xcif_ext
+
+
+def _expect_parse_error(input_string, **kwargs):
+  try:
+    xcif_ext.parse(input_string, **kwargs)
+  except (RuntimeError, ValueError):
+    return
+  raise AssertionError(
+    "expected parse error for %r (kwargs=%r)" % (input_string[:60], kwargs))
+
+
+# ─── Strict mode (default) unchanged ───────────────────────────────
+
+def test_default_is_strict():
+  _expect_parse_error("_a 1\n")
+
+def test_strict_true_rejects_leading_pair():
+  _expect_parse_error("_a 1\ndata_foo\n_x 1\n", strict=True)
+
+
+# ─── Non-strict: synthesize global_ block ──────────────────────────
+
+def test_non_strict_leading_pair_then_data_block():
+  doc = xcif_ext.parse("_a 1\ndata_foo\n_x 1\n", strict=False)
+  assert len(doc) == 2, len(doc)
+  assert doc[0].name == "global_", doc[0].name
+  assert doc[0].find_value("_a") == "1"
+  assert doc[1].name == "foo"
+  assert doc[1].find_value("_x") == "1"
+
+def test_non_strict_only_leading_pairs():
+  doc = xcif_ext.parse("_a 1\n_b 2\n", strict=False)
+  assert len(doc) == 1
+  assert doc[0].name == "global_"
+  assert doc[0].find_value("_a") == "1"
+  assert doc[0].find_value("_b") == "2"
+
+def test_non_strict_monomer_library_header_pattern():
+  src = (
+    "_lib_update       15/04/05\n"
+    "# ------------------------------------------------\n"
+    "#\n"
+    "# ---   LIST OF MONOMERS ---\n"
+    "#\n"
+    "data_comp_list\n"
+    "loop_\n"
+    "_chem_comp.id\n"
+    "ALA\n"
+    "GLY\n"
+  )
+  doc = xcif_ext.parse(src, strict=False)
+  assert len(doc) == 2
+  assert doc[0].name == "global_"
+  assert doc[0].find_value("_lib_update") == "15/04/05"
+  assert doc[1].name == "comp_list"
+  lp = doc[1].find_loop("_chem_comp.id")
+  assert lp is not None
+  assert lp.length == 2
+
+def test_non_strict_leading_loop():
+  src = "loop_\n_a\n_b\n1 2\n3 4\n"
+  doc = xcif_ext.parse(src, strict=False)
+  assert len(doc) == 1
+  assert doc[0].name == "global_"
+  lp = doc[0].find_loop("_a")
+  assert lp is not None
+  assert lp.length == 2
+  assert lp.width == 2
+
+def test_non_strict_empty_input():
+  doc = xcif_ext.parse("", strict=False)
+  assert len(doc) == 0
+
+def test_non_strict_only_data_block_unchanged():
+  doc = xcif_ext.parse("data_foo\n_x 1\n", strict=False)
+  assert len(doc) == 1
+  assert doc[0].name == "foo"
+
+def test_non_strict_find_block_by_global_name():
+  doc = xcif_ext.parse("_a 1\ndata_foo\n", strict=False)
+  g = doc.find_block("global_")
+  assert g is not None
+  assert g.name == "global_"
+
+
+# ─── Explicit global_ block header (CIF 1.1 reserved) ─────────────
+
+def test_explicit_global_header_strict():
+  doc = xcif_ext.parse("global_\n_a 1\n_b 2\n")
+  assert len(doc) == 1
+  assert doc[0].name == "global_"
+  assert doc[0].find_value("_a") == "1"
+  assert doc[0].find_value("_b") == "2"
+
+def test_explicit_global_followed_by_data_block():
+  doc = xcif_ext.parse("global_\n_a 1\ndata_foo\n_x 1\n")
+  assert len(doc) == 2
+  assert doc[0].name == "global_"
+  assert doc[0].find_value("_a") == "1"
+  assert doc[1].name == "foo"
+
+def test_explicit_global_case_insensitive():
+  doc = xcif_ext.parse("GLOBAL_\n_a 1\n")
+  assert len(doc) == 1
+  g = doc.find_block("global_")
+  assert g is not None
+
+def test_monomer_library_header_with_explicit_global():
+  src = (
+    "global_\n"
+    "_lib_name         mon_lib\n"
+    "_lib_version      4.11\n"
+    "_lib_update       15/04/05\n"
+    "# -----------------------------------------------\n"
+    "data_comp_list\n"
+    "loop_\n"
+    "_chem_comp.id\n"
+    "ALA\n"
+  )
+  doc = xcif_ext.parse(src)  # strict=True
+  assert len(doc) == 2
+  assert doc[0].name == "global_"
+  assert doc[0].find_value("_lib_version") == "4.11"
+  assert doc[1].name == "comp_list"
+
+
+def run():
+  test_default_is_strict()
+  test_strict_true_rejects_leading_pair()
+  test_non_strict_leading_pair_then_data_block()
+  test_non_strict_only_leading_pairs()
+  test_non_strict_monomer_library_header_pattern()
+  test_non_strict_leading_loop()
+  test_non_strict_empty_input()
+  test_non_strict_only_data_block_unchanged()
+  test_non_strict_find_block_by_global_name()
+  test_explicit_global_header_strict()
+  test_explicit_global_followed_by_data_block()
+  test_explicit_global_case_insensitive()
+  test_monomer_library_header_with_explicit_global()
+  print("OK")
+
+
+if __name__ == "__main__":
+  run()

--- a/xcif/regression/tst_quoted_string_delimiter.py
+++ b/xcif/regression/tst_quoted_string_delimiter.py
@@ -1,6 +1,9 @@
-"""CIF 1.1 quoted-string delimiter rule: a ' (or ") only closes a
-single-(double-)quoted string when followed by whitespace or EOL.
-An embedded delimiter followed by a non-whitespace char is part of
+"""CIF 1.1 syntax spec, paragraph 15
+(https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax): a
+quote-delimited string may contain instances of the delimiter
+provided they are not followed by whitespace. The closing `'` (or
+`"`) is only recognised when followed by whitespace or EOL; an
+embedded delimiter followed by a non-whitespace char is part of
 the string content.
 
 Motivating case — cctbx monomer library, mon_lib_list.cif line 1688:
@@ -35,7 +38,7 @@ def test_apostrophe_followed_by_letter_is_embedded():
 
 def test_double_quote_followed_by_letter_is_embedded():
   # No space before `once` — else the `" ` sequence would close the
-  # string per CIF 1.1 2.2.7.3.
+  # string per CIF 1.1 paragraph 15.
   doc = xcif_ext.parse('data_t\n_a "say "hi"once"\n')
   assert doc[0].find_value("_a") == 'say "hi"once'
 

--- a/xcif/regression/tst_quoted_string_delimiter.py
+++ b/xcif/regression/tst_quoted_string_delimiter.py
@@ -1,0 +1,102 @@
+"""CIF 1.1 quoted-string delimiter rule: a ' (or ") only closes a
+single-(double-)quoted string when followed by whitespace or EOL.
+An embedded delimiter followed by a non-whitespace char is part of
+the string content.
+
+Motivating case — cctbx monomer library, mon_lib_list.cif line 1688:
+  'N-METHYL-PYRIDOXAL-5'-PHOSPHATE     '
+The inner `'` is followed by `-`, so it must not terminate the string.
+"""
+from __future__ import absolute_import, division, print_function
+
+import xcif_ext
+
+
+# ─── Existing behaviour still works ───────────────────────────────
+
+def test_plain_single_quoted():
+  doc = xcif_ext.parse("data_t\n_a 'hello'\n")
+  assert doc[0].find_value("_a") == "hello"
+
+def test_plain_double_quoted():
+  doc = xcif_ext.parse('data_t\n_a "hello"\n')
+  assert doc[0].find_value("_a") == "hello"
+
+
+# ─── Embedded delimiter (CIF 1.1 spec requirement) ────────────────
+
+def test_apostrophe_followed_by_dash_is_embedded():
+  doc = xcif_ext.parse("data_t\n_a 'N-METHYL-PYRIDOXAL-5'-PHOSPHATE'\n")
+  assert doc[0].find_value("_a") == "N-METHYL-PYRIDOXAL-5'-PHOSPHATE"
+
+def test_apostrophe_followed_by_letter_is_embedded():
+  doc = xcif_ext.parse("data_t\n_a 'it's fine'\n")
+  assert doc[0].find_value("_a") == "it's fine"
+
+def test_double_quote_followed_by_letter_is_embedded():
+  # No space before `once` — else the `" ` sequence would close the
+  # string per CIF 1.1 2.2.7.3.
+  doc = xcif_ext.parse('data_t\n_a "say "hi"once"\n')
+  assert doc[0].find_value("_a") == 'say "hi"once'
+
+def test_multiple_embedded_apostrophes():
+  doc = xcif_ext.parse("data_t\n_a 'don't can't won't'\n")
+  assert doc[0].find_value("_a") == "don't can't won't"
+
+
+# ─── Closing rules — whitespace / EOL / tab ───────────────────────
+
+def test_apostrophe_at_end_of_input_closes():
+  doc = xcif_ext.parse("data_t\n_a 'hello'")
+  assert doc[0].find_value("_a") == "hello"
+
+def test_apostrophe_followed_by_tab_closes():
+  # Tab after the closing `'` must be recognised as whitespace so the
+  # string closes and the next tag is recognised.
+  doc = xcif_ext.parse("data_t\n_a 'hello'\t_b 3\n")
+  assert doc[0].find_value("_a") == "hello"
+  assert doc[0].find_value("_b") == "3"
+
+
+# ─── Monomer library real-world case ──────────────────────────────
+
+def test_monomer_library_apostrophe_row():
+  src = (
+    "data_t\n"
+    "loop_\n"
+    "_chem_comp.id\n"
+    "_chem_comp.three_letter_code\n"
+    "_chem_comp.name\n"
+    "_chem_comp.group\n"
+    "_chem_comp.number_atoms_all\n"
+    "_chem_comp.number_atoms_nh\n"
+    "_chem_comp.desc_level\n"
+    "MPL      .   'N-METHYL-PYRIDOXAL-5'-PHOSPHATE     ' "
+    "non-polymer  28  17 M\n"
+  )
+  doc = xcif_ext.parse(src)
+  lp = doc[0].find_loop("_chem_comp.id")
+  assert lp is not None
+  assert lp.length == 1
+  assert lp.width == 7
+  assert lp.value(0, 0) == "MPL"
+  assert lp.value(0, 2) == "N-METHYL-PYRIDOXAL-5'-PHOSPHATE     "
+  assert lp.value(0, 3) == "non-polymer"
+  assert lp.value(0, 6) == "M"
+
+
+def run():
+  test_plain_single_quoted()
+  test_plain_double_quoted()
+  test_apostrophe_followed_by_dash_is_embedded()
+  test_apostrophe_followed_by_letter_is_embedded()
+  test_double_quote_followed_by_letter_is_embedded()
+  test_multiple_embedded_apostrophes()
+  test_apostrophe_at_end_of_input_closes()
+  test_apostrophe_followed_by_tab_closes()
+  test_monomer_library_apostrophe_row()
+  print("OK")
+
+
+if __name__ == "__main__":
+  run()

--- a/xcif/regression/tst_semicolon_field_strict.py
+++ b/xcif/regression/tst_semicolon_field_strict.py
@@ -1,0 +1,76 @@
+"""CIF 1.1 §2.2.7.4: the closing delimiter of a semicolon text field
+must be a `;` at column 1 of a new line. An unterminated field (no
+such closer before EOF) is a syntax error.
+
+Previously xcif returned a partial TOKEN_VALUE for unterminated fields
+and the parse succeeded silently — masking real malformations.
+"""
+from __future__ import absolute_import, division, print_function
+
+import xcif_ext
+
+
+def _expect_parse_error(input_string, **kwargs):
+  try:
+    xcif_ext.parse(input_string, **kwargs)
+  except (RuntimeError, ValueError):
+    return
+  raise AssertionError(
+    "expected parse error for %r" % input_string[:60])
+
+
+# ─── Unterminated fields are errors ───────────────────────────────
+
+def test_semicolon_field_eof_before_close():
+  _expect_parse_error("data_t\n_a\n;line one\nline two\n")
+
+def test_semicolon_field_with_mid_line_semicolon():
+  # Mirrors tst_lex_parse_build.py::bad_semicolon_text_field
+  src = (
+    "data_sucrose\n"
+    "_a 1\n"
+    "_exptl_absorpt_process_details\n"
+    ";\n"
+    "Final HKLF 4 output contains 64446 reflections, Rint = 0.0650\n"
+    " (47528 with I > 3sig(I), Rint = 0.0624);\n"
+  )
+  _expect_parse_error(src)
+
+def test_semicolon_field_eof_at_open_line():
+  _expect_parse_error("data_t\n_a\n;no closing")
+
+
+# ─── Well-formed semicolon fields continue to parse ───────────────
+
+def test_semicolon_field_properly_closed():
+  doc = xcif_ext.parse("data_t\n_a\n;hello\n;\n")
+  assert len(doc) == 1
+  assert doc[0].find_value("_a") == "hello\n"
+
+def test_semicolon_field_multiline_closed():
+  doc = xcif_ext.parse(
+    "data_t\n"
+    "_a\n"
+    ";line one\n"
+    "line two\n"
+    "line three\n"
+    ";\n")
+  assert len(doc) == 1
+
+def test_semicolon_field_empty():
+  doc = xcif_ext.parse("data_t\n_a\n;\n;\n")
+  assert len(doc) == 1
+
+
+def run():
+  test_semicolon_field_eof_before_close()
+  test_semicolon_field_with_mid_line_semicolon()
+  test_semicolon_field_eof_at_open_line()
+  test_semicolon_field_properly_closed()
+  test_semicolon_field_multiline_closed()
+  test_semicolon_field_empty()
+  print("OK")
+
+
+if __name__ == "__main__":
+  run()

--- a/xcif/regression/tst_semicolon_field_strict.py
+++ b/xcif/regression/tst_semicolon_field_strict.py
@@ -1,6 +1,8 @@
-"""CIF 1.1 §2.2.7.4: the closing delimiter of a semicolon text field
-must be a `;` at column 1 of a new line. An unterminated field (no
-such closer before EOF) is a syntax error.
+"""CIF 1.1 syntax spec, paragraph 17
+(https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax): a
+semicolon text field is delimited by `;` appearing as the first
+character of a line. An unterminated field (no such closer before
+EOF) is a syntax error.
 
 Previously xcif returned a partial TOKEN_VALUE for unterminated fields
 and the parse succeeded silently — masking real malformations.

--- a/xcif/run_tests.py
+++ b/xcif/run_tests.py
@@ -27,6 +27,8 @@ tst_list = [
   "$D/regression/tst_non_strict_mode.py",
   "$B/regression/cpp/tst_quoted_string_delimiter",
   "$D/regression/tst_quoted_string_delimiter.py",
+  "$B/regression/cpp/tst_semicolon_field_strict",
+  "$D/regression/tst_semicolon_field_strict.py",
   "$D/regression/tst_iotbx_cif_reader_parity.py",
   "$B/regression/cpp/tst_thread_safety",
   "$B/regression/cpp/fuzz_target",

--- a/xcif/run_tests.py
+++ b/xcif/run_tests.py
@@ -27,6 +27,7 @@ tst_list = [
   "$D/regression/tst_non_strict_mode.py",
   "$B/regression/cpp/tst_quoted_string_delimiter",
   "$D/regression/tst_quoted_string_delimiter.py",
+  "$D/regression/tst_iotbx_cif_reader_parity.py",
   "$B/regression/cpp/tst_thread_safety",
   "$B/regression/cpp/fuzz_target",
 ]

--- a/xcif/run_tests.py
+++ b/xcif/run_tests.py
@@ -23,6 +23,8 @@ tst_list = [
   "$D/regression/tst_roundtrip.py",
   "$D/regression/tst_pdb_coordinates.py",
   "$D/regression/tst_pdb_sf.py",
+  "$B/regression/cpp/tst_non_strict_mode",
+  "$D/regression/tst_non_strict_mode.py",
   "$B/regression/cpp/tst_thread_safety",
   "$B/regression/cpp/fuzz_target",
 ]

--- a/xcif/run_tests.py
+++ b/xcif/run_tests.py
@@ -25,6 +25,8 @@ tst_list = [
   "$D/regression/tst_pdb_sf.py",
   "$B/regression/cpp/tst_non_strict_mode",
   "$D/regression/tst_non_strict_mode.py",
+  "$B/regression/cpp/tst_quoted_string_delimiter",
+  "$D/regression/tst_quoted_string_delimiter.py",
   "$B/regression/cpp/tst_thread_safety",
   "$B/regression/cpp/fuzz_target",
 ]

--- a/xcif/run_tests.py
+++ b/xcif/run_tests.py
@@ -30,6 +30,7 @@ tst_list = [
   "$B/regression/cpp/tst_semicolon_field_strict",
   "$D/regression/tst_semicolon_field_strict.py",
   "$D/regression/tst_iotbx_cif_reader_parity.py",
+  "$D/regression/tst_iotbx_cif_reader_engine.py",
   "$B/regression/cpp/tst_thread_safety",
   "$B/regression/cpp/fuzz_target",
 ]

--- a/xcif/tokenizer.cpp
+++ b/xcif/tokenizer.cpp
@@ -1,6 +1,7 @@
 // cctbx_project/xcif/tokenizer.cpp
 #include "xcif/tokenizer.h"
 #include "xcif/mapped_file.h"
+#include "xcif/data_model.h"  // for CifError (thrown on malformed tokens)
 #include <cstring>
 
 namespace xcif {
@@ -205,6 +206,14 @@ Token Tokenizer::read_semicolon_field(int tok_line, int tok_col) {
       ++cur_; ++col_;
     }
   }
+  // Reached EOF without finding a closing ';' at column 1. CIF 1.1
+  // §2.2.7.4 requires the terminator to be the first character of a
+  // line, so this is a syntax error — raise rather than silently
+  // returning a partial value (which would mask malformations like
+  // a trailing mid-line `;` that the user mistook for a terminator).
+  throw CifError("unterminated semicolon text field "
+                 "(expected closing ';' at column 1)",
+                 tok_line, tok_col, source_name_);
   return make_token(TOKEN_VALUE, start,
                     static_cast<std::size_t>(cur_ - start),
                     tok_line, tok_col);

--- a/xcif/tokenizer.cpp
+++ b/xcif/tokenizer.cpp
@@ -118,10 +118,12 @@ Token Tokenizer::read_quoted(char delim, int tok_line, int tok_col) {
   while (!at_end()) {
     char c = *cur_;
     if (c == delim) {
-      // CIF 1.1 (section 2.2.7.3): the closing delimiter of a quoted
-      // string is only recognised as such when followed by whitespace
-      // or end-of-input. An embedded delimiter followed by any other
-      // character is part of the string content. This is what lets
+      // CIF 1.1 syntax spec, paragraph 15
+      // (https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax):
+      // a quote-delimited character string may contain instances of
+      // the delimiter provided they are not followed by whitespace.
+      // The closing `'` or `"` is recognised only when followed by
+      // whitespace or end-of-input. This is what lets
       //   'N-METHYL-PYRIDOXAL-5'-PHOSPHATE'
       // parse as a single value (the inner `'` precedes `-`, not ws).
       char next = peek2();
@@ -212,7 +214,9 @@ Token Tokenizer::read_semicolon_field(int tok_line, int tok_col) {
     }
   }
   // Reached EOF without finding a closing ';' at column 1. CIF 1.1
-  // §2.2.7.4 requires the terminator to be the first character of a
+  // syntax spec, paragraph 17
+  // (https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax)
+  // requires the terminator to be `;` as the first character of a
   // line, so this is a syntax error — raise rather than silently
   // returning a partial value (which would mask malformations like
   // a trailing mid-line `;` that the user mistook for a terminator).

--- a/xcif/tokenizer.cpp
+++ b/xcif/tokenizer.cpp
@@ -275,6 +275,17 @@ Token Tokenizer::next() {
   int      tok_line = line_;
   int      tok_col  = col_;
 
+  // Legacy DOS end-of-file marker (0x1A / Ctrl-Z / SUB). Not part of
+  // the CIF 1.1 character set, but SHELX and many older tools append
+  // it to .hkl / .cif output, and ucif silently treats it as EOF.
+  // Match that behaviour: consume the rest of the buffer and report
+  // EOF so the 0x1A doesn't tokenise as a stray value and throw off
+  // loop count checks downstream.
+  if (c == '\x1A') {
+    cur_ = end_;
+    return make_token(TOKEN_EOF, cur_, 0, tok_line, tok_col);
+  }
+
   // Semicolon text field: only when ';' appears at column 1
   if (c == ';' && tok_col == 1) {
     return read_semicolon_field(tok_line, tok_col);

--- a/xcif/tokenizer.cpp
+++ b/xcif/tokenizer.cpp
@@ -215,6 +215,12 @@ Token Tokenizer::read_unquoted(int tok_line, int tok_col) {
   if (iprefix(start, len, "data_", 5)) {
     return make_token(TOKEN_BLOCK_HEADER, start, len, tok_line, tok_col);
   }
+  // CIF 1.1 reserved block type: 'global_' is a standalone header, exactly
+  // 7 characters, case-insensitive. Used by the cctbx monomer library
+  // (mon_lib_list.cif and friends) and inherited from mmCIF dictionaries.
+  if (len == 7 && iprefix(start, len, "global_", 7)) {
+    return make_token(TOKEN_BLOCK_HEADER, start, len, tok_line, tok_col);
+  }
   if (iprefix(start, len, "loop_", 5) && len == 5) {
     return make_token(TOKEN_LOOP, start, len, tok_line, tok_col);
   }

--- a/xcif/tokenizer.cpp
+++ b/xcif/tokenizer.cpp
@@ -144,10 +144,15 @@ Token Tokenizer::read_quoted(char delim, int tok_line, int tok_col) {
       ++cur_; ++col_;
     }
   }
-  // Unterminated quoted string — return what we have (error path)
-  return make_token(TOKEN_VALUE, start,
-                    static_cast<std::size_t>(cur_ - start),
-                    tok_line, tok_col);
+  // Unterminated quoted string — raise. The CIF 1.1 grammar
+  // (https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax)
+  // requires a matching closing delimiter; running off EOF mid-string
+  // is a syntax error.
+  throw CifError(
+    std::string("unterminated ") +
+      (delim == '\'' ? "single-quoted" : "double-quoted") +
+      " string (missing closing delimiter)",
+    tok_line, tok_col, source_name_);
 }
 
 // ---------------------------------------------------------------------------

--- a/xcif/tokenizer.cpp
+++ b/xcif/tokenizer.cpp
@@ -117,11 +117,21 @@ Token Tokenizer::read_quoted(char delim, int tok_line, int tok_col) {
   while (!at_end()) {
     char c = *cur_;
     if (c == delim) {
-      // Check for CIF2 triple-quote: we should not be here for triple-quoted
-      // (handled separately), so a lone delimiter ends the string.
-      std::size_t len = static_cast<std::size_t>(cur_ - start);
-      ++cur_; ++col_; // consume closing delimiter
-      return make_token(TOKEN_VALUE, start, len, tok_line, tok_col);
+      // CIF 1.1 (section 2.2.7.3): the closing delimiter of a quoted
+      // string is only recognised as such when followed by whitespace
+      // or end-of-input. An embedded delimiter followed by any other
+      // character is part of the string content. This is what lets
+      //   'N-METHYL-PYRIDOXAL-5'-PHOSPHATE'
+      // parse as a single value (the inner `'` precedes `-`, not ws).
+      char next = peek2();
+      if (next == '\0' || next == ' ' || next == '\t' ||
+          next == '\r' || next == '\n') {
+        std::size_t len = static_cast<std::size_t>(cur_ - start);
+        ++cur_; ++col_; // consume closing delimiter
+        return make_token(TOKEN_VALUE, start, len, tok_line, tok_col);
+      }
+      // Embedded delimiter — step over it and continue reading.
+      ++cur_; ++col_;
     } else if (c == '\r') {
       ++cur_;
       if (!at_end() && *cur_ == '\n') ++cur_;

--- a/xcif/xcif_ext.cpp
+++ b/xcif/xcif_ext.cpp
@@ -11,6 +11,7 @@
 #include <scitbx/array_family/flex_types.h>
 #include <memory>
 #include <cmath>
+#include <stdexcept>
 
 namespace bp = boost::python;
 using namespace xcif;
@@ -305,8 +306,20 @@ static bool py_is_inapplicable(const std::string& s) {
 
 // ===== Module definition ==========================================
 
+static void translate_invalid_argument(const std::invalid_argument& e) {
+  PyErr_SetString(PyExc_ValueError, e.what());
+}
+
+static void translate_overflow_error(const std::overflow_error& e) {
+  PyErr_SetString(PyExc_OverflowError, e.what());
+}
+
 BOOST_PYTHON_MODULE(xcif_ext)
 {
+  bp::register_exception_translator<std::invalid_argument>(
+    translate_invalid_argument);
+  bp::register_exception_translator<std::overflow_error>(
+    translate_overflow_error);
   bp::class_<BlockWrap>("Block", bp::no_init)
     .add_property("name", &block_name)
     .def("has_tag", &block_has_tag)

--- a/xcif/xcif_ext.cpp
+++ b/xcif/xcif_ext.cpp
@@ -81,21 +81,21 @@ struct LoopWrap {
 
 // ===== Parse (GIL released) =======================================
 
-static DocPtr py_parse(const std::string& text) {
+static DocPtr py_parse(const std::string& text, bool strict) {
   DocPtr result;
   {
     GILRelease gil;
     result = std::make_shared<Document>(
-      parse(text.c_str(), text.size(), "<string>"));
+      parse(text.c_str(), text.size(), "<string>", strict));
   }
   return result;
 }
 
-static DocPtr py_parse_file(const std::string& path) {
+static DocPtr py_parse_file(const std::string& path, bool strict) {
   DocPtr result;
   {
     GILRelease gil;
-    result = std::make_shared<Document>(parse_file(path.c_str()));
+    result = std::make_shared<Document>(parse_file(path.c_str(), strict));
   }
   return result;
 }
@@ -352,8 +352,10 @@ BOOST_PYTHON_MODULE(xcif_ext)
     ;
 
   // Free functions
-  bp::def("parse", &py_parse);
-  bp::def("parse_file", &py_parse_file);
+  bp::def("parse", &py_parse,
+          (bp::arg("text"), bp::arg("strict") = true));
+  bp::def("parse_file", &py_parse_file,
+          (bp::arg("path"), bp::arg("strict") = true));
   bp::def("as_double", &py_as_double);
   bp::def("as_int", &py_as_int);
   bp::def("as_double_with_su", &py_as_double_with_su);

--- a/xcif/xcif_ext.cpp
+++ b/xcif/xcif_ext.cpp
@@ -174,6 +174,17 @@ static bp::list block_save_frames(const BlockWrap& self) {
   return result;
 }
 
+static bp::list block_source_order(const BlockWrap& self) {
+  bp::list out;
+  const auto& order = self.p->source_order();
+  for (std::size_t i = 0; i < order.size(); ++i) {
+    out.append(bp::make_tuple(
+      static_cast<int>(order[i].first),
+      order[i].second));
+  }
+  return out;
+}
+
 static bp::object block_find_save_frame(const BlockWrap& self,
                                         const std::string& name) {
   const Block* sf = self.p->find_save_frame(string_view(name));
@@ -320,6 +331,13 @@ BOOST_PYTHON_MODULE(xcif_ext)
     translate_invalid_argument);
   bp::register_exception_translator<std::overflow_error>(
     translate_overflow_error);
+
+  bp::enum_<Block::EntryKind>("EntryKind")
+    .value("PAIR", Block::ENTRY_PAIR)
+    .value("LOOP", Block::ENTRY_LOOP)
+    .value("SAVE_FRAME", Block::ENTRY_SAVE_FRAME)
+    ;
+
   bp::class_<BlockWrap>("Block", bp::no_init)
     .add_property("name", &block_name)
     .def("has_tag", &block_has_tag)
@@ -330,6 +348,7 @@ BOOST_PYTHON_MODULE(xcif_ext)
     .add_property("pair_values", &block_pair_values)
     .add_property("save_frames", &block_save_frames)
     .def("find_save_frame", &block_find_save_frame)
+    .add_property("source_order", &block_source_order)
     ;
 
   bp::class_<LoopWrap>("Loop", bp::no_init)

--- a/xcif/xcif_ext.cpp
+++ b/xcif/xcif_ext.cpp
@@ -68,14 +68,14 @@ typedef std::shared_ptr<Document> DocPtr;
 struct BlockWrap {
   DocPtr doc;
   const Block* p;
-  BlockWrap() : p(0) {}
+  BlockWrap() : p(nullptr) {}
   BlockWrap(DocPtr d, const Block* b) : doc(d), p(b) {}
 };
 
 struct LoopWrap {
   DocPtr doc;
   const Loop* p;
-  LoopWrap() : p(0) {}
+  LoopWrap() : p(nullptr) {}
   LoopWrap(DocPtr d, const Loop* l) : doc(d), p(l) {}
 };
 


### PR DESCRIPTION
xcif — a fast C++ CIF parser — is now wired into `iotbx.cif.reader` with a single global switch in `iotbx/cif/__init__.py` (the module-level `DEFAULT_ENGINE` constant) plus a per-call `engine=` kwarg on the reader. `DEFAULT_ENGINE` stays `"ucif"` in this PR; callers who want to opt in today can pass `engine="xcif"` explicitly, and a one-line follow-up will flip the default after bake-in.

Whole set of tests including Phenix ones are passing with the switch flipped.

Benchmark on a 34 MB mmCIF (`4v9d.cif`): ~6× speedup end-to-end through `iotbx.cif.reader`, ~21× for the raw parser alone.