### PR TITLE
Add bootstrap filter method to cctbx.xfel.merge

### DIFF
--- a/xfel/merging/application/filter/experiment_filter.py
+++ b/xfel/merging/application/filter/experiment_filter.py
@@ -93,7 +93,7 @@ class experiment_filter(worker):
     filter_by_energy = 'energy' in self.params.filter.algorithm
     filter_by_bootstrap = 'bootstrap' in self.params.filter.algorithm
     # only unit_cell, n_obs, resolution, and energy algorithms are supported
-    if (not filter_by_unit_cell) and (not filter_by_n_obs) and (not filter_by_resolution) and (not filter_by_energy):
+    if (not filter_by_unit_cell) and (not filter_by_n_obs) and (not filter_by_resolution) and (not filter_by_energy) and not (filter_by_bootstrap):
       return experiments, reflections
     self.logger.log_step_time("FILTER_EXPERIMENTS")
 

--- a/xfel/merging/application/filter/experiment_filter.py
+++ b/xfel/merging/application/filter/experiment_filter.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, division, print_function
 from xfel.merging.application.worker import worker
 from cctbx import factor_ev_angstrom
 from cctbx.crystal import symmetry
+from dials.array_family import flex
+from dxtbx.model.experiment_list import ExperimentList
 from libtbx import Auto
 
 class experiment_filter(worker):
@@ -89,6 +91,7 @@ class experiment_filter(worker):
     filter_by_n_obs = 'n_obs' in self.params.filter.algorithm
     filter_by_resolution = 'resolution' in self.params.filter.algorithm
     filter_by_energy = 'energy' in self.params.filter.algorithm
+    filter_by_bootstrap = 'bootstrap' in self.params.filter.algorithm
     # only unit_cell, n_obs, resolution, and energy algorithms are supported
     if (not filter_by_unit_cell) and (not filter_by_n_obs) and (not filter_by_resolution) and (not filter_by_energy):
       return experiments, reflections
@@ -122,9 +125,10 @@ class experiment_filter(worker):
     input_len_expts = len(experiments)
     input_len_refls = len(reflections)
     new_experiments, new_reflections = experiment_filter.remove_experiments(experiments, reflections, experiment_ids_to_remove)
+    len_new_experiments = len(new_experiments)
 
     removed_reflections = input_len_refls - len(new_reflections)
-    assert len(experiment_ids_to_remove) == input_len_expts - len(new_experiments)
+    assert len(experiment_ids_to_remove) == input_len_expts - len_new_experiments
 
     self.logger.log("Experiments rejected because of unit cell dimensions: %d"%removed_for_unit_cell)
     self.logger.log("Experiments rejected because of space group %d"%removed_for_space_group)
@@ -151,6 +155,53 @@ class experiment_filter(worker):
       self.logger.main_log("Total experiments rejected because of resolution %d"%total_removed_for_resolution)
       self.logger.main_log("Total experiments rejected because of energy %d"%total_removed_for_energy)
       self.logger.main_log("Total reflections rejected because of rejected experiments %d"%total_reflections_removed)
