### PR TITLE
Match Niggli iteration-limit exception message

### DIFF
--- a/cctbx/uctbx/niggli_reduction.h
+++ b/cctbx/uctbx/niggli_reduction.h
@@ -12,14 +12,14 @@
 
 namespace cctbx { namespace uctbx {
 
-  //! Exception raised when the Niggli reduction iteration limit is exceeded.
+  //! Exception raised when the Krivy-Gruber iteration limit is exceeded.
   class niggli_reduction_iteration_limit_exceeded : public error
   {
     public:
       niggli_reduction_iteration_limit_exceeded(std::size_t limit)
       :
         error(
-          "Niggli reduction iteration limit exceeded (limit="
+          "Krivy-Gruber iteration limit exceeded (limit="
           + std::to_string(limit) + ").")
       {}
   };


### PR DESCRIPTION
The Niggli reduction algorithm was ported from python to c++ in PR
1152. When the iteration-limit was exceeded, the python code exception string was "Krivy-Gruber iteration limit exceeded" and the c++ port is "Niggli reduction iteration limit exceeded". This PR changes the c++ exception to match.