### PR TITLE
VDW/neutron fixes: element-based VDW fallback, neutron distances to ener_lib and Optimizer

### DIFF
--- a/mmtbx/hydrogens/__init__.py
+++ b/mmtbx/hydrogens/__init__.py
@@ -618,7 +618,8 @@ def place_and_optimize_hydrogens(model, do_flips=False, nuclear=False,
   # re-process below drops restraints, so it must come AFTER the Optimizer
   # (this mirrors clashscore2.check_and_add_hydrogen).
   opt = Optimizers.Optimizer(
-    probe_phil, do_flips, model, modelIndex=None, fillAtomDump=False)
+    probe_phil, do_flips, model, modelIndex=None,
+    useNeutronDistances=nuclear, fillAtomDump=False)
 
   # Delete any hydrogens that we've been asked to delete.
   for a in opt.getHydrogensToDelete():

--- a/mmtbx/probe/Helpers.py
+++ b/mmtbx/probe/Helpers.py
@@ -385,7 +385,7 @@ def getExtraAtomInfo(model, bondedNeighborLists, useNeutronDistances = False, pr
   # Traverse the hierarchy and look up the extra data to be filled in.
   extras = probeExt.ExtraAtomInfoMap([],[])
   mon_lib_srv = model.get_mon_lib_srv()
-  ener_lib = mmtbx.monomer_library.server.ener_lib()
+  ener_lib = mmtbx.monomer_library.server.ener_lib(use_neutron_distances=useNeutronDistances)
   ph = model.get_hierarchy()
   for m in ph.models():
     for chain in m.chains():

--- a/mmtbx/probe/Helpers.py
+++ b/mmtbx/probe/Helpers.py
@@ -494,6 +494,14 @@ def getExtraAtomInfo(model, bondedNeighborLists, useNeutronDistances = False, pr
               warnings += ("Warning: Could not find atom info for "+fullName+
                 " (perhaps interpretation was not run on the model?):"+
                 " keeping some default values: "+str(e)+"\n")
+              # Fall back to element-based VDW radius for atoms without
+              # restraints (e.g. unknown ligands) so probe2 can still run.
+              if extra.vdwRadius <= 0:
+                element = a.element.strip().upper()
+                if element in ener_lib.lib_atom and ener_lib.lib_atom[element].vdw_radius:
+                  extra.vdwRadius = ener_lib.lib_atom[element].vdw_radius
+                  warnings += ("Using element-based VDW radius for "+fullName+
+                    ": "+str(extra.vdwRadius)+"\n")
               extras.setMappingFor(a, extra)
 
   return getExtraAtomInfoReturn(extras, warnings)


### PR DESCRIPTION
## Summary
Three small robustness/correctness fixes for VDW radii and neutron distances in the probe2 / reduce2 path.

1. **Element-based VDW fallback for unparameterized atoms** (`mmtbx/probe/Helpers.py`). When `getExtraAtomInfo()` can't look up an atom (e.g. an unknown ligand whose `type_energies` were never assigned during interpretation), `vdwRadius` defaulted to 0, which crashes probe2. It now falls back to the element-based radius from `ener_lib` (N=1.55, C=1.70, O=1.40, …) with a warning, so probe2 can still run contact analysis on structures containing unknown ligands.

2. **Pass `useNeutronDistances` to `ener_lib` in `getExtraAtomInfo`** (`mmtbx/probe/Helpers.py`). The `ener_lib` constructor wasn't receiving the flag, so it always used X-ray VDW radii even when nuclear distances were requested.

3. **Pass `useNeutronDistances` to the reduce2 Optimizer** (`mmtbx/hydrogens/__init__.py`). `place_and_optimize_hydrogens` was passing `nuclear` to `place_hydrogens` but **not** to `Optimizers.Optimizer` (which accepts `useNeutronDistances` and defaults it to False), so neutron-distance models were optimized with X-ray distances. Now the helper forwards `useNeutronDistances=nuclear`.

## Note on commit 3's location
The original change targeted the inline Optimizer call in `clashscore2.check_and_add_hydrogen`. Master has since refactored that function to delegate to the shared `mmtbx.hydrogens.place_and_optimize_hydrogens`, so the fix is applied there instead (one place, shared by clashscore2, the kinemage view, and refinement).

## Tests
- `mmtbx/probe/tst_mmtbx_probe_ext.py` passes.
- `mmtbx.clashscore2` on a hydrogenated model: X-ray default unchanged (`clashscore = 293.67`); `nuclear=True` runs cleanly and now differs (`303.49`), confirming the neutron flag flows through.
- `mmtbx/kinemage/tst_validation.py` still passes (it also uses `place_and_optimize_hydrogens`).
