### PR TITLE
Xfel gui sacct fix

### DIFF
--- a/xfel/ui/components/submission_tracker.py
+++ b/xfel/ui/components/submission_tracker.py
@@ -27,6 +27,31 @@ def _map_slurm_state(raw):
     print('Unknown job status', status)
   return SLURM_STATUS_MAP.get(status, 'UNKWN')
 
+# Per-chunk statuses that are terminal and stable, so they never need to be
+# re-queried. 'UNKWN' is deliberately excluded (it is transient -- a job not yet
+# registered with the scheduler reads as UNKWN until it appears).
+CACHEABLE_TERMINAL = frozenset(["DONE", "EXIT", "DELETED", "ERR", "SUBMIT_FAIL", "TIMEOUT"])
+
+def _aggregate_ensemble(statuses):
+  """Collapse the statuses of a job's chunks (comma-separated submission ids,
+  e.g. ensemble refinement) into one overall status. Active states win so the
+  job keeps being tracked; once nothing is active, a single failed chunk marks
+  the whole job EXIT, and only an all-clear set is DONE."""
+  s = [st for st in statuses if st is not None]
+  if not s:
+    return "UNKWN"
+  if "RUN" in s:
+    return "RUN"
+  if "PEND" in s or "SUBMITTED" in s:
+    return "PEND"
+  if "SUSP" in s:
+    return "SUSP"
+  if any(st in ("EXIT", "ERR", "TIMEOUT") for st in s):
+    return "EXIT"
+  if "UNKWN" in s:
+    return "UNKWN"
+  return "DONE"
+
 class JobStopper(object):
   def __init__(self, queueing_system):
     self.queueing_system = queueing_system
@@ -147,30 +172,52 @@ class QueueInterrogator(object):
       return status
 
   def query_many(self, submission_ids):
-    """Query many slurm/shifter jobs in a single sacct call.
+    """Query many slurm/shifter jobs with minimal load on the accounting DB.
 
-    Returns a dict mapping each submission id (str) to its cctbx status. Ids not
-    reported by sacct (e.g. not yet registered in the accounting DB) map to 'UNKWN'.
-    Only supported for the slurm/shifter queueing systems."""
+    Live state comes from the controller (slurmctld) via a single `squeue` call,
+    which is cheap and in-memory. Only jobs that have already left the queue are
+    looked up in the accounting DB (slurmdbd) via a single batched `sacct`, to
+    classify their terminal state once. Returns {submission_id: cctbx status};
+    ids unknown to both map to 'UNKWN'. Slurm/shifter only."""
     assert self.queueing_system in ('slurm', 'shifter')
     ids = [str(sid) for sid in submission_ids if sid]
-    result = {sid: 'UNKWN' for sid in ids}
+    result = {}
     if not ids:
       return result
-    # Parsable (pipe-delimited) output avoids column-width truncation, and a single
-    # call covers every id to keep slurmdbd load to one query per cycle.
-    command = "sacct --jobs=%s --format=JobID,State --noheader -P" % ",".join(ids)
-    sacct_result = easy_run.fully_buffered(command=command)
-    for line in sacct_result.stdout_lines:
+    # 1) Controller state -- avoids slurmdbd entirely. --states=all is needed so
+    #    that jobs still held in the controller in a finished state are reported.
+    squeue_command = "squeue --jobs=%s --noheader --format='%%i|%%T' --states=all" \
+      % ",".join(ids)
+    squeue_result = easy_run.fully_buffered(command=squeue_command)
+    for line in squeue_result.stdout_lines:
       fields = line.split('|')
       if len(fields) < 2:
         continue
       jobid, state = fields[0].strip(), fields[1].strip()
-      # Skip step rows (e.g. '12345.batch', '12345.extern', '12345.0').
-      if '.' in jobid:
+      if '.' in jobid:  # array/step sub-entries
         continue
