### PR TITLE
kinemage: move generation into per-validator as_kinemage() + probe-dot reuse

### DIFF
--- a/mmtbx/kinemage/tst_validation.py
+++ b/mmtbx/kinemage/tst_validation.py
@@ -236,6 +236,9 @@ def exercise_deleted_functions():
   assert not hasattr(v, 'get_residue_bonds'), "get_residue_bonds should have been deleted"
   assert not hasattr(v, 'get_angle_outliers'), "get_angle_outliers should have been deleted"
   assert not hasattr(v, 'get_bond_outliers'), "get_bond_outliers should have been deleted"
+  assert not hasattr(v, 'rotamer_outliers'), "rotamer_outliers should have been deleted"
+  assert not hasattr(v, 'rama_outliers'), "rama_outliers should have been deleted"
+  assert not hasattr(v, 'pperp_outliers'), "pperp_outliers should have been deleted"
   print("  exercise_deleted_functions: OK")
 
 

--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -332,6 +332,66 @@ def make_probe_dots(hierarchy, keep_hydrogens=False):
       pass
   return probe_return
 
+def make_probe_dots_from_model(model_manager):
+  """Generate probe dot kinemage output from an already-hydrogenated model.
+
+  Like make_probe_dots() but skips reduce2 + Optimizer since the model
+  already has hydrogens placed (e.g. from clashscore2).
+  """
+  try:
+    from mmtbx.programs import probe2
+    import mmtbx.model
+    from libtbx.utils import null_out
+    import tempfile
+  except ImportError:
+    return ""
+
+  hierarchy = model_manager.get_hierarchy()
+  probe_return = ""
+  for i_mod, m in enumerate(hierarchy.models()):
+    r = pdb.hierarchy.root()
+    mdc = m.detached_copy()
+    r.append_model(mdc)
+
+    # Build a model manager for this sub-model
+    sub_model = mmtbx.model.manager(
+      model_input=None,
+      pdb_hierarchy=r,
+      stop_for_unknowns=False,
+      crystal_symmetry=model_manager.crystal_symmetry(),
+      log=null_out())
+
+    # Run probe2 in kinemage output mode
+    try:
+      import iotbx.cli_parser
+
+      tempName = tempfile.mktemp()
+      parser = iotbx.cli_parser.CCTBXParser(
+        program_class=probe2.Program, logger=null_out())
+      args = [
+        "approach=self",
+        "output.format=kinemage",
+        "output.filename='%s'" % tempName,
+        "output.separate_worse_clashes=True",
+        "output.report_vdws=False",
+        "output.write_files=False",
+        "count_dots=False",
+        "ignore_lack_of_explicit_hydrogens=True",
+      ]
+      parser.parse_args(args)
+      dm = parser.data_manager
+      p2 = probe2.Program(dm, parser.working_phil.extract(),
+                          master_phil=parser.master_phil, logger=null_out())
+      p2.overrideModel(sub_model)
+      dots, output = p2.run()
+      probe_return += output
+      if os.path.exists(tempName):
+        os.unlink(tempName)
+    except Exception:
+      pass
+  return probe_return
+
+
 def cbeta_dev(outliers, chain_id=None):
   cbeta_out = "@subgroup {CB dev} dominant\n"
   cbeta_out += "@balllist {CB dev Ball} color= magenta master= {Cbeta dev}\n"
@@ -755,7 +815,8 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
                     rot_outliers, rama_result, cb_result,
                     restraints_result, keep_hydrogens,
                     omega_result=None, rna_puckers_result=None,
-                    cablam_result=None):
+                    cablam_result=None,
+                    probe_dots_kin=None):
   """Shared logic for building the kinemage string.
 
   Args:
@@ -771,6 +832,9 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
     omega_result: omegalyze result object, or None (computed on-the-fly if None)
     rna_puckers_result: rna_puckers result object, or None
     cablam_result: cablamalyze result object, or None
+    probe_dots_kin: pre-computed probe dots kinemage string, or None.
+      If provided, this is used instead of calling make_probe_dots().
+      Pass "" to suppress probe dots entirely.
   """
   kin_out = get_default_header()
   altid_controls = get_altid_controls(hierarchy=hierarchy)
@@ -818,7 +882,10 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
     cablam_result.out = None
     kin_out += cablam_result.as_kinemage()
     cablam_result.out = saved_out
-  kin_out += make_probe_dots(hierarchy=hierarchy, keep_hydrogens=keep_hydrogens)
+  if probe_dots_kin is not None:
+    kin_out += probe_dots_kin
+  else:
+    kin_out += make_probe_dots(hierarchy=hierarchy, keep_hydrogens=keep_hydrogens)
   kin_out += get_footer()
   return kin_out
 

--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 import os
 from iotbx import pdb
 from mmtbx import monomer_library
-from mmtbx.chemical_components import get_bond_pairs
 from mmtbx.validation.rotalyze import rotalyze
 from mmtbx.validation.ramalyze import ramalyze
 from mmtbx.validation.cbetadev import cbetadev
@@ -14,8 +13,6 @@ from libtbx import Auto
 from scitbx import matrix
 from cctbx import geometry_restraints
 from mmtbx.monomer_library import pdb_interpretation
-from mmtbx.monomer_library import rna_sugar_pucker_analysis
-from iotbx.pdb.rna_dna_detection import residue_analysis
 import iotbx.phil
 from libtbx.utils import Sorry, Usage
 from libtbx.str_utils import show_string
@@ -351,116 +348,6 @@ def midpoint(p1, p2):
   mid[1] = (p1[1]+p2[1])/2
   mid[2] = (p1[2]+p2[2])/2
   return mid
