### PR TITLE
Residue quality score: continuous triage metric, chiral types, severity tuning

### DIFF
--- a/mmtbx/validation/regression/tst_utils.py
+++ b/mmtbx/validation/regression/tst_utils.py
@@ -1,0 +1,184 @@
+from __future__ import absolute_import, division, print_function
+from libtbx.test_utils import approx_equal
+from mmtbx.validation.utils import (
+  _clash_severity,
+  _cbeta_severity,
+  _bond_angle_severity,
+  calculate_overall_residue_quality_score,
+)
+
+
+def exercise_clash_severity():
+  # Single clash at key overlaps (non-linear power curve)
+  assert approx_equal(_clash_severity(0.4, 1), 1.39, eps=0.05)
+  assert approx_equal(_clash_severity(0.5, 1), 2.02, eps=0.05)
+  assert approx_equal(_clash_severity(0.7, 1), 3.42, eps=0.05)
+  assert approx_equal(_clash_severity(0.9, 1), 4.98, eps=0.05)
+  assert approx_equal(_clash_severity(1.5, 1), 10.30, eps=0.05)
+
+  # At threshold (0.1 A offset), severity should be zero
+  assert _clash_severity(0.1, 1) == 0.0
+
+  # Multi-clash log2 bonus
+  assert approx_equal(_clash_severity(0.5, 2), 3.02, eps=0.05)   # +1.0
+  assert approx_equal(_clash_severity(0.5, 5), 4.34, eps=0.05)   # +2.3
+  assert approx_equal(_clash_severity(0.5, 16), 6.02, eps=0.05)  # +4.0 (cap)
+
+  # Cap: 16 and 50 clashes give the same bonus
+  assert approx_equal(
+    _clash_severity(0.5, 50),
+    _clash_severity(0.5, 16),
+    eps=0.01)
+
+  print("  exercise_clash_severity: OK")
+
+
+def exercise_cbeta_severity():
+  assert approx_equal(_cbeta_severity(0.25), 1.44, eps=0.01)
+  assert approx_equal(_cbeta_severity(0.50), 4.44, eps=0.01)
+  # At baseline (0.13), severity is zero
+  assert _cbeta_severity(0.13) == 0.0
+  # Below baseline returns zero
+  assert _cbeta_severity(0.10) == 0.0
+
+  print("  exercise_cbeta_severity: OK")
+
+
+def exercise_bond_angle_severity():
+  # With sigma values
+  assert approx_equal(_bond_angle_severity(1, 4.0), 1.0, eps=0.01)
+  assert approx_equal(_bond_angle_severity(1, 6.0), 2.0, eps=0.01)
+  # Multiple outliers add 0.5 each
+  assert approx_equal(_bond_angle_severity(3, 6.0), 3.0, eps=0.01)
+
+  # Fallback without sigma
+  assert approx_equal(_bond_angle_severity(1, None), 1.0, eps=0.01)
+  assert approx_equal(_bond_angle_severity(3, None), 2.0, eps=0.01)
+
+  print("  exercise_bond_angle_severity: OK")
+
+
+def _make_residue(**overrides):
+  """Build a residue_data dict with sensible defaults."""
+  data = {
+    'ramalyze_type': 'general',
+    'ramalyze_category': 'favored',
+    'rotalyze_category': 'favored',
+    'is_glycine': False,
+    'is_cbeta_outlier': False,
+    'cbeta_deviation': 0.0,
+    'cablam_outlier_type': 'favored',
+    'omega_type': 'trans',
+    'is_proline': False,
+    'num_bad_clashes_res': 0,
+    'worst_clash_overlap': 0.0,
+    'num_bond_outliers_res': 0,
+    'worst_bond_deviation': None,
+    'num_angle_outliers_res': 0,
+    'worst_angle_deviation': None,
+    'num_chiral_handedness_res': 0,
+    'num_chiral_tetrahedral_res': 0,
+    'num_chiral_pseudochiral_res': 0,
+    'num_chiral_outliers_res': 0,
+    'is_rna_residue': False,
+  }
+  data.update(overrides)
+  return data
+
+
+def exercise_residue_quality_score():
+  score = calculate_overall_residue_quality_score
+
+  # Clean residue: all metrics present, no outliers -> 0.0
+  assert score(_make_residue()) == 0.0
+
+  # No applicable metrics -> None (glycine with everything not_evaluated)
+  assert score({
+    'ramalyze_type': 'not_applicable',
+    'rotalyze_category': 'not_evaluated',
+    'is_glycine': True,
+    'cablam_outlier_type': 'not_evaluated',
+    'omega_type': 'not_evaluated',
+  }) is None
+
+  # Twist only -> 15.0
+  assert score(_make_residue(omega_type='twisted')) == 15.0
+
+  # Rama outlier only -> 5.0
+  assert score(_make_residue(ramalyze_category='outlier')) == 5.0
+
+  # Rotamer outlier only -> 3.0
+  assert score(_make_residue(rotalyze_category='outlier')) == 3.0
+
+  # Single 0.4 A clash -> 1.4
+  assert score(_make_residue(
+    num_bad_clashes_res=1, worst_clash_overlap=-0.4)) == 1.4
+
+  # Cis non-proline -> 8.0
+  assert score(_make_residue(omega_type='cis', is_proline=False)) == 8.0
+
+  # Cis proline is not an outlier -> 0.0
+  assert score(_make_residue(omega_type='cis', is_proline=True)) == 0.0
+
+  # Chiral handedness swap -> 10.0
+  assert score(_make_residue(num_chiral_handedness_res=1)) == 10.0
+
+  # Multi-issue: twist + rama + rota -> 15 + 0.25*(5+3) = 17.0
+  assert score(_make_residue(
+    omega_type='twisted',
+    ramalyze_category='outlier',
+    rotalyze_category='outlier')) == 17.0
+
+  # 15 clashes at 1.54 A -> ~14.6
+  assert score(_make_residue(
+    num_bad_clashes_res=15, worst_clash_overlap=-1.54)) == 14.6
+
+  print("  exercise_residue_quality_score: OK")
+
+
+def exercise_ranking_invariants():
+  score = calculate_overall_residue_quality_score
+
+  twist_only = score(_make_residue(omega_type='twisted'))
+  big_clash = score(_make_residue(
+    num_bad_clashes_res=1, worst_clash_overlap=-1.5))
+  rama_only = score(_make_residue(ramalyze_category='outlier'))
+  rota_only = score(_make_residue(rotalyze_category='outlier'))
+  small_clash = score(_make_residue(
+    num_bad_clashes_res=1, worst_clash_overlap=-0.4))
+
+  # Twisted peptide > single large clash > rama > rotamer > small clash
+  assert twist_only > big_clash, \
+    "twist (%s) should outrank single 1.5A clash (%s)" % (twist_only, big_clash)
+  assert big_clash > rama_only, \
+    "1.5A clash (%s) should outrank rama outlier (%s)" % (big_clash, rama_only)
+  assert rama_only > rota_only, \
+    "rama (%s) should outrank rotamer (%s)" % (rama_only, rota_only)
+  assert rota_only > small_clash, \
+    "rotamer (%s) should outrank small clash (%s)" % (rota_only, small_clash)
+
+  # Twist + other issues should outrank clash-only with many clashes
+  twist_plus = score(_make_residue(
+    omega_type='twisted',
+    ramalyze_category='outlier',
+    rotalyze_category='outlier'))
+  many_clashes = score(_make_residue(
+    num_bad_clashes_res=18, worst_clash_overlap=-1.54))
+  assert twist_plus > many_clashes, \
+    "twist+rama+rota (%s) should outrank 18 clashes at 1.54A (%s)" % (
+      twist_plus, many_clashes)
+
+  print("  exercise_ranking_invariants: OK")
+
+
+def exercise():
+  exercise_clash_severity()
+  exercise_cbeta_severity()
+  exercise_bond_angle_severity()
+  exercise_residue_quality_score()
+  exercise_ranking_invariants()
+
+
+if __name__ == "__main__":
+  exercise()
+  print("OK")

