### PR TITLE
Niggli reduction c++ port

### DIFF
--- a/cctbx/regression/tst_niggli_reduction_cpp.py
+++ b/cctbx/regression/tst_niggli_reduction_cpp.py
@@ -208,7 +208,7 @@ def exercise_gruber_types():
   type_conditions = gruber_1973_table_1.get_type_conditions()
   for k in range(1, 29):
     tc = type_conditions[k]
-    for _ in range(10):
+    for _ in range(100):
       compare_reductions(ucgmx(random_gruber_matrix(tc)))
 
 def exercise_iteration_limit():

--- a/cctbx/regression/tst_niggli_reduction_cpp.py
+++ b/cctbx/regression/tst_niggli_reduction_cpp.py
@@ -1,0 +1,271 @@
+"""Comprehensive comparison of C++ niggli_reduction vs Python krivy_gruber_1976.
+
+Verifies that every public method on the C++ result (via
+cpp_niggli_reduction_result) matches the Python reference implementation
+for a wide range of unit cells.
+"""
+from __future__ import absolute_import, division, print_function
+from cctbx.uctbx import krivy_gruber_1976
+from cctbx.uctbx.reduction_base import iteration_limit_exceeded
+from cctbx import uctbx
+from libtbx.test_utils import Exception_expected
+
+def ucgmx(gruber_matrix):
+  (a,b,c,d,e,f) = gruber_matrix
+  return uctbx.unit_cell(metrical_matrix=(a,b,c,f/2.,e/2.,d/2.))
+
+def compare_reductions(unit_cell, relative_epsilon=None):
+  """Compare all public methods between Python and C++ niggli reduction."""
+  py_red = krivy_gruber_1976.reduction(
+    unit_cell, relative_epsilon=relative_epsilon)
+  cpp_red = unit_cell.niggli_reduction(relative_epsilon=relative_epsilon)
+
+  # Reduced cell (exact: both construct unit_cell from identical G6 values
+  # via the same C++ unit_cell(metrical_matrix=...) constructor)
+  assert cpp_red.as_unit_cell().parameters() == \
+    py_red.as_unit_cell().parameters(), \
+    "as_unit_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.as_unit_cell().parameters(), py_red.as_unit_cell().parameters())
+
+  # Change-of-basis matrix (exact integer comparison)
+  assert cpp_red.r_inv().elems == py_red.r_inv().elems, \
+    "r_inv() mismatch: C++ %s vs Python %s" % (
+      cpp_red.r_inv().elems, py_red.r_inv().elems)
+
+  # Iteration count
+  assert cpp_red.n_iterations() == py_red.n_iterations(), \
+    "n_iterations() mismatch: C++ %d vs Python %d" % (
+      cpp_red.n_iterations(), py_red.n_iterations())
+
+  # Analysis methods from gruber_parameterization
+  assert cpp_red.is_niggli_cell() == py_red.is_niggli_cell(), \
+    "is_niggli_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.is_niggli_cell(), py_red.is_niggli_cell())
+
+  assert cpp_red.is_buerger_cell() == py_red.is_buerger_cell(), \
+    "is_buerger_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.is_buerger_cell(), py_red.is_buerger_cell())
+
+  assert cpp_red.type() == py_red.type(), \
+    "type() mismatch: C++ %s vs Python %s" % (
+      cpp_red.type(), py_red.type())
+
+  assert cpp_red.meets_main_conditions() == py_red.meets_main_conditions(), \
+    "meets_main_conditions() mismatch: C++ %s vs Python %s" % (
+      cpp_red.meets_main_conditions(), py_red.meets_main_conditions())
+
+  # change_of_basis_op
+  cpp_cbop = cpp_red.change_of_basis_op()
+  py_cbop = py_red.change_of_basis_op()
+  assert cpp_cbop.c().r().as_double() == py_cbop.c().r().as_double(), \
+    "change_of_basis_op() rotation mismatch: C++ %s vs Python %s" % (
+      cpp_cbop.c().r().as_double(), py_cbop.c().r().as_double())
+  assert cpp_cbop.c().t().as_double() == py_cbop.c().t().as_double(), \
+    "change_of_basis_op() translation mismatch: C++ %s vs Python %s" % (
+      cpp_cbop.c().t().as_double(), py_cbop.c().t().as_double())
+
+  # Verify the change_of_basis_op actually works (tolerance-based because
+  # change_basis reconstructs the cell through a different arithmetic path)
+  assert unit_cell.change_basis(cpp_cbop).is_similar_to(
+    cpp_red.as_unit_cell()), \
+    "change_of_basis_op does not transform to reduced cell"
+
+def exercise_textbook_examples():
+  # Gruber 1973 example
+  cells = [
+    ucgmx((4,136,76,-155,-31,44)),   # start
+    ucgmx((4,16,16,-16,-1,-3)),      # buerger
+    ucgmx((4,16,16,16,3,4)),         # niggli (already reduced)
+  ]
+  for uc in cells:
+    compare_reductions(uc)
+
+  # Krivy-Gruber 1976 example
+  cells = [
+    ucgmx((9,27,4,-5,-4,-22)),       # start
+    ucgmx((4,9,9,-8,-1,-4)),         # intermediate buerger
+    ucgmx((4,9,9,9,1,4)),            # intermediate buerger
+    ucgmx((4,9,9,9,3,4)),            # niggli (already reduced)
+  ]
+  for uc in cells:
+    compare_reductions(uc)
+
+def exercise_problem_parameters():
+  problem_parameters = (
+    (13.892443989449804, 13.892443989449804, 14.7648230602334,
+     61.936000954634402, 61.936000954634402, 88.515487291567879),
+    (10.0, 10.0, 20.0,
+     90.0, 45.0, 120.0),
+    (10.0, 20.0, 30.0,
+     120.0, 60.0, 120.0),
+    (10.816653826391969, 13.820274961085254, 13.820274961085254,
+     60.0, 66.962544368849834, 66.962544368849834),
+    (10.148891565092219, 13.379088160259652, 13.379088160259652,
+     107.33461190548745, 107.94415159713115, 109.72759194290299),
+    (19.798989873223331, 231.21851136965654, 14.352700094407323,
+     133.37207519042573, 92.016673840743408, 134.55815348093702),
+    (10.392304845413264, 13.19090595827292, 13.19090595827292,
+     112.64730819498385, 104.36056979415913, 106.96527532101391),
+    (16.046806535881213, 13.341664064126334, 197.64614845728718,
+     153.28759931491018, 114.05435960569044, 92.543256980798247),
+    (10.488088481701515, 13.820274961085254, 13.820274961085254,
+     109.9226012907464, 104.00699650533103, 110.31922490992999),
+    (10.04987562112089, 13.19090595827292, 13.19090595827292,
+     118.05419482122835, 97.404049814230376, 106.92070123011929),
+    (10.04987562112089, 13.45362404707371, 13.45362404707371,
+     109.02416163919622, 105.88181549565937, 109.44017310001107),
+    (11.357816691600547, 13.638181696985853, 13.638181696985855,
+     115.81608733396159, 104.29612977641231, 104.29612977641233),
+    (11.832159566199232, 13.784048752090222, 13.784048752090222,
+     110.67521616123457, 104.95317005195066, 110.01926787579129))
+  for parameters in problem_parameters:
+    compare_reductions(uctbx.unit_cell(parameters))
+
+def compare_reductions_with_limit(unit_cell, iteration_limit,
+                                  relative_epsilon=None):
+  """Like compare_reductions but with an explicit iteration_limit."""
+  py_red = krivy_gruber_1976.reduction(
+    unit_cell, relative_epsilon=relative_epsilon,
+    iteration_limit=iteration_limit)
+  cpp_red = unit_cell.niggli_reduction(
+    relative_epsilon=relative_epsilon, iteration_limit=iteration_limit)
+
+  assert cpp_red.as_unit_cell().parameters() == \
+    py_red.as_unit_cell().parameters(), \
+    "as_unit_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.as_unit_cell().parameters(), py_red.as_unit_cell().parameters())
+  assert cpp_red.r_inv().elems == py_red.r_inv().elems, \
+    "r_inv() mismatch: C++ %s vs Python %s" % (
+      cpp_red.r_inv().elems, py_red.r_inv().elems)
+  assert cpp_red.n_iterations() == py_red.n_iterations(), \
+    "n_iterations() mismatch: C++ %d vs Python %d" % (
+      cpp_red.n_iterations(), py_red.n_iterations())
+  assert cpp_red.is_niggli_cell() == py_red.is_niggli_cell(), \
+    "is_niggli_cell() mismatch: C++ %s vs Python %s" % (
+      cpp_red.is_niggli_cell(), py_red.is_niggli_cell())
+  assert cpp_red.type() == py_red.type(), \
+    "type() mismatch: C++ %s vs Python %s" % (
+      cpp_red.type(), py_red.type())
+
+def exercise_extreme():
+  uc = uctbx.unit_cell((
+    69.059014477286041, 48.674386086971339, 0.0048194797114296736,
+    89.995145576185806, 89.999840576946085, 99.484656090034875))
+  compare_reductions(uc)
+  # This cell requires a high iteration limit (>1000)
+  uc = uctbx.unit_cell((
+    80.816186392181365, 81.021289502648813, 140.6784408482614,
+    29.932540128999769, 89.92047105556459, 119.85301114570319))
+  compare_reductions_with_limit(uc, iteration_limit=10000)
+
+def exercise_real_world_examples():
+  uc = uctbx.unit_cell((
+    12.7366, 29.2300, 5.0242,
+    94.6570, 100.8630, 99.7561))
+  compare_reductions(uc)
+  uc = uctbx.unit_cell((
+    12.7806, 12.7366, 29.457,
+    103.42, 103.57, 22.71))
+  compare_reductions(uc)
+
+def exercise_grid():
+  # Same angle set as tst_krivy_gruber.py (non-quick mode).
+  n_tested = 0
+  for a in (10, 20, 30):
+    for b in (10, 20, 30):
+      for c in (10, 20, 30):
+        for alpha in (10, 30, 45, 60, 90, 120, 150, 170):
+          for beta in (10, 30, 45, 60, 90, 120, 150, 170):
+            for gamma in (10, 30, 45, 60, 90, 120, 150, 170):
+              try:
+                uc = uctbx.unit_cell((a,b,c,alpha,beta,gamma))
+              except Exception:
+                continue
+              if uc.volume() < a*b*c/1000.:
+                continue
+              compare_reductions(uc)
+              n_tested += 1
+  assert n_tested > 1000, "Too few grid cells tested: %d" % n_tested
+
+def exercise_bravais_plus():
+  # Same space-group/cell combinations as tst_krivy_gruber.exercise_bravais_plus().
+  from cctbx import sgtbx
+  for pg in ("1", "2", "2 2", "4", "3*", "6", "2 2 3"):
+    for z in "PABCIRF":
+      sgi = sgtbx.space_group_info("Hall: %s %s" % (z, pg))
+      r_inv = sgi.group().z2p_op().c_inv().r()
+      uc = sgi.any_compatible_unit_cell(volume=100).change_basis(
+        r_inv.num(), r_inv.den())
+      compare_reductions(uc)
+
+def exercise_gruber_types():
+  # Same 28 Gruber types as tst_krivy_gruber.exercise_gruber_types(),
+  # 10 random trials each.  Seed is fixed for reproducibility.
+  from cctbx.uctbx import gruber_1973_table_1
+  from cctbx.regression.tst_krivy_gruber import random_gruber_matrix
+  import random
+  random.seed(0)
+  type_conditions = gruber_1973_table_1.get_type_conditions()
+  for k in range(1, 29):
+    tc = type_conditions[k]
+    for _ in range(10):
+      compare_reductions(ucgmx(random_gruber_matrix(tc)))
+
+def exercise_iteration_limit():
+  uc = ucgmx((4,16,16,-16,-1,-3))  # buerger cell, needs several iterations
+  # Python raises iteration_limit_exceeded
+  try:
+    krivy_gruber_1976.reduction(uc, iteration_limit=1)
+  except iteration_limit_exceeded:
+    pass
+  else:
+    raise Exception_expected
+  # C++ should also raise iteration_limit_exceeded
+  try:
+    uc.niggli_reduction(iteration_limit=1)
+  except iteration_limit_exceeded:
+    pass
+  else:
+    raise Exception_expected
+
+def exercise_a3_a4_zero_component():
+  """Targeted test for the zero-component edge case in do_a3_a4.
+
+  A cell with alpha=beta=90 yields xi=eta=0 and zeta > 0 in G6.
+  In sign_counts() this gives pos=1, nonneg=3 (pos != nonneg, pos%2 == 1),
+  triggering the extra negate_column branch in the all-negative/mixed case.
+  """
+  uc = uctbx.unit_cell((10, 20, 30, 90, 90, 120))
+  compare_reductions(uc)
+  cpp_red = uc.niggli_reduction()
+  assert cpp_red.is_niggli_cell(), \
+    "Reduced cell is not Niggli: %s" % str(cpp_red.as_gruber_matrix())
+
+def exercise_zero_epsilon():
+  cells = [
+    ucgmx((4,136,76,-155,-31,44)),
+    ucgmx((4,16,16,16,3,4)),
+    ucgmx((9,27,4,-5,-4,-22)),
+    uctbx.unit_cell((10, 20, 30, 90, 90, 90)),
+    uctbx.unit_cell((12.7366, 29.2300, 5.0242, 94.6570, 100.8630, 99.7561)),
+    uctbx.unit_cell((13.892443989449804, 13.892443989449804, 14.7648230602334,
+      61.936000954634402, 61.936000954634402, 88.515487291567879)),
+  ]
+  for uc in cells:
+    compare_reductions(uc, relative_epsilon=0)
+
+def exercise():
+  exercise_textbook_examples()
+  exercise_problem_parameters()
+  exercise_extreme()
+  exercise_real_world_examples()
+  exercise_grid()
+  exercise_bravais_plus()
+  exercise_gruber_types()
+  exercise_iteration_limit()
+  exercise_a3_a4_zero_component()
+  exercise_zero_epsilon()
+  print("OK")
+
+if (__name__ == "__main__"):
+  exercise()

