### PR TITLE
scitbx: fix flex.*_from_byte_str truncation of non-ASCII Unicode input

### DIFF
--- a/scitbx/array_family/boost_python/byte_str.h
+++ b/scitbx/array_family/boost_python/byte_str.h
@@ -2,6 +2,7 @@
 #define SCITBX_ARRAY_FAMILY_BOOST_PYTHON_BYTE_STR_H
 
 #include <boost/python/str.hpp>
+#include <boost/python/handle.hpp>
 #include <scitbx/array_family/shared.h>
 
 #if PY_MAJOR_VERSION >= 3
@@ -67,15 +68,21 @@ namespace scitbx { namespace af { namespace boost_python {
   {
 #ifdef IS_PY3K
     PyObject* o(byte_str.ptr());
-    const char* str_ptr;
-    if (PyUnicode_Check(o))
-      o = PyUnicode_AsUTF8String(o);
-    str_ptr = PyBytes_AsString(o);
+    // A unicode argument is re-encoded to UTF-8 bytes; keep that temporary
+    // alive (and released) with handle<>. len_byte_str must be the size of
+    // the byte buffer str_ptr points at, not len(byte_str): for non-ASCII
+    // unicode the latter is the code-point count and would truncate the array.
+    boost::python::handle<> utf8;
+    if (PyUnicode_Check(o)) {
+      utf8 = boost::python::handle<>(PyUnicode_AsUTF8String(o));
+      o = utf8.get();
+    }
+    const char* str_ptr = PyBytes_AsString(o);
+    boost::python::ssize_t len_byte_str = PyBytes_GET_SIZE(o);
 #else
     const char* str_ptr = PyString_AsString(byte_str.ptr());
+    boost::python::ssize_t len_byte_str = boost::python::len(byte_str);
 #endif
-    boost::python::ssize_t
-      len_byte_str = boost::python::len(byte_str);
     boost::python::ssize_t
       shared_array_size = len_byte_str / sizeof(ElementType);
     SCITBX_ASSERT(shared_array_size * sizeof(ElementType) == len_byte_str);

--- a/scitbx/array_family/boost_python/tst_flex.py
+++ b/scitbx/array_family/boost_python/tst_flex.py
@@ -51,6 +51,25 @@ def exercise_split_lines_unicode():
   assert list(flex.split_lines("α\nβ\n")) == ["α", "β"]
   assert list(flex.split_lines("α\r\nβ\rγ\n")) == ["α", "β", "γ"]
 
+def exercise_from_byte_str_unicode():
+  # flex.*_from_byte_str re-encodes a unicode argument as UTF-8, so the result
+  # must equal passing the UTF-8 bytes directly. Regression for a code-point
+  # vs byte-count mismatch in the unicode branch of shared_from_byte_str:
+  # for non-ASCII input the code-point count is smaller than the byte buffer,
+  # which truncated the array. uint8 has element size 1, so any byte length
+  # is valid.
+  for u in ["", "abc", "aα本", "résumé", "α😀z"]:
+    utf8 = u.encode("utf-8")
+    from_bytes = list(flex.uint8_from_byte_str(utf8))
+    from_str = list(flex.uint8_from_byte_str(u))
+    assert from_str == from_bytes, (repr(u), from_str, from_bytes)
+    assert len(from_str) == len(utf8), (repr(u), len(from_str), len(utf8))
+  # element size > 1: "αβγδ" is 8 UTF-8 bytes, i.e. exactly one double.
+  u = "αβγδ"
+  assert len(u.encode("utf-8")) == 8
+  assert (list(flex.double_from_byte_str(u))
+          == list(flex.double_from_byte_str(u.encode("utf-8"))))
+
 def exercise_flex_grid():
   g = flex.grid()
   assert g.nd() == 0
@@ -3773,6 +3792,7 @@ def run(iterations):
   i = 0
   while (iterations == 0 or i < iterations):
     exercise_split_lines_unicode()
+    exercise_from_byte_str_unicode()
     exercise_flex_sum_axis()
     exercise_nd_slicing()
     exercise_set_nd_slicing()


### PR DESCRIPTION
- shared_from_byte_str (flex.int_from_byte_str, double_from_byte_str, size_t_from_byte_str, ...) re-encodes a unicode argument to UTF-8 bytes but took its length from len(byte_str), the code-point count; for non-ASCII input that is smaller than the UTF-8 buffer, so the resulting array was silently truncated
- take the length from the byte buffer actually used (PyBytes_GET_SIZE), keeping the pointer and size consistent
- own the re-encoded UTF-8 bytes with handle<>, releasing them; the unicode branch previously leaked the PyUnicode_AsUTF8String reference
- add exercise_from_byte_str_unicode regression test