--- a/mmtbx/validation/utils.py
+++ b/mmtbx/validation/utils.py
@@ -136,134 +136,190 @@ def molprobity_score(clashscore, rota_out, rama_fav):
     return -1 # FIXME prevents crashing on RNA and None in inputs
   return mpscore
 
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
+
+def _clash_severity(abs_overlap, num_clashes):
+    """Map clash overlap magnitude and count to a continuous severity.
+
+    Uses the worst overlap as the primary signal, scaled linearly from
+    the 0.4 A outlier threshold.  Additional clashes beyond the first
+    add a small increment each (0.5 per extra clash) so that a single
+    severe clash always dominates over many minor ones.
+
+    Severity scale (approximate):
+      0.4 A overlap -> 1.5    (minor)
+      0.5 A         -> 3.0    (moderate)
+      0.7 A         -> 6.0    (severe)
+      0.9 A         -> 9.0    (very severe)
+    """
+    severity = max(0.0, (abs_overlap - 0.1) * 10.0)
+    if num_clashes > 1:
+        severity += (num_clashes - 1) * 0.5
+    return severity
+
+def _cbeta_severity(deviation):
+    """Map C-beta deviation to a continuous severity.
+
+    Outlier threshold is 0.25 A.  Scales linearly so that:
+      0.25 A -> 1.0
+      0.50 A -> 4.0
+      0.75 A -> 7.0
+    """
+    return max(0.0, (deviation - 0.13) * 12.0)
+
+def _bond_angle_severity(num_outliers, worst_sigma):
+    """Map bond/angle outlier count and worst sigma to a continuous severity.
+
+    Uses worst deviation in sigma units as primary signal.  The 4-sigma
+    outlier threshold is the floor.
+
+    Severity scale (approximate):
+      4 sigma  -> 1.0
+      6 sigma  -> 2.0
+      10 sigma -> 4.0
+    Additional outliers beyond the first add 0.5 each.
+    """
+    if worst_sigma is None or worst_sigma == 0:
+        # Fall back to count-based if no sigma available
+        return 1.0 + max(0, num_outliers - 1) * 0.5
+    severity = max(0.0, (abs(worst_sigma) - 2.0) * 0.5)
+    if num_outliers > 1:
+        severity += (num_outliers - 1) * 0.5
+    return severity
 
 def calculate_overall_residue_quality_score(
     residue_data: Dict[str, Any],
-    weights: Optional[Dict[str, float]] = None
 ) -> Optional[float]:
     """
-    Calculates a penalty score for a single residue based on validation outliers.
+    Calculates a triage priority score for a single residue based on
+    validation outliers.
 
-    The score starts at 0 (no issues) and increases with each outlier found.
-    More severe outliers contribute larger penalties. The score is the sum of
-    all applicable tiered penalties.
+    The score is designed to rank residues by how urgently they need
+    attention: higher scores indicate problems that are more likely to
+    be genuine modeling errors.  The combination rule ensures that a
+    single severe problem (e.g. a twisted peptide) always outranks an
+    accumulation of minor issues.
+
+    Combination rule:
+      score = worst_severity + 0.25 * sum(remaining_severities)
+
+    Where possible, continuous values (clash overlap in A, C-beta
+    deviation in A, bond/angle deviation in sigma) are used rather
+    than discrete outlier/not-outlier bins.
 
     Args:
-        residue_data (Dict[str, Any]): A dictionary containing all the extracted
-                                         validation metrics for a single residue.
-        weights: Unused, kept for API compatibility.
+        residue_data: Dictionary of validation metrics for one residue.
+            Recognized keys:
+              num_bad_clashes_res (int), worst_clash_overlap (float, negative),
+              ramalyze_type (str), ramalyze_category (str),
+              rotalyze_category (str),
+              is_glycine (bool), is_cbeta_outlier (bool), cbeta_deviation (float),
+              cablam_outlier_type (str),
+              omega_type (str), is_proline (bool),
+              num_bond_outliers_res (int), worst_bond_sigma (float),
+              num_angle_outliers_res (int), worst_angle_sigma (float),
+              num_chiral_outliers_res (int),
+              is_rna_residue (bool), is_rna_suite_outlier (bool),
+              is_rna_pucker_outlier (bool).
 
     Returns:
-        Optional[float]: The penalty score (0 = no issues, higher = worse),
-                         or None if no applicable metrics.
+        The triage score rounded to 1 decimal place (0.0 = no issues,
+        higher = worse), or None if no applicable metrics were found.
     """
 
