### PR TITLE
Reduce2 opt only

### DIFF
--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -1274,6 +1274,9 @@ NOTES:
         startAdd = time.time()
         self._AddHydrogens()
         doneAdd = time.time()
+      else:
+        # We need restraints on the model for optimization, so we interpret it to get them.
+        self._ReinterpretModel(make_restraints=True)
 
       # NOTE: We always optimize all models (leave modelIndex alone) because we've removed all
       # but the desired model ID structure from the model.
@@ -1297,7 +1300,8 @@ NOTES:
       if len(warnings) > 0:
         print('\nWarnings during optimization:\n'+warnings, file=self.logger)
       outString += opt.getInfo()
-      outString += 'Time to Add Hydrogen = {:.3f} sec'.format(doneAdd-startAdd)+'\n'
+      if self.params.approach == 'add':
+        outString += 'Time to Add Hydrogen = {:.3f} sec'.format(doneAdd-startAdd)+'\n'
       outString += 'Time to Optimize = {:.3f} sec'.format(doneOpt-startOpt)+'\n'
       if self.params.output.print_atom_info:
         print('Atom information used during calculations:', file=self.logger)

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -37,10 +37,10 @@ import csv
 version = "2.15.0"
 
 master_phil_str = '''
-approach = *add remove
+approach = *add remove optimize
   .type = choice
-  .short_caption = Add or remove Hydrogens
-  .help = Determines whether Reduce will add (and optimize) or remove Hydrogens from the model
+  .short_caption = Add (and optimize), remove, or optimize Hydrogens
+  .help = Determines whether Reduce will add (and optimize), remove, or optimize Hydrogens from the model
 keep_existing_H = False
   .type = bool
   .short_caption = Do not remove Hydrogens in the original model
@@ -1266,12 +1266,14 @@ NOTES:
     # about the original model for use by Kinemages.
     initialModel = self.model.deep_copy()
 
-    if self.params.approach == 'add':
-      # Add Hydrogens to the model
-      make_sub_header('Adding Hydrogens', out=self.logger)
-      startAdd = time.time()
-      self._AddHydrogens()
-      doneAdd = time.time()
+    if self.params.approach == 'add' or self.params.approach == 'optimize':
+
+      if self.params.approach == 'add':
+        # Add Hydrogens to the model
+        make_sub_header('Adding Hydrogens', out=self.logger)
+        startAdd = time.time()
+        self._AddHydrogens()
+        doneAdd = time.time()
 
       # NOTE: We always optimize all models (leave modelIndex alone) because we've removed all
       # but the desired model ID structure from the model.

--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -40,7 +40,7 @@ master_phil_str = '''
 approach = *add remove optimize
   .type = choice
   .short_caption = Add (and optimize), remove, or optimize Hydrogens
-  .help = Determines whether Reduce will add (and optimize), remove, or optimize Hydrogens from the model
+  .help = Determines whether Reduce will add (and optimize), remove, or optimize Hydrogens from the model. Note: if using optimize and add_flip_movers=True, all possible hydrogens must be added to histidines (even ones making collision).
 keep_existing_H = False
   .type = bool
   .short_caption = Do not remove Hydrogens in the original model


### PR DESCRIPTION
Adds a third 'optimize' option to the available approaches for reduce2. This neither adds nor removes hydrogens, but assumes all (non-water) hydrogens are on the model and optimizes them.

Tested by running mmtx.debugging.hydrogenate on a model followed by mmtbx.reduce2 approach=optimize; got the same result as running mmtbx.reduce2 approach=add on the original model.