-
-def pperp_outliers(hierarchy, chain):
-  kin_out = "@vectorlist {ext} color= magenta master= {base-P perp}\n"
-  rv = rna_validate.rna_puckers(pdb_hierarchy=hierarchy)
-  outliers = rv.results
-  params = rna_sugar_pucker_analysis.master_phil.extract()
-  outlier_key_list = []
-  for outlier in outliers:
-    outlier_key_list.append(outlier.id_str())
-  for conformer in chain.conformers():
-    for residue in conformer.residues():
-      if common_residue_names_get_class(residue.resname) != "common_rna_dna":
-        continue
-      ra1 = residue_analysis(
-        residue_atoms=residue.atoms(),
-        distance_tolerance=params.bond_detection_distance_tolerance)
-      if (ra1.problems is not None): continue
-      if (not ra1.is_rna): continue
-      try:
-        key = residue.find_atom_by(name=" C1'").pdb_label_columns()[4:]
-      except Exception:
-        continue
-      if key in outlier_key_list:
-        if rv.pucker_perp_xyz[key][0] is not None:
-          perp_xyz = rv.pucker_perp_xyz[key][0] #p_perp_xyz
-        else:
-          perp_xyz = rv.pucker_perp_xyz[key][1] #o3p_perp_xyz
-        if rv.pucker_dist[key][0] is not None:
-          perp_dist = rv.pucker_dist[key][0]
-          if perp_dist < 2.9:
-            pucker_text = " 2'?"
-          else:
-            pucker_text = " 3'?"
-        else:
-          perp_dist = rv.pucker_dist[key][1]
-          if perp_dist < 2.4:
-            pucker_text = " 2'?"
-          else:
-            pucker_text = " 3'?"
-        key = key[0:4].lower()+key[4:]
-        key += pucker_text
-        kin_out += kin_vec(key, perp_xyz[0], key, perp_xyz[1])
-        a = matrix.col(perp_xyz[1])
-        b = matrix.col(residue.find_atom_by(name=" C1'").xyz)
-        c = (a-b).normalize()
-        new = a-(c*.8)
-        kin_out += kin_vec(key, perp_xyz[1], key, tuple(new), 4)
-        new = a+(c*.4)
-        kin_out += kin_vec(key, perp_xyz[1], key, tuple(new), 4)
-        r_vec = matrix.col(perp_xyz[1]) - matrix.col(perp_xyz[0])
-        r = r_vec.axis_and_angle_as_r3_rotation_matrix(angle=90, deg=True)
-        new = r*(new-a)+a
-        kin_out += kin_vec(key, perp_xyz[1], key, tuple(new), 4)
-        r = r_vec.axis_and_angle_as_r3_rotation_matrix(angle=180, deg=True)
-        new = r*(new-a)+a
-        kin_out += kin_vec(key, perp_xyz[1], key, tuple(new), 4)
-  return kin_out
-
-def rama_outliers(chain, pdbID, ram_outliers):
-  ram_out = "@subgroup {Rama outliers} master= {Rama outliers}\n"
-  ram_out += "@vectorlist {bad Rama Ca} width= 4 color= green\n"
-  outlier_list = []
-  for outlier in ram_outliers.results :
-    if (not outlier.is_outlier()) : continue
-    if outlier.chain_id == chain.id :
-      ram_out += outlier.as_kinemage()
-  return ram_out
-
-def rotamer_outliers(chain, pdbID, rot_outliers):
-  mc_atoms = ["N", "C", "O", "OXT"]
-  rot_out = "@subgroup {Rota outliers} dominant\n"
-  rot_out += "@vectorlist {chain %s} color= gold  master= {Rota outliers}\n" % chain.id
-  outlier_list = []
-  for outlier in rot_outliers.results :
-    if (not outlier.is_outlier()) : continue
-    outlier_list.append(outlier.atom_group_id_str())
-  for residue_group in chain.residue_groups():
-    for atom_group in residue_group.atom_groups():
-      check_key = atom_group.id_str()
-      if (check_key in outlier_list):
-        key_hash = {}
-        xyz_hash = {}
-        for atom in atom_group.atoms():
-          key = "%s %s %s%s  B%.2f %s" % (
-              atom.name.lower(),
-              atom_group.resname.lower(),
-              chain.id,
-              residue_group.resid(),
-              atom.b,
-              pdbID)
-          key_hash[atom.name.strip()] = key
-          xyz_hash[atom.name.strip()] = atom.xyz
-        bonds = get_bond_pairs(code=atom_group.resname)
-        for bond in bonds:
-          if bond[0] in mc_atoms or bond[1] in mc_atoms:
-            continue
-          elif bond[0].startswith('H') or bond[1].startswith('H'):
-            continue
-          if (key_hash.get(bond[0]) == None or
-              key_hash.get(bond[1]) == None or
-              xyz_hash.get(bond[0]) == None or
-              xyz_hash.get(bond[1]) == None):
-            continue
-          rot_out += kin_vec(key_hash[bond[0]],
-                             xyz_hash[bond[0]],
-                             key_hash[bond[1]],
-                             xyz_hash[bond[1]])
-  if len(rot_out.splitlines()) == 2:
-    rot_out = ""
-  return rot_out
 
 def get_chain_color(index):
   chain_colors = ['white',
@@ -866,7 +753,9 @@ def _build_bond_hash(bond_proxies, i_seq_name_hash):
 
 def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
                     rot_outliers, rama_result, cb_result,
-                    restraints_result, keep_hydrogens):
+                    restraints_result, keep_hydrogens,
+                    omega_result=None, rna_puckers_result=None,
+                    cablam_result=None):
   """Shared logic for building the kinemage string.
 
   Args:
@@ -879,6 +768,9 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
     cb_result: cbetadev result object
     restraints_result: mmtbx.validation.restraints.combined result object
     keep_hydrogens: whether to keep hydrogens for probe dots
+    omega_result: omegalyze result object, or None (computed on-the-fly if None)
+    rna_puckers_result: rna_puckers result object, or None
+    cablam_result: cablamalyze result object, or None
   """
   kin_out = get_default_header()
   altid_controls = get_altid_controls(hierarchy=hierarchy)