-    penalty = 0.0
+    severities: List[float] = []
     has_any_metric = False
 
-    # --- Helper to safely get data ---
-    def get_data(key, default=None):
+    def get(key, default=None):
         return residue_data.get(key, default)
 
-    # --- 1. Steric Clash Penalty ---
-    num_bad_clashes = get_data('num_bad_clashes_res', 0)
+    # --- 1. Steric Clashes ---
+    num_bad_clashes = get('num_bad_clashes_res', 0)
     if num_bad_clashes > 0:
         has_any_metric = True
-        worst_overlap = get_data('worst_clash_overlap', 0.0)
-        # Tier based on worst overlap magnitude (values are negative)
-        abs_overlap = abs(worst_overlap) if worst_overlap else 0.0
-        if abs_overlap > 0.7:
-            penalty += 3  # Severe clash
-        elif abs_overlap > 0.5:
-            penalty += 2  # Moderate clash
-        else:
-            penalty += 1  # Minor clash (0.4-0.5 range)
-        # Additional clashes beyond the first
-        if num_bad_clashes > 1:
-            penalty += (num_bad_clashes - 1)
+        worst_overlap = get('worst_clash_overlap', 0.0)
+        abs_overlap = abs(worst_overlap) if worst_overlap else 0.4
+        severities.append(_clash_severity(abs_overlap, num_bad_clashes))
 