+
+    if filter_by_bootstrap:
+      self.logger.main_log("Performing random bootstrap method, randomly selecting with replacement")
+      # keep track of which rank has which experiment by creating a list of tuples (rank, expt_id)
+      rank_experiment_tuples = comm.gather(tuple((self.mpi_helper.rank, i) for i in range(len_new_experiments)), root=0)
+      if self.mpi_helper.rank == 0:
+        # unpack into single list
+        rank_experiment_tuples = [t for sublist in rank_experiment_tuples for t in sublist]
+        total_experiments = len(rank_experiment_tuples)
+        mt = flex.mersenne_twister(seed = self.params.filter.bootstrap.random_seed)
+        # random selection with replacement
+        selected = mt.random_size_t(total_experiments, modulus=total_experiments)
+        # for each rank, send a list of expt_ids to keep and/or duplicate
+        experiment_ids_by_rank = [[] for i in range(self.mpi_helper.size)]
+        for i in range(total_experiments):
+          rank, expt_id = rank_experiment_tuples[selected[i]]
+          experiment_ids_by_rank[rank].append(expt_id)
+      else:
+        experiment_ids_by_rank = None
+      bootstrapped_expt_ids = list(sorted(self.mpi_helper.comm.scatter(experiment_ids_by_rank, root=0)))
+      bootstrapped_expts = ExperimentList()
+      bootstrapped_refls = []
+      counter = 0
+      duplications = 0
+      for i, expt_id in enumerate(bootstrapped_expt_ids):
+        new_expt = new_experiments[expt_id]
+        new_refls = new_reflections.select(new_reflections['id'] == expt_id)
+
+        # check if previous entry is the same as this one indicating the data is a duplication
+        if i-1 >= 0 and bootstrapped_expt_ids[i-1] == expt_id:
+          counter += 1
+        else:
+          duplications += counter
+          counter = 0
+
+        # handle duplications by tagging the identifier with a counter
+        ident = new_expt.identifier + f"_{counter}"
+        new_expt.identifier = ident
+        new_refls.experiment_identifiers()[expt_id] = ident
+        bootstrapped_expts.append(new_expt)
+        bootstrapped_refls.append(new_refls)
+      duplications += counter
+      new_experiments = bootstrapped_expts
+      new_reflections = flex.reflection_table.concat(bootstrapped_refls)
+      total_duplications = comm.reduce(duplications, MPI.SUM, 0)
+    if self.mpi_helper.rank == 0:
+      self.logger.main_log("Total duplications during bootstrapping: %d"%total_duplications)
 
     self.logger.log_step_time("FILTER_EXPERIMENTS", True)
 

--- a/xfel/merging/application/filter/experiment_filter.py
+++ b/xfel/merging/application/filter/experiment_filter.py
@@ -200,8 +200,8 @@ class experiment_filter(worker):
       new_experiments = bootstrapped_expts
       new_reflections = flex.reflection_table.concat(bootstrapped_refls)
       total_duplications = comm.reduce(duplications, MPI.SUM, 0)
-    if self.mpi_helper.rank == 0:
-      self.logger.main_log("Total duplications during bootstrapping: %d"%total_duplications)
+      if self.mpi_helper.rank == 0:
+        self.logger.main_log("Total duplications during bootstrapping: %d"%total_duplications)
 
     self.logger.log_step_time("FILTER_EXPERIMENTS", True)
 

--- a/xfel/merging/application/filter/experiment_filter.py
+++ b/xfel/merging/application/filter/experiment_filter.py
@@ -157,10 +157,10 @@ class experiment_filter(worker):
       self.logger.main_log("Total reflections rejected because of rejected experiments %d"%total_reflections_removed)
 
     if filter_by_bootstrap:
-      self.logger.main_log("Performing random bootstrap method, randomly selecting with replacement")
       # keep track of which rank has which experiment by creating a list of tuples (rank, expt_id)
       rank_experiment_tuples = comm.gather(tuple((self.mpi_helper.rank, i) for i in range(len_new_experiments)), root=0)
       if self.mpi_helper.rank == 0:
+        self.logger.main_log("Performing random bootstrap method, randomly selecting with replacement")
         # unpack into single list
         rank_experiment_tuples = [t for sublist in rank_experiment_tuples for t in sublist]
         total_experiments = len(rank_experiment_tuples)

--- a/xfel/merging/application/filter/experiment_filter.py
+++ b/xfel/merging/application/filter/experiment_filter.py
@@ -175,6 +175,7 @@ class experiment_filter(worker):
       else:
         experiment_ids_by_rank = None
       bootstrapped_expt_ids = list(sorted(self.mpi_helper.comm.scatter(experiment_ids_by_rank, root=0)))
+      #self.logger.log('Experiment ids after bootstrapping: %s'%', '.join([str(i) for i in bootstrapped_expt_ids]))
       bootstrapped_expts = ExperimentList()
       bootstrapped_refls = []
       counter = 0