@@ -904,19 +796,28 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
       # emitted once per unique chain ID (not once per chain segment).
       if chain.id not in validated_chains:
         if (chain.is_protein()):
-          kin_out += rotamer_outliers(chain=chain, pdbID=pdbID,
-            rot_outliers=rot_outliers)
-          kin_out += rama_outliers(chain=chain, pdbID=pdbID,
-            ram_outliers=rama_result)
+          kin_out += rot_outliers.as_kinemage(chain_id=chain.id,
+            pdb_hierarchy=hierarchy)
+          kin_out += rama_result.as_kinemage(chain_id=chain.id)
         kin_out += restraints_result.as_kinemage(chain_id=chain.id)
         if (chain.is_protein()):
           kin_out += cb_result.as_kinemage(chain_id=chain.id)
-        kin_out += pperp_outliers(hierarchy=hierarchy,
-                                  chain=chain)
+        if rna_puckers_result is not None:
+          kin_out += rna_puckers_result.as_kinemage(chain_id=chain.id,
+            pdb_hierarchy=hierarchy)
         validated_chains.append(chain.id)
       counter += 1
-  kin_out += omegalyze.omegalyze(pdb_hierarchy=hierarchy,nontrans_only=True,
-    out=None,quiet=False).as_kinemage()
+  if omega_result is not None:
+    kin_out += omega_result.as_kinemage()
+  else:
+    kin_out += omegalyze.omegalyze(pdb_hierarchy=hierarchy,nontrans_only=True,
+      out=None,quiet=False).as_kinemage()
+  if cablam_result is not None:
+    # Suppress self.out write for assembled kinemage; use returned string only
+    saved_out = cablam_result.out
+    cablam_result.out = None
+    kin_out += cablam_result.as_kinemage()
+    cablam_result.out = saved_out
   kin_out += make_probe_dots(hierarchy=hierarchy, keep_hydrogens=keep_hydrogens)
   kin_out += get_footer()
   return kin_out
@@ -938,6 +839,28 @@ def make_multikin(f, processed_pdb_file, pdbID=None, keep_hydrogens=False):
   rot_outliers = rotalyze(pdb_hierarchy=hierarchy, outliers_only=True)
   cb = cbetadev(pdb_hierarchy=hierarchy, outliers_only=True)
   rama = ramalyze(pdb_hierarchy=hierarchy, outliers_only=True)
+  omega = omegalyze.omegalyze(pdb_hierarchy=hierarchy, nontrans_only=True,
+    out=None, quiet=True)
+
+  # RNA puckers (only if RNA is present)
+  rna_puckers_result = None
+  has_rna = any(chain.is_na() for model in hierarchy.models()
+                for chain in model.chains())
+  if has_rna:
+    rna_puckers_result = rna_validate.rna_puckers(pdb_hierarchy=hierarchy)
+
+  # CaBLAM
+  from mmtbx.validation.cablam import cablamalyze
+  cablam_result = None
+  has_protein = any(chain.is_protein() for model in hierarchy.models()
+                    for chain in model.chains())
+  if has_protein:
+    from libtbx.utils import null_out
+    cablam_result = cablamalyze(
+      pdb_hierarchy=hierarchy,
+      outliers_only=True,
+      out=null_out(),
+      quiet=True)
 
   # Build restraints validation using mmtbx.validation.restraints
   from mmtbx.validation.restraints import combined as restraints_combined
@@ -958,7 +881,10 @@ def make_multikin(f, processed_pdb_file, pdbID=None, keep_hydrogens=False):
     rama_result=rama,
     cb_result=cb,
     restraints_result=restraints_result,
-    keep_hydrogens=keep_hydrogens)
+    keep_hydrogens=keep_hydrogens,
+    omega_result=omega,
+    rna_puckers_result=rna_puckers_result,
+    cablam_result=cablam_result)
 
   outfile = open(f, 'w')
   outfile.write(kin_out)
@@ -1054,7 +980,8 @@ def export_molprobity_result_as_kinemage(
     geometry,
     probe_file,
     keep_hydrogens=False,
-    pdbID="PDB"):
+    pdbID="PDB",
+    cablam_result=None):
   assert (result.restraints is not None)
   i_seq_name_hash = build_name_hash(pdb_hierarchy=pdb_hierarchy)
   sites_cart = pdb_hierarchy.atoms().extract_xyz()
@@ -1063,6 +990,12 @@ def export_molprobity_result_as_kinemage(
                                        sites_cart=sites_cart)
   bond_proxies = pair_proxies.bond_proxies
   quick_bond_hash = _build_bond_hash(bond_proxies, i_seq_name_hash)
+  rna_puckers_result = None
+  if hasattr(result, 'rna') and result.rna is not None:
+    rna_puckers_result = result.rna.puckers
+  omega_result = None
+  if hasattr(result, 'omegalyze'):
+    omega_result = result.omegalyze
   return _build_kinemage(
     hierarchy=pdb_hierarchy,
     bond_hash=quick_bond_hash,
@@ -1072,4 +1005,7 @@ def export_molprobity_result_as_kinemage(
     rama_result=result.ramalyze,
     cb_result=result.cbetadev,
     restraints_result=result.restraints,
-    keep_hydrogens=keep_hydrogens)
+    keep_hydrogens=keep_hydrogens,
+    omega_result=omega_result,
+    rna_puckers_result=rna_puckers_result,
+    cablam_result=cablam_result)