-    # --- 2. Ramachandran Penalty ---
-    if get_data('ramalyze_type') not in ['not_applicable', 'not_evaluated']:
+    # --- 2. Ramachandran ---
+    if get('ramalyze_type') not in ['not_applicable', 'not_evaluated']:
         has_any_metric = True
-        if get_data('ramalyze_category') == 'outlier':
-            penalty += 3
+        if get('ramalyze_category') == 'outlier':
+            severities.append(5.0)
 
-    # --- 3. Rotamer Penalty ---
-    if get_data('rotalyze_category') not in ['not_evaluated', None]:
+    # --- 3. Rotamer ---
+    if get('rotalyze_category') not in ['not_evaluated', None]:
         has_any_metric = True
-        if get_data('rotalyze_category') == 'outlier':
-            penalty += 2
+        if get('rotalyze_category') == 'outlier':
+            severities.append(3.0)
 
-    # --- 4. C-beta Deviation Penalty ---
-    if not get_data('is_glycine', False):
+    # --- 4. C-beta Deviation ---
+    if not get('is_glycine', False):
         has_any_metric = True
-        if get_data('is_cbeta_outlier'):
-            deviation = get_data('cbeta_deviation', 0.0) or 0.0
-            if deviation > 0.5:
-                penalty += 2  # Severe distortion
-            else:
-                penalty += 1  # Standard outlier (>0.25)
+        if get('is_cbeta_outlier'):
+            deviation = get('cbeta_deviation', 0.0) or 0.0
+            severities.append(_cbeta_severity(deviation))
 
-    # --- 5. CaBLAM Penalty ---
-    cablam_type = get_data('cablam_outlier_type')
+    # --- 5. CaBLAM ---
+    cablam_type = get('cablam_outlier_type')
     if cablam_type not in ['not_evaluated', None]:
         has_any_metric = True
-        if cablam_type == 'outlier':
-            penalty += 2
-        elif cablam_type == 'ca_geom_outlier':
-            penalty += 2
+        if cablam_type in ('outlier', 'ca_geom_outlier'):
+            severities.append(3.0)
         elif cablam_type == 'disfavored':
-            penalty += 1
+            severities.append(1.0)
 
-    # --- 6. Omega Angle Penalty ---
-    omega_type = get_data('omega_type')
+    # --- 6. Omega Angle ---
+    omega_type = get('omega_type')
     if omega_type not in ['not_applicable', 'not_evaluated', None]:
         has_any_metric = True
         if omega_type == 'twisted':
-            penalty += 3
-        elif omega_type == 'cis' and not get_data('is_proline'):
-            penalty += 3  # Cis non-proline
+            severities.append(10.0)
+        elif omega_type == 'cis' and not get('is_proline'):
+            severities.append(8.0)
 