--- a/xfel/merging/application/filter/experiment_filter.py
+++ b/xfel/merging/application/filter/experiment_filter.py
@@ -178,6 +178,7 @@ class experiment_filter(worker):
       bootstrapped_expts = ExperimentList()
       bootstrapped_refls = []
       counter = 0
+      root_ident = ""
       duplications = 0
       for i, expt_id in enumerate(bootstrapped_expt_ids):
         new_expt = new_experiments[expt_id]
@@ -189,9 +190,10 @@ class experiment_filter(worker):
         else:
           duplications += counter
           counter = 0
+          root_ident = new_expt.identifier
 
         # handle duplications by tagging the identifier with a counter
-        ident = new_expt.identifier + f"_{counter}"
+        ident = root_ident + f"_{counter}"
         new_expt.identifier = ident
         new_refls.experiment_identifiers()[expt_id] = ident
         bootstrapped_expts.append(new_expt)

--- a/xfel/merging/application/filter/reflection_filter.py
+++ b/xfel/merging/application/filter/reflection_filter.py
@@ -272,7 +272,12 @@ class reflection_filter(worker):
       intensity_counts_rank, intensity_counts, op=self.mpi_helper.MPI.SUM, root=0
       )
     if self.mpi_helper.rank == 0:
-      binned_mean = intensity_summation / intensity_counts
+      with np.errstate(invalid='ignore', divide='ignore'):
+        binned_mean = np.where(
+          intensity_counts > 0,
+          intensity_summation / intensity_counts,
+          np.nan
+        )
     else:
       binned_mean = np.zeros(n_bins)
     self.mpi_helper.comm.Bcast(binned_mean, root=0)
@@ -284,6 +289,8 @@ class reflection_filter(worker):
         q2_rank >= q2_bins[bin_index],
         q2_rank < q2_bins[bin_index + 1]
         )
+      if np.isnan(binned_mean[bin_index]):
+        continue
       intensity_normalized_rank[indices] = intensity_rank[indices] / binned_mean[bin_index]
     reflections['intensity_normalized'] = flex.double(intensity_normalized_rank)
 
@@ -304,6 +311,18 @@ class reflection_filter(worker):
       q2_rank_bin = q2_rank[indices]
 
       bin_sizes = self.mpi_helper.comm.gather(q2_rank_bin.size, root=0)
+
+      if self.mpi_helper.rank == 0:
+        total_bin_size = intensity_counts[bin_index]
+      else:
+        total_bin_size = None
+      total_bin_size = self.mpi_helper.comm.bcast(total_bin_size, root=0)
+      if total_bin_size == 0:
+        if self.mpi_helper.rank == 0:
+          lower_tail.append(np.zeros((0, 2)))
+          upper_tail.append(np.zeros((0, 2)))
+        continue
+
       if self.mpi_helper.rank == 0:
         q2_bin = np.zeros(intensity_counts[bin_index])
         intensity_normalized_bin = np.zeros(intensity_counts[bin_index])

--- a/xfel/merging/application/phil/phil.py
+++ b/xfel/merging/application/phil/phil.py
@@ -133,7 +133,7 @@ filter
   .help = or to modify the entire experiment by a reindexing operator
   .help = refer to the select section for filtering of individual reflections
   {
-  algorithm = n_obs resolution unit_cell energy
+  algorithm = n_obs resolution unit_cell energy bootstrap
     .type = choice(multi=True)
   n_obs {
     min = None
@@ -230,6 +230,11 @@ filter
     max_eV = None
       .type = float
       .help = Filter out lattices with beam energy higher than or equal to this number
+  }
+  bootstrap {
+    random_seed = 0
+      .type = int
+      .help = seed for the bootstrap filtering algorithm (random selection with replacement)
   }
 }
 """


### PR DESCRIPTION
See Grünbein 2021, this adds subsampling with replacement of the lattices to enable creating replicates that can be individually used with structure refinement.  The average atomic positions provide an estimate of coordinate error.