### PR TITLE
Add mmtbx.naiad: H-bond-aware water hydrogen placement

### DIFF
--- a/mmtbx/command_line/naiad.py
+++ b/mmtbx/command_line/naiad.py
@@ -1,0 +1,9 @@
+"""mmtbx.naiad: H-bond-aware placement of hydrogens on water residues."""
+
+from __future__ import absolute_import, division, print_function
+
+from iotbx.cli_parser import run_program
+from mmtbx.programs import water_protonation
+
+if __name__ == "__main__":
+  run_program(water_protonation.Program)

--- a/mmtbx/command_line/naiad.py
+++ b/mmtbx/command_line/naiad.py
@@ -1,3 +1,4 @@
+# LIBTBX_SET_DISPATCHER_NAME mmtbx.development.naiad
 """mmtbx.naiad: H-bond-aware placement of hydrogens on water residues."""
 
 from __future__ import absolute_import, division, print_function

--- a/mmtbx/hydrogens/tst_water_protonation.py
+++ b/mmtbx/hydrogens/tst_water_protonation.py
@@ -1,0 +1,407 @@
+"""Regression tests for ``water_protonation.place_water_hydrogens``: the
+H-bond-aware water-hydrogen placer.
+
+Minimal, self-contained cases exercise the parts that have been easy
+to get wrong:
+
+* **Acceptor-directed placement.** One HOH flanked by two acceptor O on the
+  H-O-H cone.  Each placed proton must point at an acceptor (H1 -> nearer,
+  H2 -> the other), clash-free and at the right O-H / H-O-H geometry.  This
+  is also the regression for the ``memory_id`` atom-identity bug: with the
+  water's own atoms not excluded from its clash search, the protons stopped
+  pointing at the acceptors.
+
+* **Cation repulsion.** A water coordinating an Mg whose only acceptor is
+  on the metal side.  Both protons must still end up in the hemisphere
+  *away* from the metal (pointing H+ at M(n+) is electrostatically wrong);
+  acceptor-direction alone would pull one toward it.
+
+* **Protonated N is a donor.** An N that already carries an H is excluded
+  as an acceptor, so a water points at a nearby bare N instead.
+
+* **Lone-pair-directed placement.** With ``lone_pair_directed`` the O-H aims
+  at a carbonyl O's sp2 lone-pair lobe (~120 deg off the C=O axis) rather
+  than its nucleus; off by default it aims at the nucleus.
+
+* **Joint H1/H2 placement.** With two acceptors too acute (60 deg) for both
+  H-bonds from an on-acceptor H1, ``joint`` balances the pair so the worse
+  H-bond is much better than greedy's leftover.
+
+* **Idempotency.** A water that already carries two H is left untouched.
+
+* **Reorient existing.** With ``reorient_existing`` a protonated water whose
+  H point the wrong way is stripped and re-placed toward its acceptor; the
+  default leaves it alone.
+
+* **Refinement.** A tight cluster of bare waters clashes after the greedy
+  pass; the relaxation sweeps must reduce the count of close H-H contacts.
+
+* **Element override.** ``element="D"`` forces deuterium (named ``D1``/``D2``)
+  onto an HOH water; the default places H.
+
+* **Experiment detection.** ``_detect_neutron`` reads the experiment type
+  (EXPDTA / ``_exptl.method``) and falls back to the presence of D atoms.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import math
+
+import iotbx.pdb
+from scitbx import matrix
+from libtbx.utils import format_cpu_times
+
+from mmtbx.hydrogens import water_protonation as wp
+
+
+# One HOH (bare O) with two acceptor O placed on the 104.5 deg H-O-H cone:
+# A1 at 2.6 A along +x, A2 at 2.8 A at 104.5 deg from +x (+z azimuth).  The
+# placer should orient H1 -> A1 (nearer) and H2 -> A2.
+_TWO_ACCEPTOR_PDB = """\
+HETATM    1  O   HOH W   1       5.000   5.000   5.000  1.00 10.00           O
+HETATM    2  O   ACA D   1       7.600   5.000   5.000  1.00 10.00           O
+HETATM    3  O   ACB D   2       4.299   5.000   7.711  1.00 10.00           O
+END
+"""
+
+# Water O coordinating an Mg (2.5 A along +x). The ONLY acceptor sits on
+# the Mg side (30 deg off the O->Mg axis), so acceptor-direction alone
+# would pull an H toward the metal -- only the cation repulsion keeps both
+# protons in the hemisphere away from it.
+_MG_WATER_PDB = """\
+HETATM    1 MG    MG A   1       2.500   0.000   0.000  1.00 10.00          MG
+HETATM    2  O   HOH W   1       0.000   0.000   0.000  1.00 10.00           O
+HETATM    3  O   ACA D   1       2.338   1.350   0.000  1.00 10.00           O
+END
+"""
+
+# A water flanked by two N: a *nearer* protonated N (a donor: it carries an
+# H) and a farther bare N (an acceptor). H1 must skip the donor and point
+# at the bare N.
+_DONOR_N_PDB = """\
+HETATM    1  O   HOH W   1       0.000   0.000   0.000  1.00 10.00           O
+HETATM    2  N   ACC D   1      -2.800   0.000   0.000  1.00 10.00           N
+HETATM    3  N   DNR E   1       2.600   0.000   0.000  1.00 10.00           N
+HETATM    4  H   DNR E   1       3.600   0.000   0.000  1.00 10.00           H
+END
+"""
+
+# A water in the plane of an sp2 carbonyl (C=O with the C bonded to two
+# more C, defining the plane), off to one side. With lone-pair-directed
+# placement the O-H aims at an in-plane lobe (~120 deg from C=O); without
+# it, at the O nucleus (a poorer C=O...H angle).
+_CARBONYL_PDB = """\
+HETATM    1  O   HOH W   1       2.000   1.500   0.000  1.00 10.00           O
+HETATM    2  O   ACO A   1       0.000   0.000   0.000  1.00 10.00           O
+HETATM    3  C   ACO A   1      -1.220   0.000   0.000  1.00 10.00           C
+HETATM    4  C   ACO A   1      -1.950   1.260   0.000  1.00 10.00           C
+HETATM    5  C   ACO A   1      -1.950  -1.260   0.000  1.00 10.00           C
+END
+"""
+
+# A water flanked by two acceptor O only 60 deg apart -- too acute for the
+# 104.5 deg H-O-H to hit both from an on-acceptor H1. Greedy nails one and
+# leaves the other poorly aligned; joint placement balances the two.
+_TWO_ACCEPTOR_60_PDB = """\
+HETATM    1  O   HOH W   1       0.000   0.000   0.000  1.00 10.00           O
+HETATM    2  O   ACA D   1       2.800   0.000   0.000  1.00 10.00           O
+HETATM    3  O   ACB E   1       1.400   2.424   0.000  1.00 10.00           O
+END
+"""
+
+# A water that is already protonated (O + 2 H) -- must be left untouched.
+_PROTONATED_WATER_PDB = """\
+HETATM    1  O   HOH W   1       0.000   0.000   0.000  1.00 10.00           O
+HETATM    2  H1  HOH W   1       0.000   0.957   0.000  1.00 10.00           H
+HETATM    3  H2  HOH W   1       0.926  -0.239   0.000  1.00 10.00           H
+END
+"""
+
+# A protonated water whose H point AWAY from the lone acceptor (+x): with
+# --reorient-existing the H are stripped and re-placed toward the acceptor.
+_BAD_PROTONATED_PDB = """\
+HETATM    1  O   HOH W   1       0.000   0.000   0.000  1.00 10.00           O
+HETATM    2  H1  HOH W   1      -0.984   0.000   0.000  1.00 10.00           H
+HETATM    3  H2  HOH W   1       0.000  -0.984   0.000  1.00 10.00           H
+HETATM    4  O   ACA D   1       2.700   0.000   0.000  1.00 10.00           O
+END
+"""
+
+# Six bare waters on a tight 2.8 A grid with no other acceptors: the greedy
+# pass leaves at least one close H-H contact that refinement relaxes.
+_WATER_CLUSTER_PDB = """\
+HETATM    1  O   HOH W   1       0.000   0.000   0.000  1.00 10.00           O
+HETATM    2  O   HOH W   2       0.000   2.800   0.000  1.00 10.00           O
+HETATM    3  O   HOH W   3       2.800   0.000   0.000  1.00 10.00           O
+HETATM    4  O   HOH W   4       2.800   2.800   0.000  1.00 10.00           O
+HETATM    5  O   HOH W   5       5.600   0.000   0.000  1.00 10.00           O
+HETATM    6  O   HOH W   6       5.600   2.800   0.000  1.00 10.00           O
+END
+"""
+
+
+def _hierarchy(pdb_str):
+  """Build a hierarchy from an inline PDB string.
+
+  Parameters
+  ----------
+  pdb_str : str
+      PDB-format record text.
+
+  Returns
+  -------
+  iotbx.pdb.hierarchy.root
+      The constructed hierarchy.
+  """
+  return iotbx.pdb.input(
+    source_info=None, lines=pdb_str.split("\n")).construct_hierarchy()
+
+
+def _water_atoms(hier):
+  """Pull the O and placed H of the single HOH in a hierarchy.
+
+  Parameters
+  ----------
+  hier : iotbx.pdb.hierarchy.root
+      Hierarchy containing exactly one HOH residue.
+
+  Returns
+  -------
+  tuple
+      ``(o, hs)``: the O atom and a ``{name: atom}`` dict of its H/D.
+  """
+  water = [a for a in hier.atoms() if a.parent().resname.strip() == "HOH"]
+  o = next(a for a in water if a.element.strip().upper() == "O")
+  hs = {a.name.strip(): a for a in water
+        if a.element.strip().upper() in ("H", "D")}
+  return o, hs
+
+
+def _unit(a, b):
+  """Unit vector from atom/point ``b`` to atom/point ``a``.
+
+  Parameters
+  ----------
+  a, b : iotbx.pdb.hierarchy.atom or sequence of float
+      Endpoints, each either an atom (``.xyz`` is read) or an ``(x, y, z)``.
+
+  Returns
+  -------
+  scitbx.matrix.col
+      The unit vector ``(a - b)``.
+  """
+  va = matrix.col(a.xyz) if hasattr(a, "xyz") else matrix.col(a)
+  vb = matrix.col(b.xyz) if hasattr(b, "xyz") else matrix.col(b)
+  return (va - vb).normalize()
+
+
+def exercise_acceptor_directed():
+  """Both protons point at the flanking acceptors, clash-free, with the
+  right O-H length and H-O-H angle."""
+  hier = _hierarchy(_TWO_ACCEPTOR_PDB)
+  wp.place_water_hydrogens(hier, n_refine=0)
+  atoms = list(hier.atoms())
+  o, hs = _water_atoms(hier)
+  assert set(hs) == {"H1", "H2"}, f"expected H1 and H2; got {sorted(hs)}"
+
+  acc = sorted([a for a in atoms if a.parent().resname.strip() in ("ACA", "ACB")],
+               key=lambda a: a.distance(o))
+  a1, a2 = acc  # nearer first -> matches H1
+  assert _unit(hs["H1"], o).dot(_unit(a1, o)) > 0.9, (
+    "H1 should point at the nearest acceptor")
+  assert _unit(hs["H2"], o).dot(_unit(a2, o)) > 0.9, (
+    "H2 should point at the second acceptor, not open space")
+
+  non_water = [a for a in atoms if a.parent().resname.strip() != "HOH"]
+  for h in (hs["H1"], hs["H2"]):
+    d = min(h.distance(a) for a in non_water)
+    assert d >= wp._WATER_MIN_CLEARANCE - 1e-6, (
+      f"placed H too close to a non-water atom: {d:.3f} A")
+
+  oh = (matrix.col(hs["H1"].xyz) - matrix.col(o.xyz)).length()
+  assert abs(oh - wp._WATER_OH_NEUTRON) < 1e-3, f"O-H length off: {oh:.3f}"
+  ang = math.degrees(_unit(hs["H1"], o).angle(_unit(hs["H2"], o)))
+  assert abs(ang - wp._WATER_HOH_DEG) < 1.0, f"H-O-H angle off: {ang:.1f}"
+
+
+def exercise_cation_repulsion():
+  """Both protons of a metal-coordinating water sit in the hemisphere away
+  from the cation, even though the only acceptor is on the metal side."""
+  hier = _hierarchy(_MG_WATER_PDB)
+  wp.place_water_hydrogens(hier, n_refine=0)
+  mg = next(a for a in hier.atoms() if a.element.strip().upper() == "MG")
+  o, hs = _water_atoms(hier)
+  assert len(hs) == 2, f"expected two placed H; got {sorted(hs)}"
+
+  to_mg = _unit(mg, o)
+  for h in hs.values():
+    proj = (matrix.col(h.xyz) - matrix.col(o.xyz)).dot(to_mg)
+    assert proj <= 1e-3, (
+      f"water H should point away from the cation (proj={proj:.2f})")
+
+
+def exercise_idempotent():
+  """A water that already has two H is left exactly as-is."""
+  hier = _hierarchy(_PROTONATED_WATER_PDB)
+  before = [(a.name.strip(), tuple(a.xyz)) for a in hier.atoms()]
+  wp.place_water_hydrogens(hier)
+  after = [(a.name.strip(), tuple(a.xyz)) for a in hier.atoms()]
+  assert after == before, (
+    f"already-protonated water must be untouched:\n{before}\n{after}")
+
+
+def exercise_protonated_n_not_acceptor():
+  """An N that already carries an H is a donor, not an acceptor: H1 skips
+  the nearer protonated N and points at the farther bare N instead."""
+  hier = _hierarchy(_DONOR_N_PDB)
+  wp.place_water_hydrogens(hier, n_refine=0)
+  o, hs = _water_atoms(hier)
+  o_xyz = matrix.col(o.xyz)
+  acc = matrix.col((-1.0, 0.0, 0.0))   # toward the bare N (acceptor)
+  don = matrix.col((1.0, 0.0, 0.0))    # toward the protonated N (donor)
+  best_acc = max((matrix.col(h.xyz) - o_xyz).normalize().dot(acc)
+                 for h in hs.values())
+  best_don = max((matrix.col(h.xyz) - o_xyz).normalize().dot(don)
+                 for h in hs.values())
+  assert best_acc > 0.9, "H should point at the bare (acceptor) N"
+  assert best_don < 0.9, "no H should point at the protonated (donor) N"
+
+
+def exercise_lone_pair_directed():
+  """``lone_pair_directed`` aims the O-H at a carbonyl O's sp2 lone-pair
+  lobe (~120 deg from C=O); the default aims at the nucleus (~180 deg)."""
+  o_c = matrix.col((0.0, 0.0, 0.0))    # carbonyl O
+  c = matrix.col((-1.220, 0.0, 0.0))   # its carbon
+
+  def co_h_angle(lone_pair):
+    hier = _hierarchy(_CARBONYL_PDB)
+    wp.place_water_hydrogens(hier, n_refine=0, lone_pair_directed=lone_pair)
+    _, hs = _water_atoms(hier)
+    h = min(hs.values(), key=lambda a: (matrix.col(a.xyz) - o_c).length())
+    return (c - o_c).angle(matrix.col(h.xyz) - o_c, deg=True)
+
+  off = co_h_angle(False)
+  on = co_h_angle(True)
+  assert off > 135.0, f"default should aim near the nucleus (got {off:.1f} deg)"
+  assert abs(on - 120.0) < 15.0, (
+    f"lone-pair placement should give a ~120 deg C=O...H angle (got {on:.1f})")
+
+
+def exercise_joint_balances_acceptors():
+  """With two acceptors too acute (60 deg) for both H-bonds from an
+  on-acceptor H1, joint placement balances them -- the worse of the two
+  H-bonds is markedly better than greedy's leftover."""
+  a = matrix.col((2.800, 0.000, 0.000))
+  b = matrix.col((1.400, 2.424, 0.000))
+
+  def worse_alignment(joint):
+    hier = _hierarchy(_TWO_ACCEPTOR_60_PDB)
+    wp.place_water_hydrogens(hier, n_refine=0, joint=joint)
+    o, hs = _water_atoms(hier)
+    da = (a - matrix.col(o.xyz)).normalize()
+    db = (b - matrix.col(o.xyz)).normalize()
+    align_a = max(_unit(h, o).dot(da) for h in hs.values())
+    align_b = max(_unit(h, o).dot(db) for h in hs.values())
+    return min(align_a, align_b)        # quality of the worse H-bond
+
+  greedy = worse_alignment(False)
+  joint = worse_alignment(True)
+  assert joint > greedy + 0.1, (
+    f"joint should balance the two H-bonds (worse-bond align "
+    f"{greedy:.2f} -> {joint:.2f})")
+  assert joint > 0.85, (
+    f"joint's worse H-bond should still be good (got {joint:.2f})")
+
+
+def exercise_reorient_existing():
+  """``reorient_existing`` strips the existing (mis-oriented) H and
+  re-places them toward the acceptor; the default leaves them as-is."""
+  acc = matrix.col((2.700, 0.000, 0.000))
+
+  def best_align(hier):
+    o, hs = _water_atoms(hier)
+    return max((matrix.col(h.xyz) - matrix.col(o.xyz)).normalize().dot(
+                 (acc - matrix.col(o.xyz)).normalize()) for h in hs.values())
+
+  kept = _hierarchy(_BAD_PROTONATED_PDB)
+  wp.place_water_hydrogens(kept, n_refine=0)
+  assert best_align(kept) < 0.5, (
+    "default run must not reorient existing H toward the acceptor")
+
+  redone = _hierarchy(_BAD_PROTONATED_PDB)
+  wp.place_water_hydrogens(redone, n_refine=0, reorient_existing=True)
+  _, hs = _water_atoms(redone)
+  assert len(hs) == 2, f"reorient must leave exactly two H; got {sorted(hs)}"
+  assert best_align(redone) > 0.9, (
+    "reorient_existing should re-place an H toward the acceptor")
+
+
+def exercise_refinement_reduces_clashes():
+  """Refinement relaxes the water-water H clashes the greedy pass leaves in
+  a tight cluster."""
+  greedy = _hierarchy(_WATER_CLUSTER_PDB)
+  wp.place_water_hydrogens(greedy, n_refine=0)
+  refined = _hierarchy(_WATER_CLUSTER_PDB)
+  wp.place_water_hydrogens(refined, n_refine=5)
+
+  n_greedy = wp._water_clash_stats(greedy)[1]
+  n_refined = wp._water_clash_stats(refined)[1]
+  assert n_greedy >= 1, (
+    f"cluster should clash without refinement (got {n_greedy})")
+  assert n_refined < n_greedy, (
+    f"refinement should reduce close contacts ({n_greedy} -> {n_refined})")
+
+
+def exercise_element_override():
+  """``element="D"`` forces deuterium (named D1/D2); the default is H."""
+  default = _hierarchy(_TWO_ACCEPTOR_PDB)
+  wp.place_water_hydrogens(default, n_refine=0)
+  _, hs = _water_atoms(default)
+  assert set(hs) == {"H1", "H2"}, f"default should place H; got {sorted(hs)}"
+
+  deut = _hierarchy(_TWO_ACCEPTOR_PDB)
+  wp.place_water_hydrogens(deut, n_refine=0, element="D")
+  _, hs = _water_atoms(deut)
+  assert set(hs) == {"D1", "D2"}, f"element='D' should place D; got {sorted(hs)}"
+  for d in hs.values():
+    assert d.element.strip().upper() == "D", "placed atom element must be D"
+
+
+def exercise_detect_neutron():
+  """``_detect_neutron`` prefers the experiment type, then D-atom presence."""
+  def pdb_in(lines):
+    return iotbx.pdb.input(source_info=None, lines=lines.split("\n"))
+
+  neutron = "EXPDTA    NEUTRON DIFFRACTION\n" + _TWO_ACCEPTOR_PDB
+  xray = "EXPDTA    X-RAY DIFFRACTION\n" + _TWO_ACCEPTOR_PDB
+  # No experiment record, but a D atom present -> neutron by fallback.
+  d_atom = """\
+HETATM    1  O   HOH W   1       0.000   0.000   0.000  1.00 10.00           O
+HETATM    2  D   DNR E   1       3.600   0.000   0.000  1.00 10.00           D
+END
+"""
+
+  for src, want in ((neutron, True), (xray, False), (d_atom, True)):
+    pi = pdb_in(src)
+    got, _ = wp._detect_neutron(pi, pi.construct_hierarchy())
+    assert got is want, f"_detect_neutron returned {got}, expected {want}"
+
+
+def run():
+  """Run every exercise and print the CPU times and ``OK`` on success."""
+  exercise_acceptor_directed()
+  exercise_cation_repulsion()
+  exercise_protonated_n_not_acceptor()
+  exercise_lone_pair_directed()
+  exercise_joint_balances_acceptors()
+  exercise_idempotent()
+  exercise_reorient_existing()
+  exercise_refinement_reduces_clashes()
+  exercise_element_override()
+  exercise_detect_neutron()
+  print(format_cpu_times())
+  print("OK")
+
+
+if __name__ == "__main__":
+  run()