--- a/mmtbx/validation/cablam.py
+++ b/mmtbx/validation/cablam.py
@@ -645,18 +645,19 @@ class cablam_result(residue):
 
   #{{{ as_kinemage
   #-----------------------------------------------------------------------------
-  def as_kinemage(self, mode=None, out=sys.stdout):
-    #prints kinemage markup for this residue
+  def as_kinemage(self, mode=None, out=None):
+    #returns kinemage markup for this residue as a string
     #has separate output modes for cablam outliers and for ca geom outliers
+    kin_text = ""
     if mode == 'ca_geom':
       if self.feedback.c_alpha_geom_outlier is not None:
         stats = self.mp_id() + " ca_geom=%.2f alpha=%.2f beta=%.2f three-ten=%.2f" %(self.scores.c_alpha_geom*100, self.scores.alpha*100, self.scores.beta*100, self.scores.threeten*100)
         CA_1 = self.prevres.get_atom(' CA ').xyz
         CA_2 = self.get_atom(' CA ').xyz
         CA_3 = self.nextres.get_atom(' CA ').xyz
-        out.write('\n{'+stats+'} P '+str(CA_2[0]-(CA_2[0]-CA_1[0])*0.9)+' '+str(CA_2[1]-(CA_2[1]-CA_1[1])*0.9)+' '+str(CA_2[2]-(CA_2[2]-CA_1[2])*0.9))
-        out.write('\n{'+stats+'} '+str(CA_2[0])+' '+str(CA_2[1])+' '+str(CA_2[2]))
-        out.write('\n{'+stats+'} '+str(CA_2[0]-(CA_2[0]-CA_3[0])*0.9)+' '+str(CA_2[1]-(CA_2[1]-CA_3[1])*0.9)+' '+str(CA_2[2]-(CA_2[2]-CA_3[2])*0.9))
+        kin_text += '\n{'+stats+'} P '+str(CA_2[0]-(CA_2[0]-CA_1[0])*0.9)+' '+str(CA_2[1]-(CA_2[1]-CA_1[1])*0.9)+' '+str(CA_2[2]-(CA_2[2]-CA_1[2])*0.9)
+        kin_text += '\n{'+stats+'} '+str(CA_2[0])+' '+str(CA_2[1])+' '+str(CA_2[2])
+        kin_text += '\n{'+stats+'} '+str(CA_2[0]-(CA_2[0]-CA_3[0])*0.9)+' '+str(CA_2[1]-(CA_2[1]-CA_3[1])*0.9)+' '+str(CA_2[2]-(CA_2[2]-CA_3[2])*0.9)
     elif mode == 'cablam':
       if self.feedback.cablam_outlier is not None:
         stats = self.mp_id() + " cablam=%.2f alpha=%.2f beta=%.2f three-ten=%.2f" %(self.scores.cablam*100, self.scores.alpha*100, self.scores.beta*100, self.scores.threeten*100)
@@ -666,11 +667,14 @@ class cablam_result(residue):
         X_1 = perptersect(CA_1,CA_2,O_1)
         X_2 = perptersect(CA_2,CA_3,O_2)
         midpoint = [ (X_1[0]+X_2[0])/2.0 , (X_1[1]+X_2[1])/2.0 , (X_1[2]+X_2[2])/2.0 ]
-        out.write('\n{'+stats+'} P '+ str(O_1[0]) +' '+ str(O_1[1]) +' '+ str(O_1[2]))
-        out.write('\n{'+stats+'} '+ str(X_1[0]) +' '+ str(X_1[1]) +' '+ str(X_1[2]))
-        out.write('\n{'+stats+'} '+ str(midpoint[0]) +' '+ str(midpoint[1]) +' '+ str(midpoint[2]))
-        out.write('\n{'+stats+'} '+ str(X_2[0]) +' '+ str(X_2[1]) +' '+ str(X_2[2]))
-        out.write('\n{'+stats+'} '+ str(O_2[0]) +' '+ str(O_2[1]) +' '+ str(O_2[2]))
+        kin_text += '\n{'+stats+'} P '+ str(O_1[0]) +' '+ str(O_1[1]) +' '+ str(O_1[2])
+        kin_text += '\n{'+stats+'} '+ str(X_1[0]) +' '+ str(X_1[1]) +' '+ str(X_1[2])
+        kin_text += '\n{'+stats+'} '+ str(midpoint[0]) +' '+ str(midpoint[1]) +' '+ str(midpoint[2])
+        kin_text += '\n{'+stats+'} '+ str(X_2[0]) +' '+ str(X_2[1]) +' '+ str(X_2[2])
+        kin_text += '\n{'+stats+'} '+ str(O_2[0]) +' '+ str(O_2[1]) +' '+ str(O_2[2])
+    if out is not None:
+      out.write(kin_text)
+    return kin_text
   #-----------------------------------------------------------------------------
   #}}}
 
@@ -1359,38 +1363,46 @@ class cablamalyze(validation):
   #}}}
 
   def cablam_wheel_triangle(self, wheel_center, wedge, color):