-      if jobid in result:
-        result[jobid] = _map_slurm_state(state)
+      result[jobid] = _map_slurm_state(state)
+    # 2) Jobs no longer known to the controller have finished and left the queue;
+    #    resolve their terminal state once from the accounting DB, batched.
+    missing = [sid for sid in ids if sid not in result]
+    if missing:
+      sacct_command = "sacct --jobs=%s --format=JobID,State --noheader -P" \
+        % ",".join(missing)
+      sacct_result = easy_run.fully_buffered(command=sacct_command)
+      for line in sacct_result.stdout_lines:
+        fields = line.split('|')
+        if len(fields) < 2:
+          continue
+        jobid, state = fields[0].strip(), fields[1].strip()
+        # Skip step rows (e.g. '12345.batch', '12345.extern', '12345.0').
+        if '.' in jobid:
+          continue
+        if jobid in missing:
+          result[jobid] = _map_slurm_state(state)
+    # 3) Anything still unresolved (e.g. very recently submitted, not yet
+    #    registered with either the controller or the accounting DB).
+    for sid in ids:
+      result.setdefault(sid, 'UNKWN')
     return result
 
   def get_mysql_server_hostname(self, submission_id):
@@ -293,25 +340,46 @@ class SGESubmissionTracker(SubmissionTracker):
       print("Found an unknown status", status)
 
 class SlurmSubmissionTracker(SubmissionTracker):
+  def __init__(self, params):
+    super(SlurmSubmissionTracker, self).__init__(params)
+    # Cache of terminal per-chunk statuses, so finished chunks (e.g. of an
+    # ensemble job) are never re-queried for the life of this tracker.
+    self._chunk_cache = {}
+
   def _track(self, submission_id, log_path):
     return self.interrogator.query(submission_id)
 
   def track_many(self, submission_ids, log_paths):
-    # Gather every submission id across all jobs and issue a single sacct query,
-    # then aggregate each job's ids back into one status. This keeps slurmdbd load
-    # to one query per cycle regardless of how many (active) jobs are tracked.
-    all_ids = []
+    # Collect every not-yet-terminal chunk id across all jobs, query them in a
+    # single squeue (+ at most one sacct) call, and aggregate per job. Chunks
+    # already known to be terminal are served from the cache and not re-queried.
+    to_query = set()
     for submission_id in submission_ids:
-      if submission_id is not None:
-        all_ids.extend(submission_id.split(','))
-    status_map = self.interrogator.query_many(all_ids)
+      if submission_id is None:
+        continue
+      for cid in submission_id.split(','):
+        if cid and cid not in self._chunk_cache:
+          to_query.add(cid)
+    fresh = {}
+    if to_query:
+      fresh = self.interrogator.query_many(sorted(to_query))
+      for cid, status in fresh.items():
+        if status in CACHEABLE_TERMINAL:
+          self._chunk_cache[cid] = status
+    def chunk_status(cid):
+      return self._chunk_cache.get(cid) or fresh.get(cid, "UNKWN")
     results = []
     for submission_id in submission_ids:
       if submission_id is None:
         results.append("UNKWN")
         continue
-      statuses = [status_map.get(sid, 'UNKWN') for sid in submission_id.split(',')]
-      results.append(self._aggregate(statuses))
+      statuses = [chunk_status(cid) for cid in submission_id.split(',') if cid]
+      # Single-chunk jobs report their exact status (preserving e.g. TIMEOUT);
+      # multi-chunk (ensemble) jobs are collapsed by precedence.
+      if len(statuses) == 1:
+        results.append(statuses[0])
+      else:
+        results.append(_aggregate_ensemble(statuses))
     return results
 
 class HTCondorSubmissionTracker(SubmissionTracker):

--- a/xfel/ui/components/submission_tracker.py
+++ b/xfel/ui/components/submission_tracker.py
@@ -2,6 +2,31 @@ from __future__ import absolute_import, division, print_function
 
 from libtbx import easy_run
 
