### PR TITLE
Don't add phantom hydrogens to water oxygens in reduce2 when there ar…

### DIFF
--- a/mmtbx/probe/Helpers.py
+++ b/mmtbx/probe/Helpers.py
@@ -680,7 +680,7 @@ def getPhantomHydrogensFor(largestISeq, atom, spatialQuery, extraAtomInfo, minOc
   maxDist = 4.0
   nearby = sorted(spatialQuery.neighbors(atom.xyz, 0.001, maxDist), key=lambda x:x.i_seq)
 
-  # Candidates for nearby atoms.  We use this list to keep track of one ones we
+  # Candidates for nearby atoms.  We use this list to keep track of ones we
   # have already found so that we can compare against them to only get one for each
   # aromatic ring.
   class Candidate(object):

--- a/mmtbx/reduce/Optimizers.py
+++ b/mmtbx/reduce/Optimizers.py
@@ -424,6 +424,9 @@ class Optimizer(object):
         for a in self._atoms:
           if a.element == 'O' and common_residue_names_get_class(name=a.parent().resname) == "common_water":
             if a.occ >= self._waterOccCutoff and a.b < self._waterBCutoff:
+              # If the Oxygen is bonded (presumably to hydrogens/deuteriums), then we just leave it alone.
+              if len(bondedNeighborLists[a]) > 0:
+                self._infoString += _VerboseCheck(self._verbosity, 3,"Not adding phantom Hydrogens on {} due to bonded neighbors\n".format(_ResNameAndID(a)))
 
               # We're an acceptor and not a donor.
               ei = self._extraAtomInfo.getMappingFor(a)


### PR DESCRIPTION
…e already bonded atoms to the waters, so we don't duplicate hydrogens.