-    self.out.write('\n{} P X %s %.3f %.3f %.3f' % (color, wheel_center[0], wheel_center[1], wheel_center[2]))
-    self.out.write('\n{} %s %.3f %.3f %.3f' % (color, wedge.start[0], wedge.start[1], wedge.start[2]))
-    self.out.write('\n{} %s %.3f %.3f %.3f' % (color, wedge.end[0], wedge.end[1], wedge.end[2]))
+    kin_text = ""
+    kin_text += '\n{} P X %s %.3f %.3f %.3f' % (color, wheel_center[0], wheel_center[1], wheel_center[2])
+    kin_text += '\n{} %s %.3f %.3f %.3f' % (color, wedge.start[0], wedge.start[1], wedge.start[2])
+    kin_text += '\n{} %s %.3f %.3f %.3f' % (color, wedge.end[0], wedge.end[1], wedge.end[2])
+    return kin_text
 
   def cablam_wheel_edge(self, wheel_center, wedge, prevwedge):
     pass
 
   #{{{ as_kinemage
   #-----------------------------------------------------------------------------
-  def as_kinemage(self):
-    #output cablam validation as standalone kinemage markup for viewing in KiNG
-    self.out.write('\n@subgroup {cablam disfavored} dominant\n')
-    self.out.write('@vectorlist {cablam disfavored} color= purple width= 4 master={cablam disfavored} off') #default off
+  def as_kinemage(self, chain_id=None):
+    #output cablam validation as kinemage markup, returns string
+    kin_out = '\n@subgroup {cablam disfavored} dominant\n'
+    kin_out += '@vectorlist {cablam disfavored} color= purple width= 4 master={cablam disfavored} off' #default off
     for result in self.results:
       if not result.has_ca:
+        continue
+      if chain_id is not None and result.chain_id.strip() != chain_id.strip():
         continue
       if result.feedback.cablam_disfavored:
-        result.as_kinemage(mode="cablam", out=self.out)
-    self.out.write('\n@subgroup {cablam outlier} dominant\n')
-    self.out.write('@vectorlist {cablam outlier} color= magenta width= 4 master={cablam outlier}') #default on
+        kin_out += result.as_kinemage(mode="cablam")
+    kin_out += '\n@subgroup {cablam outlier} dominant\n'
+    kin_out += '@vectorlist {cablam outlier} color= magenta width= 4 master={cablam outlier}' #default on
     for result in self.results:
       if not result.has_ca:
+        continue
+      if chain_id is not None and result.chain_id.strip() != chain_id.strip():
         continue
       if result.feedback.cablam_outlier:
-        result.as_kinemage(mode="cablam", out=self.out)
-    self.out.write('\n@subgroup {ca geom outlier} dominant\n')
-    self.out.write('@vectorlist {ca geom outlier} color= red width= 4 master={ca geom outlier}') #default on
+        kin_out += result.as_kinemage(mode="cablam")
+    kin_out += '\n@subgroup {ca geom outlier} dominant\n'
+    kin_out += '@vectorlist {ca geom outlier} color= red width= 4 master={ca geom outlier}' #default on
     for result in self.results:
       if not result.has_ca:
         continue
+      if chain_id is not None and result.chain_id.strip() != chain_id.strip():
+        continue
       if result.feedback.c_alpha_geom_outlier:
-        result.as_kinemage(mode="ca_geom", out=self.out)
+        kin_out += result.as_kinemage(mode="ca_geom")
     #----------------------------
     #"wheels" show favorable and unfavorabe regions for each peptide plane involved in a cablam outlier
     #Some additional calculations are required to generate these wheels
@@ -1399,11 +1411,13 @@ class cablamalyze(validation):
     for result in self.results:
       if not result.has_ca:
         continue
+      if chain_id is not None and result.chain_id.strip() != chain_id.strip():
+        continue
       if result.feedback.cablam_disfavored:
         wheels_list.extend(result.calculate_kinemage_wheels(cablam_contours=cablam_contours))
     #wheels are made of 10-degree wedges, each wedge drawn as a triangle
-    self.out.write('\n@subgroup {cablam_wheels} dominant master={cablam wheels}\n')
-    self.out.write('@trianglelist {cablam_wheels} alpha=0.75')
+    kin_out += '\n@subgroup {cablam_wheels} dominant master={cablam wheels}\n'
+    kin_out += '@trianglelist {cablam_wheels} alpha=0.75'
     for cablam_wheel in wheels_list:
       wheel = cablam_wheel[0]
       wheel_center = cablam_wheel[1]
@@ -1414,12 +1428,9 @@ class cablamalyze(validation):
           color = 'magenta'
         else:
           color = 'purple'
-        self.cablam_wheel_triangle(wheel_center, wedge, color)
-        #self.out.write('\n{} P X %s %.3f %.3f %.3f' % (color, wheel_center[0], wheel_center[1], wheel_center[2]))
-        #self.out.write('\n{} %s %.3f %.3f %.3f' % (color, wedge.start[0], wedge.start[1], wedge.start[2]))
-        #self.out.write('\n{} %s %.3f %.3f %.3f' % (color, wedge.end[0], wedge.end[1], wedge.end[2]))
+        kin_out += self.cablam_wheel_triangle(wheel_center, wedge, color)
     #a thin black line outlining the wheel greatly aids visual interpretation
-    self.out.write('\n@vectorlist {cablam_wheels_lines} color=deadblack width= 1 alpha=0.75')
+    kin_out += '\n@vectorlist {cablam_wheels_lines} color=deadblack width= 1 alpha=0.75'
     for cablam_wheel in wheels_list:
       wheel = cablam_wheel[0]
       wheel_center = cablam_wheel[1]
@@ -1427,22 +1438,26 @@ class cablamalyze(validation):
       new_poly = ' P' #starts a new polyline in kinemage format, print this for each new wheel
       for wedge in wheel:
         if wedge and prevwedge:
-          self.out.write('\n{}%s %.3f %.3f %.3f' % (new_poly, wedge.start[0], wedge.start[1], wedge.start[2]))
-          self.out.write('\n{} %.3f %.3f %.3f' % (wedge.end[0], wedge.end[1], wedge.end[2]))
+          kin_out += '\n{}%s %.3f %.3f %.3f' % (new_poly, wedge.start[0], wedge.start[1], wedge.start[2])
+          kin_out += '\n{} %.3f %.3f %.3f' % (wedge.end[0], wedge.end[1], wedge.end[2])
         elif wedge and not prevwedge:
-          self.out.write('\n{}%s %.3f %.3f %.3f' % (new_poly, wheel_center[0], wheel_center[1], wheel_center[2]))
-          self.out.write('\n{} %.3f %.3f %.3f' % (wedge.start[0], wedge.start[1], wedge.start[2]))
-          self.out.write('\n{} %.3f %.3f %.3f' % (wedge.end[0], wedge.end[1], wedge.end[2]))
+          kin_out += '\n{}%s %.3f %.3f %.3f' % (new_poly, wheel_center[0], wheel_center[1], wheel_center[2])
+          kin_out += '\n{} %.3f %.3f %.3f' % (wedge.start[0], wedge.start[1], wedge.start[2])
+          kin_out += '\n{} %.3f %.3f %.3f' % (wedge.end[0], wedge.end[1], wedge.end[2])
         elif prevwedge and not wedge:
-          self.out.write('\n{}%s %.3f %.3f %.3f' % (new_poly, prevwedge.end[0], prevwedge.end[1], prevwedge.end[2]))
-          self.out.write('\n{} %.3f %.3f %.3f' % (wheel_center[0], wheel_center[1], wheel_center[2]))
+          kin_out += '\n{}%s %.3f %.3f %.3f' % (new_poly, prevwedge.end[0], prevwedge.end[1], prevwedge.end[2])
+          kin_out += '\n{} %.3f %.3f %.3f' % (wheel_center[0], wheel_center[1], wheel_center[2])
         else:
           prevwedge = wedge
           continue
         prevwedge = wedge
         new_poly=''
     #----------------------------
-    self.out.write('\n')
+    kin_out += '\n'
+    # Write to self.out for backward compatibility with standalone use
+    if self.out is not None:
+      self.out.write(kin_out)
+    return kin_out
   #-----------------------------------------------------------------------------
   #}}}
 

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -41,7 +41,8 @@ class clashscore2(validation):
     "fast",
     "condensed_probe",
     "probe_file",
-    "probe_clashscore_manager"
+    "probe_clashscore_manager",
+    "hydrogenated_model"
   ]
   program_description = "Analyze clashscore for protein model"
   gui_list_headers = ["Atom 1", "Atom 2", "Overlap"]
@@ -74,6 +75,7 @@ class clashscore2(validation):
     self.clash_dict_b_cutoff = {}
     self.list_dict = {}
     self.probe_file = None
+    self.hydrogenated_model = None
     if verbose:
       if not nuclear:
         print("\nUsing electron cloud x-H distances and vdW radii")
@@ -97,6 +99,9 @@ class clashscore2(validation):
       keep_hydrogens=keep_hydrogens,
       do_flips = do_flips,
       log=out)
+
+    # Save the hydrogenated model for downstream use (e.g. kinemage generation)
+    self.hydrogenated_model = data_manager_model
 
     # First we must rebuild the model from the new hierarchy so that the copy can succeed.
     # Make a copy of the original model to use for submodel processing, we'll trim atoms out

--- a/mmtbx/validation/ramalyze.py
+++ b/mmtbx/validation/ramalyze.py
@@ -493,12 +493,17 @@ class ramalyze(validation):
     #atom.id_str() returns 'pdb=" CA  LYS    16 "'
     #The [9:-1] slice gives ' LYS    16 '
     if None in c_alphas: return ''
+    # Draw from midpoint(prev_CA, central_CA) -> central_CA ->
+    # midpoint(central_CA, next_CA) so the markup spans only the region
+    # around the central residue, matching the old MolProbity/prekin style.
+    mid_01 = tuple((a + b) / 2.0 for a, b in zip(c_alphas[0].xyz, c_alphas[1].xyz))
+    mid_12 = tuple((a + b) / 2.0 for a, b in zip(c_alphas[1].xyz, c_alphas[2].xyz))
     ram_out = "{%s CA}P %s\n" % (c_alphas[0].id_str()[9:-1], "%.3f %.3f %.3f" %
-      c_alphas[0].xyz)
+      mid_01)
     ram_out += "{%s CA} %s\n" % (c_alphas[1].id_str()[9:-1], "%.3f %.3f %.3f" %
       c_alphas[1].xyz)
     ram_out += "{%s CA} %s\n" % (c_alphas[2].id_str()[9:-1], "%.3f %.3f %.3f" %
-      c_alphas[2].xyz)
+      mid_12)
     return ram_out
 
   def as_kinemage(self, chain_id=None):

--- a/mmtbx/validation/ramalyze.py
+++ b/mmtbx/validation/ramalyze.py
@@ -501,12 +501,13 @@ class ramalyze(validation):
       c_alphas[2].xyz)
     return ram_out
 
-  def as_kinemage(self):
+  def as_kinemage(self, chain_id=None):
     ram_out = "@subgroup {Rama outliers} master= {Rama outliers}\n"
     ram_out += "@vectorlist {bad Rama Ca} width= 4 color= green\n"
     for rama in self.results :
       if rama.is_outlier():