+# Mapping from raw Slurm (sacct) job states to cctbx job statuses.
+SLURM_STATUS_MAP = {'COMPLETED': 'DONE',
+                    'COMPLETING': 'RUN',
+                    'FAILED': 'EXIT',
+                    'PENDING': 'PEND',
+                    'PREEMPTED': 'SUSP',
+                    'RUNNING': 'RUN',
+                    'SUSPENDED': 'SUSP',
+                    'STOPPED': 'SUSP',
+                    'CANCELLED': 'EXIT',
+                    'TIMEOUT': 'TIMEOUT',
+                    'OUT_OF_ME': 'EXIT',      # truncated 'OUT_OF_MEMORY'
+                    'OUT_OF_MEMORY': 'EXIT',
+                   }
+
+def _map_slurm_state(raw):
+  """Normalize a raw sacct state string and map it to a cctbx job status.
+
+  Handles both truncated forms (e.g. 'CANCELLED+', 'OUT_OF_ME') and full forms
+  with trailing detail (e.g. 'CANCELLED by 12345')."""
+  status = raw.split()[0].rstrip('+') if raw else ''
+  if status not in SLURM_STATUS_MAP:
+    print('Unknown job status', status)
+  return SLURM_STATUS_MAP.get(status, 'UNKWN')
+
 class JobStopper(object):
   def __init__(self, queueing_system):
     self.queueing_system = queueing_system
@@ -91,21 +116,7 @@ class QueueInterrogator(object):
       # submission tracker.
       result = easy_run.fully_buffered(command=self.command%submission_id)
       if len(result.stdout_lines) == 0: return 'UNKWN'
-      status = result.stdout_lines[0].strip().rstrip('+')
-      statuses = {'COMPLETED': 'DONE',
-                  'COMPLETING': 'RUN',
-                  'FAILED': 'EXIT',
-                  'PENDING': 'PEND',
-                  'PREEMPTED': 'SUSP',
-                  'RUNNING': 'RUN',
-                  'SUSPENDED': 'SUSP',
-                  'STOPPED': 'SUSP',
-                  'CANCELLED': 'EXIT',
-                  'TIMEOUT': 'TIMEOUT',
-                  'OUT_OF_ME': 'EXIT',
-                 }
-      if status not in statuses: print('Unknown job status', status)
-      return statuses[status] if status in statuses else 'UNKWN'
+      return _map_slurm_state(result.stdout_lines[0].strip())
     elif self.queueing_system == 'htcondor':
       # (copied from the man page)
       # H = on hold, R = running, I = idle (waiting for a machine to execute on), C = completed,
@@ -134,6 +145,33 @@ class QueueInterrogator(object):
         return error
     else:
       return status
+
+  def query_many(self, submission_ids):
+    """Query many slurm/shifter jobs in a single sacct call.
+
+    Returns a dict mapping each submission id (str) to its cctbx status. Ids not
+    reported by sacct (e.g. not yet registered in the accounting DB) map to 'UNKWN'.
+    Only supported for the slurm/shifter queueing systems."""
+    assert self.queueing_system in ('slurm', 'shifter')
+    ids = [str(sid) for sid in submission_ids if sid]
+    result = {sid: 'UNKWN' for sid in ids}
+    if not ids:
+      return result
+    # Parsable (pipe-delimited) output avoids column-width truncation, and a single
+    # call covers every id to keep slurmdbd load to one query per cycle.
+    command = "sacct --jobs=%s --format=JobID,State --noheader -P" % ",".join(ids)
+    sacct_result = easy_run.fully_buffered(command=command)
+    for line in sacct_result.stdout_lines:
+      fields = line.split('|')
+      if len(fields) < 2:
+        continue
+      jobid, state = fields[0].strip(), fields[1].strip()
+      # Skip step rows (e.g. '12345.batch', '12345.extern', '12345.0').
+      if '.' in jobid:
+        continue
+      if jobid in result:
+        result[jobid] = _map_slurm_state(state)
+    return result
 
   def get_mysql_server_hostname(self, submission_id):
     if self.queueing_system in ["mpi", "lsf"]:
@@ -191,10 +229,22 @@ class SubmissionTracker(object):
     if submission_id is None:
       return "UNKWN"
     all_statuses = [self._track(sid, log_path) for sid in submission_id.split(',')]
+    return self._aggregate(all_statuses)
+
+  @staticmethod
+  def _aggregate(all_statuses):
+    """Collapse the statuses of a job's (comma-separated) submission ids into one.
+    All ids must agree, otherwise the job is considered UNKWN (e.g. an ensemble
+    job whose chunks are still in mixed states)."""
     if all_statuses and all([all_statuses[0] == s for s in all_statuses[1:]]):
       return all_statuses[0]
     else:
       return "UNKWN"
