### PR TITLE
Fix water/ligand classification and single-atom het rendering in kinemage

### DIFF
--- a/mmtbx/kinemage/tst_validation.py
+++ b/mmtbx/kinemage/tst_validation.py
@@ -38,8 +38,8 @@ END
 """
 
 
-# PDB with hets (SO4 ligand), ions (ZN), and waters (HOH + WAT)
-# to test het/ion/water handling
+# PDB with hets (SO4 ligand), ions (ZN), waters (HOH + WAT),
+# and a single-atom SO4 (like in 1nxb) to test het/ion/water handling
 pdb_het_str = """\
 CRYST1   30.000   30.000   30.000  90.00  90.00  90.00 P 1
 ATOM      1  N   ALA A   1       1.000   1.000   1.000  1.00 10.00           N
@@ -55,6 +55,7 @@ HETATM   10  O3  SO4 A 200      14.800  13.800  15.800  1.00 20.00           O
 HETATM   11  O4  SO4 A 200      15.300  15.200  13.600  1.00 20.00           O
 HETATM   12  O   HOH A 301      20.000  20.000  20.000  1.00 25.00           O
 HETATM   13  O   WAT A 302      22.000  22.000  22.000  1.00 25.00           O
+HETATM   14  S   SO4 A 400      25.000  25.000  25.000  1.00 20.00           S
 END
 """
 
@@ -334,6 +335,20 @@ def exercise_het_ion_water():
           het_section += line + "\n"
       assert "wat" not in het_section.lower(), \
         "WAT should be drawn as water ball, not as het bonds"
+
+      # Single-atom SO4 (res 400) should appear as a sphere in the ion list,
+      # not be invisible. This tests the fix for structures like 1nxb where
+      # SO4 has only an S atom.
+      ion_section = ""
+      in_ion = False
+      for line in kin_out.splitlines():
+        if "@spherelist {het M}" in line:
+          in_ion = True
+        if in_ion:
+          ion_section += line + "\n"
+      # The single-atom SO4 should be in the ion spherelist alongside ZN
+      assert " s  " in ion_section.lower() or "so4" in ion_section.lower(), \
+        "Single-atom SO4 should appear in ion spherelist"
 
   print("  exercise_het_ion_water: OK")
 

--- a/mmtbx/kinemage/tst_validation.py
+++ b/mmtbx/kinemage/tst_validation.py
@@ -38,6 +38,27 @@ END
 """
 
 
+# PDB with hets (SO4 ligand), ions (ZN), and waters (HOH + WAT)
+# to test het/ion/water handling
+pdb_het_str = """\
+CRYST1   30.000   30.000   30.000  90.00  90.00  90.00 P 1
+ATOM      1  N   ALA A   1       1.000   1.000   1.000  1.00 10.00           N
+ATOM      2  CA  ALA A   1       2.458   1.000   1.000  1.00 10.00           C
+ATOM      3  C   ALA A   1       3.009   2.425   1.000  1.00 10.00           C
+ATOM      4  O   ALA A   1       2.249   3.390   1.000  1.00 10.00           O
+ATOM      5  CB  ALA A   1       2.982   0.231   2.207  1.00 10.00           C
+HETATM    6 ZN    ZN A 100      10.000  10.000  10.000  1.00 15.00          ZN
+HETATM    7  S   SO4 A 200      15.000  15.000  15.000  1.00 20.00           S
+HETATM    8  O1  SO4 A 200      16.200  15.500  15.200  1.00 20.00           O
+HETATM    9  O2  SO4 A 200      14.200  16.000  15.500  1.00 20.00           O
+HETATM   10  O3  SO4 A 200      14.800  13.800  15.800  1.00 20.00           O
+HETATM   11  O4  SO4 A 200      15.300  15.200  13.600  1.00 20.00           O
+HETATM   12  O   HOH A 301      20.000  20.000  20.000  1.00 25.00           O
+HETATM   13  O   WAT A 302      22.000  22.000  22.000  1.00 25.00           O
+END
+"""
+
+
 def exercise_build_kinemage():
   """Test that _build_kinemage produces valid kinemage output with expected
   sections."""
@@ -242,6 +263,81 @@ def exercise_deleted_functions():
   print("  exercise_deleted_functions: OK")
 
 