--- a/mmtbx/hydrogens/water_protonation.py
+++ b/mmtbx/hydrogens/water_protonation.py
@@ -1,0 +1,1183 @@
+"""H-bond-aware placement of the two hydrogens on bare water oxygens.
+
+A map-free, H-bond-network-aware placer for water hydrogens. For every
+bare ``HOH``/``DOD`` oxygen it places the two H so they (a) point at real
+H-bond acceptors, (b) avoid clashes against the whole structure (including
+H placed on other waters), and (c) keep off metal cations -- purely from
+geometry, with no experimental data/map, no residue-name tables and no
+monomer library. It enforces O-H = 0.984 A (neutron) or 0.957 A (X-ray)
+and H-O-H = 104.5 deg.
+
+The public entry point is :func:`place_water_hydrogens`, which modifies a
+hierarchy in place. The :class:`mmtbx.programs.water_protonation.Program`
+wraps it with DataManager I/O, experiment-aware defaults, and a clash
+report; the command-line dispatcher is ``mmtbx.naiad``.
+
+Needs ``scipy`` (KDTree).
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import math
+import random
+
+import iotbx.pdb
+from scitbx import matrix
+from scipy.spatial import KDTree
+
+
+# ---------------------------------------------------------------------------
+# Constants for the H-bond-aware water-H placer (``place_water_hydrogens``).
+# ---------------------------------------------------------------------------
+
+_WATER_OH_XRAY = 0.957        # canonical X-ray O-H bond length (A)
+_WATER_OH_NEUTRON = 0.984     # canonical neutron O-H bond length (A)
+_WATER_HOH_DEG = 104.5        # canonical H-O-H angle (deg)
+_WATER_ACCEPTOR_RADIUS = 3.5  # max distance to search for H-bond acceptors (A)
+_WATER_ACCEPTOR_ELEMENTS = frozenset({"O", "N", "F", "S", "CL"})
+_WATER_NH_BOND = 1.3          # max N-H distance for the "N carries an H" test (A)
+# Lone-pair-directed placement (opt-in). When on, H1 aims at an acceptor's
+# lone-pair lobe (derived from its bonded-neighbour geometry) rather than
+# its nucleus, giving better D-H...A angles. Helper distances/angles:
+_WATER_BOND_HEAVY = 1.9       # max heavy-heavy bond distance for lobe geometry (A)
+_WATER_HBOND_HA = 1.8         # nominal H...acceptor distance for the lobe target (A)
+_WATER_SP2_LOBE_DEG = 60.0    # half-angle of the two sp2 carbonyl/-late lobes
+_WATER_CONE_SAMPLES = 18      # angular samples around the O-H1 cone
+# Element-aware "clash-free" thresholds. A candidate H must clear every
+# heavy atom by _WATER_MIN_CLEARANCE and every hydrogen (and cation) by
+# the larger _WATER_MIN_H_CLEARANCE. ~1.5 A still admits a genuine
+# H...acceptor contact (the acceptor heavy atom sits ~1.7-1.8 A from the
+# H); the larger H...H bound keeps two protons from facing each other
+# (donor-donor) -- a uniform raise to 2.0 would instead reject real
+# H-bonds, hence the split by element.
+_WATER_MIN_CLEARANCE = 1.5
+_WATER_MIN_H_CLEARANCE = 2.0
+_WATER_CLEARANCE_RADIUS = 3.0  # neighbour search radius for clearance (A)
+# The KDTree over already-placed water H is expensive to rebuild from
+# scratch every water (O(n) each -> O(n^2) overall). Instead the bulk of
+# the placed H live in a "prefix" tree rebuilt only once this many new H
+# have accumulated; the few placed since then live in a small "pending"
+# tree rebuilt each water. Their union is still every earlier water's H.
+_WATER_TREE_REBUILD = 64
+# Relaxation sweeps after the greedy pass. Each re-places every water
+# against the final positions of all the others, relaxing the water-water
+# clashes the order-dependent greedy pass leaves in dense clusters. Each
+# sweep ~halves the remaining clash count at ~one placement-pass cost.
+_WATER_REFINE_SWEEPS = 5
+# Early-stop tolerance: keep refining only while a sweep removes at least
+# this many close (<2.0 A) H-H contacts; below it, treat as converged.
+# 1 = stop at a true plateau; larger = stop sooner on diminishing returns.
+_WATER_REFINE_TOL = 1
+# Basin-hopping (opt-in): each round restarts from the best state, randomly
+# re-orients the still-clashing waters, and relaxes -- to escape the local
+# minima refinement settles into. Seeded for reproducibility.
+_WATER_BASIN_SEED = 0
+_WATER_BASIN_RELAX = 2        # relaxation sweeps after each random kick
+# Metal cations carry a positive charge, so a water that coordinates one
+# (via its O lone pair) should keep both H in the hemisphere *away* from
+# the metal -- pointing H+ at M(n+) is electrostatically unfavourable.
+# Cations within _WATER_CATION_RADIUS of the water O are treated as
+# repellers (hemisphere constraint), not acceptors.
+_WATER_CATION_ELEMENTS = frozenset({
+  "LI", "NA", "K", "RB", "CS",
+  "MG", "CA", "SR", "BA",
+  "MN", "FE", "CO", "NI", "CU", "ZN", "CD", "HG",
+  "AL",
+})
+_WATER_CATION_RADIUS = 3.0
+
+
+def _fibonacci_sphere(n):
+  """Roughly-uniform unit vectors over the sphere (Fibonacci spiral).
+
+  Used as generic fallback directions when no acceptor gives a clash-free
+  H -- dense enough to find an open "away from everything" pocket.
+
+  Parameters
+  ----------
+  n : int
+      Number of points to generate.
+
+  Returns
+  -------
+  tuple of tuple of float
+      ``n`` unit vectors as ``(x, y, z)`` tuples.
+  """
+  golden = math.pi * (3.0 - math.sqrt(5.0))
+  pts = []
+  for i in range(n):
+    y = 1.0 - 2.0 * (i + 0.5) / n
+    r = math.sqrt(max(0.0, 1.0 - y * y))
+    th = golden * i
+    pts.append((math.cos(th) * r, y, math.sin(th) * r))
+  return tuple(pts)
+
+
+_WATER_FALLBACK_DIRECTIONS = _fibonacci_sphere(64)
+
+
+def _strip_water_hydrogens(hier):
+  """Remove every H/D from HOH/DOD residues, leaving bare O.
+
+  The stripped waters are re-placed from scratch by the caller.
+
+  Parameters
+  ----------
+  hier : iotbx.pdb.hierarchy.root
+      Hierarchy to modify in place.
+
+  Returns
+  -------
+  int
+      Number of H/D atoms removed.
+  """
+  n = 0
+  for ag in hier.atom_groups():
+    if ag.resname.strip().upper() not in ("HOH", "DOD"):
+      continue
+    for a in list(ag.atoms()):
+      if a.element.strip().upper() in ("H", "D"):
+        ag.remove_atom(a)
+        n += 1
+  return n
+
+
+def _new_h_atom(name, element, xyz, occ, b):
+  """Build a hierarchy atom for a placed water H.
+
+  The atom is given a blank segid, like the parent O.
+
+  Parameters
+  ----------
+  name : str
+      Atom name (e.g. ``" H1 "``).
+  element : str
+      Element symbol (``"H"`` or ``"D"``).
+  xyz : tuple of float
+      Cartesian coordinates.
+  occ : float
+      Occupancy (inherited from the parent O).
+  b : float
+      B factor (inherited from the parent O).
+
+  Returns
+  -------
+  iotbx.pdb.hierarchy.atom
+      The new atom.
+  """
+  atom = iotbx.pdb.hierarchy.atom()
+  atom.name = name
+  atom.element = element
+  atom.xyz = xyz
+  atom.occ = occ
+  atom.b = b
+  atom.segid = " " * 4
+  return atom
+
+
+def _ortho_frame(d1):
+  """Build an orthonormal frame around a direction.
+
+  Parameters
+  ----------
+  d1 : scitbx.matrix.col
+      Unit direction (the O-H1 axis).
+
+  Returns
+  -------
+  tuple of scitbx.matrix.col
+      Two unit vectors ``p, q`` with ``(d1, p, q)`` mutually perpendicular
+      -- the frame for sampling the H2 cone around ``d1``.
+  """
+  helper = matrix.col((1.0, 0.0, 0.0))
+  if abs(d1.dot(helper)) > 0.95:
+    helper = matrix.col((0.0, 1.0, 0.0))
+  p = (helper - d1 * d1.dot(helper)).normalize()
+  return p, d1.cross(p)
+
+
+def _tilt_dir(dir_a, dir_b, hoh_rad):
+  """H1 direction near one acceptor but tilted so H2 can reach a second.
+
+  The returned direction is near acceptor ``dir_a`` but tilted *away* from
+  acceptor ``dir_b`` in their shared plane, so an H2 on H1's H-O-H cone can
+  reach ``dir_b`` -- the balanced two-acceptor placement. When the
+  acceptors subtend angle phi, each H ends up ``(104.5 - phi) / 2`` off its
+  acceptor, so both H-bonds are near-ideal.
+
+  Parameters
+  ----------
+  dir_a : scitbx.matrix.col
+      Unit direction toward the first acceptor.
+  dir_b : scitbx.matrix.col
+      Unit direction toward the second acceptor.
+  hoh_rad : float
+      Target H-O-H angle in radians.
+
+  Returns
+  -------
+  scitbx.matrix.col
+      The tilted H1 unit direction, or ``dir_a`` if the two acceptors are
+      collinear.
+  """
+  w = dir_b - dir_a * dir_a.dot(dir_b)
+  if w.length() < 1e-6:
+    return dir_a
+  w = w.normalize()
+  delta = (hoh_rad - dir_a.angle(dir_b)) / 2.0
+  return (dir_a * math.cos(delta) - w * math.sin(delta)).normalize()
+
+
+def _rand_unit(rng):
+  """A random unit vector (rejection-free Gaussian normalization).
+
+  Parameters
+  ----------
+  rng : random.Random
+      Seeded RNG (for reproducibility).
+
+  Returns
+  -------
+  scitbx.matrix.col
+      A uniformly random unit vector.
+  """
+  while True:
+    v = matrix.col((rng.gauss(0, 1), rng.gauss(0, 1), rng.gauss(0, 1)))
+    if v.length() > 1e-6:
+      return v.normalize()
+
+
+def _kick_water(record, placed_coords, oh_length, cos_hoh, sin_hoh, rng):
+  """Re-orient one water to a random orientation.
+
+  H1 is placed along a random axis and H2 on the H-O-H cone at a random
+  azimuth, updating the water's placed-H coordinates and atoms in place.
+  Used to kick a water out of its local minimum during basin-hopping.
+
+  Parameters
+  ----------
+  record : tuple
+      Per-water record ``(o_xyz, own_idx, slots)`` (see
+      ``place_water_hydrogens``); only ``o_xyz`` and ``slots`` are used.
+  placed_coords : list of tuple
+      Global list of placed-H coordinates, updated in place.
+  oh_length : float
+      O-H bond length.
+  cos_hoh, sin_hoh : float
+      Cosine and sine of the H-O-H angle.
+  rng : random.Random
+      Seeded RNG.
+  """
+  o_xyz, _own_idx, slots = record
+  d1 = _rand_unit(rng)
+  helper = matrix.col((1.0, 0.0, 0.0))
+  if abs(d1.dot(helper)) > 0.95:
+    helper = matrix.col((0.0, 1.0, 0.0))
+  p = (helper - d1 * d1.dot(helper)).normalize()
+  q = d1.cross(p)
+  theta = rng.uniform(0.0, 2.0 * math.pi)
+  d2 = cos_hoh * d1 + sin_hoh * (math.cos(theta) * p + math.sin(theta) * q)
+  dirs = {1: d1, 2: d2}
+  for atom, slot, di in slots:
+    xyz = tuple(o_xyz + oh_length * dirs[di])
+    placed_coords[slot] = xyz
+    atom.set_xyz(xyz)
+
+
+def _sp2_plane_normal(atoms, static_tree, c, exclude):
+  """Unit normal of the sp2 plane around an atom.
+
+  Computed from the heavy substituents of atom index ``c`` (the atom a
+  terminal acceptor O is bonded to) other than ``exclude``.
+
+  Parameters
+  ----------
+  atoms : list of iotbx.pdb.hierarchy.atom
+      All atoms (positionally indexed).
+  static_tree : scipy.spatial.KDTree
+      KDTree over the atom coordinates.
+  c : int
+      Index of the atom whose substituent plane is wanted.
+  exclude : int
+      Index of the bonded acceptor O to exclude (supplies one in-plane
+      vector).
+
+  Returns
+  -------
+  scitbx.matrix.col or None
+      Unit normal of the plane, or None if underdetermined.
+  """
+  C = matrix.col(atoms[c].xyz)
+  oc = matrix.col(atoms[exclude].xyz) - C   # C -> O
+  for k in static_tree.query_ball_point(atoms[c].xyz, _WATER_BOND_HEAVY):
+    if k == c or k == exclude:
+      continue
+    if atoms[k].element.strip().upper() in ("H", "D"):
+      continue
+    v = matrix.col(atoms[k].xyz) - C
+    if v.length() > _WATER_BOND_HEAVY:
+      continue
+    nrm = oc.cross(v)
+    if nrm.length() > 1e-3:
+      return nrm.normalize()
+  return None
+
+
+def _acceptor_lobes(atoms, static_tree, donor_n):
+  """Estimate lone-pair lobe directions for every acceptor atom.
+
+  The lobes are derived from each acceptor's bonded-neighbour geometry
+  (library-free):
+
+  - terminal O (1 bond, carbonyl/carboxylate): two in-plane sp2 lobes
+    ~``2 * _WATER_SP2_LOBE_DEG`` apart, straddling the direction away from
+    the bonded atom, in that atom's substituent plane.
+  - otherwise: a single lobe along the open hemisphere (opposite the sum
+    of the bond directions).
+
+  Acceptors whose geometry can't be resolved get an empty list, and the
+  caller falls back to aiming at the nucleus.
+
+  Parameters
+  ----------
+  atoms : list of iotbx.pdb.hierarchy.atom
+      All atoms (positionally indexed).
+  static_tree : scipy.spatial.KDTree
+      KDTree over the atom coordinates.
+  donor_n : set of int
+      Indices of N atoms that carry an H (donors, excluded as acceptors).
+
+  Returns
+  -------
+  dict
+      Maps each acceptor-atom index to a list of lone-pair lobe unit
+      vectors (``scitbx.matrix.col``); the list is empty when the geometry
+      is underdetermined.
+  """
+  lobes = {}
+  for i, a in enumerate(atoms):
+    el = a.element.strip().upper()
+    if el not in _WATER_ACCEPTOR_ELEMENTS:
+      continue
+    if el == "N" and i in donor_n:
+      continue  # protonated N is a donor, not an acceptor
+    A = matrix.col(a.xyz)
+    nbrs = []
+    for j in static_tree.query_ball_point(a.xyz, _WATER_BOND_HEAVY):
+      if j == i:
+        continue
+      ej = atoms[j].element.strip().upper()
+      d = (matrix.col(atoms[j].xyz) - A).length()
+      if (d <= _WATER_NH_BOND) if ej in ("H", "D") else (d <= _WATER_BOND_HEAVY):
+        nbrs.append(j)
+    bond_dirs = [(matrix.col(atoms[j].xyz) - A).normalize() for j in nbrs]
+    if not bond_dirs:
+      lobes[i] = []
+    elif el == "O" and len(nbrs) == 1:
+      away = bond_dirs[0] * -1.0
+      n = _sp2_plane_normal(atoms, static_tree, nbrs[0], i)
+      if n is None:
+        lobes[i] = [away]
+      else:
+        lobes[i] = [
+          away.rotate_around_origin(axis=n, angle=_WATER_SP2_LOBE_DEG, deg=True),
+          away.rotate_around_origin(axis=n, angle=-_WATER_SP2_LOBE_DEG, deg=True)]
+    else:
+      bsum = matrix.col((0.0, 0.0, 0.0))
+      for b in bond_dirs:
+        bsum = bsum + b
+      lobes[i] = [(bsum * -1.0).normalize()] if bsum.length() > 1e-6 else []
+  return lobes
+
+
+class _WaterHydrogenPlacer(object):
+  """The H-bond-aware water-hydrogen placer (engine behind
+  :func:`place_water_hydrogens`).
+
+  Holds the shared placement state -- the static-atom KDTree, the
+  donor/acceptor bookkeeping, the geometry constants, and the growing set
+  of placed protons (a prefix + pending KDTree pair) -- and the per-water
+  placement, refinement and basin-hopping logic. :func:`place_water_hydrogens`
+  is a thin wrapper that constructs this and calls :meth:`run`.
+
+  The constructor only records the parameters; all the work (and all the
+  derived state) happens in :meth:`run`, which modifies the hierarchy in
+  place. See :func:`place_water_hydrogens` for the parameter semantics.
+  """
+
+  def __init__(self, hier, oh_length=_WATER_OH_NEUTRON, element=None,
+               n_refine=_WATER_REFINE_SWEEPS, refine_tol=_WATER_REFINE_TOL,
+               n_basin=0, reorient_existing=False, lone_pair_directed=False,
+               joint=False, on_state=None):
+    self.hier = hier
+    self.oh_length = oh_length
+    self.element = element
+    self.n_refine = n_refine
+    self.refine_tol = refine_tol
+    self.n_basin = n_basin
+    self.reorient_existing = reorient_existing
+    self.lone_pair_directed = lone_pair_directed
+    self.joint = joint
+    self.on_state = on_state
+
+    # Placed-H state (the two KDTrees and their coordinate backing store),
+    # set up in run(). placed_tree covers placed_coords[:n_built], the
+    # rebuilt "prefix"; pending_tree covers placed_coords[n_built:], the
+    # small "pending" set; their union is every placed water H.
+    self.placed_coords = []
+    self.placed_tree = None
+    self.pending_tree = None
+    self.n_built = 0
+    # Per-water records (o_xyz, own_idx, [(atom, slot, di), ...]); the
+    # refinement/basin passes re-place each against the final environment.
+    self.records = []
+
+  def _clearances(self, cands, own_idx, own_slots):
+    """Batched clearance test over candidate H positions.
+
+    One KDTree query per tree covers all candidates, rather than one query
+    per candidate.
+
+    Parameters
+    ----------
+    cands : list of scitbx.matrix.col
+        Candidate H positions to score.
+    own_idx : set of int
+        Static-atom indices belonging to the water being placed (excluded).
+    own_slots : set of int
+        Placed-H slot indices belonging to the water being placed
+        (excluded).
+
+    Returns
+    -------
+    list of tuple
+        One ``(min_dist, ok)`` per candidate, where ``min_dist`` is the
+        distance to the nearest non-own atom within
+        ``_WATER_CLEARANCE_RADIUS`` (the search radius if nothing is near,
+        a soft tie-breaker) and ``ok`` is True iff the candidate clears
+        every heavy atom by ``_WATER_MIN_CLEARANCE`` and every hydrogen
+        (static or placed) by the larger ``_WATER_MIN_H_CLEARANCE``. The
+        element split lets an H sit at H-bonding distance from an acceptor
+        heavy atom while keeping it away from other protons.
+    """
+    if not cands:
+      return []
+    pts = [tuple(c) for c in cands]
+    best = [_WATER_CLEARANCE_RADIUS] * len(cands)
+    ok = [True] * len(cands)
+    for ci, nbrs in enumerate(
+        self.static_tree.query_ball_point(pts, _WATER_CLEARANCE_RADIUS)):
+      c = cands[ci]
+      for j in nbrs:
+        if j in own_idx:
+          continue
+        d = (matrix.col(self.static_coords[j]) - c).length()
+        if d < best[ci]:
+          best[ci] = d
+        thr = _WATER_MIN_H_CLEARANCE if self.static_is_h[j] else _WATER_MIN_CLEARANCE
+        if d < thr:
+          ok[ci] = False
+    # placed H live in two trees (prefix + pending); base maps a tree-local
+    # index back to its global placed_coords slot. Placed atoms are all H.
+    for tree, base in ((self.placed_tree, 0), (self.pending_tree, self.n_built)):
+      if tree is None:
+        continue
+      for ci, nbrs in enumerate(
+          tree.query_ball_point(pts, _WATER_CLEARANCE_RADIUS)):
+        c = cands[ci]
+        for j in nbrs:
+          slot = base + j
+          if slot in own_slots:
+            continue
+          d = (matrix.col(self.placed_coords[slot]) - c).length()
+          if d < best[ci]:
+            best[ci] = d
+          if d < _WATER_MIN_H_CLEARANCE:
+            ok[ci] = False
+    return list(zip(best, ok))
+
+  def _place_one(self, o_xyz, own_idx, own_slots):
+    """Compute the two H positions for one water O.
+
+    Clash-aware against the current environment (the water's own static
+    atoms and own placed H are excluded).
+
+    Parameters
+    ----------
+    o_xyz : scitbx.matrix.col
+        Coordinates of the water O.
+    own_idx : set of int
+        Static-atom indices belonging to this water (excluded).
+    own_slots : set of int
+        Placed-H slot indices belonging to this water (excluded).
+
+    Returns
+    -------
+    tuple of scitbx.matrix.col
+        ``(h1_xyz, h2_xyz)``, the placed H1 and H2 positions.
+    """
+    atoms = self.atoms
+    # Acceptors (static O/N/F/S/Cl) within range, nearest first. Keep them
+    # all so H1 can skip a near acceptor whose own H is in the way.
+    acceptors = []
+    for i in self.static_tree.query_ball_point(tuple(o_xyz),
+                                          _WATER_ACCEPTOR_RADIUS):
+      if i in own_idx:
+        continue
+      if i in self.donor_n:
+        continue  # protonated N: a donor, not a usable acceptor
+      a = atoms[i]
+      if a.element.strip().upper() not in _WATER_ACCEPTOR_ELEMENTS:
+        continue
+      d = (matrix.col(a.xyz) - o_xyz).length()
+      if d < 1e-3:
+        continue  # atom coincident with O (alt-conf / overlap): no direction
+      acceptors.append((d, i))
+    acceptors.sort(key=lambda t: t[0])
+    acceptors = [i for _, i in acceptors]
+
+    def accept_dir(i):
+      """Unit direction from the water O toward acceptor ``i``.
+
+      Aimed at a lone-pair lobe when lone-pair-directed placement is on and
+      a lobe faces the water, else straight at the acceptor nucleus.
+
+      Parameters
+      ----------
+      i : int
+          Acceptor atom index.
+
+      Returns
+      -------
+      scitbx.matrix.col
+          The O-H unit direction.
+      """
+      a_xyz = matrix.col(atoms[i].xyz)
+      if self.lone_pair_directed:
+        toward = (o_xyz - a_xyz).normalize()
+        best = None
+        for lobe in self.acc_lobes.get(i, ()):
+          if best is None or lobe.dot(toward) > best.dot(toward):
+            best = lobe
+        if best is not None and best.dot(toward) > 0.0:
+          return (a_xyz + best * _WATER_HBOND_HA - o_xyz).normalize()
+      return (a_xyz - o_xyz).normalize()
+
+    # Nearby metal cations: O->cation unit directions. A placed H should
+    # stay out of the metal's hemisphere (see cation_ok below).
+    cation_dirs = []
+    for i in self.static_tree.query_ball_point(tuple(o_xyz),
+                                          _WATER_CATION_RADIUS):
+      if i in own_idx:
+        continue
+      a = atoms[i]
+      if a.element.strip().upper() not in _WATER_CATION_ELEMENTS:
+        continue
+      v = matrix.col(a.xyz) - o_xyz
+      if v.length() < 1e-3:
+        continue
+      cation_dirs.append(v.normalize())
+
+    def cation_ok(cand):
+      """Whether an H candidate is clear of every nearby cation.
+
+      True if ``cand`` is in the hemisphere away from every nearby cation,
+      i.e. ``(H - O).(cation - O) <= 0`` for all of them.
+
+      Parameters
+      ----------
+      cand : scitbx.matrix.col
+          Candidate H position.
+
+      Returns
+      -------
+      bool
+          True if the candidate avoids every cation hemisphere.
+      """
+      if not cation_dirs:
+        return True
+      dh = cand - o_xyz
+      return all(dh.dot(cd) <= 0.0 for cd in cation_dirs)
+
+    # H1: nearest acceptor giving a placement that is away from cations and
+    # clash-free; else the best direction over acceptors + a dense fallback
+    # sphere, ranked (away-from-cation, clash-free, clearance). Candidate
+    # clearances are evaluated in batches (one query set covering all of
+    # them) rather than one direction at a time.
+    acc_dirs = [accept_dir(i) for i in acceptors]
+    acc_pts = [o_xyz + self.oh_length * dv for dv in acc_dirs]
+    acc_res = self._clearances(acc_pts, own_idx, own_slots) if acc_pts else []
+
+    # Joint H1/H2 search (opt-in): pick the (H1, H2) orientation maximizing
+    # the summed acceptor alignment of both protons, among clash-free,
+    # cation-OK placements -- balancing the two H-bonds instead of greedily
+    # perfecting H1. H1 candidates are the acceptor directions plus, for each
+    # ordered acceptor pair, a "tilt" direction off one acceptor away from
+    # the other (so H1 can sit between two acceptors); each viable H1 gets an
+    # H2 cone. Falls through to the greedy path if no clash-free pair exists.
+    if self.joint and acc_dirs:
+      hoh_rad = math.radians(_WATER_HOH_DEG)
+      tilts = [_tilt_dir(acc_dirs[a], acc_dirs[b], hoh_rad)
+               for a in range(len(acc_dirs))
+               for b in range(len(acc_dirs)) if a != b]
+      d1_dirs = acc_dirs + tilts
+      d1_pts = acc_pts + [o_xyz + self.oh_length * dv for dv in tilts]
+      d1_res = acc_res + self._clearances(d1_pts[len(acc_pts):], own_idx, own_slots)
+
+      def _align(dh):
+        return max((dh.dot(a) for a in acc_dirs), default=0.0)
+
+      viable = [m for m in range(len(d1_dirs))
+                if d1_res[m][1] and cation_ok(d1_pts[m])]
+      cone = []                       # (m, d2) for each viable H1 m
+      for m in viable:
+        fp, fq = _ortho_frame(d1_dirs[m])
+        for k in range(_WATER_CONE_SAMPLES):
+          th = 2.0 * math.pi * k / _WATER_CONE_SAMPLES
+          cone.append((m, self.cos_hoh * d1_dirs[m]
+                       + self.sin_hoh * (math.cos(th) * fp + math.sin(th) * fq)))
+      cone_pts = [o_xyz + self.oh_length * d2 for _, d2 in cone]
+      cone_res = self._clearances(cone_pts, own_idx, own_slots) if cone else []
+      a1 = {m: _align(d1_dirs[m]) for m in viable}
+      best_s = None
+      best_pair = None
+      for idx, (m, d2) in enumerate(cone):
+        if not cone_res[idx][1] or not cation_ok(cone_pts[idx]):
+          continue
+        s = a1[m] + _align(d2)
+        if best_s is None or s > best_s:
+          best_s = s
+          best_pair = (d1_pts[m], cone_pts[idx])
+      if best_pair is not None:
+        return best_pair
+
+    d1 = None
+    h1_acc = None
+    for k, i in enumerate(acceptors):
+      if acc_res[k][1] and cation_ok(acc_pts[k]):  # ok and away from cations
+        d1 = acc_dirs[k]
+        h1_acc = i
+        break
+    if d1 is None:
+      sph_dirs = [matrix.col(v).normalize() for v in _WATER_FALLBACK_DIRECTIONS]
+      sph_pts = [o_xyz + self.oh_length * dv for dv in sph_dirs]
+      cand_dirs = acc_dirs + sph_dirs
+      cand_pts = acc_pts + sph_pts
+      cand_res = acc_res + self._clearances(sph_pts, own_idx, own_slots)
+      best_j = max(
+        range(len(cand_dirs)),
+        key=lambda j: (cation_ok(cand_pts[j]),
+                       cand_res[j][1], cand_res[j][0]))
+      d1 = cand_dirs[best_j]
+    h1_xyz = o_xyz + self.oh_length * d1
+
+    # Orthonormal frame for the H2 cone (d1, p, q mutually perpendicular)
+    p, q = _ortho_frame(d1)
+
+    # H2: directed at the nearest acceptor not used by H1. Sample the cone
+    # and rank each angle (away-from-cation, clash-free, acceptor
+    # alignment, clearance); acceptor alignment only counts once the
+    # higher-priority constraints are met, and the clearest angle wins if
+    # none satisfies them.
+    target = None
+    for i in acceptors:
+      if i == h1_acc:
+        continue
+      target = accept_dir(i)
+      break
+
+    cone_dirs = []
+    for k in range(_WATER_CONE_SAMPLES):
+      theta = 2.0 * math.pi * k / _WATER_CONE_SAMPLES
+      cone_dirs.append(self.cos_hoh * d1
+                       + self.sin_hoh * (math.cos(theta) * p + math.sin(theta) * q))
+    cone_pts = [o_xyz + self.oh_length * d2 for d2 in cone_dirs]
+    cone_res = self._clearances(cone_pts, own_idx, own_slots)
+
+    best_h2_xyz = None
+    best_key = None
+    for k, d2 in enumerate(cone_dirs):
+      min_dist, ok = cone_res[k]
+      cat_ok = cation_ok(cone_pts[k])
+      good = cat_ok and ok
+      align = d2.dot(target) if target is not None else 0.0
+      key = (cat_ok, ok, align if good else 0.0, min_dist)
+      if best_key is None or key > best_key:
+        best_key = key
+        best_h2_xyz = cone_pts[k]
+    return h1_xyz, best_h2_xyz
+
+  def _apply_sweep(self):
+    """Run one relaxation sweep.
+
+    Re-places every recorded water against the current positions of all the
+    others (its own H excluded), updating ``placed_coords`` and the atoms in
+    place.
+    """
+    self.placed_tree = KDTree(self.placed_coords) if self.placed_coords else None
+    self.pending_tree = None
+    self.n_built = len(self.placed_coords)
+    for o_xyz, own_idx, slots in self.records:
+      own_slots = {slot for _, slot, _ in slots}
+      h_xyz = dict(zip((1, 2), self._place_one(o_xyz, own_idx, own_slots)))
+      for atom, slot, di in slots:
+        self.placed_coords[slot] = tuple(h_xyz[di])
+        atom.set_xyz(tuple(h_xyz[di]))
+
+  def _restore(self, coords):
+    """Reset all placed H to a coordinate snapshot.
+
+    Parameters
+    ----------
+    coords : list of tuple
+        Per-slot placed-H coordinates to restore (a snapshot of
+        ``placed_coords``).
+    """
+    for _, _, slots in self.records:
+      for atom, slot, di in slots:
+        self.placed_coords[slot] = coords[slot]
+        atom.set_xyz(coords[slot])
+
+  def _clashing_records(self):
+    """Find records whose placed H still clash.
+
+    Returns
+    -------
+    list of int
+        Indices into ``records`` of waters with a placed H that fails the
+        clash gate.
+    """
+    self.placed_tree = KDTree(self.placed_coords) if self.placed_coords else None
+    self.pending_tree = None
+    self.n_built = len(self.placed_coords)
+    bad = []
+    for ri, (o_xyz, own_idx, slots) in enumerate(self.records):
+      own_slots = {slot for _, slot, _ in slots}
+      pts = [matrix.col(self.placed_coords[slot]) for _, slot, _ in slots]
+      if any(not ok for _, ok in self._clearances(pts, own_idx, own_slots)):
+        bad.append(ri)
+    return bad
+
+  def run(self):
+    """Place H on every bare water, refine, optionally basin-hop, keep best.
+
+    Modifies the hierarchy in place. Returns the kept-state label (see
+    :func:`place_water_hydrogens`).
+    """
+    hier = self.hier
+    if self.reorient_existing:
+      _strip_water_hydrogens(hier)
+
+    atoms = list(hier.atoms())
+    if not atoms:
+      return None
+    self.atoms = atoms
+
+    # Static neighbours (protein, ligands, water O, any pre-existing H):
+    # fixed, so the KDTree is built once. The water H we place live in a
+    # separate, much smaller list/tree that is cheap to rebuild as
+    # placement and refinement proceed.
+    self.static_coords = [tuple(a.xyz) for a in atoms]
+    self.static_tree = KDTree(self.static_coords)
+    self.static_is_h = [a.element.strip().upper() in ("H", "D") for a in atoms]
+    # Key by memory_id() (stable C++ identity), not id(): iotbx returns a
+    # fresh Python wrapper on each atom access, so id() is not stable across
+    # the hier.atoms() and ag.atoms() calls used to build the per-water
+    # own_idx below.
+    pos_by_id = {a.memory_id(): i for i, a in enumerate(atoms)}
+
+    # N atoms that already carry an H are donors, not acceptors -- their lone
+    # pair is occupied/conjugated (amide, ammonium, guanidinium, protonated
+    # His ring N, ...). An N's bonded H thus encodes its donor/acceptor role,
+    # charge and tautomer, giving a name-free, library-free donor test. O
+    # always accepts (it keeps lone pairs even when donating), so only N is
+    # filtered. Inert on an unprotonated model (no H -> no N flagged -> every
+    # N stays an acceptor).
+    self.donor_n = set()
+    for i, a in enumerate(atoms):
+      if not self.static_is_h[i]:
+        continue
+      for j in self.static_tree.query_ball_point(a.xyz, _WATER_NH_BOND):
+        if j != i and atoms[j].element.strip().upper() == "N":
+          self.donor_n.add(j)
+
+    # Lone-pair lobe directions per acceptor (opt-in; empty when off).
+    self.acc_lobes = _acceptor_lobes(atoms, self.static_tree, self.donor_n) \
+        if self.lone_pair_directed else {}
+
+    self.cos_hoh = math.cos(math.radians(_WATER_HOH_DEG))
+    self.sin_hoh = math.sin(math.radians(_WATER_HOH_DEG))
+
+    # Gather the waters to protonate. Order them most-crowded first: a water
+    # boxed in by many neighbours is the hardest to satisfy, so placing it
+    # while few water H are fixed gives it the most freedom; roomy waters have
+    # options left over and adapt around it. ``crowd`` is the neighbour count
+    # within the clash radius (excluding the water's own atoms).
+    waters = []
+    for ag in hier.atom_groups():
+      resname = ag.resname.strip().upper()
+      if resname not in ("HOH", "DOD"):
+        continue
+      if len(ag.atoms()) >= 3:
+        continue  # already protonated
+      o = next((a for a in ag.atoms()
+                if a.element.strip().upper() == "O"), None)
+      if o is None:
+        continue
+      own_idx = {pos_by_id[a.memory_id()] for a in ag.atoms()
+                 if a.memory_id() in pos_by_id}
+      crowd = sum(
+        1 for j in self.static_tree.query_ball_point(o.xyz, _WATER_CLEARANCE_RADIUS)
+        if j not in own_idx)
+      waters.append((crowd, ag, o, own_idx))
+    waters.sort(key=lambda w: w[0], reverse=True)
+
+    # Initial greedy pass over the ordered waters, each avoiding the H already
+    # placed on earlier ones (prefix + pending trees, refreshed below).
+    # ``records`` keeps per-water (o_xyz, own_idx, placed-H slots) so the
+    # refinement sweeps can re-place each water against the *final*
+    # environment, breaking the order-dependence of the greedy pass.
+    self.records = []   # list of (o_xyz, own_idx, [(atom, slot, di), ...])
+    for crowd, ag, o, own_idx in waters:
+      if self.element is not None:
+        proton_element = self.element
+      else:
+        proton_element = "D" if ag.resname.strip().upper() == "DOD" else "H"
+      o_xyz = matrix.col(o.xyz)
+      existing_names = {a.name.strip() for a in ag.atoms()}
+
+      # Refresh the placed-H trees. Fold the pending H into the (rebuilt)
+      # prefix tree once enough have accumulated; otherwise just rebuild the
+      # small pending tree so this water sees the previous waters' H. Their
+      # union is every earlier water's H, exactly as a single rebuilt tree.
+      if len(self.placed_coords) - self.n_built >= _WATER_TREE_REBUILD:
+        self.placed_tree = KDTree(self.placed_coords)
+        self.n_built = len(self.placed_coords)
+        self.pending_tree = None
+      else:
+        pending = self.placed_coords[self.n_built:]
+        self.pending_tree = KDTree(pending) if pending else None
+      h_xyz = dict(zip((1, 2), self._place_one(o_xyz, own_idx, set())))
+
+      slots = []
+      for di in (1, 2):
+        proton_name = f" {proton_element}{di} "
+        if proton_name.strip() in existing_names:
+          continue
+        atom = _new_h_atom(proton_name, proton_element,
+                           tuple(h_xyz[di]), o.occ, o.b)
+        ag.append_atom(atom)
+        slots.append((atom, len(self.placed_coords), di))
+        self.placed_coords.append(tuple(h_xyz[di]))
+      if slots:
+        self.records.append((o_xyz, own_idx, slots))
+
+    # Refinement sweeps: re-place each water against the *final* set of all
+    # placed H (its own excluded), so a water no longer ignores neighbours
+    # placed after it. This relaxes the water-water clashes the greedy pass
+    # leaves in dense clusters. With refine_tol > 0 it stops early once a
+    # sweep reduces the close (<2.0 A) contact count by fewer than refine_tol
+    # (n_refine is then a cap); refine_tol == 0 runs all n_refine sweeps.
+    # Refinement isn't strictly monotonic, so the best state is kept and
+    # restored at the end -- the result is never worse than any state seen.
+    stats = _water_clash_stats(hier) \
+        if (self.on_state or self.n_refine or self.n_basin) else None
+    if self.on_state is not None:
+      self.on_state("initial", stats)
+    prev_n20 = stats[1] if stats is not None else None
+    best_n20 = prev_n20
+    best_coords = list(self.placed_coords) if (self.n_refine or self.n_basin) else None
+    best_label = "initial"
+    for i in range(self.n_refine):
+      self._apply_sweep()
+      stats = _water_clash_stats(hier)
+      if self.on_state is not None:
+        self.on_state(f"sweep {i + 1}", stats)
+      if best_n20 is None or stats[1] < best_n20:
+        best_n20 = stats[1]
+        best_coords = list(self.placed_coords)
+        best_label = f"sweep {i + 1}"
+      if self.refine_tol and prev_n20 is not None and prev_n20 - stats[1] < self.refine_tol:
+        break  # gain below tolerance -- converged
+      prev_n20 = stats[1]
+
+    # Basin-hopping (optional): each round restarts from the best state, kicks
+    # the still-clashing waters to a random orientation, relaxes, and keeps
+    # the result if it improved. Deterministic (seeded). Helps only where a
+    # better orientation exists -- it re-aims the H, so a clash rooted in a
+    # misplaced water O won't resolve.
+    if self.n_basin and best_coords is not None:
+      rng = random.Random(_WATER_BASIN_SEED)
+      for it in range(self.n_basin):
+        self._restore(best_coords)
+        offenders = self._clashing_records()
+        if not offenders:
+          break  # nothing left to relax
+        for ri in offenders:
+          _kick_water(self.records[ri], self.placed_coords, self.oh_length,
+                      self.cos_hoh, self.sin_hoh, rng)
+        for s in range(_WATER_BASIN_RELAX):
+          self._apply_sweep()
+          stats = _water_clash_stats(hier)
+          label = f"basin {it + 1}.{s + 1}"
+          if self.on_state is not None:
+            self.on_state(label, stats)
+          if best_n20 is None or stats[1] < best_n20:
+            best_n20 = stats[1]
+            best_coords = list(self.placed_coords)
+            best_label = label
+
+    if best_coords is not None:
+      self._restore(best_coords)
+    return best_label if (self.n_refine or self.n_basin) else None
+
+
+def place_water_hydrogens(hier, oh_length=_WATER_OH_NEUTRON, element=None,
+                          n_refine=_WATER_REFINE_SWEEPS,
+                          refine_tol=_WATER_REFINE_TOL, n_basin=0,
+                          reorient_existing=False, lone_pair_directed=False,
+                          joint=False, on_state=None):
+  """Place the two H on every bare HOH/DOD water, H-bond-aware.
+
+  For each HOH/DOD residue missing H:
+
+  - H1 along O -> nearest H-bond acceptor (within
+    ``_WATER_ACCEPTOR_RADIUS``, element in ``_WATER_ACCEPTOR_ELEMENTS``,
+    excluding N that already carry an H -- those are donors, not
+    acceptors) that yields a *clash-free* H -- acceptors whose own H would
+    collide with the placed proton are skipped; falls back to the
+    max-clearance direction (over a dense sphere) if none is clash-free.
+  - H2 on the cone of half-angle ``_WATER_HOH_DEG`` around the O-H1 axis.
+    Among clash-free cone angles it points toward a second acceptor when
+    one exists, else maximizes clearance; if no angle is clash-free it
+    falls back to the clearest one.
+
+  Clash avoidance is global: every candidate position is scored against
+  all other atoms *and all other waters' placed H* (a small KDTree of the
+  placed protons, separate from the static-atom tree, so neighbouring
+  waters don't aim H at each other). Positions stay at least
+  ``_WATER_MIN_CLEARANCE`` from everything else where the local packing
+  allows it; in genuinely crowded pockets the clearest available position
+  is used.
+
+  Waters are placed most-crowded first (the hardest to satisfy get the
+  most freedom), then up to ``n_refine`` refinement sweeps re-place each
+  water against the final environment to relax water-water clashes; the
+  best sweep is always kept, so the result is never worse than any state
+  seen. New H inherit the parent O's occupancy and B factor.
+
+  Modifies *hier* in place. By default it is idempotent: HOH residues
+  already carrying H are left untouched.
+
+  This is a thin wrapper around :class:`_WaterHydrogenPlacer`; the
+  parameters and return value are documented here.
+
+  Parameters
+  ----------
+  hier : iotbx.pdb.hierarchy.root
+      Model hierarchy; modified in place.
+  oh_length : float, optional
+      O-H bond length in A (default neutron, 0.984; pass
+      ``_WATER_OH_XRAY`` = 0.957 for X-ray-style placement).
+  element : str or None, optional
+      Element of the placed atoms: ``"H"`` or ``"D"`` forces that element
+      on every water; None (default) picks per residue -- ``"D"`` for DOD,
+      ``"H"`` for HOH. Atom names follow the element (``H1``/``H2`` or
+      ``D1``/``D2``).
+  n_refine : int, optional
+      Maximum relaxation sweeps after the greedy pass; 0 disables
+      refinement.
+  refine_tol : int, optional
+      Stop refining once a sweep removes fewer than this many close
+      (<2.0 A) H-H contacts (so ``n_refine`` is a cap). 1 = stop at a true
+      plateau, larger = stop sooner on diminishing returns, 0 = run all
+      ``n_refine`` sweeps.
+  n_basin : int, optional
+      Basin-hopping rounds after refinement (default 0 = off). Each
+      restarts from the best state, randomly re-orients the waters still in
+      a clash, relaxes, and keeps the result if it improved (deterministic,
+      seeded). Helps only where a better orientation exists.
+  reorient_existing : bool, optional
+      If True, strip any H already on waters and re-place every water from
+      scratch; otherwise already-protonated waters are left untouched.
+  lone_pair_directed : bool, optional
+      If True, each O-H aims at an acceptor's lone-pair lobe (estimated
+      from the acceptor's bonded-neighbour geometry) rather than its
+      nucleus, for better D-H...A angles.
+  joint : bool, optional
+      If True, optimize both O-H together (the orientation maximizing the
+      summed acceptor alignment of the pair) rather than greedily fixing H1
+      then placing H2 -- so a water flanked by two acceptors can donate
+      well to both. Falls back to the greedy path where no clash-free pair
+      exists.
+  on_state : callable, optional
+      If given, called as ``on_state(label, stats)`` once the placement
+      reaches each state -- ``"initial"`` after the greedy pass, then
+      ``"sweep N"`` after each refinement sweep (and ``"basin N.M"`` during
+      basin-hopping) -- where ``stats`` is the ``_water_clash_stats``
+      tuple. Lets a caller stream a progress table row by row.
+
+  Returns
+  -------
+  str or None
+      The label of the kept state (``"initial"``, ``"sweep N"`` or
+      ``"basin N.M"``) when refinement or basin-hopping ran, else None.
+  """
+  return _WaterHydrogenPlacer(
+    hier, oh_length=oh_length, element=element, n_refine=n_refine,
+    refine_tol=refine_tol, n_basin=n_basin,
+    reorient_existing=reorient_existing,
+    lone_pair_directed=lone_pair_directed, joint=joint,
+    on_state=on_state).run()
+
+
+def _water_clash_stats(hier):
+  """Count water-H vs water-H contacts between different waters.
+
+  Heavy-atom contacts are not counted -- the placer's clash gate keeps
+  those clear by construction.
+
+  Parameters
+  ----------
+  hier : iotbx.pdb.hierarchy.root
+      Model hierarchy.
+
+  Returns
+  -------
+  tuple
+      ``(n_placed, n_lt_20, n_lt_18, n_lt_15, closest)``: the number of
+      placed water H, the counts of inter-water H-H contacts below
+      2.0/1.8/1.5 A, and the closest such distance (None if no pair is
+      within 2.0 A).
+  """
+  wh = []
+  for ag in hier.atom_groups():
+    if ag.resname.strip().upper() not in ("HOH", "DOD"):
+      continue
+    wid = ag.memory_id()
+    for a in ag.atoms():
+      if a.element.strip().upper() in ("H", "D"):
+        wh.append((tuple(a.xyz), wid))
+  if len(wh) < 2:
+    return len(wh), 0, 0, 0, None
+  tree = KDTree([x for x, _ in wh])
+  n20 = n18 = n15 = 0
+  worst = None
+  for i, (x, wid) in enumerate(wh):
+    xc = matrix.col(x)
+    for j in tree.query_ball_point(x, 2.0):
+      if j <= i or wh[j][1] == wid:  # skip self-pair and same-water H
+        continue
+      d = (matrix.col(wh[j][0]) - xc).length()
+      if worst is None or d < worst:
+        worst = d
+      n20 += 1
+      n18 += d < 1.8
+      n15 += d < 1.5
+  return len(wh), n20, n18, n15, worst
+
+
+def _clash_row(label, stats, log):
+  """Print one row of the per-sweep clash table.
+
+  Parameters
+  ----------
+  label : str
+      Row label (state name, e.g. ``"sweep 2"``).
+  stats : tuple
+      A ``_water_clash_stats`` tuple.
+  log : file object
+      Destination stream.
+  """
+  _, n20, n18, n15, worst = stats
+  w = f"{worst:.2f}" if worst is not None else ">2.0"
+  print(f"  {label:<9} <2.0={n20:<5} <1.8={n18:<5} <1.5={n15:<5} closest={w}",
+        file=log)
+
+
+def _atom_id(a):
+  """Compact identity string for an atom, e.g. ``"HOH A 863 H2"``.
+
+  Parameters
+  ----------
+  a : iotbx.pdb.hierarchy.atom
+      Atom to identify.
+
+  Returns
+  -------
+  str
+      ``"<resname> <chain> <resseq> <name>"``.
+  """
+  rg = a.parent().parent()
+  return (f"{a.parent().resname.strip()} {rg.parent().id.strip()} "
+          f"{rg.resseq.strip()} {a.name.strip()}")
+
+
+def _worst_water_clashes(hier, limit):
+  """Closest inter-water H-H contacts -- the offenders behind the counts.
+
+  Parameters
+  ----------
+  hier : iotbx.pdb.hierarchy.root
+      Model hierarchy.
+  limit : int
+      Maximum number of contacts to return.
+
+  Returns
+  -------
+  list of tuple
+      Up to ``limit`` ``(distance, id_a, id_b)`` tuples for water-H vs
+      water-H contacts between different waters within 2.0 A, closest
+      first.
+  """
+  wh = []
+  for ag in hier.atom_groups():
+    if ag.resname.strip().upper() not in ("HOH", "DOD"):
+      continue
+    wid = ag.memory_id()
+    for a in ag.atoms():
+      if a.element.strip().upper() in ("H", "D"):
+        wh.append((tuple(a.xyz), wid, a))
+  if len(wh) < 2:
+    return []
+  tree = KDTree([x for x, _, _ in wh])
+  pairs = []
+  for i, (x, wid, a) in enumerate(wh):
+    xc = matrix.col(x)
+    for j in tree.query_ball_point(x, 2.0):
+      if j <= i or wh[j][1] == wid:
+        continue
+      pairs.append(((matrix.col(wh[j][0]) - xc).length(), a, wh[j][2]))
+  pairs.sort(key=lambda t: t[0])
+  return [(d, _atom_id(a), _atom_id(b)) for d, a, b in pairs[:limit]]
+
+
+def _detect_neutron(pdb_in, hier):
+  """Classify a model as neutron- or X-ray-like for O-H distance selection.
+
+  Prefers the deposited experiment type (``EXPDTA`` in PDB, ``_exptl.method``
+  in mmCIF); when that is absent or inconclusive, falls back to the presence
+  of D atoms (only neutron / joint refinements model deuterium).
+
+  Parameters
+  ----------
+  pdb_in : iotbx.pdb.input or iotbx.pdb.mmcif.cif_input
+      The parsed input (carries the experiment-type metadata).
+  hier : iotbx.pdb.hierarchy.root
+      The model hierarchy (for the D-atom fallback).
+
+  Returns
+  -------
+  tuple
+      ``(is_neutron, source)``: whether neutron O-H distances should be
+      used, and a short human-readable string explaining the decision.
+  """
+  exp = pdb_in.get_experiment_type()
+  if not exp.is_empty():
+    if exp.is_neutron():            # includes joint X-ray/neutron
+      return True, f"experiment type {exp!r}"
+    if exp.is_xray() or exp.is_electron_microscopy():
+      return False, f"experiment type {exp!r}"
+  if any(a.element.strip().upper() == "D" for a in hier.atoms()):
+    return True, "D atoms present (no conclusive experiment metadata)"
+  return False, "no neutron signal (assuming X-ray)"

--- a/mmtbx/programs/water_protonation.py
+++ b/mmtbx/programs/water_protonation.py
@@ -133,6 +133,23 @@ By default it is idempotent: waters that already carry H are left untouched
           % ("auto (H for HOH, D for DOD)" if placer_element is None
              else placer_element), file=self.logger)
 
+    # Consistency warning: deuterium is modelled only from neutron (or joint)
+    # data, whose O-D distances are the longer neutron value. Placing D at the
+    # shorter X-ray length is geometrically inconsistent, so warn. The reverse
+    # (H at the neutron length, e.g. a hydrogenous neutron structure) is
+    # legitimate, so it is not flagged.
+    places_d = (placer_element == "D"
+                or (placer_element is None
+                    and any(ag.resname.strip().upper() == "DOD"
+                            for ag in hier.atom_groups())))
+    if places_d and not neutron:
+      print("warning: placing D (deuterium) at the X-ray O-H length (%.3f A); "
+            "deuterium is normally neutron-derived and uses the longer neutron "
+            "distance (%.3f A). Pass oh_distance=neutron for consistent "
+            "geometry." % (water_protonation._WATER_OH_XRAY,
+                           water_protonation._WATER_OH_NEUTRON),
+            file=self.logger)
+
     n_before = self._count_water_h(hier)
     report_stats = self.params.stats
     n_worst = self.params.stats_worst if self.params.stats_worst is not None else 0

--- a/mmtbx/programs/water_protonation.py
+++ b/mmtbx/programs/water_protonation.py
@@ -218,8 +218,7 @@ By default it is idempotent: waters that already carry H are left untouched
     as_pdb = (self.params.output.format == "pdb"
               and hier.fits_in_pdb_format(use_hybrid36=False))
     if self.params.output.format == "pdb" and not as_pdb:
-      print("note: structure does not fit standard PDB format "
-            "(multi-char chain ID, >99999 atoms, or resseq >9999); "
+      print("note: structure does not fit standard PDB format; "
             "writing mmCIF instead", file=self.logger)
 
     ext = "pdb" if as_pdb else "cif"

--- a/mmtbx/programs/water_protonation.py
+++ b/mmtbx/programs/water_protonation.py
@@ -1,0 +1,263 @@
+"""H-bond-aware placement of hydrogens on water (HOH/DOD) residues.
+
+Thin DataManager/PHIL wrapper around
+:func:`mmtbx.hydrogens.water_protonation.place_water_hydrogens`. The
+command-line dispatcher is ``mmtbx.naiad``.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import os
+
+from libtbx import group_args
+from libtbx.program_template import ProgramTemplate
+from libtbx.str_utils import make_sub_header
+from libtbx.utils import Sorry
+
+from mmtbx.hydrogens import water_protonation
+
+master_phil_str = '''
+oh_distance = *auto neutron xray
+  .type = choice(multi=False)
+  .short_caption = O-H bond length
+  .help = "O-H bond length to place: neutron (0.984 A), xray (0.957 A), or auto to pick from the experiment type (neutron diffraction or D atoms present gives neutron, else X-ray)."
+element = *auto H D
+  .type = choice(multi=False)
+  .short_caption = Hydrogen element
+  .help = "Element for the placed water hydrogens: H, D, or auto (D for DOD residues, H for HOH)."
+reorient_existing = False
+  .type = bool
+  .short_caption = Reorient existing water H
+  .help = "Strip any H already on waters and re-place them, instead of leaving already-protonated waters untouched (the default)."
+lone_pair = False
+  .type = bool
+  .short_caption = Lone-pair-directed placement
+  .help = "Aim each O-H at an acceptor lone-pair lobe (derived from its bonded-neighbour geometry) rather than its nucleus, for better D-H...A angles."
+joint = False
+  .type = bool
+  .short_caption = Joint H1/H2 optimization
+  .help = "Optimize both O-H together: pick the orientation that best satisfies two acceptors at once, instead of placing H1 greedily then H2 on its cone. Slower; falls back to greedy in crowded pockets."
+refine
+  .short_caption = Refinement sweeps
+{
+  max_sweeps = 5
+    .type = int
+    .short_caption = Maximum relaxation sweeps
+    .help = "Maximum relaxation sweeps re-placing each water against the final environment to relax water-water clashes. Each sweep costs about one placement pass; 0 disables refinement. Sweeping stops early once a sweep removes fewer than tolerance close contacts, so a generous cap is safe."
+  tolerance = 1
+    .type = int
+    .short_caption = Early-stop tolerance
+    .help = "Stop refining once a sweep removes fewer than this many close (<2.0 A) H-H contacts (1 = stop at a true plateau, larger = stop sooner on diminishing returns, 0 = run all max_sweeps). The best sweep is always kept."
+}
+basin
+  .short_caption = Basin-hopping
+{
+  rounds = 0
+    .type = int
+    .short_caption = Basin-hopping rounds
+    .help = "Basin-hopping rounds after refinement (0 = off): each round randomly re-orients the still-clashing waters and relaxes, keeping the best. Deterministic (seeded); helps only where a better orientation exists."
+}
+stats = False
+  .type = bool
+  .short_caption = Report water-H clashes
+  .help = "After placement, print the per-sweep water-H clash summary (count of H-H contacts below 2.0/1.8/1.5 A between different waters, and the closest contact)."
+stats_worst = None
+  .type = int
+  .short_caption = List worst contacts
+  .help = "List the N closest residual water-H contacts with their residue IDs (implies stats=True)."
+output {
+  format = *mmcif pdb
+    .type = choice(multi=False)
+    .short_caption = Output format
+    .help = "Output format. mmCIF by default (PDB format breaks on large structures); pdb falls back to mmCIF when the structure does not fit the standard PDB format."
+}
+'''
+
+
+class Program(ProgramTemplate):
+  description = '''
+mmtbx.naiad: H-bond-aware placement of hydrogens on water residues.
+
+Adds the two H atoms to every bare HOH/DOD oxygen in a model, orienting each
+proton toward a nearby H-bond acceptor while staying clash-free against the
+whole structure (including H placed on other waters) and keeping off metal
+cations. Map-free and library-free -- placement is purely from geometry.
+
+Inputs:
+  PDB or mmCIF file containing an atomic model.
+Output:
+  Model with water hydrogens added (mmCIF by default), written to
+  <model-stem>_waters_protonated.<ext> unless output.file_name is given.
+
+By default it is idempotent: waters that already carry H are left untouched
+(reorient_existing=True strips and re-places them).
+'''
+  datatypes = ['model', 'phil']
+  master_phil_str = master_phil_str
+  data_manager_options = ['model_skip_expand_with_mtrix',
+                          'model_skip_ss_annotations']
+
+  # ----------------------------------------------------------------------------
+
+  def validate(self):
+    self.data_manager.has_models(
+      raise_sorry = True,
+      expected_n  = 1,
+      exact_count = True)
+    if self.params.refine.max_sweeps < 0:
+      raise Sorry("refine.max_sweeps must be >= 0")
+    if self.params.refine.tolerance < 0:
+      raise Sorry("refine.tolerance must be >= 0")
+    if self.params.basin.rounds < 0:
+      raise Sorry("basin.rounds must be >= 0")
+    if self.params.stats_worst is not None:
+      if self.params.stats_worst < 0:
+        raise Sorry("stats_worst must be >= 0")
+      self.params.stats = True   # listing offenders only makes sense with stats
+
+  # ----------------------------------------------------------------------------
+
+  def run(self):
+    model = self.data_manager.get_model()
+    hier = model.get_hierarchy()
+    pdb_in = model.get_model_input()
+
+    # O-H distance: honour an explicit choice, else infer from the structure.
+    if self.params.oh_distance == "auto":
+      neutron, source = water_protonation._detect_neutron(pdb_in, hier)
+      print("O-H distance: %s (auto: %s)"
+            % ("neutron" if neutron else "X-ray", source), file=self.logger)
+    else:
+      neutron = self.params.oh_distance == "neutron"
+      print("O-H distance: %s (forced)" % self.params.oh_distance,
+            file=self.logger)
+    oh = water_protonation._WATER_OH_NEUTRON if neutron \
+        else water_protonation._WATER_OH_XRAY
+
+    # Element: "auto" leaves the per-residue choice (DOD->D, HOH->H) to the
+    # placer (element=None); "H"/"D" force it.
+    placer_element = None if self.params.element == "auto" else self.params.element
+    print("water hydrogen element: %s"
+          % ("auto (H for HOH, D for DOD)" if placer_element is None
+             else placer_element), file=self.logger)
+
+    n_before = self._count_water_h(hier)
+    report_stats = self.params.stats
+    n_worst = self.params.stats_worst if self.params.stats_worst is not None else 0
+
+    # Stream the clash table as the sweeps complete. The summary line and
+    # header print lazily on the first state (after the greedy pass, when the
+    # H count is final), then each row is printed as its sweep finishes.
+    header = {"printed": False}
+    def on_state(label, stats):
+      if not header["printed"]:
+        print(self._summary(n_before, self._count_water_h(hier)),
+              file=self.logger)
+        print("water H clash report (%d placed; H-H between different "
+              "waters):" % stats[0], file=self.logger)
+        header["printed"] = True
+      water_protonation._clash_row(label, stats, self.logger)
+
+    make_sub_header('Placing water hydrogens', out=self.logger)
+    kept_label = water_protonation.place_water_hydrogens(
+      hier,
+      oh_length          = oh,
+      element            = placer_element,
+      n_refine           = self.params.refine.max_sweeps,
+      refine_tol         = self.params.refine.tolerance,
+      n_basin            = self.params.basin.rounds,
+      reorient_existing  = self.params.reorient_existing,
+      lone_pair_directed = self.params.lone_pair,
+      joint              = self.params.joint,
+      on_state           = on_state if report_stats else None)
+
+    n_after = self._count_water_h(hier)
+    self.n_added = n_after - n_before
+    self.kept_label = kept_label
+    if not report_stats:
+      print(self._summary(n_before, n_after), file=self.logger)
+    elif header["printed"]:
+      if kept_label is not None:
+        print("  kept: %s" % kept_label, file=self.logger)
+      if n_worst:
+        worst = water_protonation._worst_water_clashes(hier, n_worst)
+        if worst:
+          print("  worst %d contacts:" % len(worst), file=self.logger)
+          for d, id_a, id_b in worst:
+            print("    %.2f A  %s  <->  %s" % (d, id_a, id_b),
+                  file=self.logger)
+        else:
+          print("  no contacts < 2.0 A", file=self.logger)
+
+    self.model = model
+    self._write_output(model, hier)
+
+  # ----------------------------------------------------------------------------
+
+  def _write_output(self, model, hier):
+    """Serialize the (in-place mutated) hierarchy and write via DataManager.
+
+    mmCIF by default; 'pdb' is honoured only if the structure fits the
+    standard PDB format, else it falls back to mmCIF with a note. The output
+    extension is forced to match the format actually written.
+    """
+    # New H atoms come back with blank serial numbers; the mmCIF writer
+    # rejects blanks as "invalid number literal". Re-number first.
+    hier.atoms().reset_serial()
+    cs = model.crystal_symmetry()
+
+    as_pdb = (self.params.output.format == "pdb"
+              and hier.fits_in_pdb_format(use_hybrid36=False))
+    if self.params.output.format == "pdb" and not as_pdb:
+      print("note: structure does not fit standard PDB format "
+            "(multi-char chain ID, >99999 atoms, or resseq >9999); "
+            "writing mmCIF instead", file=self.logger)
+
+    ext = "pdb" if as_pdb else "cif"
+    self.output_file_name = self._output_file_name(ext)
+    if as_pdb:
+      txt = hier.as_pdb_string(crystal_symmetry=cs)
+    else:
+      txt = hier.as_mmcif_string(crystal_symmetry=cs)
+    self.data_manager.write_model_file(
+      model_str = txt,
+      filename  = self.output_file_name,
+      format    = ext)
+    print("Wrote file: %s" % self.output_file_name, file=self.logger)
+
+  def _output_file_name(self, ext):
+    """``output.file_name`` (extension forced to ``ext``), else the default
+    ``<model-stem>_waters_protonated.<ext>``."""
+    # output.file_name and output.filename are PHIL aliases; honour either.
+    given = self.params.output.file_name or self.params.output.filename
+    if given is not None:
+      return os.path.splitext(given)[0] + "." + ext
+    stem = os.path.splitext(os.path.basename(
+      self.data_manager.get_default_model_name()))[0]
+    return "%s_waters_protonated.%s" % (stem, ext)
+
+  @staticmethod
+  def _count_water_h(hier):
+    return sum(
+      1 for ag in hier.atom_groups()
+      if ag.resname.strip().upper() in ("HOH", "DOD")
+      for a in ag.atoms()
+      if a.element.strip().upper() in ("H", "D"))
+
+  def _summary(self, n_before, n_now):
+    added = n_now - n_before
+    # With reorient_existing the existing H were stripped and re-placed, so
+    # report the reoriented count (the net change alone reads as "+0").
+    if self.params.reorient_existing and n_before:
+      return ("water H/D atoms: %d -> %d (reoriented %d, +%d)"
+              % (n_before, n_now, n_before, added))
+    return "water H/D atoms: %d -> %d (+%d)" % (n_before, n_now, added)
+
+  # ----------------------------------------------------------------------------
+
+  def get_results(self):
+    return group_args(
+      model            = self.model,
+      n_added          = self.n_added,
+      kept_label       = self.kept_label,
+      output_file_name = self.output_file_name)