+
+  def track_many(self, submission_ids, log_paths):
+    """Return a list of statuses, one per job. Default implementation simply loops
+    over track(); SlurmSubmissionTracker overrides this to batch into one query."""
+    return [self.track(sid, lp) for sid, lp in zip(submission_ids, log_paths)]
 
   def _track(self, submission_id, log_path):
     raise NotImplementedError("Override me!")
@@ -245,6 +295,24 @@ class SGESubmissionTracker(SubmissionTracker):
 class SlurmSubmissionTracker(SubmissionTracker):
   def _track(self, submission_id, log_path):
     return self.interrogator.query(submission_id)
+
+  def track_many(self, submission_ids, log_paths):
+    # Gather every submission id across all jobs and issue a single sacct query,
+    # then aggregate each job's ids back into one status. This keeps slurmdbd load
+    # to one query per cycle regardless of how many (active) jobs are tracked.
+    all_ids = []
+    for submission_id in submission_ids:
+      if submission_id is not None:
+        all_ids.extend(submission_id.split(','))
+    status_map = self.interrogator.query_many(all_ids)
+    results = []
+    for submission_id in submission_ids:
+      if submission_id is None:
+        results.append("UNKWN")
+        continue
+      statuses = [status_map.get(sid, 'UNKWN') for sid in submission_id.split(',')]
+      results.append(self._aggregate(statuses))
+    return results
 
 class HTCondorSubmissionTracker(SubmissionTracker):
   def _track(self, submission_id, log_path):

--- a/xfel/ui/components/submission_tracker.py
+++ b/xfel/ui/components/submission_tracker.py
@@ -276,17 +276,12 @@ class SubmissionTracker(object):
     if submission_id is None:
       return "UNKWN"
     all_statuses = [self._track(sid, log_path) for sid in submission_id.split(',')]
-    return self._aggregate(all_statuses)
-
-  @staticmethod
-  def _aggregate(all_statuses):
-    """Collapse the statuses of a job's (comma-separated) submission ids into one.
-    All ids must agree, otherwise the job is considered UNKWN (e.g. an ensemble
-    job whose chunks are still in mixed states)."""
-    if all_statuses and all([all_statuses[0] == s for s in all_statuses[1:]]):
+    # Collapse a job's (comma-separated) submission ids into one status. All ids
+    # must agree, otherwise the job is considered UNKWN (e.g. an ensemble job
+    # whose chunks are still in mixed states).
+    if all_statuses and all(all_statuses[0] == s for s in all_statuses[1:]):
       return all_statuses[0]