+def exercise_het_ion_water():
+  """Test handling of heteroatoms (ligands), ions, and waters."""
+  from mmtbx.kinemage.validation import (
+    build_name_hash, _build_bond_hash, get_kin_lots)
+  from mmtbx.monomer_library import pdb_interpretation
+  from mmtbx import monomer_library
+  from cctbx import geometry_restraints
+  from iotbx import pdb
+
+  pdb_io = pdb.input(source_info=None, lines=pdb_het_str)
+  mon_lib_srv = monomer_library.server.server()
+  ener_lib = monomer_library.server.ener_lib()
+  processed_pdb_file = pdb_interpretation.process(
+    mon_lib_srv=mon_lib_srv,
+    ener_lib=ener_lib,
+    pdb_inp=pdb_io,
+    substitute_non_crystallographic_unit_cell_if_necessary=True)
+
+  hierarchy = processed_pdb_file.all_chain_proxies.pdb_hierarchy
+  sites_cart = processed_pdb_file.all_chain_proxies.sites_cart
+  geometry = processed_pdb_file.geometry_restraints_manager()
+  i_seq_name_hash = build_name_hash(pdb_hierarchy=hierarchy)
+  flags = geometry_restraints.flags.flags(default=True)
+  pair_proxies = geometry.pair_proxies(flags=flags, sites_cart=sites_cart)
+  bond_proxies = pair_proxies.bond_proxies
+  quick_bond_hash = _build_bond_hash(bond_proxies, i_seq_name_hash)
+
+  for model in hierarchy.models():
+    for chain in model.chains():
+      kin_out = get_kin_lots(
+        chain=chain,
+        bond_hash=quick_bond_hash,
+        i_seq_name_hash=i_seq_name_hash,
+        pdbID="het_test",
+        index=0)
+
+      # Ion (ZN) should appear as a spherelist
+      assert "@spherelist {het M}" in kin_out, "Missing ion spherelist"
+      assert "color= gray" in kin_out, "Ion spherelist should be gray"
+      # The ZN key should appear in the ion spherelist
+      assert "zn" in kin_out.lower(), "ZN ion not found in output"
+
+      # SO4 ligand should have het bonds drawn (pink vectorlist)
+      assert "@vectorlist {het}" in kin_out, "Missing het vectorlist"
+      assert "color= pink" in kin_out, "Het bonds should be pink"
+      # SO4 has S-O bonds that should be drawn
+      assert "so4" in kin_out.lower(), "SO4 ligand not found in output"
+
+      # HOH water should appear as a balllist
+      assert "@balllist {water O}" in kin_out, "Missing water balllist"
+      assert "peachtint" in kin_out, "Water balllist should be peachtint"
+
+      # WAT water should ALSO appear as a water ball (not as a het)
+      # This tests the fix: using res_class == "common_water" instead of
+      # resname.lower() == 'hoh'
+      water_lines = [l for l in kin_out.splitlines()
+                     if "wat" in l.lower() and "water" not in l.lower()
+                     and "hoh" not in l.lower()]
+      # WAT should NOT appear in the het vectorlist
+      het_section = ""
+      in_het = False
+      for line in kin_out.splitlines():
+        if "@vectorlist {het}" in line:
+          in_het = True
+          continue
+        if in_het and line.startswith("@"):
+          in_het = False
+        if in_het:
+          het_section += line + "\n"
+      assert "wat" not in het_section.lower(), \
+        "WAT should be drawn as water ball, not as het bonds"
+
+  print("  exercise_het_ion_water: OK")
+
+
 def run():
   print("Testing mmtbx.kinemage.validation:")
   exercise_helper_functions()
@@ -249,6 +345,7 @@ def run():
   exercise_altloc_handling()
   exercise_build_kinemage()
   exercise_make_multikin()
+  exercise_het_ion_water()
   print("All tests passed.")
 
 