--- a/mmtbx/programs/water_protonation.py
+++ b/mmtbx/programs/water_protonation.py
@@ -12,7 +12,6 @@ import os
 from libtbx import group_args
 from libtbx.program_template import ProgramTemplate
 from libtbx.str_utils import make_sub_header
-from libtbx.utils import Sorry
 
 from mmtbx.hydrogens import water_protonation
 
@@ -41,11 +40,11 @@ refine
   .short_caption = Refinement sweeps
 {
   max_sweeps = 5
-    .type = int
+    .type = int(value_min=0)
     .short_caption = Maximum relaxation sweeps
     .help = "Maximum relaxation sweeps re-placing each water against the final environment to relax water-water clashes. Each sweep costs about one placement pass; 0 disables refinement. Sweeping stops early once a sweep removes fewer than tolerance close contacts, so a generous cap is safe."
   tolerance = 1
-    .type = int
+    .type = int(value_min=0)
     .short_caption = Early-stop tolerance
     .help = "Stop refining once a sweep removes fewer than this many close (<2.0 A) H-H contacts (1 = stop at a true plateau, larger = stop sooner on diminishing returns, 0 = run all max_sweeps). The best sweep is always kept."
 }
@@ -53,7 +52,7 @@ basin
   .short_caption = Basin-hopping
 {
   rounds = 0
-    .type = int
+    .type = int(value_min=0)
     .short_caption = Basin-hopping rounds
     .help = "Basin-hopping rounds after refinement (0 = off): each round randomly re-orients the still-clashing waters and relaxes, keeping the best. Deterministic (seeded); helps only where a better orientation exists."
 }