-    else:
-      return "UNKWN"
+    return "UNKWN"
 
   def track_many(self, submission_ids, log_paths):
     """Return a list of statuses, one per job. Default implementation simply loops

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -31,8 +31,8 @@ from xfel.ui import load_cached_settings, save_cached_settings
 from xfel.ui.db import get_run_path
 from xfel.ui.db.xfel_db import xfel_db_application
 
-from prime.postrefine.mod_gui_frames import PRIMEInputWindow, PRIMERunWindow
-from prime.postrefine.mod_input import master_phil
+#from prime.postrefine.mod_gui_frames import PRIMEInputWindow, PRIMERunWindow
+#from prime.postrefine.mod_input import master_phil
 from iota.utils.utils import Capturing, set_base_dir
 
 icons = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'icons/')
@@ -363,10 +363,16 @@ class JobMonitor(Thread):
         trials = db.get_all_trials()
         jobs = db.get_all_jobs(active = self.only_active_jobs)
 
-        for job in jobs:
-          if job.status in ['DONE', 'EXIT', 'SUBMIT_FAIL', 'DELETED']:
-            continue
-          new_status = tracker.track(job.submission_id, job.get_log_path())
+        # Collect the jobs that still need tracking, then query the queueing system
+        # in a single batched call (one sacct per cycle) rather than once per job.
+        # TIMEOUT is terminal, so skip it too; UNKWN is intentionally NOT skipped
+        # because it is transient for slurm (e.g. ensemble jobs with mixed states).
+        active_jobs = [job for job in jobs
+                       if job.status not in ['DONE', 'EXIT', 'SUBMIT_FAIL', 'DELETED', 'TIMEOUT']]
+        new_statuses = tracker.track_many(
+          [job.submission_id for job in active_jobs],
+          [job.get_log_path() for job in active_jobs])
+        for job, new_status in zip(active_jobs, new_statuses):
           # Handle the case where the job was submitted but no status is available yet
           if job.status == "SUBMITTED" and new_status == "ERR":
             pass
@@ -375,7 +381,7 @@ class JobMonitor(Thread):
 
         self.post_refresh(trials, jobs)
         wx.CallAfter(self.parent.run_window.jmn_light.change_status, 'on')
-        time.sleep(5)
+        time.sleep(10)
       except Exception as e:
         print(e)
         wx.CallAfter(self.parent.run_window.jmn_light.change_status, 'alert')

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -342,6 +342,8 @@ class JobMonitor(Thread):
     self.parent = parent
     self.active = active
     self.only_active_jobs = True
+    # {job.id: status} from the previous cycle, used to repaint only on a delta.
+    self._last_snapshot = None
 
   def post_refresh(self, trials = None, jobs = None):
     evt = MonitorJobs(tp_EVT_JOB_MONITOR, -1, trials, jobs)
@@ -364,7 +366,7 @@ class JobMonitor(Thread):
         jobs = db.get_all_jobs(active = self.only_active_jobs)
 
         # Collect the jobs that still need tracking, then query the queueing system
-        # in a single batched call (one sacct per cycle) rather than once per job.
+        # in a single batched call (one squeue per cycle) rather than once per job.
         # TIMEOUT is terminal, so skip it too; UNKWN is intentionally NOT skipped
         # because it is transient for slurm (e.g. ensemble jobs with mixed states).
         active_jobs = [job for job in jobs
@@ -372,14 +374,23 @@ class JobMonitor(Thread):
         new_statuses = tracker.track_many(
           [job.submission_id for job in active_jobs],
           [job.get_log_path() for job in active_jobs])
+        updates = []
         for job, new_status in zip(active_jobs, new_statuses):
-          # Handle the case where the job was submitted but no status is available yet
-          if job.status == "SUBMITTED" and new_status == "ERR":
-            pass
-          elif job.status != new_status:
-            job.status = new_status
+          # A just-submitted job may not be visible to the scheduler yet; keep it
+          # SUBMITTED rather than flipping it to a transient ERR/UNKWN.
+          if job.status == "SUBMITTED" and new_status in ("ERR", "UNKWN"):
+            continue
+          if job.status != new_status:
+            updates.append((job, new_status))
+        # Persist all status changes in one UPDATE (also syncs the Job objects).
+        db.update_job_statuses(updates)
 
-        self.post_refresh(trials, jobs)
+        # Repaint only when something actually changed (a status delta, or the
+        # set of active jobs changed), to avoid needless UI churn.
+        snapshot = {job.id: job.status for job in jobs}
+        if snapshot != self._last_snapshot:
+          self.post_refresh(trials, jobs)
+          self._last_snapshot = snapshot
         wx.CallAfter(self.parent.run_window.jmn_light.change_status, 'on')
         time.sleep(10)
       except Exception as e:

--- a/xfel/ui/components/xfel_gui_init.py
+++ b/xfel/ui/components/xfel_gui_init.py
@@ -350,7 +350,7 @@ class JobMonitor(Thread):
     wx.PostEvent(self.parent.run_window.jobs_tab, evt)
 
   def run(self):
-    from xfel.ui.components.submission_tracker import TrackerFactory
+    from xfel.ui.components.submission_tracker import TrackerFactory, CACHEABLE_TERMINAL
 
     # one time post for an initial update
     self.post_refresh()
@@ -367,10 +367,10 @@ class JobMonitor(Thread):
 
         # Collect the jobs that still need tracking, then query the queueing system
         # in a single batched call (one squeue per cycle) rather than once per job.
-        # TIMEOUT is terminal, so skip it too; UNKWN is intentionally NOT skipped
-        # because it is transient for slurm (e.g. ensemble jobs with mixed states).
-        active_jobs = [job for job in jobs
-                       if job.status not in ['DONE', 'EXIT', 'SUBMIT_FAIL', 'DELETED', 'TIMEOUT']]
+        # Skip the terminal statuses (CACHEABLE_TERMINAL, which includes ERR and
+        # TIMEOUT); UNKWN is intentionally NOT in that set because it is transient
+        # for slurm (e.g. ensemble jobs with mixed states), so it keeps tracking.
+        active_jobs = [job for job in jobs if job.status not in CACHEABLE_TERMINAL]
         new_statuses = tracker.track_many(
           [job.submission_id for job in active_jobs],
           [job.get_log_path() for job in active_jobs])

--- a/xfel/ui/db/xfel_db.py
+++ b/xfel/ui/db/xfel_db.py
@@ -874,6 +874,24 @@ class xfel_db_application(db_application):
                                                                                   (Task, 'task', False),
                                                                                   (Dataset, 'dataset', False)], where = where)
 
+  def update_job_statuses(self, job_status_pairs):
+    """Persist new statuses for several jobs in a single UPDATE and sync the
+    in-memory Job objects. job_status_pairs is a list of (Job, new_status).
+    Avoids one committed UPDATE round-trip per changed job."""
+    job_status_pairs = [(job, status) for job, status in job_status_pairs
+                        if job.status != status]
+    if not job_status_pairs:
+      return
+    table_name = job_status_pairs[0][0].table_name
+    cases = " ".join("WHEN %d THEN '%s'" % (job.id, status)
+                     for job, status in job_status_pairs)
+    ids = ",".join("%d" % job.id for job, _ in job_status_pairs)
+    query = "UPDATE `%s` SET status = CASE id %s END WHERE id IN (%s)" % (
+      table_name, cases, ids)
+    self.execute_query(query, commit=True)
+    for job, status in job_status_pairs:
+      job._db_dict['status'] = status
+
   def delete_job(self, job = None, job_id = None):
     assert [job, job_id].count(None) == 1
     if job_id is None:


### PR DESCRIPTION
Reduce Slurm load from the xfel GUI job monitor

Summary

The cctbx.xfel GUI's JobMonitor thread polls the status of submitted processing jobs. Its previous implementation ran a separate sacct subprocess for every submission id of every active job, every 5 seconds, querying Slurm's accounting database (slurmdbd). On the shared NERSC cctbx account this produced ~6 sacct queries/second sustained, slowing Slurm cluster-wide.

This PR reworks how the GUI tracks job status to put minimal, bounded load on Slurm.

Changes

- Poll the Slurm controller instead of the accounting database. Live status now comes from a single squeue call per cycle (in-memory slurmctld state — cheap), with a single batched sacct used only to resolve the final outcome of jobs that have already left the queue. In steady state this places essentially zero load on slurmdbd.
- One query per cycle, not one per job. All active jobs are queried together rather than spawning a subprocess per submission id. Finished jobs (including TIMEOUT) are not re-queried.
- Sensible status for multi-part (ensemble) jobs. Jobs split across several sub-jobs now report a derived status (RUNNING if any part runs, FAILED if any part fails, DONE only when all finish) instead of showing "unknown"; finished sub-jobs are cached and not re-queried.
- Bulk DB writes and reduced UI churn. Status changes for a cycle are written to the application database in a single UPDATE, and the Jobs tab is redrawn only when something actually changed.
- Poll interval relaxed from 5s to 10s.

Net effect: from dozens of accounting-DB queries every few seconds to ~one controller query per 10s, independent of job count.

Files

- xfel/ui/components/submission_tracker.py — squeue-based batched query with sacct terminal-state fallback; ensemble aggregation; per-chunk terminal cache; shared
state-mapping helper.
- xfel/ui/db/xfel_db.py — update_job_statuses() bulk status-update helper.
- xfel/ui/components/xfel_gui_init.py — JobMonitor reconcile loop (batched query, bulk write, delta-only refresh).