### PR TITLE
xfel: removed missed unused imports

### DIFF
--- a/xfel/command_line/cspad_cbf_metrology.py
+++ b/xfel/command_line/cspad_cbf_metrology.py
@@ -4,7 +4,7 @@
 #
 from __future__ import absolute_import, division, print_function
 from six.moves import range
-import os, sys, random
+import os, sys
 from iotbx.phil import parse
 from libtbx import easy_run
 from libtbx.utils import Sorry

--- a/xfel/cxi/cspad_ana/mod_ledge.py
+++ b/xfel/cxi/cspad_ana/mod_ledge.py
@@ -433,7 +433,7 @@ class mod_ledge(common_mode.common_mode_correction):
     """
 
     from pyana.event import Event
-    from acqiris_ext import acqiris_integrate, apd_hitfind
+    from acqiris_ext import acqiris_integrate
 
     super(mod_ledge, self).event(evt, env)
     if evt.status() != Event.Normal:

--- a/xfel/cxi/data_utils.py
+++ b/xfel/cxi/data_utils.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
-from six.moves import range
 import math
 import sys
 from dials.array_family import flex

--- a/xfel/cxi/data_utils.py
+++ b/xfel/cxi/data_utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from six.moves import range
 import math
 import sys
 from dials.array_family import flex

--- a/xfel/cxi/data_utils.py
+++ b/xfel/cxi/data_utils.py
@@ -3,7 +3,6 @@ from six.moves import range
 import math
 import sys
 from dials.array_family import flex
-from six.moves import cPickle as pickle
 from rstbx.dials_core.integration_core import show_observations
 
 class reduction(object):

--- a/xfel/merging/application/model/resolution_binner.py
+++ b/xfel/merging/application/model/resolution_binner.py
@@ -12,17 +12,6 @@ class resolution_binner(worker):
   def run(self, experiments, reflections):
     '''Set up resolution bins; assign bin number to each hkl in the full miller set'''
 
-    '''
-    # for debugging purposes on Cori
-    memory_MB = get_memory_usage()
-    self.logger.log("Starting resolution_binner with memory usage: %d"%memory_MB)
-    comm = self.mpi_helper.comm
-    MPI = self.mpi_helper.MPI
-    max_memory_usage_MB = comm.reduce(memory_MB, MPI.MAX)
-    if self.mpi_helper.rank == 0:
-      self.logger.main_log("Maximum memory usage per process: %d MB"%max_memory_usage_MB)
-    '''
-
     # Create resolution binner
     full_miller_set = self.params.scaling.miller_set
     full_miller_set.setup_binner(d_max=100000, d_min=self.params.merging.d_min, n_bins=self.params.statistics.n_bins)

--- a/xfel/merging/application/model/resolution_binner.py
+++ b/xfel/merging/application/model/resolution_binner.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 from xfel.merging.application.worker import worker
-from xfel.merging.application.utils.memory_usage import get_memory_usage
 
 class resolution_binner(worker):
 

--- a/xfel/merging/application/modify/aux_cosym.py
+++ b/xfel/merging/application/modify/aux_cosym.py
@@ -3,7 +3,7 @@ import os
 from scitbx.array_family import flex
 from cctbx.array_family import flex as cctbx_flex
 from cctbx import sgtbx, miller
-from libtbx import easy_mp, Auto
+from libtbx import Auto
 from scipy import sparse
 import numpy as np
 from ordered_set import OrderedSet

--- a/xfel/merging/general_fcalc.py
+++ b/xfel/merging/general_fcalc.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 import mmtbx.programs.fmodel
 import mmtbx.utils
 import iotbx.pdb
-import libtbx.phil.command_line
 import sys
 import math
 

--- a/xfel/small_cell/command_line/powder_from_spots.py
+++ b/xfel/small_cell/command_line/powder_from_spots.py
@@ -5,7 +5,6 @@ from __future__ import division
 import logging
 
 from iotbx.phil import parse
-from dials.util import log
 from dials.util import show_mail_on_error
 from dials.util.options import ArgumentParser
 from xfel.small_cell.powder_util import Spotfinder_radial_average, Center_scan

--- a/xfel/small_cell/command_line/powder_from_spots.py
+++ b/xfel/small_cell/command_line/powder_from_spots.py
@@ -2,16 +2,12 @@
 
 # LIBTBX_SET_DISPATCHER_NAME cctbx.xfel.powder_from_spots
 from __future__ import division
-import logging
 
 from iotbx.phil import parse
 from dials.util import show_mail_on_error
 from dials.util.options import ArgumentParser
 from xfel.small_cell.powder_util import Spotfinder_radial_average, Center_scan
 
-
-
-logger = logging.getLogger("dials.command_line.powder_from_spots")
 
 help_message = """
 Script to synthesize a powder pattern from DIALS spotfinding output
@@ -119,8 +115,6 @@ filter {
 
 }
 output {
-  log = dials.powder_from_spots.log
-    .type = str
   xy_file = None
     .type = str
   xy_file_units = *d q

--- a/xfel/small_cell/command_line/powder_refine_geometry.py
+++ b/xfel/small_cell/command_line/powder_refine_geometry.py
@@ -3,7 +3,6 @@ from __future__ import division
 import logging
 
 from iotbx.phil import parse
-from dials.util import log
 from dials.util import show_mail_on_error
 from dials.util.options import ArgumentParser
 from xfel.small_cell.geometry_refiner import PowderGeometryRefiner

--- a/xfel/small_cell/command_line/powder_refine_geometry.py
+++ b/xfel/small_cell/command_line/powder_refine_geometry.py
@@ -1,14 +1,11 @@
 # LIBTBX_SET_DISPATCHER_NAME cctbx.xfel.powder_refine_geometry
 from __future__ import division
-import logging
 
 from iotbx.phil import parse
 from dials.util import show_mail_on_error
 from dials.util.options import ArgumentParser
 from xfel.small_cell.geometry_refiner import PowderGeometryRefiner
 
-
-logger = logging.getLogger("dials.command_line.powder_refine_geometry")
 
 help_message = """
 Refine detector geometry using powder diffraction d-spacings.
@@ -93,9 +90,6 @@ output {
   experiments = refined.expt
     .type = path
     .help = Output filename for refined experiments
-  log = powder_refine_geometry.log
-    .type = path
-    .help = Output log file
 }
 """
 )

--- a/xfel/xpp/progress_support.py
+++ b/xfel/xpp/progress_support.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
-from six.moves import range
 from cctbx.array_family import flex
 from cctbx.miller import match_multi_indices
 from cctbx.miller import set as mset


### PR DESCRIPTION
There was a bug in the clutter code where words in doc strings were treated as code. The fix revealed more imports that are unused.