@@ -62,7 +61,7 @@ stats = False
   .short_caption = Report water-H clashes
   .help = "After placement, print the per-sweep water-H clash summary (count of H-H contacts below 2.0/1.8/1.5 A between different waters, and the closest contact)."
 stats_worst = None
-  .type = int
+  .type = int(value_min=0)
   .short_caption = List worst contacts
   .help = "List the N closest residual water-H contacts with their residue IDs (implies stats=True)."
 output {
@@ -104,15 +103,8 @@ By default it is idempotent: waters that already carry H are left untouched
       raise_sorry = True,
       expected_n  = 1,
       exact_count = True)
-    if self.params.refine.max_sweeps < 0:
-      raise Sorry("refine.max_sweeps must be >= 0")
-    if self.params.refine.tolerance < 0:
-      raise Sorry("refine.tolerance must be >= 0")
-    if self.params.basin.rounds < 0:
-      raise Sorry("basin.rounds must be >= 0")
+    # Non-negativity of the int params is enforced by value_min=0 in the PHIL.
     if self.params.stats_worst is not None:
-      if self.params.stats_worst < 0:
-        raise Sorry("stats_worst must be >= 0")
       self.params.stats = True   # listing offenders only makes sense with stats
 
   # ----------------------------------------------------------------------------