-        ram_out += rama.as_kinemage()
+        if chain_id is None or rama.chain_id == chain_id:
+          ram_out += rama.as_kinemage()
     return ram_out
 
   def as_coot_data(self):

--- a/mmtbx/validation/rna_validate.py
+++ b/mmtbx/validation/rna_validate.py
@@ -448,6 +448,86 @@ class rna_puckers(rna_geometry):
     data['summary_results'] = summary_results
     return json.dumps(data, indent=2)
 
+  def as_kinemage(self, chain_id=None, pdb_hierarchy=None):
+    """Return kinemage markup for pperp outliers (magenta vectorlist).
+
+    Uses stored pucker_perp_xyz and pucker_dist data. Needs pdb_hierarchy
+    only to find C1' atom for arrow direction.
+    """
+    from mmtbx.kinemage import kin_vec
+    from scitbx import matrix
+    kin_out = ""
+    outlier_key_list = []
+    for outlier in self.results:
+      if chain_id is not None and outlier.chain_id != chain_id:
+        continue
+      outlier_key_list.append(outlier.id_str())
+    if not outlier_key_list:
+      return ""
+    kin_out += "@vectorlist {ext} color= magenta master= {base-P perp}\n"
+    for key in outlier_key_list:
+      if key not in self.pucker_perp_xyz:
+        continue
+      if self.pucker_perp_xyz[key][0] is not None:
+        perp_xyz = self.pucker_perp_xyz[key][0]
+      else:
+        perp_xyz = self.pucker_perp_xyz[key][1]
+      if self.pucker_dist[key][0] is not None:
+        perp_dist = self.pucker_dist[key][0]
+        if perp_dist < 2.9:
+          pucker_text = " 2'?"
+        else:
+          pucker_text = " 3'?"
+      else:
+        perp_dist = self.pucker_dist[key][1]
+        if perp_dist < 2.4:
+          pucker_text = " 2'?"
+        else:
+          pucker_text = " 3'?"
+      display_key = key + pucker_text
+      kin_out += kin_vec(display_key, perp_xyz[0], display_key, perp_xyz[1])
+      # Draw arrow pointing away from C1'
+      c1_xyz = None
+      if pdb_hierarchy is not None:
+        for model in pdb_hierarchy.models():
+          for chain_obj in model.chains():
+            if chain_id is not None and chain_obj.id != chain_id:
+              continue
+            for conformer in chain_obj.conformers():
+              for res in conformer.residues():
+                c1_atom = res.find_atom_by(name=" C1'")
+                if c1_atom is not None:
+                  # Build key for this residue to match
+                  res_key = "%2s%4s%1s%1s%3s" % (
+                    chain_obj.id, res.resseq, res.icode,
+                    conformer.altloc, res.resname)
+                  if res_key == key:
+                    c1_xyz = c1_atom.xyz
+                    break
+              if c1_xyz is not None:
+                break
+            if c1_xyz is not None:
+              break
+          if c1_xyz is not None:
+            break
+      if c1_xyz is None:
+        continue
+      a = matrix.col(perp_xyz[1])
+      b = matrix.col(c1_xyz)
+      c = (a - b).normalize()
+      new = a - (c * .8)
+      kin_out += kin_vec(display_key, perp_xyz[1], display_key, tuple(new), 4)
+      new = a + (c * .4)
+      kin_out += kin_vec(display_key, perp_xyz[1], display_key, tuple(new), 4)
+      r_vec = matrix.col(perp_xyz[1]) - matrix.col(perp_xyz[0])
+      r = r_vec.axis_and_angle_as_r3_rotation_matrix(angle=90, deg=True)
+      new = r * (new - a) + a
+      kin_out += kin_vec(display_key, perp_xyz[1], display_key, tuple(new), 4)
+      r = r_vec.axis_and_angle_as_r3_rotation_matrix(angle=180, deg=True)
+      new = r * (new - a) + a
+      kin_out += kin_vec(display_key, perp_xyz[1], display_key, tuple(new), 4)
+    return kin_out
+
   def show_summary(self, out=sys.stdout, prefix=""):
     if (self.n_total == 0):
       print(prefix + "No RNA sugar groups found.", file=out)
@@ -515,6 +595,10 @@ class rna_validation(slots_getstate_setstate):
     #  pdb_hierarchy=pdb_hierarchy,
     #  geometry_restraints_manager=geometry_restraints_manager,
     #  outliers_only=outliers_only)
+
+  def as_kinemage(self, chain_id=None, pdb_hierarchy=None):
+    return self.puckers.as_kinemage(chain_id=chain_id,
+      pdb_hierarchy=pdb_hierarchy)
 
   def show_summary(self, out=sys.stdout, prefix=""):
     pass

--- a/mmtbx/validation/rotalyze.py
+++ b/mmtbx/validation/rotalyze.py
@@ -339,6 +339,66 @@ class rotalyze(validation):
     data['summary_results'] = summary_results
     return json.dumps(data, indent=2)
 