-    # --- 7. Bond Length Penalty ---
-    num_bond_outliers = get_data('num_bond_outliers_res', 0)
+    # --- 7. Bond Lengths ---
+    num_bond_outliers = get('num_bond_outliers_res', 0)
     if num_bond_outliers > 0:
         has_any_metric = True
-        if num_bond_outliers >= 2:
-            penalty += 2
-        else:
-            penalty += 1
+        worst_bond = get('worst_bond_sigma')
+        severities.append(_bond_angle_severity(num_bond_outliers, worst_bond))
 
-    # --- 8. Bond Angle Penalty ---
-    num_angle_outliers = get_data('num_angle_outliers_res', 0)
+    # --- 8. Bond Angles ---
+    num_angle_outliers = get('num_angle_outliers_res', 0)
     if num_angle_outliers > 0:
         has_any_metric = True
-        if num_angle_outliers >= 2:
-            penalty += 2
-        else:
-            penalty += 1
+        worst_angle = get('worst_angle_sigma')
+        severities.append(_bond_angle_severity(num_angle_outliers, worst_angle))
 
-    # --- 9. Chirality Penalty ---
-    if get_data('num_chiral_outliers_res', 0) > 0:
+    # --- 9. Chirality ---
+    if get('num_chiral_outliers_res', 0) > 0:
         has_any_metric = True
-        penalty += 3
+        severities.append(10.0)
 
-    # --- 10. RNA Suite Penalty ---
-    if get_data('is_rna_residue', False):
+    # --- 10. RNA Suite ---
+    if get('is_rna_residue', False):
         has_any_metric = True
-        if get_data('is_rna_suite_outlier', False):
-            penalty += 2
+        if get('is_rna_suite_outlier', False):
+            severities.append(3.0)
 
-    # --- 11. RNA Pucker Penalty ---
-    if get_data('is_rna_residue', False):
+    # --- 11. RNA Pucker ---
+    if get('is_rna_residue', False):
         has_any_metric = True
-        if get_data('is_rna_pucker_outlier', False):
-            penalty += 2
+        if get('is_rna_pucker_outlier', False):
+            severities.append(3.0)
 
-    if has_any_metric:
-        return penalty
-    else:
+    if not has_any_metric:
         return None
+    if not severities:
+        return 0.0
+
+    # Combination rule: worst finding dominates, additional findings
+    # contribute at 25% so accumulation of minor issues cannot outrank
+    # a single severe problem.
+    severities.sort(reverse=True)
+    score = severities[0] + 0.25 * sum(severities[1:])
+    return round(score, 1)
 
 def use_segids_in_place_of_chainids(hierarchy, strict=False):
   use_segids = False