--- a/cctbx/run_tests.py
+++ b/cctbx/run_tests.py
@@ -57,6 +57,7 @@ tst_list = [
   "$D/adp_restraints/tst_ext.py",
   "$D/regression/tst_math_module.py",
   ["$D/regression/tst_krivy_gruber.py", "--Quick"],
+  "$D/regression/tst_niggli_reduction_cpp.py",
   "$D/regression/tst_sgtbx.py",
   "$D/regression/tst_itvb_2001_table_a1427_hall_symbols.py",
   "$D/regression/tst_space_group_type_tidy_cb_op_t.py",

--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -191,8 +191,11 @@ class _():
     return gruber_parameterization(self, relative_epsilon).is_niggli_cell()
 
   def niggli_reduction(self, relative_epsilon=None, iteration_limit=None):
-    from cctbx.uctbx import krivy_gruber_1976
-    return krivy_gruber_1976.reduction(self, relative_epsilon, iteration_limit)
+    if relative_epsilon is None:
+      relative_epsilon = 1.e-5
+    if iteration_limit is None:
+      iteration_limit = 1000
+    return ext.niggli_reduction(self, relative_epsilon, iteration_limit)
 
   def niggli_cell(self,
         relative_epsilon=None,
@@ -296,6 +299,22 @@ class _():
       h, u_star, exp_arg_limit, truncate_exp_arg)
 
   debye_waller_factor = debye_waller_factors
+
+# Wrap niggli_reduction.r_inv() so it returns a matrix.sqr (with .elems),
+# matching the interface of the Python krivy_gruber_1976.reduction.r_inv().
+# The C++ binding converts scitbx::mat3<int> to a plain Python tuple; we
+# rewrap it here so callers can use .elems and pass it to change_basis().
+_cpp_niggli_reduction_r_inv = ext.niggli_reduction.r_inv
+
+@bp.inject_into(ext.niggli_reduction)
+class _():
+  def r_inv(self):
+    return matrix.sqr(_cpp_niggli_reduction_r_inv(self))
+
+  def change_of_basis_op(self):
+    from cctbx import sgtbx
+    return sgtbx.change_of_basis_op(
+      sgtbx.rt_mx(sgtbx.rot_mx(self.r_inv().elems, 1))).inverse()
 
 def non_crystallographic_buffer_layer(
       sites_cart_min,

--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -300,17 +300,11 @@ class _():
 
   debye_waller_factor = debye_waller_factors
 
-# Wrap niggli_reduction.r_inv() so it returns a matrix.sqr (with .elems),
-# matching the interface of the Python krivy_gruber_1976.reduction.r_inv().
-# The C++ binding converts scitbx::mat3<int> to a plain Python tuple; we
-# rewrap it here so callers can use .elems and pass it to change_basis().
-_cpp_niggli_reduction_r_inv = ext.niggli_reduction.r_inv
-
+# r_inv() is exposed directly from C++ and returns scitbx.matrix.sqr.
+# change_of_basis_op() uses a deferred sgtbx import because cctbx_sgtbx_ext
+# is not guaranteed to be loaded by a plain "from cctbx import uctbx".
 @bp.inject_into(ext.niggli_reduction)
 class _():
-  def r_inv(self):
-    return matrix.sqr(_cpp_niggli_reduction_r_inv(self))
-
   def change_of_basis_op(self):
     from cctbx import sgtbx
     return sgtbx.change_of_basis_op(

--- a/cctbx/uctbx/__init__.py
+++ b/cctbx/uctbx/__init__.py
@@ -300,15 +300,6 @@ class _():
 
   debye_waller_factor = debye_waller_factors
 
-# r_inv() is exposed directly from C++ and returns scitbx.matrix.sqr.
-# change_of_basis_op() uses a deferred sgtbx import because cctbx_sgtbx_ext
-# is not guaranteed to be loaded by a plain "from cctbx import uctbx".
-@bp.inject_into(ext.niggli_reduction)
-class _():
-  def change_of_basis_op(self):
-    from cctbx import sgtbx
-    return sgtbx.change_of_basis_op(
-      sgtbx.rt_mx(sgtbx.rot_mx(self.r_inv().elems, 1))).inverse()
 
 def non_crystallographic_buffer_layer(
       sites_cart_min,

--- a/cctbx/uctbx/boost_python/SConscript
+++ b/cctbx/uctbx/boost_python/SConscript
@@ -3,4 +3,5 @@ env = env_cctbx_boost_python_ext.Clone()
 env.Prepend(LIBS=["cctbx"])
 env.SharedLibrary(
   target="#lib/cctbx_uctbx_ext",
-  source=["uctbx_ext.cpp", "fast_minimum_reduction.cpp"])
+  source=["uctbx_ext.cpp", "fast_minimum_reduction.cpp",
+          "niggli_reduction.cpp"])

--- a/cctbx/uctbx/boost_python/niggli_reduction.cpp
+++ b/cctbx/uctbx/boost_python/niggli_reduction.cpp
@@ -20,6 +20,14 @@ namespace {
     // niggli_reduction object is constructed (cctbx.array_family.flex imports
     // it transitively before cctbx_uctbx_ext is initialised).
     static boost::python::object
+    change_of_basis_op_as_py(w_t const& self)
+    {
+      namespace bp = boost::python;
+      bp::import("cctbx.sgtbx");
+      return bp::object(self.change_of_basis_op());
+    }
+
+    static boost::python::object
     r_inv_as_sqr(w_t const& self)
     {
       namespace bp = boost::python;
@@ -41,6 +49,7 @@ namespace {
         .def("as_niggli_matrix",         &w_t::as_niggli_matrix)
         .def("as_sym_mat3",              &w_t::as_sym_mat3)
         .def("as_unit_cell",             &w_t::as_unit_cell)
+        .def("change_of_basis_op",       change_of_basis_op_as_py)
         .def("r_inv",                    r_inv_as_sqr)
         .def("n_iterations",             &w_t::n_iterations)
         .def("iteration_limit",          &w_t::iteration_limit)

--- a/cctbx/uctbx/boost_python/niggli_reduction.cpp
+++ b/cctbx/uctbx/boost_python/niggli_reduction.cpp
@@ -1,0 +1,78 @@
+#include <boost/python/class.hpp>
+#include <boost/python/args.hpp>
+#include <boost/python/return_value_policy.hpp>
+#include <boost/python/copy_const_reference.hpp>
+#include <boost/python/exception_translator.hpp>
+#include <boost/python/import.hpp>
+#include <boost/python/str.hpp>
+#include <cctbx/uctbx/niggli_reduction.h>
+
+namespace cctbx { namespace uctbx { namespace boost_python {
+
+namespace {
+
+  struct niggli_reduction_wrappers
+  {
+    typedef niggli_reduction<> w_t;
+
+    static void
+    wrap()
+    {
+      using namespace boost::python;
+      typedef return_value_policy<copy_const_reference> ccr;
+      class_<w_t>("niggli_reduction", no_init)
+        .def(init<unit_cell const&, double, std::size_t>((
+          arg("unit_cell"),
+          arg("relative_epsilon"),
+          arg("iteration_limit"))))
+        .def("as_gruber_matrix",         &w_t::as_gruber_matrix)
+        .def("as_niggli_matrix",         &w_t::as_niggli_matrix)
+        .def("as_sym_mat3",              &w_t::as_sym_mat3)
+        .def("as_unit_cell",             &w_t::as_unit_cell)
+        .def("r_inv",                    &w_t::r_inv, ccr())
+        .def("n_iterations",             &w_t::n_iterations)
+        .def("iteration_limit",          &w_t::iteration_limit)
+        .def("type",                     &w_t::type)
+        .def("meets_primary_conditions", &w_t::meets_primary_conditions)
+        .def("meets_main_conditions",    &w_t::meets_main_conditions)
+        .def("is_buerger_cell",          &w_t::is_buerger_cell)
+        .def("is_niggli_cell",           &w_t::is_niggli_cell)
+      ;
+    }
+  };
+
+  // Exception translator: maps niggli_reduction_iteration_limit_exceeded to
+  // the Python class reduction_base.iteration_limit_exceeded.  This is
+  // required so that client code using "except iteration_limit_exceeded:"
+  // (imported from cctbx.uctbx.reduction_base) correctly catches exceptions
+  // raised by the C++ algorithm.
+  //
+  // The import is deferred to raise-time (not module-init time) to avoid
+  // circular imports: cctbx_uctbx_ext is imported by cctbx.uctbx.__init__,
+  // which imports cctbx.uctbx.reduction_base, so the latter is guaranteed
+  // to be loaded before any Niggli reduction can be called.
+  void translate_niggli_iter_limit(
+    niggli_reduction_iteration_limit_exceeded const& e)
+  {
+    namespace bp = boost::python;
+    try {
+      bp::object rb = bp::import("cctbx.uctbx.reduction_base");
+      bp::object exc_class = rb.attr("iteration_limit_exceeded");
+      PyErr_SetObject(exc_class.ptr(), bp::str(e.what()).ptr());
+    } catch (...) {
+      // Fallback: raise as a plain RuntimeError so something reaches Python.
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+    }
+  }
+
+} // namespace <anonymous>
+
+  void wrap_niggli_reduction()
+  {
+    boost::python::register_exception_translator<
+      niggli_reduction_iteration_limit_exceeded>(
+        translate_niggli_iter_limit);
+    niggli_reduction_wrappers::wrap();
+  }
+
+}}} // namespace cctbx::uctbx::boost_python

--- a/cctbx/uctbx/boost_python/niggli_reduction.cpp
+++ b/cctbx/uctbx/boost_python/niggli_reduction.cpp
@@ -1,7 +1,6 @@
 #include <boost/python/class.hpp>
 #include <boost/python/args.hpp>
-#include <boost/python/return_value_policy.hpp>
-#include <boost/python/copy_const_reference.hpp>
+#include <boost/python/tuple.hpp>
 #include <boost/python/exception_translator.hpp>
 #include <boost/python/import.hpp>
 #include <boost/python/str.hpp>
@@ -15,11 +14,24 @@ namespace {
   {
     typedef niggli_reduction<> w_t;
 
+    // Return r_inv as scitbx.matrix.sqr directly, bypassing the intermediate
+    // boost.python mat3<int>->tuple conversion and the Python inject_into layer.
+    // scitbx.matrix is guaranteed to be in sys.modules by the time any
+    // niggli_reduction object is constructed (cctbx.array_family.flex imports
+    // it transitively before cctbx_uctbx_ext is initialised).
+    static boost::python::object
+    r_inv_as_sqr(w_t const& self)
+    {
+      namespace bp = boost::python;
+      scitbx::mat3<int> const& m = self.r_inv();
+      return bp::import("scitbx.matrix").attr("sqr")(
+        bp::make_tuple(m[0],m[1],m[2],m[3],m[4],m[5],m[6],m[7],m[8]));
+    }
+
     static void
     wrap()
     {
       using namespace boost::python;
-      typedef return_value_policy<copy_const_reference> ccr;
       class_<w_t>("niggli_reduction", no_init)
         .def(init<unit_cell const&, double, std::size_t>((
           arg("unit_cell"),
@@ -29,7 +41,7 @@ namespace {
         .def("as_niggli_matrix",         &w_t::as_niggli_matrix)
         .def("as_sym_mat3",              &w_t::as_sym_mat3)
         .def("as_unit_cell",             &w_t::as_unit_cell)
-        .def("r_inv",                    &w_t::r_inv, ccr())
+        .def("r_inv",                    r_inv_as_sqr)
         .def("n_iterations",             &w_t::n_iterations)
         .def("iteration_limit",          &w_t::iteration_limit)
         .def("type",                     &w_t::type)

--- a/cctbx/uctbx/boost_python/uctbx_ext.cpp
+++ b/cctbx/uctbx/boost_python/uctbx_ext.cpp
@@ -17,6 +17,7 @@
 namespace cctbx { namespace uctbx { namespace boost_python {
 
   void wrap_fast_minimum_reduction();
+  void wrap_niggli_reduction();
 
 namespace {
 
@@ -390,6 +391,7 @@ namespace {
 
     unit_cell_wrappers::wrap();
     wrap_fast_minimum_reduction();
+    wrap_niggli_reduction();
 
     def("fractional_unit_shifts", fractional_unit_shifts_d, (
       arg("distance_frac")));

--- a/cctbx/uctbx/niggli_reduction.h
+++ b/cctbx/uctbx/niggli_reduction.h
@@ -1,0 +1,462 @@
+#ifndef CCTBX_UCTBX_NIGGLI_REDUCTION_H
+#define CCTBX_UCTBX_NIGGLI_REDUCTION_H
+
+#include <cctbx/uctbx.h>
+#include <cctbx/error.h>
+#include <cctbx/sgtbx/change_of_basis_op.h>
+#include <scitbx/array_family/tiny.h>
+#include <cmath>
+#include <string>
+
+namespace cctbx { namespace uctbx {
+
+  //! Exception raised when the Niggli reduction iteration limit is exceeded.
+  class niggli_reduction_iteration_limit_exceeded : public error
+  {
+    public:
+      niggli_reduction_iteration_limit_exceeded(std::size_t limit)
+      :
+        error(
+          "Niggli reduction iteration limit exceeded (limit="
+          + std::to_string(limit) + ").")
+      {}
+  };
+
+  /*! \brief C++ implementation of the Krivy-Gruber 1976 Niggli cell
+      reduction algorithm.
+
+      Reference: I. Krivy and B. Gruber, Acta Cryst. A32, 297-298 (1976).
+
+      Uses epsilon-aware comparisons throughout (unlike fast_minimum_reduction
+      which uses exact comparisons).  The algorithm and action matrices are an
+      exact port of cctbx/uctbx/krivy_gruber_1976.py.
+
+      Template parameters:
+        FloatType       – floating-point type for cell parameters (default double)
+        IntFromFloatType – integer type for change-of-basis matrix (default int)
+   */
+  template <typename FloatType=double,
+            typename IntFromFloatType=int>
+  class niggli_reduction
+  {
+    public:
+      //! Default constructor. Data members are not initialized.
+      niggli_reduction() {}
+
+      /*! \brief Execute the Niggli reduction algorithm.
+
+          \param unit_cell      Input cell to reduce.
+          \param relative_epsilon  Tolerance relative to volume^(1/3).
+                                   Caller must resolve Python None to 1.e-5.
+          \param iteration_limit   Maximum number of change-of-basis steps.
+                                   Caller must resolve Python None to 1000.
+       */
+      niggli_reduction(
+        uctbx::unit_cell const& unit_cell,
+        FloatType relative_epsilon,
+        std::size_t iteration_limit)
+      :
+        iteration_limit_(iteration_limit),
+        r_inv_(scitbx::mat3<IntFromFloatType>(1)),
+        n_iterations_(0)
+      {
+        uc_sym_mat3 const& g = unit_cell.metrical_matrix();
+        a_ = g[0];
+        b_ = g[1];
+        c_ = g[2];
+        d_ = 2 * g[5];
+        e_ = 2 * g[4];
+        f_ = 2 * g[3];
+        FloatType vol = unit_cell.volume();
+        epsilon_ = std::pow(vol, FloatType(1) / FloatType(3))
+                   * relative_epsilon;
+        while (step());
+      }
+
+      //! Gruber parameterization (a, b, c, d, e, f).
+      af::double6
+      as_gruber_matrix() const
+      {
+        return af::double6(a_, b_, c_, d_, e_, f_);
+      }
+
+      //! Niggli parameterization (a, b, c, d/2, e/2, f/2).
+      af::double6
+      as_niggli_matrix() const
+      {
+        return af::double6(a_, b_, c_, d_/2, e_/2, f_/2);
+      }
+
+      //! Parameterization compatible with uctbx::unit_cell::metrical_matrix().
+      uc_sym_mat3
+      as_sym_mat3() const
+      {
+        return uc_sym_mat3(a_, b_, c_, f_/2, e_/2, d_/2);
+      }
+
+      //! Conversion to uctbx::unit_cell.
+      uctbx::unit_cell
+      as_unit_cell() const
+      {
+        return uctbx::unit_cell(as_sym_mat3());
+      }
+
+      //! Change-of-basis matrix compatible with uctbx::unit_cell::change_basis().
+      scitbx::mat3<IntFromFloatType> const&
+      r_inv() const { return r_inv_; }
+
+      //! Number of change-of-basis steps executed.
+      std::size_t
+      n_iterations() const { return n_iterations_; }
+
+      //! Value as passed to the constructor.
+      std::size_t
+      iteration_limit() const { return iteration_limit_; }
+
+      //! Cell type (1 = all d,e,f positive; 2 = all non-positive; 0 = mixed).
+      int
+      type() const
+      {
+        af::tiny<int, 2> nz_np = def_test();
+        if (nz_np[1] == 3) return 1;
+        if (nz_np[1] == 0) return 2;
+        return 0;
+      }
+
+      //! True if a <= b <= c and |d|<=b, |e|<=a, |f|<=a (epsilon-aware).
+      bool
+      meets_primary_conditions() const
+      {
+        if (eps_gt(a_, b_)) return false;
+        if (eps_gt(b_, c_)) return false;
+        if (eps_gt(std::abs(d_), b_)) return false;
+        if (eps_gt(std::abs(e_), a_)) return false;
+        if (eps_gt(std::abs(f_), a_)) return false;
+        return true;
+      }
+
+      //! True if primary conditions hold, type != 0, and type-2 sum condition.
+      bool
+      meets_main_conditions() const
+      {
+        if (!meets_primary_conditions()) return false;
+        int t = type();
+        if (t == 0) return false;
+        if (t == 2) {
+          if (eps_lt(d_ + e_ + f_ + a_ + b_, FloatType(0))) return false;
+        }
+        return true;
+      }
+
+      //! True if meets_main_conditions and tie-breaking on equal lengths.
+      bool
+      is_buerger_cell() const
+      {
+        if (!meets_main_conditions()) return false;
+        if (eps_eq(a_, b_)) {
+          if (eps_gt(std::abs(d_), std::abs(e_))) return false;
+        }
+        if (eps_eq(b_, c_)) {
+          if (eps_gt(std::abs(e_), std::abs(f_))) return false;
+        }
+        return true;
+      }
+
+      //! True if Buerger cell and 7 Niggli boundary uniqueness conditions.
+      bool
+      is_niggli_cell() const
+      {
+        if (!is_buerger_cell()) return false;
+        if (eps_eq(d_, b_)) {
+          if (eps_gt(f_, e_ + e_)) return false;
+        }
+        if (eps_eq(e_, a_)) {
+          if (eps_gt(f_, d_ + d_)) return false;
+        }
+        if (eps_eq(f_, a_)) {
+          if (eps_gt(e_, d_ + d_)) return false;
+        }
+        if (eps_eq(d_, -b_)) {
+          if (!eps_eq(f_, FloatType(0))) return false;
+        }
+        if (eps_eq(e_, -a_)) {
+          if (!eps_eq(f_, FloatType(0))) return false;
+        }
+        if (eps_eq(f_, -a_)) {
+          if (!eps_eq(e_, FloatType(0))) return false;
+        }
+        if (eps_eq(d_ + e_ + f_ + a_ + b_, FloatType(0))) {
+          if (eps_gt(a_ + a_ + e_ + e_ + f_, FloatType(0))) return false;
+        }
+        return true;
+      }
+
+      /*! \brief Change-of-basis operator that transforms the input cell to
+          the reduced Niggli cell.
+
+          Uses sgtbx types.  The translator is constructed from the accumulated
+          integer matrix r_inv_ in the same way as reduction_base.change_of_basis_op().
+       */
+      sgtbx::change_of_basis_op
+      change_of_basis_op() const
+      {
+        // r_inv_ is scitbx::mat3<int>; rot_mx takes (mat3<int>, denominator).
+        sgtbx::rot_mx rot(r_inv_, 1);
+        sgtbx::rt_mx rt(rot);
+        return sgtbx::change_of_basis_op(rt).inverse();
+      }
+
+    protected:
+
+      // ---------------------------------------------------------------
+      // Epsilon-aware comparison helpers
+      // ---------------------------------------------------------------
+
+      bool eps_lt(FloatType x, FloatType y) const
+      {
+        return x < y - epsilon_;
+      }
+
+      bool eps_gt(FloatType x, FloatType y) const
+      {
+        return y < x - epsilon_;
+      }
+
+      bool eps_eq(FloatType x, FloatType y) const
+      {
+        return !(eps_lt(x, y) || eps_lt(y, x));
+      }
+
+      // ---------------------------------------------------------------
+      // Gruber sign analysis (epsilon-aware, matches reduction_base.def_test)
+      // ---------------------------------------------------------------
+
+      // Returns (n_zero, n_positive) for d_, e_, f_ using epsilon.
+      af::tiny<int, 2>
+      def_test() const
+      {
+        int n_zero = 0;
+        int n_positive = 0;
+        // eps_lt(0, x) means x > epsilon (positive in epsilon sense)
+        // not eps_lt(x, 0) means x >= -epsilon (non-negative in epsilon sense)
+        if (eps_lt(FloatType(0), d_)) n_positive++;
+        else if (!eps_lt(d_, FloatType(0))) n_zero++;
+        if (eps_lt(FloatType(0), e_)) n_positive++;
+        else if (!eps_lt(e_, FloatType(0))) n_zero++;
+        if (eps_lt(FloatType(0), f_)) n_positive++;
+        else if (!eps_lt(f_, FloatType(0))) n_zero++;
+        return af::tiny<int, 2>(n_zero, n_positive);
+      }
+
+      // True when all three are positive, or none are zero and exactly one positive.
+      bool
+      def_gt_0() const
+      {
+        af::tiny<int, 2> nz_np = def_test();
+        return nz_np[1] == 3 || (nz_np[0] == 0 && nz_np[1] == 1);
+      }
+
+      // ---------------------------------------------------------------
+      // Change-of-basis tracking
+      // ---------------------------------------------------------------
+
+      void
+      cb_update(scitbx::mat3<IntFromFloatType> const& m)
+      {
+        if (n_iterations_ == iteration_limit_) {
+          throw niggli_reduction_iteration_limit_exceeded(iteration_limit_);
+        }
+        r_inv_ = r_inv_ * m;
+        n_iterations_ += 1;
+      }
+
+      // ---------------------------------------------------------------
+      // N-actions (shared primitives; n3_true/false use epsilon)
+      // ---------------------------------------------------------------
+
+      void n1_action()
+      {
+        cb_update(scitbx::mat3<IntFromFloatType>(0,-1,0, -1,0,0, 0,0,-1));
+        std::swap(a_, b_);
+        std::swap(d_, e_);
+      }
+
+      void n2_action()
+      {
+        cb_update(scitbx::mat3<IntFromFloatType>(-1,0,0, 0,0,-1, 0,-1,0));
+        std::swap(b_, c_);
+        std::swap(e_, f_);
+      }
+
+      // Make d_,e_,f_ all non-negative (epsilon-aware sign check).
+      void n3_true_action()
+      {
+        scitbx::mat3<IntFromFloatType> m(1);  // identity
+        if (eps_lt(d_, FloatType(0))) m[0] = -1;
+        if (eps_lt(e_, FloatType(0))) m[4] = -1;
+        if (eps_lt(f_, FloatType(0))) m[8] = -1;
+        cb_update(m);
+        d_ = std::abs(d_);
+        e_ = std::abs(e_);
+        f_ = std::abs(f_);
+      }
+
+      // Make d_,e_,f_ all non-positive (epsilon-aware sign check).
+      // z tracks which component is epsilon-zero (component index 0/1/2).
+      void n3_false_action()
+      {
+        int f[3] = {1, 1, 1};
+        int z = -1;
+        if (eps_gt(d_, FloatType(0)))       f[0] = -1;
+        else if (!eps_lt(d_, FloatType(0))) z = 0;
+        if (eps_gt(e_, FloatType(0)))       f[1] = -1;
+        else if (!eps_lt(e_, FloatType(0))) z = 1;
+        if (eps_gt(f_, FloatType(0)))       f[2] = -1;
+        else if (!eps_lt(f_, FloatType(0))) z = 2;
+        if (f[0] * f[1] * f[2] < 0) {
+          CCTBX_ASSERT(z != -1);
+          f[z] = -1;
+        }
+        cb_update(scitbx::mat3<IntFromFloatType>(
+          f[0],0,0, 0,f[1],0, 0,0,f[2]));
+        d_ = -std::abs(d_);
+        e_ = -std::abs(e_);
+        f_ = -std::abs(f_);
+      }
+
+      // ---------------------------------------------------------------
+      // A-actions (direct port of krivy_gruber_1976.py a*_action methods)
+      // Note: a5/a6/a7 use exact sign comparison (d_>0, etc.), not epsilon.
+      // This matches the Python source exactly.
+      // ---------------------------------------------------------------
+
+      void a1_action() { n1_action(); }
+      void a2_action() { n2_action(); }
+      void a3_action() { n3_true_action(); }
+      void a4_action() { n3_false_action(); }
+
+      void a5_action()
+      {
+        if (d_ > 0) {
+          cb_update(scitbx::mat3<IntFromFloatType>(1,0,0, 0,1,-1, 0,0,1));
+          c_ += b_ - d_;
+          d_ -= b_ + b_;
+          e_ -= f_;
+        } else {
+          cb_update(scitbx::mat3<IntFromFloatType>(1,0,0, 0,1,1, 0,0,1));
+          c_ += b_ + d_;
+          d_ += b_ + b_;
+          e_ += f_;
+        }
+        CCTBX_ASSERT(c_ > 0);
+      }
+
+      void a6_action()
+      {
+        if (e_ > 0) {
+          cb_update(scitbx::mat3<IntFromFloatType>(1,0,-1, 0,1,0, 0,0,1));
+          c_ += a_ - e_;
+          d_ -= f_;
+          e_ -= a_ + a_;
+        } else {
+          cb_update(scitbx::mat3<IntFromFloatType>(1,0,1, 0,1,0, 0,0,1));
+          c_ += a_ + e_;
+          d_ += f_;
+          e_ += a_ + a_;
+        }
+        CCTBX_ASSERT(c_ > 0);
+      }
+
+      void a7_action()
+      {
+        if (f_ > 0) {
+          cb_update(scitbx::mat3<IntFromFloatType>(1,-1,0, 0,1,0, 0,0,1));
+          b_ += a_ - f_;
+          d_ -= e_;
+          f_ -= a_ + a_;
+        } else {
+          cb_update(scitbx::mat3<IntFromFloatType>(1,1,0, 0,1,0, 0,0,1));
+          b_ += a_ + f_;
+          d_ += e_;
+          f_ += a_ + a_;
+        }
+        CCTBX_ASSERT(b_ > 0);
+      }
+
+      void a8_action()
+      {
+        cb_update(scitbx::mat3<IntFromFloatType>(1,0,1, 0,1,1, 0,0,1));
+        c_ += a_ + b_ + d_ + e_ + f_;
+        d_ += b_ + b_ + f_;
+        e_ += a_ + a_ + f_;
+        CCTBX_ASSERT(c_ > 0);
+      }
+
+      // ---------------------------------------------------------------
+      // Main step function — exact port of krivy_gruber_1976.step()
+      // ---------------------------------------------------------------
+
+      bool step()
+      {
+        // A1
+        if (eps_gt(a_, b_)
+            || (eps_eq(a_, b_) && eps_gt(std::abs(d_), std::abs(e_)))) {
+          a1_action();
+        }
+        // A2
+        if (eps_gt(b_, c_)
+            || (eps_eq(b_, c_) && eps_gt(std::abs(e_), std::abs(f_)))) {
+          a2_action();
+          return true;
+        }
+        // A3 / A4
+        if (def_gt_0()) {
+          a3_action();
+        } else {
+          a4_action();
+        }
+        // A5
+        if (eps_gt(std::abs(d_), b_)
+            || (eps_eq(d_, b_)  && eps_lt(e_ + e_, f_))
+            || (eps_eq(d_, -b_) && eps_lt(f_, FloatType(0)))) {
+          a5_action();
+          return true;
+        }
+        // A6
+        if (eps_gt(std::abs(e_), a_)
+            || (eps_eq(e_, a_)  && eps_lt(d_ + d_, f_))
+            || (eps_eq(e_, -a_) && eps_lt(f_, FloatType(0)))) {
+          a6_action();
+          return true;
+        }
+        // A7
+        if (eps_gt(std::abs(f_), a_)
+            || (eps_eq(f_, a_)  && eps_lt(d_ + d_, e_))
+            || (eps_eq(f_, -a_) && eps_lt(e_, FloatType(0)))) {
+          a7_action();
+          return true;
+        }
+        // A8
+        if (eps_lt(d_ + e_ + f_ + a_ + b_, FloatType(0))
+            || (eps_eq(d_ + e_ + f_ + a_ + b_, FloatType(0))
+                && eps_gt(a_ + a_ + e_ + e_ + f_, FloatType(0)))) {
+          a8_action();
+          return true;
+        }
+        return false;
+      }
+
+      // ---------------------------------------------------------------
+      // Data members
+      // ---------------------------------------------------------------
+
+      std::size_t iteration_limit_;
+      scitbx::mat3<IntFromFloatType> r_inv_;
+      std::size_t n_iterations_;
+      FloatType epsilon_;
+      FloatType a_, b_, c_, d_, e_, f_;
+  };
+
+}} // namespace cctbx::uctbx
+
+#endif // CCTBX_UCTBX_NIGGLI_REDUCTION_H

--- a/cctbx/uctbx/niggli_reduction.h
+++ b/cctbx/uctbx/niggli_reduction.h
@@ -6,6 +6,9 @@
 #include <scitbx/array_family/tiny.h>
 #include <cmath>
 #include <string>
+#include <cctbx/sgtbx/change_of_basis_op.h>
+#include <cctbx/sgtbx/rt_mx.h>
+#include <cctbx/sgtbx/rot_mx.h>
 
 namespace cctbx { namespace uctbx {
 
@@ -156,6 +159,14 @@ namespace cctbx { namespace uctbx {
           if (eps_gt(std::abs(e_), std::abs(f_))) return false;
         }
         return true;
+      }
+
+      //! Change-of-basis operator that transforms the input cell to the Niggli cell.
+      sgtbx::change_of_basis_op
+      change_of_basis_op() const
+      {
+        return sgtbx::change_of_basis_op(
+          sgtbx::rt_mx(sgtbx::rot_mx(r_inv_, 1))).inverse();
       }
 
       //! True if Buerger cell and 7 Niggli boundary uniqueness conditions.

--- a/cctbx/uctbx/niggli_reduction.h
+++ b/cctbx/uctbx/niggli_reduction.h
@@ -3,7 +3,6 @@
 
 #include <cctbx/uctbx.h>
 #include <cctbx/error.h>
-#include <cctbx/sgtbx/change_of_basis_op.h>
 #include <scitbx/array_family/tiny.h>
 #include <cmath>
 #include <string>
@@ -40,9 +39,6 @@ namespace cctbx { namespace uctbx {
   class niggli_reduction
   {
     public:
-      //! Default constructor. Data members are not initialized.
-      niggli_reduction() {}
-
       /*! \brief Execute the Niggli reduction algorithm.
 
           \param unit_cell      Input cell to reduce.
@@ -189,21 +185,6 @@ namespace cctbx { namespace uctbx {
           if (eps_gt(a_ + a_ + e_ + e_ + f_, FloatType(0))) return false;
         }
         return true;
-      }
-
-      /*! \brief Change-of-basis operator that transforms the input cell to
-          the reduced Niggli cell.
-
-          Uses sgtbx types.  The translator is constructed from the accumulated
-          integer matrix r_inv_ in the same way as reduction_base.change_of_basis_op().
-       */
-      sgtbx::change_of_basis_op
-      change_of_basis_op() const
-      {
-        // r_inv_ is scitbx::mat3<int>; rot_mx takes (mat3<int>, denominator).
-        sgtbx::rot_mx rot(r_inv_, 1);
-        sgtbx::rt_mx rt(rot);
-        return sgtbx::change_of_basis_op(rt).inverse();
       }
 
     protected:


### PR DESCRIPTION
This PR replaces the existing Niggli reduction with a c++ implementation. This PR ports the cctbx Niggli from python to c++ and was done with Claude Code. A new comphrensive test cross-check the public methods of the new c++ implementation with the existing python implementation.

During serial data reduction, when multiple lattices are present on an image, indexing is performed by repetitive indexing attempts with subsampled observations. Profiling showed the existing Niggli Reduction contributed a significant amount of execution time. This PR reduces the fraction of time in the Niggli reduction from 27.4% to 4% in one test case and from 34% to 3.4% in another.