--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -541,16 +541,7 @@ def _draw_residue_bonds(residue, bond_hash, i_seq_name_hash, key_hash,
         continue
       is_hydrogen = (atom_1.startswith('H') or atom_2.startswith('H') or
                      atom_1.startswith('D') or atom_2.startswith('D'))
-      if res_class in ('other', 'common_small_molecule'):
-        if is_hydrogen:
-          if show_hydrogen and atom_1 in het_hash and atom_2 in het_hash:
-            result['het_h'] += kin_vec(het_hash[atom_1][0], het_hash[atom_1][1],
-                                       het_hash[atom_2][0], het_hash[atom_2][1])
-        else:
-          if atom_1 in het_hash and atom_2 in het_hash:
-            result['het'] += kin_vec(het_hash[atom_1][0], het_hash[atom_1][1],
-                                     het_hash[atom_2][0], het_hash[atom_2][1])
-      elif res_class in ("common_amino_acid", "common_rna_dna"):
+      if res_class in ("common_amino_acid", "common_rna_dna"):
         if atom_1 in mc_atoms and atom_2 in mc_atoms:
           # Skip inter-residue bonds handled separately (C-N, O3'-P)
           if not ((atom_1 == "C" and atom_2 == "N") or
@@ -569,6 +560,17 @@ def _draw_residue_bonds(residue, bond_hash, i_seq_name_hash, key_hash,
           result['sc'] += kin_vec(key_hash[atom_1], xyz_hash[atom_1],
                                   key_hash[atom_2], xyz_hash[atom_2])
         drawn_bonds.append(drawn_key)
+      else:
+        # Het/ligand bonds (covers 'other', 'common_small_molecule',
+        # 'common_saccharide', and any other non-polymer classes)
+        if is_hydrogen:
+          if show_hydrogen and atom_1 in het_hash and atom_2 in het_hash:
+            result['het_h'] += kin_vec(het_hash[atom_1][0], het_hash[atom_1][1],
+                                       het_hash[atom_2][0], het_hash[atom_2][1])
+        else:
+          if atom_1 in het_hash and atom_2 in het_hash:
+            result['het'] += kin_vec(het_hash[atom_1][0], het_hash[atom_1][1],
+                                     het_hash[atom_2][0], het_hash[atom_2][1])
   return result
 
 def get_kin_lots(chain, bond_hash, i_seq_name_hash, pdbID=None, index=0, show_hydrogen=True):
@@ -682,7 +684,7 @@ def get_kin_lots(chain, bond_hash, i_seq_name_hash, pdbID=None, index=0, show_hy
           elif res_class == "other" and len(residue.atoms()) == 1:
             ion_list += "{%s} %.3f %.3f %.3f\n" % (
               key, atom.xyz[0], atom.xyz[1], atom.xyz[2])
-          elif residue.resname.lower() == 'hoh':
+          elif res_class == "common_water":
             if atom.name == ' O  ':
               water_list += "{%s} P %.3f %.3f %.3f\n" % (
                 key, atom.xyz[0], atom.xyz[1], atom.xyz[2])

--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -681,13 +681,15 @@ def get_kin_lots(chain, bond_hash, i_seq_name_hash, pdbID=None, index=0, show_hy
           elif res_class == "common_element":
             ion_list += "{%s} %.3f %.3f %.3f\n" % (
               key, atom.xyz[0], atom.xyz[1], atom.xyz[2])
-          elif res_class == "other" and len(residue.atoms()) == 1:
-            ion_list += "{%s} %.3f %.3f %.3f\n" % (
-              key, atom.xyz[0], atom.xyz[1], atom.xyz[2])
           elif res_class == "common_water":
             if atom.name == ' O  ':
               water_list += "{%s} P %.3f %.3f %.3f\n" % (
                 key, atom.xyz[0], atom.xyz[1], atom.xyz[2])
+          elif len(residue.atoms()) == 1:
+            # Single-atom non-polymer residue (e.g., lone S from SO4,
+            # unknown ligand with one atom) — draw as a sphere
+            ion_list += "{%s} %.3f %.3f %.3f\n" % (
+              key, atom.xyz[0], atom.xyz[1], atom.xyz[2])
           else:
             het_hash[atom.name.strip()] = [key, atom.xyz]
 


### PR DESCRIPTION
## Summary

Two small fixes to how non-polymer residues (heteroatoms, ions, waters) are rendered in
the MolProbity kinemage output.

## What changed (`mmtbx/kinemage/validation.py`)

1. **Water and ligand classification** (`_draw_residue_bonds`, `get_kin_lots`):
   - Classify waters by residue class (`res_class == "common_water"`) instead of
     `resname == 'hoh'`, so `WAT`/`DOD` waters are drawn as water balls rather than pink
     het bonds.
   - Make het-bond drawing the `else` fallback, so non-polymer classes that aren't `other`
     or `common_small_molecule` (e.g. `common_saccharide` — NAG, MAN, …) get their bonds drawn.

2. **Single-atom het residues** (`get_kin_lots`): draw any single-atom non-polymer residue
   as a sphere (not just `res_class == "other"`). This covers cases like a lone `S` from an
   `SO4` that would otherwise be dropped (as happens in 1nxb).

## Testing

- New `exercise_het_ion_water` test in `tst_validation.py` exercises ions (ZN), an SO4
  ligand, `HOH`/`WAT` waters, and a single-atom SO4; the full `tst_validation.py` passes.
- `phenix_regression/validation/tst_kinemage.py` passes.
- Functional check on 1nxb: waters render as balls, the single-atom SO4 now appears in the
  ion spherelist, and probe-dot output is unchanged.
