### PR TITLE
Security: Unsafe use of eval() in show_platform_info

### DIFF
--- a/boost_adaptbx/command_line/show_platform_info.py
+++ b/boost_adaptbx/command_line/show_platform_info.py
@@ -29,7 +29,7 @@ def run(out=None, omit_unicode_experiment=False):
   print("platform.architecture():", platform.architecture(), file=out)
   for attr in ["division_by_zero", "invalid", "overflow"]:
     attr = "floating_point_exceptions.%s_trapped" % attr
-    print("%s:" % attr, eval("bp.%s" % attr), file=out)
+    print("%s:" % attr, getattr(bp, attr), file=out)
   print("number of processors:", introspection.number_of_processors(
     return_value_if_unknown="unknown"), file=out)
   introspection.machine_memory_info().show(out=out)


### PR DESCRIPTION
## Summary

Security: Unsafe use of eval() in show_platform_info

## Problem

**Severity**: `Medium` | **File**: `boost_adaptbx/command_line/show_platform_info.py:L42`

The code uses eval('bp.%s' % attr) to dynamically execute attribute access. While the attribute is currently hardcoded, using eval() is inherently dangerous and could lead to code execution if the attribute source changes.

## Solution

Replace eval() with getattr(bp, attr_name) to safely access attributes by name without executing arbitrary code.

## Changes

- `boost_adaptbx/command_line/show_platform_info.py` (modified)