### PR TITLE
Use structured atom-label dict instead of pdb_label_columns slicing in kinemage

### DIFF
--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -50,7 +50,15 @@ def get_master_phil():
 def build_name_hash(pdb_hierarchy):
   i_seq_name_hash = dict()
   for atom in pdb_hierarchy.atoms():
-    i_seq_name_hash[atom.i_seq]=atom.pdb_label_columns()
+    labels = atom.fetch_labels()
+    i_seq_name_hash[atom.i_seq] = {
+      'name':     labels.name,
+      'altloc':   labels.altloc,
+      'resname':  labels.resname,
+      'chain_id': labels.chain_id,
+      'resseq':   labels.resseq,
+      'icode':    labels.icode,
+    }
   return i_seq_name_hash
 
 
@@ -522,12 +530,10 @@ def _draw_residue_bonds(residue, bond_hash, i_seq_name_hash, key_hash,
     if cur_bonds is None:
       continue
     for bond in cur_bonds:
-      atom_1 = i_seq_name_hash.get(atom.i_seq)
-      if atom_1 is not None:
-        atom_1 = atom_1[0:4].strip()
-      atom_2 = i_seq_name_hash.get(bond)
-      if atom_2 is not None:
-        atom_2 = atom_2[0:4].strip()
+      info_1 = i_seq_name_hash.get(atom.i_seq)
+      atom_1 = info_1['name'].strip() if info_1 is not None else None
+      info_2 = i_seq_name_hash.get(bond)
+      atom_2 = info_2['name'].strip() if info_2 is not None else None
       if atom_1 is None or atom_2 is None:
         continue
       # handle altlocs
@@ -741,8 +747,8 @@ def get_kin_lots(chain, bond_hash, i_seq_name_hash, pdbID=None, index=0,
     # Collect i_seqs involved in SS bonds for this chain
     ss_i_seqs = set()
     for i_seq_0, i_seq_1 in ss_bonds:
-      name_0 = i_seq_name_hash.get(i_seq_0)
-      if name_0 is not None and name_0[8:10].strip() == chain.id:
+      info_0 = i_seq_name_hash.get(i_seq_0)
+      if info_0 is not None and info_0['chain_id'] == chain.id:
         ss_i_seqs.add(i_seq_0)
         ss_i_seqs.add(i_seq_1)
     # Build B-factor lookup for just the SS atoms we need
@@ -751,21 +757,21 @@ def get_kin_lots(chain, bond_hash, i_seq_name_hash, pdbID=None, index=0,
       for atom in chain.parent().parent().atoms():
         if atom.i_seq in ss_i_seqs:
           b_hash[atom.i_seq] = atom.b
-    def _ss_key(name, i_seq):
-      return "%s%s%s %s%s  B%.2f %s" % (
-        name[0:4].lower(), name[4:5].lower(), name[5:8].lower(),
-        name[8:10].strip(), name[10:15], b_hash.get(i_seq, 0.0), pdbID)
+    def _ss_key(info, i_seq):
+      return "%s%s%s %s%s%s  B%.2f %s" % (
+        info['name'].lower(), info['altloc'].lower(), info['resname'].lower(),
+        info['chain_id'], info['resseq'], info['icode'],
+        b_hash.get(i_seq, 0.0), pdbID)
     for i_seq_0, i_seq_1 in ss_bonds:
-      name_0 = i_seq_name_hash.get(i_seq_0)
-      name_1 = i_seq_name_hash.get(i_seq_1)
-      if name_0 is None or name_1 is None:
+      info_0 = i_seq_name_hash.get(i_seq_0)
+      info_1 = i_seq_name_hash.get(i_seq_1)
+      if info_0 is None or info_1 is None:
         continue
       # Only draw when the first atom belongs to this chain (avoid duplicates)
-      # pdb_label_columns format: name(4) altloc(1) resname(3) chain(2) resseq(4) icode(1)
-      if name_0[8:10].strip() != chain.id:
+      if info_0['chain_id'] != chain.id:
         continue
-      key_0 = _ss_key(name_0, i_seq_0)
-      key_1 = _ss_key(name_1, i_seq_1)
+      key_0 = _ss_key(info_0, i_seq_0)
+      key_1 = _ss_key(info_1, i_seq_1)
       ss_veclist += kin_vec(key_0, sites_cart[i_seq_0],
                             key_1, sites_cart[i_seq_1])
     if len(ss_veclist.splitlines()) > 1:
@@ -845,28 +851,28 @@ def _build_ss_bond_list(bond_proxies, i_seq_name_hash):
   Returns a list of (i_seq_0, i_seq_1) tuples for each SS bond."""
   ss_bonds = []
   for bp in bond_proxies.simple:
-    name_0 = i_seq_name_hash.get(bp.i_seqs[0])
-    name_1 = i_seq_name_hash.get(bp.i_seqs[1])
-    if name_0 is None or name_1 is None:
+    info_0 = i_seq_name_hash.get(bp.i_seqs[0])
+    info_1 = i_seq_name_hash.get(bp.i_seqs[1])
+    if info_0 is None or info_1 is None:
       continue
-    # pdb_label_columns: [0:4] atom name, [4:8] altloc+resname, [8:14] resname+chain+resseq
-    # atom name " SG " at [0:4], resname "CYS" at [5:8] (or check [4:8] for " CYS"/"ACYS" etc.)
-    atom_name_0 = name_0[0:4].strip()
-    atom_name_1 = name_1[0:4].strip()
-    resname_0 = name_0[5:8].strip()
-    resname_1 = name_1[5:8].strip()
-    if (atom_name_0 == "SG" and atom_name_1 == "SG" and
-        resname_0 == "CYS" and resname_1 == "CYS"):
+    if (info_0['name'].strip() == "SG" and info_1['name'].strip() == "SG" and
+        info_0['resname'].strip() == "CYS" and info_1['resname'].strip() == "CYS"):
       ss_bonds.append((bp.i_seqs[0], bp.i_seqs[1]))
   return ss_bonds
+
+def _same_residue(info_a, info_b):
+  """Check whether two atom info dicts belong to the same residue."""
+  return (info_a['chain_id'] == info_b['chain_id'] and
+          info_a['resseq'] == info_b['resseq'] and
+          info_a['icode'] == info_b['icode'])
 
 def _build_bond_hash(bond_proxies, i_seq_name_hash):
   """Build a hash mapping atom i_seq to bonded atom i_seqs within the same
   residue. Shared by make_multikin and export_molprobity_result_as_kinemage."""
   quick_bond_hash = {}
   for bp in bond_proxies.simple:
-    if (i_seq_name_hash[bp.i_seqs[0]][9:14] ==
-        i_seq_name_hash[bp.i_seqs[1]][9:14]):
+    if _same_residue(i_seq_name_hash[bp.i_seqs[0]],
+                     i_seq_name_hash[bp.i_seqs[1]]):
       if quick_bond_hash.get(bp.i_seqs[0]) is None:
         quick_bond_hash[bp.i_seqs[0]] = []
       quick_bond_hash[bp.i_seqs[0]].append(bp.i_seqs[1])
@@ -884,7 +890,8 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
   Args:
     hierarchy: PDB hierarchy
     bond_hash: mapping of atom i_seq to bonded i_seqs (from _build_bond_hash)
-    i_seq_name_hash: mapping of i_seq to pdb_label_columns (from build_name_hash)
+    i_seq_name_hash: mapping of i_seq to a dict of atom label fields
+      (name/altloc/resname/chain_id/resseq/icode, from build_name_hash)
     pdbID: structure identifier string
     rot_outliers: rotalyze result object
     rama_result: ramalyze result object

--- a/mmtbx/validation/cablam.py
+++ b/mmtbx/validation/cablam.py
@@ -1470,7 +1470,7 @@ class cablamalyze(validation):
     #Pdb-to-kinemage printing has been hijacked from mmtbx.kinemage.validation
     #  That code was not meant to be used outside its original context, so this
     #  may be fragile.
-    from mmtbx.kinemage.validation import get_kin_lots, build_name_hash
+    from mmtbx.kinemage.validation import get_kin_lots, build_name_hash, _build_bond_hash
     from mmtbx import monomer_library
     from mmtbx.monomer_library import pdb_interpretation
     i_seq_name_hash = build_name_hash(pdb_hierarchy=self.pdb_hierarchy)
@@ -1488,12 +1488,7 @@ class cablamalyze(validation):
     #angle_proxies = geometry.angle_proxies
     pair_proxies = geometry.pair_proxies(flags=flags, sites_cart=sites_cart)
     bond_proxies = pair_proxies.bond_proxies
-    quick_bond_hash = {}
-    for bp in bond_proxies.simple:
-      if (i_seq_name_hash[bp.i_seqs[0]][9:14] == i_seq_name_hash[bp.i_seqs[1]][9:14]):
-        if quick_bond_hash.get(bp.i_seqs[0]) is None:
-          quick_bond_hash[bp.i_seqs[0]] = []
-        quick_bond_hash[bp.i_seqs[0]].append(bp.i_seqs[1])
+    quick_bond_hash = _build_bond_hash(bond_proxies, i_seq_name_hash)
 
     for model in self.pdb_hierarchy.models():
       for chain in model.chains():


### PR DESCRIPTION
## Summary

Refactors the kinemage code to identify atoms by a structured dict of label fields
instead of slicing a fixed-width `pdb_label_columns()` string. This fixes CIF
compatibility, where chain IDs, residue names, and atom names can exceed the classic
PDB column widths and would break fixed-offset slicing.

## What changed

**`mmtbx/kinemage/validation.py`**
- `build_name_hash()` now stores a dict per atom — `name`, `altloc`, `resname`,
  `chain_id`, `resseq`, `icode` (via `atom.fetch_labels()`) — instead of the
  `pdb_label_columns()` string.
- All consumers updated to read named fields instead of fixed offsets:
  `_draw_residue_bonds`, the SS-bond drawing in `get_kin_lots`, `_build_ss_bond_list`,
  and `_build_bond_hash`.
- Adds a small `_same_residue(info_a, info_b)` helper (replaces the `[9:14]` slice
  equality used to group intra-residue bonds).

**`mmtbx/validation/cablam.py`**
- `cablamalyze.as_full_kinemage()` now uses the shared `_build_bond_hash` helper
  instead of an inline copy of the (now dict-based) bond-hash logic.

## Notes

- Blast radius is limited to these two files: `cablam.py` is the only module that
  imports `build_name_hash` from `mmtbx.kinemage.validation`. The identically-named
  helpers in `mmtbx/validation/utils.py` and
  `mmtbx/geometry_restraints/torsion_restraints/utils.py` are separate and untouched.
- The original commit also converted the `pperp_outliers`/`rama_outliers`/
  `rotamer_outliers` wrapper functions, but those were already removed upstream (their
  logic now lives in the validation classes' `as_kinemage()`), so that part is dropped.

## Testing

- `mmtbx/kinemage/tst_validation.py`, `phenix_regression/validation/tst_kinemage.py`,
  `tst_cablam.py`, `tst_cablam_2.py` all pass.
- Direct check of `cablamalyze.as_full_kinemage()` produces valid vectorlist output
  through the new dict path.
- Functional `phenix.kinemage` on 1nxb: disulfides, het/water rendering, and probe
  dots are all unchanged.