--- a/mmtbx/run_tests.py
+++ b/mmtbx/run_tests.py
@@ -170,6 +170,7 @@ general_tests = [
   "$D/hydrogens/tst_add_hydrogen_10.py",
   "$D/hydrogens/tst_add_hydrogen_11.py",
   #"$D/hydrogens/tst_add_hydrogen_time.py",
+  "$D/hydrogens/tst_water_protonation.py",
   "$D/hydrogens/tst_validate_H.py",
   "$D/hydrogens/tst_connectivity.py",
   "$D/hydrogens/tst_const_dihedral.py",


### PR DESCRIPTION
## Summary
Adds a new mmtbx tool, `mmtbx.naiad`, that places the two H/D atoms
(H for HOH, D for DOD) on every bare HOH/DOD oxygen. Each proton is
oriented toward a nearby H-bond acceptor while staying clash-free against
the whole structure (including H placed on other waters) and keeping off
metal cations — purely from geometry, with no map, no residue-name tables,
and no monomer library.

It fills the gap between the two existing water-H options:
- `mmtbx.ligands.ready_set_utils.add_water_hydrogen_atoms_simple` — geometry
  but clash-only.
- `mmtbx.hydrogens.find.build_water_hydrogens_from_map` — H-bond-aware but
  needs a map/fmodel.

## What's included
- **`mmtbx/hydrogens/water_protonation.py`** — library. `place_water_hydrogens(hier, ...)`
  (in-place) over a `_WaterHydrogenPlacer` engine: crowded-first greedy
  placement, refinement sweeps (keep-best), optional basin-hopping,
  lone-pair-directed and joint two-acceptor modes, donor-N/cation awareness,
  and neutron/X-ray experiment detection.
- **`mmtbx/programs/water_protonation.py`** — `Program(ProgramTemplate)` + PHIL
  scope, DataManager I/O, optional per-sweep water-H clash report.
- **`mmtbx/command_line/naiad.py`** — the `mmtbx.naiad` dispatcher.
- **`mmtbx/hydrogens/tst_water_protonation.py`** — 10 regression cases;
  registered in `mmtbx/run_tests.py`.

## Usage
```
mmtbx.naiad model.cif
mmtbx.naiad model.pdb output.format=pdb element=D
mmtbx.naiad model.cif oh_distance=xray stats=True basin.rounds=5
```

Output defaults to `<stem>_waters_protonated.cif` (mmCIF by default;
`output.format=pdb` falls back to mmCIF when the structure doesn't fit
standard PDB format). Idempotent by default — waters already carrying H are
left alone (`reorient_existing=True` strips and re-places them).

## Testing
- `mmtbx.python mmtbx/hydrogens/tst_water_protonation.py` → `OK` (all 10
  cases: acceptor-directed + `memory_id` regression, cation repulsion,
  protonated-N-not-acceptor, lone-pair angle, joint balancing, idempotency,
  reorient-existing, refinement-reduces-clashes, element override, experiment
  detection).

## Notes
- Depends on `scipy` (KDTree).
- Not symmetry aware; current clash search covers the ASU.
- Not altloc aware.