--- a/mmtbx/validation/utils.py
+++ b/mmtbx/validation/utils.py
@@ -218,7 +218,9 @@ def calculate_overall_residue_quality_score(
               omega_type (str), is_proline (bool),
               num_bond_outliers_res (int), worst_bond_sigma (float),
               num_angle_outliers_res (int), worst_angle_sigma (float),
-              num_chiral_outliers_res (int),
+              num_chiral_handedness_res (int), num_chiral_tetrahedral_res (int),
+              num_chiral_pseudochiral_res (int),
+              num_chiral_outliers_res (int, fallback if typed counts unavailable),
               is_rna_residue (bool), is_rna_suite_outlier (bool),
               is_rna_pucker_outlier (bool).
 
@@ -293,9 +295,27 @@ def calculate_overall_residue_quality_score(
         severities.append(_bond_angle_severity(num_angle_outliers, worst_angle))
 
     # --- 9. Chirality ---
-    if get('num_chiral_outliers_res', 0) > 0:
+    # Three distinct types with very different implications:
+    #   - Handedness swap: true chirality inversion (e.g. L->D), serious error
+    #   - Tetrahedral geometry: distorted geometry, needs attention
+    #   - Pseudochiral naming: swapped names on chemically identical atoms
+    #     (e.g. VAL CG1/CG2), cosmetic fix only
+    n_handedness = get('num_chiral_handedness_res', 0)
+    n_tetrahedral = get('num_chiral_tetrahedral_res', 0)
+    n_pseudochiral = get('num_chiral_pseudochiral_res', 0)
+    n_chiral_total = n_handedness + n_tetrahedral + n_pseudochiral
+    if n_chiral_total > 0:
         has_any_metric = True
-        severities.append(10.0)
+        if n_handedness > 0:
+            severities.append(10.0)
+        if n_tetrahedral > 0:
+            severities.append(5.0)
+        if n_pseudochiral > 0:
+            severities.append(1.5)
+    elif get('num_chiral_outliers_res', 0) > 0:
+        # Fallback if only total count is available
+        has_any_metric = True
+        severities.append(5.0)
 
     # --- 10. RNA Suite ---
     if get('is_rna_residue', False):

--- a/mmtbx/validation/utils.py
+++ b/mmtbx/validation/utils.py
@@ -141,20 +141,29 @@ from typing import Dict, Any, Optional, List
 def _clash_severity(abs_overlap, num_clashes):
     """Map clash overlap magnitude and count to a continuous severity.
 
-    Uses the worst overlap as the primary signal, scaled linearly from
-    the 0.4 A outlier threshold.  Additional clashes beyond the first
-    add a small increment each (0.5 per extra clash) so that a single
-    severe clash always dominates over many minor ones.
+    Uses a non-linear power curve on the worst overlap so that small
+    clashes near the 0.4 A threshold are mild while large overlaps
+    grow sublinearly, staying below the twisted-peptide tier.  The
+    count bonus uses log2 with a cap at 4.0, because high clash counts
+    typically reflect many atom-atom contacts from a single bad
+    pairwise interaction rather than independent problems.
 
-    Severity scale (approximate):
-      0.4 A overlap -> 1.5    (minor)
-      0.5 A         -> 3.0    (moderate)
-      0.7 A         -> 6.0    (severe)
-      0.9 A         -> 9.0    (very severe)
+    Severity scale (single clash, approximate):
+      0.4 A overlap -> 1.4    (minor)
+      0.5 A         -> 2.0    (moderate)
+      0.7 A         -> 3.4    (moderate)
+      0.9 A         -> 5.0    (significant)
+      1.5 A         -> 10.3   (severe, still below twisted peptide)
+
+    Count bonus (log2, capped):
+      2 clashes  -> +1.0
+      5 clashes  -> +2.3
+      16 clashes -> +4.0  (cap reached)
+      50 clashes -> +4.0
     """
-    severity = max(0.0, (abs_overlap - 0.1) * 10.0)
+    severity = max(0.0, (abs_overlap - 0.1) * 10.0) ** 1.3 / 3.0
     if num_clashes > 1:
-        severity += (num_clashes - 1) * 0.5
+        severity += min(math.log2(num_clashes), 4.0) * 1.0
     return severity
 
 def _cbeta_severity(deviation):
@@ -276,7 +285,7 @@ def calculate_overall_residue_quality_score(
     if omega_type not in ['not_applicable', 'not_evaluated', None]:
         has_any_metric = True
         if omega_type == 'twisted':
-            severities.append(10.0)
+            severities.append(15.0)
         elif omega_type == 'cis' and not get('is_proline'):
             severities.append(8.0)
 


### PR DESCRIPTION
## Summary
Redesign the per-residue **quality score** in `mmtbx/validation/utils.py` into a continuous triage-priority metric, and add a regression test for it.

Three commits:
1. **Redesign residue quality score as a continuous triage priority metric** — replaces the previous discrete scheme with a continuous priority used to rank residues by how much attention they need.
2. **Differentiate chiral outlier types** in the score.
3. **Tune the score** — non-linear clash severity and a higher twisted-peptide penalty.

## Test
Adds `mmtbx/validation/regression/tst_utils.py`, covering the severity helpers (`_clash_severity`, `_cbeta_severity`, `_bond_angle_severity`), the overall `calculate_overall_residue_quality_score`, and ranking invariants. Passes locally.

## Notes
This metric is consumed by MolProbity-side tooling; no other code in `cctbx_project` calls these functions (the change is additive within `utils.py`), so the blast radius is limited to the residue-quality scoring.
