### PR TITLE
Added the 'UHF' keyword for non-singlet calculations.

### DIFF
--- a/mmtbx/geometry_restraints/mopac_manager.py
+++ b/mmtbx/geometry_restraints/mopac_manager.py
@@ -52,7 +52,7 @@ class mopac_manager(base_qm_manager.base_qm_manager):
                         'quintet', # - 4 unpaired electrons
                         'sextet', # - 5 unpaired electrons
                         'septet',
-                        ][self.multiplicity]
+                        ][self.multiplicity] + ' UHF'
     additional_options=''
     if gradients_only:
       additional_options+=' 1SCF GRAD ANALYT'


### PR DESCRIPTION
MOPAC defaults to RHF calculations, i.e. singlet state. If the multiplicitly is changed from singlet, this also requires the UHF keyword to be present.