+  def as_kinemage(self, chain_id=None, pdb_hierarchy=None):
+    """Return kinemage markup string for rotamer outlier sidechains.
+
+    Requires pdb_hierarchy to look up atom coordinates and bond connectivity.
+    """
+    from mmtbx.chemical_components import get_bond_pairs
+    from mmtbx.kinemage import kin_vec
+    mc_atoms = ["N", "C", "O", "OXT"]
+    outlier_ids = set()
+    for outlier in self.results:
+      if not outlier.is_outlier():
+        continue
+      if chain_id is not None and outlier.chain_id != chain_id:
+        continue
+      outlier_ids.add(outlier.atom_group_id_str())
+    if not outlier_ids or pdb_hierarchy is None:
+      return ""
+    rot_out = "@subgroup {Rota outliers} dominant\n"
+    rot_out += "@vectorlist {chain %s} color= gold  master= {Rota outliers}\n" % (
+      chain_id if chain_id is not None else "all")
+    found = False
+    for model in pdb_hierarchy.models():
+      for chain in model.chains():
+        if chain_id is not None and chain.id != chain_id:
+          continue
+        for residue_group in chain.residue_groups():
+          for atom_group in residue_group.atom_groups():
+            if atom_group.id_str() not in outlier_ids:
+              continue
+            key_hash = {}
+            xyz_hash = {}
+            for atom in atom_group.atoms():
+              key = "%s %s %s%s  B%.2f" % (
+                atom.name.lower(),
+                atom_group.resname.lower(),
+                chain.id,
+                residue_group.resid(),
+                atom.b)
+              key_hash[atom.name.strip()] = key
+              xyz_hash[atom.name.strip()] = atom.xyz
+            bonds = get_bond_pairs(code=atom_group.resname)
+            for bond in bonds:
+              if bond[0] in mc_atoms or bond[1] in mc_atoms:
+                continue
+              elif bond[0].startswith('H') or bond[1].startswith('H'):
+                continue
+              if (key_hash.get(bond[0]) is None or
+                  key_hash.get(bond[1]) is None or
+                  xyz_hash.get(bond[0]) is None or
+                  xyz_hash.get(bond[1]) is None):
+                continue
+              rot_out += kin_vec(key_hash[bond[0]],
+                                 xyz_hash[bond[0]],
+                                 key_hash[bond[1]],
+                                 xyz_hash[bond[1]])
+              found = True
+    if not found:
+      return ""
+    return rot_out
+
   def as_coot_data(self):
     data = []
     for result in self.results :

--- a/mmtbx/validation/utils.py
+++ b/mmtbx/validation/utils.py
@@ -225,8 +225,8 @@ def calculate_overall_residue_quality_score(
               is_glycine (bool), is_cbeta_outlier (bool), cbeta_deviation (float),
               cablam_outlier_type (str),
               omega_type (str), is_proline (bool),
-              num_bond_outliers_res (int), worst_bond_sigma (float),
-              num_angle_outliers_res (int), worst_angle_sigma (float),
+              num_bond_outliers_res (int), worst_bond_deviation (float, sigma),
+              num_angle_outliers_res (int), worst_angle_deviation (float, sigma),
               num_chiral_handedness_res (int), num_chiral_tetrahedral_res (int),
               num_chiral_pseudochiral_res (int),
               num_chiral_outliers_res (int, fallback if typed counts unavailable),
@@ -293,14 +293,14 @@ def calculate_overall_residue_quality_score(
     num_bond_outliers = get('num_bond_outliers_res', 0)
     if num_bond_outliers > 0:
         has_any_metric = True
-        worst_bond = get('worst_bond_sigma')
+        worst_bond = get('worst_bond_deviation')
         severities.append(_bond_angle_severity(num_bond_outliers, worst_bond))
 
     # --- 8. Bond Angles ---
     num_angle_outliers = get('num_angle_outliers_res', 0)
     if num_angle_outliers > 0:
         has_any_metric = True
-        worst_angle = get('worst_angle_sigma')
+        worst_angle = get('worst_angle_deviation')
         severities.append(_bond_angle_severity(num_angle_outliers, worst_angle))
 
     # --- 9. Chirality ---


### PR DESCRIPTION
## Summary

Moves MolProbity kinemage generation out of standalone wrapper functions in
`mmtbx/kinemage/validation.py` and into per-validator `as_kinemage()` methods, so each
validator owns its own kinemage output, and adds a reusable probe-dot path.

Three focused commits:

1. **Move kinemage generation into individual validation classes.** Adds `as_kinemage()`
   methods to `rotalyze`, `ramalyze`, `rna_puckers`, and `cablam`. Removes the old
   `rotamer_outliers()`, `rama_outliers()`, and `pperp_outliers()` wrapper functions from
   `kinemage/validation.py` (and their now-unused imports). `_build_kinemage`,
   `make_multikin`, and `export_molprobity_result_as_kinemage` now call those methods and
   wire in omega, RNA-pucker, and CaBLAM results.

2. **Fix Rama outlier kinemage markup to draw from CA midpoints** — the highlight now spans
   only the half-region around the central residue, matching the old MolProbity/prekin style.

3. **Add `make_probe_dots_from_model()`** to reuse an already-hydrogenated model for probe
   dots (skipping reduce2/Optimizer), plus a `probe_dots_kin` param on `_build_kinemage` to
   accept pre-computed dots, and save the hydrogenated model on `clashscore2` for downstream
   reuse. The default path is unchanged (`probe_dots_kin=None` → `make_probe_dots`).

## Notes

- Ribbon rendering and secondary-structure (`ss_bonds`/`ss_annotation`) plumbing that
  accompanied this work on the source branch are intentionally **deferred to a later PR**;
  this PR is scoped to the `as_kinemage()` migration + omega/RNA/CaBLAM + probe-dot reuse.

## Testing

- `mmtbx/kinemage/tst_validation.py` — all groups OK.
- phenix_regression `validation/tst_kinemage.py` — OK (probe dots non-empty, 69 greentint
  on the test structure).
- `tst_rotalyze`, `tst_ramalyze`, `tst_cablam`, `tst_rna_validate` — OK.
- `phenix.kinemage` on a full model (1nxbH) renders all sections (Rama/Rota/Cbeta/CaBLAM/
  omega) with non-empty probe dots.
- `libtbx.find_clutter` clean (exit 0); `py_compile` clean.
