### PR TITLE
Extract ribbon rendering into a reusable module and add to MolProbity kinemage

### DIFF
--- a/mmtbx/kinemage/ribbon_rendering.py
+++ b/mmtbx/kinemage/ribbon_rendering.py
@@ -1,0 +1,740 @@
+"""Ribbon rendering for kinemage output.
+
+Extracted from mmtbx/programs/ribbons.py into standalone classes and functions
+that can be reused by both the standalone ribbon program and the MolProbity
+kinemage validation pipeline.
+
+Uses scitbx.matrix.col throughout instead of numpy for consistency with the
+rest of the kinemage code.
+"""
+
+from __future__ import absolute_import, division, print_function
+from scitbx.matrix import col
+from mmtbx.kinemage.nrubs import Triple, NRUBS
+from mmtbx.kinemage.ribbons import (
+    find_contiguous_protein_residues, find_contiguous_nucleic_acid_residues,
+    make_protein_guidepoints, make_nucleic_acid_guidepoints,
+    untwist_ribbon, swap_edge_and_face, _FindNamedAtomInResidue,
+    _IsNucleicAcidResidue, chain_has_DNA, chain_has_RNA)
+
+
+class Crayon(object):
+  """Controls per-point coloring for ribbon kinemage output.
+
+  Can produce rainbow coloring (smoothly varying across a chain) or a
+  constant color string.
+  """
+
+  _rainbowColors = [
+      "blue", "sky", "cyan", "sea", "green",
+      "lime", "yellow", "gold", "orange", "red"]
+
+  def __init__(self, do_rainbow, color=None):
+    self._do_rainbow = do_rainbow
+    self._color = color
+
+  def for_ribbon(self, start_guide):
+    """Update color based on the ribbon position (rainbow mode only)."""
+    if self._do_rainbow:
+      res = start_guide.prevRes
+      chain = res.parent()
+      first_resid = chain.residue_groups()[0].resseq_as_int()
+      last_resid = chain.residue_groups()[-1].resseq_as_int()
+      denom = last_resid - first_resid
+      if denom == 0:
+        norm_res = 0.0
+      else:
+        norm_res = (res.resseq_as_int() - first_resid) / denom
+      scaled_index = int(norm_res * len(self._rainbowColors))
+      if scaled_index >= len(self._rainbowColors):
+        scaled_index = len(self._rainbowColors) - 1
+      self._color = self._rainbowColors[scaled_index]
+
+  def get_kin_string(self):
+    if self._color is None:
+      return ""
+    return self._color
+
+  def should_print(self):
+    return True
+
+
+class Range(object):
+  """A secondary structure range (HELIX/SHEET/COIL) with sheet linkage info."""
+
+  def __init__(self, ss_type='COIL', chain_id='', init_seq=0, end_seq=0,
+               sense=0, strand=1, sheet_id=' ', flipped=False):
+    self.type = ss_type
+    self.chain_id = chain_id
+    self.initSeqNum = init_seq
+    self.endSeqNum = end_seq
+    self.sense = sense
+    self.strand = strand
+    self.sheetID = sheet_id
+    self.flipped = flipped
+    self.previous = None
+    self.next = None
+    self.duplicateOf = None
+
+  def __str__(self):
+    return ('Range: type={}, init={}, end={}, sense={}, strand={}, '
+            'sheet={}, flipped={}'.format(
+                self.type, self.initSeqNum, self.endSeqNum,
+                self.sense, self.strand, self.sheetID, self.flipped))
+
+
+class RibbonElement(object):
+  """A segment of rendered ribbon with start/end spline indices and SS type."""
+
+  def __init__(self, other=None, set_range=None):
+    self.start = 0
+    self.end = 0
+    self.type = 'COIL'
+    self.range = set_range
+    if other is not None:
+      self.like(other)
+    if self.range is not None:
+      if self.range.type is None or self.range.type == 'TURN':
+        self.type = 'COIL'
+      else:
+        self.type = self.range.type
+
+  def same_sse(self, that):
+    return self.type == that.type and self.range == that.range
+
+  def like(self, that):
+    self.start = that.start
+    self.end = that.end
+    self.type = that.type
+    self.range = that.range
+
+  def __lt__(self, that):
+    a = 0
+    b = 0
+    if self.range is not None:
+      a = self.range.strand
+    if that.range is not None:
+      b = that.range.strand
+    return a < b
+
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+
+def build_secondary_structure_map(hierarchy, annotation=None, log=None):
+  """Build dict[resseq_as_int -> Range] from an annotation object.
+
+  If annotation is None, computes SS via ksdssp. Uses annotation.helices
+  and annotation.sheets[].strands directly via get_start_resseq_as_int() /
+  get_end_resseq_as_int() instead of parsing PDB-format text records.
+
+  Args:
+    hierarchy: iotbx.pdb.hierarchy object
+    annotation: iotbx.pdb.secondary_structure.annotation, or None to compute
+    log: output stream for messages (may be None)
+
+  Returns:
+    dict mapping resseq_as_int -> Range
+  """
+  import mmtbx.secondary_structure
+
+  if log is None:
+    from libtbx.utils import null_out
+    log = null_out()
+
+  # Compute SS annotation if not provided
+  if annotation is None:
+    try:
+      params = mmtbx.secondary_structure.manager.get_default_ss_params()
+      params.secondary_structure.protein.search_method = "from_ca"
+      params = params.secondary_structure
+      ss_manager = mmtbx.secondary_structure.manager(
+          hierarchy,
+          params=params,
+          sec_str_from_pdb_file=None,
+          log=log)
+      annotation = ss_manager.actual_sec_str
+    except Exception:
+      annotation = None  # fall through to all-COIL
+
+  # Initialize all residues as COIL
+  ss_map = {}
+  for model in hierarchy.models():
+    for chain in model.chains():
+      for rg in chain.residue_groups():
+        ss_map[rg.resseq_as_int()] = Range()
+
+  if annotation is None or annotation.is_empty():
+    return ss_map
+
+  # Process helices
+  for helix in annotation.helices:
+    start = helix.get_start_resseq_as_int()
+    end = helix.get_end_resseq_as_int()
+    if start is None or end is None:
+      continue
+    r = Range(
+        ss_type='HELIX',
+        chain_id=helix.start_chain_id.strip() if helix.start_chain_id else '',
+        init_seq=start,
+        end_seq=end,
+        sheet_id=helix.helix_id.strip() if helix.helix_id else '')
+    for i in range(start, end + 1):
+      ss_map[i] = r
+
+  # Process sheets
+  for sheet in annotation.sheets:
+    for strand in sheet.strands:
+      start = strand.get_start_resseq_as_int()
+      end = strand.get_end_resseq_as_int()
+      if start is None or end is None:
+        continue
+      r = Range(
+          ss_type='SHEET',
+          chain_id=strand.start_chain_id.strip() if strand.start_chain_id else '',
+          init_seq=start,
+          end_seq=end,
+          sense=int(strand.sense) if strand.sense is not None else 0,
+          strand=int(strand.strand_id) if strand.strand_id is not None else 1,
+          sheet_id=sheet.sheet_id.strip() if sheet.sheet_id else ' ')
+      for i in range(start, end + 1):
+        ss_map[i] = r
+
+  return ss_map
+
+
+def consolidate_sheets(secondary_structure):
+  """Link sheet strand Range objects by setting previous/next/duplicateOf.
+
+  Args:
+    secondary_structure: dict[resseq_as_int -> Range] from
+        build_secondary_structure_map()
+  """
+  unique_strands = {}
+
+  for rng in secondary_structure.values():
+    if rng.type != 'SHEET':
+      continue
+
+    key = str(int(rng.initSeqNum)) + rng.chain_id
+    if key not in unique_strands:
+      unique_strands[key] = rng
+    else:
+      rng.duplicateOf = unique_strands[key]
+
+    for rng2 in secondary_structure.values():
+      if rng2.type != 'SHEET':
+        continue
+      if rng2.sheetID == rng.sheetID and rng2.strand == rng.strand - 1:
+        rng.previous = rng2
+        rng2.next = rng
+
+  for rng in secondary_structure.values():
+    if rng.type != 'SHEET':
+      continue
+    if rng.duplicateOf is None and rng.next is not None and rng.next.duplicateOf is not None:
+      rng.next.duplicateOf.previous = rng
+    if rng.duplicateOf is None and rng.previous is not None and rng.previous.duplicateOf is not None:
+      rng.previous = rng.previous.duplicateOf
+
+
+def spline_interpolate(points, n_intervals):
+  """Interpolate points using NRUBS B-spline.
+
+  Args:
+    points: list of scitbx.matrix.col (3D positions)
+    n_intervals: number of intervals between each pair of guide points
+
+  Returns:
+    list of scitbx.matrix.col
+  """
+  nrubs = NRUBS()
+  triples = []
+  for pt in points:
+    triples.append(Triple(pt[0], pt[1], pt[2]))
+  result = nrubs.spline(triples, n_intervals)
+  return [col((r.x, r.y, r.z)) for r in result]
+
+
+def get_point_id(start_guide, end_guide, interval, n_intervals,
+                 last_point_id, dna_style=False):
+  """Generate kinemage point label for a ribbon point.
+
+  Args:
+    start_guide: GuidePoint at the start of this segment
+    end_guide: GuidePoint at the end of this segment
+    interval: current interval index within the segment
+    n_intervals: total intervals per segment
+    last_point_id: previous point ID string (for deduplication)
+    dna_style: if True, use prevRes for early intervals (DNA/RNA)
+
+  Returns:
+    tuple of (point_id_str, updated_last_point_id)
+  """
+  res = start_guide.nextRes
+  if dna_style and interval <= n_intervals // 2:
+    res = start_guide.prevRes
+
+  buf = (res.atom_groups()[0].resname.strip() + " " +
+         res.parent().id.strip() + " " +
+         res.resseq.strip() + res.icode)
+  point_id = buf.lower().strip()
+
+  if point_id == last_point_id:
+    return '"', last_point_id
+  else:
+    return point_id, point_id
+
+
+def format_ribbon_point(guides, splines, i, crayon, last_point_id,
+                        line_break=False, dna_style=False):
+  """Format one spline point as kinemage text.
+
+  Args:
+    guides: list of GuidePoint objects
+    splines: list of spline-interpolated col points
+    i: index into splines
+    crayon: Crayon object for coloring
+    last_point_id: previous point ID string
+    line_break: if True, emit a 'P' (pen-up) marker
+    dna_style: if True, use DNA-style point ID labeling
+
+  Returns:
+    tuple of (kin_text, updated_last_point_id)
+  """
+  n_intervals = (len(splines) - 1) // (len(guides) - 3)
+  interval = i % n_intervals
+  start_idx = (i // n_intervals) + 1
+
+  point_id, last_point_id = get_point_id(
+      guides[start_idx], guides[start_idx + 1],
+      interval, n_intervals, last_point_id, dna_style)
+
+  ret = "{" + point_id + "}"
+  if line_break:
+    ret += "P "
+  crayon.for_ribbon(guides[start_idx])
+  ret += crayon.get_kin_string()
+  ret += " "
+  pt = splines[i]
+  ret += "{:.3f} {:.3f} {:.3f}\n".format(pt[0], pt[1], pt[2])
+
+  return ret, last_point_id
+
+
+def render_fancy_ribbon(guides, secondary_structure, n_intervals=4,
+                        width_alpha=2.0, width_beta=2.2, width_coil=1.0,
+                        list_alpha="", list_beta="", list_coil="",
+                        list_coil_outline=None, do_rainbow=False,
+                        dna_style=False):
+  """Render complete ribbon for one contiguous segment as kinemage text.
+
+  This is the core ribbon rendering function, extracted from
+  Program.printFancyRibbon() in mmtbx/programs/ribbons.py.
+
+  Args:
+    guides: list of GuidePoint objects for this segment
+    secondary_structure: dict[resseq_as_int -> Range]
+    n_intervals: spline subdivisions per guide segment
+    width_alpha: half-width of alpha helix ribbon
+    width_beta: half-width of beta sheet ribbon
+    width_coil: width of coil
+    list_alpha: kinemage list attributes for helix
+    list_beta: kinemage list attributes for sheet
+    list_coil: kinemage list attributes for coil
+    list_coil_outline: kinemage list attributes for coil outline (or None)
+    do_rainbow: if True, color by rainbow instead of SS type
+    dna_style: if True, use DNA-style point labeling
+
+  Returns:
+    kinemage text string
+  """
+  ret = ""
+  sec_struct = secondary_structure
+
+  # Seven strands of guide points: coil, +/-alpha, +/-beta, +/-beta arrowheads
+  half_widths = [0.0, -width_alpha / 2, width_alpha / 2,
+                 -width_beta / 2, width_beta / 2,
+                 -width_beta, width_beta]
+  strands = [[] for _ in range(len(half_widths))]
+  for g in guides:
+    for i in range(len(half_widths)):
+      strands[i].append(g.pos + g.dvec * half_widths[i])
+
+  # Seven strands of interpolated points
+  splinepts = []
+  for i in range(len(strands)):
+    splinepts.append(spline_interpolate(strands[i], n_intervals))
+
+  # Discover ribbon elements
+  ribbon_elements = []
+  rib_element = RibbonElement()
+  prev_rib_elt = RibbonElement()
+  ribbon_elements.append(rib_element)
+  rib_element.type = None
+
+  for i in range(len(guides) - 1 - 2):
+    g1 = guides[i + 1]
+    g2 = guides[i + 2]
+
+    curr_ss = RibbonElement(set_range=sec_struct.get(g1.nextRes.resseq_as_int(), Range()))
+    next_ss = RibbonElement(set_range=sec_struct.get(g2.nextRes.resseq_as_int(), Range()))
+
+    if rib_element.type is None:
+      rib_element.like(curr_ss)
+
+    if i == 0 or not rib_element.same_sse(curr_ss):
+      if curr_ss.type == 'HELIX' or curr_ss.type == 'SHEET':
+        rib_element.end = n_intervals * i + 1
+        rib_element = RibbonElement(curr_ss)
+        ribbon_elements.append(rib_element)
+        rib_element.start = n_intervals * i + 1
+
+    if not rib_element.same_sse(next_ss):
+      if curr_ss.type == 'HELIX' or curr_ss.type == 'SHEET':
+        end = n_intervals * i + 0
+        if curr_ss.type == 'SHEET':
+          end += n_intervals - 1
+        rib_element.end = end
+        rib_element = RibbonElement()
+        ribbon_elements.append(rib_element)
+        rib_element.type = 'COIL'
+        rib_element.start = end
+
+  rib_element.end = len(splinepts[0]) - 1
+
+  # Crayons for coloring
+  normal_crayon = Crayon(do_rainbow)
+  edge_crayon = Crayon(False)  # No color; deadblack set on vectorlist
+
+  # Sort by strand number
+  ribbon_elements.sort()
+
+  # Create list of just sheets for searching
+  sheet_elts = [r for r in ribbon_elements if r.type == 'SHEET']
+
+  last_point_id = ""
+
+  for rib_elt in ribbon_elements:
+    st_guide = (rib_elt.start // n_intervals) + 2
+    end_guide = (rib_elt.end // n_intervals) - 1
+
+    if rib_elt.type == 'HELIX':
+      k = (rib_elt.start + rib_elt.end) // 2
+      pt = splinepts[2][k]
+      v1 = splinepts[1][k] - pt
+      v2 = splinepts[1][k + 1] - pt
+      cross = v1.cross(v2)
+      # Bug fix: original used np.dot(np.linalg.norm(cross), np.linalg.norm(...))
+      # which is scalar*scalar, not a dot product. The intent is a sign check
+      # for sidedness using the cross product dotted with the guide cvec.
+      guide_idx = k // n_intervals + 1
+      if guide_idx < len(guides):
+        dot = cross.dot(col(guides[guide_idx].cvec))
+      else:
+        dot = cross.dot(col(guides[-1].cvec))
+
+      crayon = normal_crayon
+      ret += "@ribbonlist {fancy helix} " + list_alpha + "\n"
+      last_point_id = ""
+
+      for i in range(rib_elt.start, rib_elt.end):
+        if dot > 0:
+          text, last_point_id = format_ribbon_point(
+              guides, splinepts[2], i, crayon, last_point_id, dna_style=dna_style)
+          ret += text
+          text, last_point_id = format_ribbon_point(
+              guides, splinepts[1], i, crayon, last_point_id, dna_style=dna_style)
+          ret += text
+        else:
+          text, last_point_id = format_ribbon_point(
+              guides, splinepts[1], i, crayon, last_point_id, dna_style=dna_style)
+          ret += text
+          text, last_point_id = format_ribbon_point(
+              guides, splinepts[2], i, crayon, last_point_id, dna_style=dna_style)
+          ret += text
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[0], rib_elt.end, crayon, last_point_id, dna_style=dna_style)
+      ret += text
+
+      crayon = edge_crayon
+      ret += "@vectorlist {fancy helix edges} width=1 " + list_alpha + " color= deadblack\n"
+      last_point_id = ""
+      # Left edge
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[0], rib_elt.start, crayon, last_point_id,
+          line_break=True, dna_style=dna_style)
+      ret += text
+      for i in range(rib_elt.start, rib_elt.end):
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[1], i, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[0], rib_elt.end, crayon, last_point_id, dna_style=dna_style)
+      ret += text
+      # Right edge
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[0], rib_elt.start, crayon, last_point_id,
+          line_break=True, dna_style=dna_style)
+      ret += text
+      for i in range(rib_elt.start, rib_elt.end):
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[2], i, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[0], rib_elt.end, crayon, last_point_id, dna_style=dna_style)
+      ret += text
+
+    elif rib_elt.type == 'SHEET':
+      dot = 0.0
+
+      if rib_elt.range is not None and rib_elt.range.strand != 1:
+        for se in sheet_elts:
+          if se.range == rib_elt.range.previous:
+            prev_rib_elt = se
+            break
+
+        prev_range = prev_rib_elt.range
+        if prev_range is None:
+          prev_rib_elt = rib_elt
+
+        prev_st_guide = (prev_rib_elt.start // n_intervals) + 2
+        prev_end_guide = (prev_rib_elt.end // n_intervals) + 1
+        cur_closest = st_guide
+        prev_closest = prev_st_guide
+        close_dist = 1e10
+        for i in range(st_guide, end_guide + 2 + 1):
+          for j in range(prev_st_guide, prev_end_guide + 2 + 1):
+            try:
+              O = _FindNamedAtomInResidue(guides[i].prevRes, ["O"])
+              N = _FindNamedAtomInResidue(guides[j].prevRes, ["N"])
+              if O is None or N is None:
+                continue
+              # Bug fix: original used O.pos which doesn't exist; use col(O.xyz)
+              dist = (col(O.xyz) - col(N.xyz)).length()
+              if dist < close_dist:
+                close_dist = dist
+                cur_closest = i
+                prev_closest = j
+            except Exception:
+              pass
+
+        k_cur = min(n_intervals * (cur_closest - 1), len(splinepts[4]) - 1)
+        k_prev = min(n_intervals * (prev_closest - 1), len(splinepts[4]) - 1)
+        pt_cur = splinepts[4][k_cur]
+        v1_cur = splinepts[3][k_cur] - pt_cur
+        if k_cur + 1 < len(splinepts[3]):
+          v2_cur = splinepts[3][k_cur + 1] - pt_cur
+          cross_cur = v1_cur.cross(v2_cur)
+          pt_prev = splinepts[4][k_prev]
+          v1_prev = splinepts[3][k_prev] - pt_prev
+          if k_prev + 1 < len(splinepts[3]):
+            v2_prev = splinepts[3][k_prev + 1] - pt_prev
+            cross_prev = v1_prev.cross(v2_prev)
+            dot = cross_cur.dot(cross_prev)
+
+      crayon = normal_crayon
+      ret += "@ribbonlist {fancy sheet} " + list_beta + "\n"
+      last_point_id = ""
+      for i in range(rib_elt.start, rib_elt.end - 1):
+        if ((dot < 0 and not prev_rib_elt.range.flipped) or
+            (dot > 0 and prev_rib_elt.range.flipped)):
+          text, last_point_id = format_ribbon_point(
+              guides, splinepts[4], i, crayon, last_point_id, dna_style=dna_style)
+          ret += text
+          text, last_point_id = format_ribbon_point(
+              guides, splinepts[3], i, crayon, last_point_id, dna_style=dna_style)
+          ret += text
+          if rib_elt.range is not None:
+            rib_elt.range.flipped = True
+        else:
+          text, last_point_id = format_ribbon_point(
+              guides, splinepts[3], i, crayon, last_point_id, dna_style=dna_style)
+          ret += text
+          text, last_point_id = format_ribbon_point(
+              guides, splinepts[4], i, crayon, last_point_id, dna_style=dna_style)
+          ret += text
+
+      # Arrowhead
+      if ((dot < 0 and not prev_rib_elt.range.flipped) or
+          (dot > 0 and prev_rib_elt.range.flipped)):
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[6], rib_elt.end - 2, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[5], rib_elt.end - 2, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[0], rib_elt.end, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+      else:
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[5], rib_elt.end - 2, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[6], rib_elt.end - 2, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[0], rib_elt.end, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+
+      # Borders
+      crayon = edge_crayon
+      ret += "@vectorlist {fancy sheet edges} width=1 " + list_beta + " color= deadblack\n"
+      last_point_id = ""
+      # Left edge
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[0], rib_elt.start, crayon, last_point_id,
+          line_break=True, dna_style=dna_style)
+      ret += text
+      for i in range(rib_elt.start, rib_elt.end - 1):
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[3], i, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[5], rib_elt.end - 2, crayon, last_point_id, dna_style=dna_style)
+      ret += text
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[0], rib_elt.end, crayon, last_point_id, dna_style=dna_style)
+      ret += text
+      # Right edge
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[0], rib_elt.start, crayon, last_point_id,
+          line_break=True, dna_style=dna_style)
+      ret += text
+      for i in range(rib_elt.start, rib_elt.end - 1):
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[4], i, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[6], rib_elt.end - 2, crayon, last_point_id, dna_style=dna_style)
+      ret += text
+      text, last_point_id = format_ribbon_point(
+          guides, splinepts[0], rib_elt.end, crayon, last_point_id, dna_style=dna_style)
+      ret += text
+
+    else:  # Coil
+      if list_coil_outline is not None:
+        crayon = normal_crayon
+        ret += "@vectorlist {fancy coil edges} " + list_coil_outline + "\n"
+        last_point_id = ""
+        for i in range(rib_elt.start, rib_elt.end + 1):
+          text, last_point_id = format_ribbon_point(
+              guides, splinepts[0], i, crayon, last_point_id, dna_style=dna_style)
+          ret += text
+
+      crayon = normal_crayon
+      ret += "@vectorlist {fancy coil} " + list_coil + "\n"
+      last_point_id = ""
+      for i in range(rib_elt.start, rib_elt.end + 1):
+        text, last_point_id = format_ribbon_point(
+            guides, splinepts[0], i, crayon, last_point_id, dna_style=dna_style)
+        ret += text
+
+    crayon = normal_crayon
+
+  return ret
+
+
+def generate_chain_ribbons(chain, secondary_structure, chain_id,
+                           chain_color="white", do_protein=True,
+                           do_nucleic_acid=True, untwist=True,
+                           dna_style=False, do_plain_coils=False,
+                           coil_width=1.0, color_by="secondary_structure",
+                           nucleic_acid_as_helix=True,
+                           has_dna=False, has_rna=False):
+  """Generate complete ribbon kinemage text for one chain.
+
+  Top-level function called per chain to produce ribbon content including
+  colorset definitions, subgroup headers, and all ribbon lists.
+
+  Args:
+    chain: iotbx.pdb.hierarchy chain object
+    secondary_structure: dict[resseq_as_int -> Range]
+    chain_id: chain identifier string
+    chain_color: base color for this chain
+    do_protein: generate protein ribbons
+    do_nucleic_acid: generate nucleic acid ribbons
+    untwist: remove excess twist from ribbons
+    dna_style: use DNA-style ribbon orientation
+    do_plain_coils: if True, omit coil outlines (halo)
+    coil_width: width of the coil part
+    color_by: "rainbow", "secondary_structure", or "solid"
+    nucleic_acid_as_helix: treat nucleic acids as helix in SS map
+    has_dna: whether DNA is present in the model
+    has_rna: whether RNA is present in the model
+
+  Returns:
+    kinemage text string for this chain's ribbons
+  """
+  out = ""
+  do_rainbow = (color_by == "rainbow")
+
+  # --- Protein ribbons ---
+  if do_protein:
+    contiguous_lists = find_contiguous_protein_residues(chain)
+    if len(contiguous_lists) > 0:
+      out += "@subgroup {ribbon %s}\n" % chain_id
+
+      if chain_color == "white" and color_by != "solid":
+        out += "@colorset {{alph{}}} red\n".format(chain_id)
+        out += "@colorset {{beta{}}} lime\n".format(chain_id)
+        out += "@colorset {{coil{}}} white\n".format(chain_id)
+      else:
+        out += "@colorset {{alph{}}} {}\n".format(chain_id, chain_color)
+        out += "@colorset {{beta{}}} {}\n".format(chain_id, chain_color)
+        out += "@colorset {{coil{}}} {}\n".format(chain_id, chain_color)
+
+      for contig in contiguous_lists:
+        guidepoints = make_protein_guidepoints(contig)
+        if untwist:
+          untwist_ribbon(guidepoints)
+        if do_plain_coils:
+          out += render_fancy_ribbon(
+              guidepoints, secondary_structure,
+              width_alpha=2.0, width_beta=2.2, width_coil=coil_width,
+              list_alpha="color= {alph" + chain_id + "} master= {protein} master= {ribbon} master= {alpha}",
+              list_beta="color= {beta" + chain_id + "} master= {protein} master= {ribbon} master= {beta}",
+              list_coil="width= 4 color= {coil" + chain_id + "} master= {protein} master= {ribbon} master= {coil}",
+              do_rainbow=do_rainbow, dna_style=dna_style)
+        else:
+          out += render_fancy_ribbon(
+              guidepoints, secondary_structure,
+              width_alpha=2.0, width_beta=2.2, width_coil=coil_width,
+              list_alpha="color= {alph" + chain_id + "} master= {protein} master= {ribbon} master= {alpha}",
+              list_beta="color= {beta" + chain_id + "} master= {protein} master= {ribbon} master= {beta}",
+              list_coil="width= 4 fore color= {coil" + chain_id + "} master= {protein} master= {ribbon} master= {coil}",
+              list_coil_outline="width= 6 rear color= deadblack master= {protein} master= {ribbon} master= {coil}",
+              do_rainbow=do_rainbow, dna_style=dna_style)
+
+  # --- Nucleic acid ribbons ---
+  if do_nucleic_acid:
+    contiguous_lists = find_contiguous_nucleic_acid_residues(chain)
+    if len(contiguous_lists) > 0:
+      out += "@subgroup {ribbon %s NA}\n" % chain_id
+
+      if chain_color == "white":
+        out += "@colorset {{nucl{}}} lime\n".format(chain_id)
+        out += "@colorset {{ncoi{}}} white\n".format(chain_id)
+      else:
+        out += "@colorset {{nucl{}}} {}\n".format(chain_id, chain_color)
+        out += "@colorset {{ncoi{}}} {}\n".format(chain_id, chain_color)
+
+      for contig in contiguous_lists:
+        guidepoints = make_nucleic_acid_guidepoints(contig)
+        if untwist:
+          untwist_ribbon(guidepoints)
+        use_dna_style = dna_style or (has_dna and has_rna and chain_has_DNA(chain))
+        if use_dna_style:
+          swap_edge_and_face(guidepoints)
+
+        out += render_fancy_ribbon(
+            guidepoints, secondary_structure,
+            width_alpha=3.0, width_beta=3.0, width_coil=coil_width,
+            list_alpha="color= {nucl" + chain_id + "} master= {nucleic acid} master= {ribbon} master= {RNA helix?}",
+            list_beta="color= {nucl" + chain_id + "} master= {nucleic acid} master= {ribbon} master= {A-form}",
+            list_coil="width= 4 color= {ncoi" + chain_id + "} master= {nucleic acid} master= {ribbon} master= {coil}",
+            do_rainbow=do_rainbow, dna_style=use_dna_style)
+
+  return out

--- a/mmtbx/kinemage/tst_validation.py
+++ b/mmtbx/kinemage/tst_validation.py
@@ -353,6 +353,722 @@ def exercise_het_ion_water():
   print("  exercise_het_ion_water: OK")
 
 
+# Longer PDB with 8 residues and HELIX/SHEET records for ribbon testing.
+# Two-stranded beta sheet (res 1-3, 6-8) and a short loop (res 4-5).
+# Coordinates are idealized to give proper CA distances (~3.8A).
+pdb_ribbon_str = """\
+CRYST1   50.000   50.000   50.000  90.00  90.00  90.00 P 1
+HELIX    1 H1  ALA A    4  ALA A    5  1                                   2
+SHEET    1 S1  2 ALA A   1  ALA A   3  0
+SHEET    2 S1  2 ALA A   6  ALA A   8 -1
+ATOM      1  N   ALA A   1       1.000   1.000   1.000  1.00 10.00           N
+ATOM      2  CA  ALA A   1       2.430   1.000   1.000  1.00 10.00           C
+ATOM      3  C   ALA A   1       3.013   2.404   1.000  1.00 10.00           C
+ATOM      4  O   ALA A   1       2.253   3.370   1.000  1.00 10.00           O
+ATOM      5  CB  ALA A   1       2.930   0.250   2.230  1.00 10.00           C
+ATOM      6  N   ALA A   2       4.315   2.500   1.000  1.00 10.00           N
+ATOM      7  CA  ALA A   2       4.990   3.800   1.000  1.00 10.00           C
+ATOM      8  C   ALA A   2       6.500   3.660   1.000  1.00 10.00           C
+ATOM      9  O   ALA A   2       7.050   2.560   1.000  1.00 10.00           O
+ATOM     10  CB  ALA A   2       4.540   4.640   2.200  1.00 10.00           C
+ATOM     11  N   ALA A   3       7.140   4.840   1.000  1.00 10.00           N
+ATOM     12  CA  ALA A   3       8.600   4.900   1.000  1.00 10.00           C
+ATOM     13  C   ALA A   3       9.110   6.330   1.000  1.00 10.00           C
+ATOM     14  O   ALA A   3       8.330   7.290   1.000  1.00 10.00           O
+ATOM     15  CB  ALA A   3       9.140   4.150   2.220  1.00 10.00           C
+ATOM     16  N   ALA A   4      10.410   6.400   1.000  1.00 10.00           N
+ATOM     17  CA  ALA A   4      11.050   7.700   1.000  1.00 10.00           C
+ATOM     18  C   ALA A   4      12.560   7.600   1.000  1.00 10.00           C
+ATOM     19  O   ALA A   4      13.110   6.500   1.000  1.00 10.00           O
+ATOM     20  CB  ALA A   4      10.550   8.540   2.200  1.00 10.00           C
+ATOM     21  N   ALA A   5      13.200   8.770   1.000  1.00 10.00           N
+ATOM     22  CA  ALA A   5      14.650   8.830   1.000  1.00 10.00           C
+ATOM     23  C   ALA A   5      15.160  10.260   1.000  1.00 10.00           C
+ATOM     24  O   ALA A   5      14.380  11.220   1.000  1.00 10.00           O
+ATOM     25  CB  ALA A   5      15.190   8.080   2.220  1.00 10.00           C
+ATOM     26  N   ALA A   6      16.460  10.340   1.000  1.00 10.00           N
+ATOM     27  CA  ALA A   6      17.100  11.640   1.000  1.00 10.00           C
+ATOM     28  C   ALA A   6      18.610  11.540   1.000  1.00 10.00           C
+ATOM     29  O   ALA A   6      19.160  10.440   1.000  1.00 10.00           O
+ATOM     30  CB  ALA A   6      16.600  12.480   2.200  1.00 10.00           C
+ATOM     31  N   ALA A   7      19.250  12.710   1.000  1.00 10.00           N
+ATOM     32  CA  ALA A   7      20.700  12.770   1.000  1.00 10.00           C
+ATOM     33  C   ALA A   7      21.210  14.200   1.000  1.00 10.00           C
+ATOM     34  O   ALA A   7      20.430  15.160   1.000  1.00 10.00           O
+ATOM     35  CB  ALA A   7      21.240  12.020   2.220  1.00 10.00           C
+ATOM     36  N   ALA A   8      22.510  14.270   1.000  1.00 10.00           N
+ATOM     37  CA  ALA A   8      23.150  15.570   1.000  1.00 10.00           C
+ATOM     38  C   ALA A   8      24.660  15.470   1.000  1.00 10.00           C
+ATOM     39  O   ALA A   8      25.210  14.370   1.000  1.00 10.00           O
+ATOM     40  CB  ALA A   8      22.650  16.410   2.200  1.00 10.00           C
+END
+"""
+
+# PDB with two CYS residues forming a disulfide bond (SG-SG ~2.03A)
+pdb_disulfide_str = """\
+CRYST1   30.000   30.000   30.000  90.00  90.00  90.00 P 1
+SSBOND   1 CYS A    2    CYS A    4                          2.03
+ATOM      1  N   ALA A   1       1.000   1.000   1.000  1.00 10.00           N
+ATOM      2  CA  ALA A   1       2.458   1.000   1.000  1.00 10.00           C
+ATOM      3  C   ALA A   1       3.009   2.425   1.000  1.00 10.00           C
+ATOM      4  O   ALA A   1       2.249   3.390   1.000  1.00 10.00           O
+ATOM      5  CB  ALA A   1       2.982   0.231   2.207  1.00 10.00           C
+ATOM      6  N   CYS A   2       4.316   2.498   1.000  1.00 10.00           N
+ATOM      7  CA  CYS A   2       4.988   3.798   1.000  1.00 10.00           C
+ATOM      8  C   CYS A   2       6.504   3.664   1.000  1.00 10.00           C
+ATOM      9  O   CYS A   2       7.054   2.562   1.000  1.00 10.00           O
+ATOM     10  CB  CYS A   2       4.538   4.637   2.196  1.00 10.00           C
+ATOM     11  SG  CYS A   2       5.100   6.350   2.100  1.00 10.00           S
+ATOM     12  N   ALA A   3       7.142   4.835   1.000  1.00 10.00           N
+ATOM     13  CA  ALA A   3       8.598   4.893   1.000  1.00 10.00           C
+ATOM     14  C   ALA A   3       9.108   6.330   1.000  1.00 10.00           C
+ATOM     15  O   ALA A   3       8.330   7.286   1.000  1.00 10.00           O
+ATOM     16  CB  ALA A   3       9.137   4.148   2.215  1.00 10.00           C
+ATOM     17  N   CYS A   4      10.410   6.400   1.000  1.00 10.00           N
+ATOM     18  CA  CYS A   4      11.050   7.700   1.000  1.00 10.00           C
+ATOM     19  C   CYS A   4      12.560   7.600   1.000  1.00 10.00           C
+ATOM     20  O   CYS A   4      13.110   6.500   1.000  1.00 10.00           O
+ATOM     21  CB  CYS A   4      10.550   8.540   2.200  1.00 10.00           C
+ATOM     22  SG  CYS A   4       5.120   8.380   2.100  1.00 10.00           S
+END
+"""
+
+def exercise_ribbon_rendering():
+  """Test the ribbon_rendering module classes and functions."""
+  from mmtbx.kinemage.ribbon_rendering import (
+      Crayon, Range, RibbonElement,
+      build_secondary_structure_map, consolidate_sheets,
+      spline_interpolate, generate_chain_ribbons)
+  from scitbx.matrix import col
+  from iotbx import pdb
+  from libtbx.utils import null_out
+
+  # --- Test Range class ---
+  r = Range()
+  assert r.type == 'COIL'
+  assert r.strand == 1
+  assert r.previous is None
+
+  r = Range(ss_type='HELIX', chain_id='A', init_seq=10, end_seq=20)
+  assert r.type == 'HELIX'
+  assert r.initSeqNum == 10
+  assert r.endSeqNum == 20
+
+  # --- Test RibbonElement class ---
+  re1 = RibbonElement()
+  assert re1.type == 'COIL'
+  re2 = RibbonElement(set_range=Range(ss_type='HELIX'))
+  assert re2.type == 'HELIX'
+  re3 = RibbonElement(set_range=Range(ss_type='TURN'))
+  assert re3.type == 'COIL'  # TURN maps to COIL
+  # same_sse
+  assert not re1.same_sse(re2)
+  r_shared = Range(ss_type='SHEET')
+  re4 = RibbonElement(set_range=r_shared)
+  re5 = RibbonElement(set_range=r_shared)
+  assert re4.same_sse(re5)
+  # sorting by strand
+  re4.range.strand = 2
+  re5.range = Range(ss_type='SHEET', strand=1)
+  assert not re4 < re5  # strand 2 > strand 1
+
+  # --- Test Crayon class ---
+  c = Crayon(do_rainbow=False, color="red")
+  assert c.get_kin_string() == "red"
+  assert c.should_print()
+  c2 = Crayon(do_rainbow=False)
+  assert c2.get_kin_string() == ""
+
+  # --- Test spline_interpolate ---
+  # Straight line: 6 points along x-axis (need >= 4 for one spline segment)
+  pts = [col((float(i), 0.0, 0.0)) for i in range(6)]
+  result = spline_interpolate(pts, 4)
+  assert len(result) > 0
+  # All y and z coords should be ~0 for a straight line
+  for pt in result:
+    assert abs(pt[1]) < 1e-6
+    assert abs(pt[2]) < 1e-6
+
+  # --- Test build_secondary_structure_map with annotation ---
+  hierarchy = pdb.input(source_info=None, lines=pdb_ribbon_str).construct_hierarchy()
+  annotation = pdb.input(source_info=None,
+      lines=pdb_ribbon_str).extract_secondary_structure()
+  ss_map = build_secondary_structure_map(
+      hierarchy, annotation=annotation, log=null_out())
+  # Check that the map has entries for all 8 residues
+  assert len(ss_map) == 8
+  # Residues 1-3 should be SHEET, 4-5 should be HELIX, 6-8 should be SHEET
+  assert ss_map[1].type == 'SHEET', "res 1 should be SHEET, got %s" % ss_map[1].type
+  assert ss_map[3].type == 'SHEET', "res 3 should be SHEET, got %s" % ss_map[3].type
+  assert ss_map[4].type == 'HELIX', "res 4 should be HELIX, got %s" % ss_map[4].type
+  assert ss_map[5].type == 'HELIX', "res 5 should be HELIX, got %s" % ss_map[5].type
+  assert ss_map[6].type == 'SHEET', "res 6 should be SHEET, got %s" % ss_map[6].type
+  assert ss_map[8].type == 'SHEET', "res 8 should be SHEET, got %s" % ss_map[8].type
+
+  # strand IDs should be ints after conversion
+  for rng in ss_map.values():
+    if rng.type == 'SHEET':
+      assert isinstance(rng.strand, int), "strand should be int, got %s" % type(rng.strand)
+
+  # --- Test consolidate_sheets ---
+  consolidate_sheets(ss_map)
+  # Sheet strands with strand==2 should have previous pointing to strand==1
+  for rng in ss_map.values():
+    if rng.type == 'SHEET' and rng.strand == 2 and rng.duplicateOf is None:
+      assert rng.previous is not None, "strand 2 should have a previous strand"
+
+  # --- Test build_secondary_structure_map without annotation (from_ca fallback) ---
+  ss_map_auto = build_secondary_structure_map(
+      hierarchy, annotation=None, log=null_out())
+  assert len(ss_map_auto) == 8
+  # All entries should be valid Range objects
+  for rng in ss_map_auto.values():
+    assert rng.type in ('COIL', 'HELIX', 'SHEET')
+
+  # --- Test generate_chain_ribbons ---
+  for chain in hierarchy.models()[0].chains():
+    ribbon_out = generate_chain_ribbons(
+        chain=chain, secondary_structure=ss_map,
+        chain_id=chain.id, chain_color="white")
+    assert len(ribbon_out) > 0, "generate_chain_ribbons produced no output"
+    assert "@subgroup" in ribbon_out
+    assert "@colorset" in ribbon_out
+    # Should contain ribbon list content
+    assert "master= {ribbon}" in ribbon_out
+
+  print("  exercise_ribbon_rendering: OK")
+
+
+def exercise_ribbon_in_kinemage():
+  """Test that ribbon content appears within the main group in
+  _build_kinemage output, not as a separate top-level group."""
+  from mmtbx.kinemage.validation import (
+      build_name_hash, _build_bond_hash, _build_kinemage,
+      get_default_header, get_footer)
+  from mmtbx.monomer_library import pdb_interpretation
+  from mmtbx import monomer_library
+  from cctbx import geometry_restraints
+  from mmtbx.validation.rotalyze import rotalyze
+  from mmtbx.validation.ramalyze import ramalyze
+  from mmtbx.validation.cbetadev import cbetadev
+  from mmtbx.validation.restraints import combined as restraints_combined
+  from iotbx import pdb
+  from libtbx.utils import null_out
+
+  # Check that header and footer have ribbon master controls
+  header = get_default_header()
+  footer = get_footer()
+  assert "@master {ribbon} indent" in header, "Missing ribbon master in header"
+  assert "@master {ribbon} off" in footer, "Missing ribbon master in footer"
+
+  # Build full kinemage from the 8-residue PDB with SS records
+  pdb_io = pdb.input(source_info=None, lines=pdb_ribbon_str)
+  annotation = pdb_io.extract_secondary_structure()
+  mon_lib_srv = monomer_library.server.server()
+  ener_lib = monomer_library.server.ener_lib()
+  processed_pdb_file = pdb_interpretation.process(
+      mon_lib_srv=mon_lib_srv,
+      ener_lib=ener_lib,
+      pdb_inp=pdb_io,
+      substitute_non_crystallographic_unit_cell_if_necessary=True)
+
+  hierarchy = processed_pdb_file.all_chain_proxies.pdb_hierarchy
+  sites_cart = processed_pdb_file.all_chain_proxies.sites_cart
+  geometry = processed_pdb_file.geometry_restraints_manager()
+  xray_structure = processed_pdb_file.xray_structure()
+  i_seq_name_hash = build_name_hash(pdb_hierarchy=hierarchy)
+  flags = geometry_restraints.flags.flags(default=True)
+  pair_proxies = geometry.pair_proxies(flags=flags, sites_cart=sites_cart)
+  bond_proxies = pair_proxies.bond_proxies
+  quick_bond_hash = _build_bond_hash(bond_proxies, i_seq_name_hash)
+
+  rot_outliers = rotalyze(pdb_hierarchy=hierarchy, outliers_only=True)
+  cb = cbetadev(pdb_hierarchy=hierarchy, outliers_only=True)
+  rama = ramalyze(pdb_hierarchy=hierarchy, outliers_only=True)
+  restraints_result = restraints_combined(
+      pdb_hierarchy=hierarchy,
+      xray_structure=xray_structure,
+      geometry_restraints_manager=geometry,
+      ignore_hd=True,
+      outliers_only=True)
+
+  kin_out = _build_kinemage(
+      hierarchy=hierarchy,
+      bond_hash=quick_bond_hash,
+      i_seq_name_hash=i_seq_name_hash,
+      pdbID="ribbon_test",
+      rot_outliers=rot_outliers,
+      rama_result=rama,
+      cb_result=cb,
+      restraints_result=restraints_result,
+      keep_hydrogens=False,
+      ss_annotation=annotation,
+      probe_dots_kin="")  # suppress probe dots so this test isolates ribbon
+                          # placement (probe dots emit their own @group {dots})
+
+  # Ribbon content should be present
+  assert "master= {ribbon}" in kin_out, "No ribbon content in kinemage output"
+  assert "@subgroup {ribbon" in kin_out, "Missing ribbon subgroup"
+  assert "@colorset" in kin_out, "Missing ribbon colorset"
+
+  # Ribbon should NOT be a separate top-level @group
+  assert "@group {ribbon}" not in kin_out, \
+      "Ribbon should be a subgroup within the main group, not a separate @group"
+
+  # There should be exactly one top-level @group (the main model group)
+  group_lines = [l for l in kin_out.splitlines()
+                 if l.startswith("@group")]
+  assert len(group_lines) == 1, \
+      "Expected 1 @group, got %d: %s" % (len(group_lines), group_lines)
+  assert "{ribbon_test}" in group_lines[0]
+
+  print("  exercise_ribbon_in_kinemage: OK")
+
+
+def exercise_build_name_hash():
+  """Test that build_name_hash returns structured dicts (not raw strings)."""
+  from mmtbx.kinemage.validation import build_name_hash
+  from mmtbx.monomer_library import pdb_interpretation
+  from mmtbx import monomer_library
+  from iotbx import pdb
+
+  pdb_io = pdb.input(source_info=None, lines=pdb_str)
+  mon_lib_srv = monomer_library.server.server()
+  ener_lib = monomer_library.server.ener_lib()
+  processed_pdb_file = pdb_interpretation.process(
+    mon_lib_srv=mon_lib_srv,
+    ener_lib=ener_lib,
+    pdb_inp=pdb_io,
+    substitute_non_crystallographic_unit_cell_if_necessary=True)
+
+  hierarchy = processed_pdb_file.all_chain_proxies.pdb_hierarchy
+  name_hash = build_name_hash(pdb_hierarchy=hierarchy)
+
+  # Should have entries for all atoms
+  assert len(name_hash) == len(list(hierarchy.atoms()))
+
+  # Each entry should be a dict with the expected keys
+  for i_seq, info in name_hash.items():
+    assert isinstance(info, dict), "Expected dict, got %s" % type(info)
+    for key in ('name', 'altloc', 'resname', 'chain_id', 'resseq', 'icode'):
+      assert key in info, "Missing key '%s' in name_hash entry" % key
+
+  # Check specific values for the first atom (N of ALA A 1)
+  first_atom = list(hierarchy.atoms())[0]
+  info = name_hash[first_atom.i_seq]
+  assert info['name'].strip() == 'N', "Expected 'N', got '%s'" % info['name'].strip()
+  assert info['resname'].strip() == 'ALA', "Expected 'ALA', got '%s'" % info['resname'].strip()
+  assert info['chain_id'].strip() == 'A', "Expected 'A', got '%s'" % info['chain_id'].strip()
+
+  print("  exercise_build_name_hash: OK")
+
+
+def exercise_same_residue():
+  """Test the _same_residue helper function."""
+  from mmtbx.kinemage.validation import _same_residue
+
+  info_a = {'chain_id': 'A', 'resseq': '   1', 'icode': ' ',
+            'name': ' N  ', 'altloc': ' ', 'resname': 'ALA'}
+  info_b = {'chain_id': 'A', 'resseq': '   1', 'icode': ' ',
+            'name': ' CA ', 'altloc': ' ', 'resname': 'ALA'}
+  info_c = {'chain_id': 'A', 'resseq': '   2', 'icode': ' ',
+            'name': ' N  ', 'altloc': ' ', 'resname': 'ALA'}
+  info_d = {'chain_id': 'B', 'resseq': '   1', 'icode': ' ',
+            'name': ' N  ', 'altloc': ' ', 'resname': 'ALA'}
+  info_e = {'chain_id': 'A', 'resseq': '   1', 'icode': 'A',
+            'name': ' N  ', 'altloc': ' ', 'resname': 'ALA'}
+
+  # Same residue (different atom names)
+  assert _same_residue(info_a, info_b) == True
+  # Different resseq
+  assert _same_residue(info_a, info_c) == False
+  # Different chain
+  assert _same_residue(info_a, info_d) == False
+  # Different icode
+  assert _same_residue(info_a, info_e) == False
+
+  print("  exercise_same_residue: OK")
+
+
+def exercise_disulfide_bonds():
+  """Test _build_ss_bond_list and SS bond drawing in get_kin_lots."""
+  from mmtbx.kinemage.validation import (
+    build_name_hash, _build_bond_hash, _build_ss_bond_list, get_kin_lots)
+  from mmtbx.monomer_library import pdb_interpretation
+  from mmtbx import monomer_library
+  from cctbx import geometry_restraints
+  from iotbx import pdb
+
+  pdb_io = pdb.input(source_info=None, lines=pdb_disulfide_str)
+  mon_lib_srv = monomer_library.server.server()
+  ener_lib = monomer_library.server.ener_lib()
+  processed_pdb_file = pdb_interpretation.process(
+    mon_lib_srv=mon_lib_srv,
+    ener_lib=ener_lib,
+    pdb_inp=pdb_io,
+    substitute_non_crystallographic_unit_cell_if_necessary=True)
+
+  hierarchy = processed_pdb_file.all_chain_proxies.pdb_hierarchy
+  sites_cart = processed_pdb_file.all_chain_proxies.sites_cart
+  geometry = processed_pdb_file.geometry_restraints_manager()
+  i_seq_name_hash = build_name_hash(pdb_hierarchy=hierarchy)
+  flags = geometry_restraints.flags.flags(default=True)
+  pair_proxies = geometry.pair_proxies(flags=flags, sites_cart=sites_cart)
+  bond_proxies = pair_proxies.bond_proxies
+
+  # Test _build_ss_bond_list
+  ss_bonds = _build_ss_bond_list(bond_proxies, i_seq_name_hash)
+  assert len(ss_bonds) >= 1, "Expected at least 1 SS bond, got %d" % len(ss_bonds)
+  # Each entry should be a tuple of two i_seqs
+  for i_seq_0, i_seq_1 in ss_bonds:
+    info_0 = i_seq_name_hash[i_seq_0]
+    info_1 = i_seq_name_hash[i_seq_1]
+    assert info_0['name'].strip() == 'SG', "Expected SG, got %s" % info_0['name'].strip()
+    assert info_1['name'].strip() == 'SG', "Expected SG, got %s" % info_1['name'].strip()
+    assert info_0['resname'].strip() == 'CYS'
+    assert info_1['resname'].strip() == 'CYS'
+
+  # Test that get_kin_lots includes SS bond vectorlist when ss_bonds provided
+  quick_bond_hash = _build_bond_hash(bond_proxies, i_seq_name_hash)
+  for model in hierarchy.models():
+    for chain in model.chains():
+      kin_out = get_kin_lots(
+        chain=chain,
+        bond_hash=quick_bond_hash,
+        i_seq_name_hash=i_seq_name_hash,
+        pdbID="ss_test",
+        index=0,
+        ss_bonds=ss_bonds,
+        sites_cart=sites_cart)
+      assert "@vectorlist {SS}" in kin_out, "Missing SS vectorlist"
+      assert "color= yellow" in kin_out, "SS bonds should be yellow"
+
+  # Test that get_kin_lots without ss_bonds does NOT include SS vectorlist
+  for model in hierarchy.models():
+    for chain in model.chains():
+      kin_out_no_ss = get_kin_lots(
+        chain=chain,
+        bond_hash=quick_bond_hash,
+        i_seq_name_hash=i_seq_name_hash,
+        pdbID="ss_test",
+        index=0)
+      assert "@vectorlist {SS}" not in kin_out_no_ss, \
+        "SS vectorlist should not appear without ss_bonds"
+
+  print("  exercise_disulfide_bonds: OK")
+
+
+def exercise_draw_residue_bonds():
+  """Test _draw_residue_bonds sorting into mc/sc/het categories."""
+  from mmtbx.kinemage.validation import (
+    build_name_hash, _build_bond_hash, _draw_residue_bonds)
+  from mmtbx.monomer_library import pdb_interpretation
+  from mmtbx import monomer_library
+  from cctbx import geometry_restraints
+  from iotbx import pdb
+
+  pdb_io = pdb.input(source_info=None, lines=pdb_str)
+  mon_lib_srv = monomer_library.server.server()
+  ener_lib = monomer_library.server.ener_lib()
+  processed_pdb_file = pdb_interpretation.process(
+    mon_lib_srv=mon_lib_srv,
+    ener_lib=ener_lib,
+    pdb_inp=pdb_io,
+    substitute_non_crystallographic_unit_cell_if_necessary=True)
+
+  hierarchy = processed_pdb_file.all_chain_proxies.pdb_hierarchy
+  sites_cart = processed_pdb_file.all_chain_proxies.sites_cart
+  geometry = processed_pdb_file.geometry_restraints_manager()
+  i_seq_name_hash = build_name_hash(pdb_hierarchy=hierarchy)
+  flags = geometry_restraints.flags.flags(default=True)
+  pair_proxies = geometry.pair_proxies(flags=flags, sites_cart=sites_cart)
+  bond_proxies = pair_proxies.bond_proxies
+  quick_bond_hash = _build_bond_hash(bond_proxies, i_seq_name_hash)
+
+  mc_atoms = ["N", "CA", "C", "O", "OXT",
+              "P", "OP1", "OP2", "OP3", "O5'", "C5'", "C4'", "O4'", "C1'",
+              "C3'", "O3'", "C2'", "O2'"]
+
+  # Test with the first residue
+  for model in hierarchy.models():
+    for chain in model.chains():
+      for residue_group in chain.residue_groups():
+        for conformer in residue_group.conformers():
+          for residue in conformer.residues():
+            key_hash = {}
+            xyz_hash = {}
+            het_hash = {}
+            iseq_altloc = {}
+            for atom in residue.atoms():
+              key = "%s %s %s" % (atom.name.lower(), residue.resname.lower(),
+                                  chain.id)
+              key_hash[atom.name.strip()] = key
+              xyz_hash[atom.name.strip()] = atom.xyz
+              iseq_altloc[atom.i_seq] = ' '
+
+            drawn_bonds = []
+            result = _draw_residue_bonds(
+              residue, quick_bond_hash, i_seq_name_hash, key_hash,
+              xyz_hash, het_hash, iseq_altloc, ' ',
+              mc_atoms, False, drawn_bonds)
+
+            # Result should be a dict with expected keys
+            assert isinstance(result, dict)
+            for key in ('mc', 'sc', 'mc_h', 'sc_h', 'het', 'het_h'):
+              assert key in result, "Missing key '%s' in result" % key
+
+            # For ALA, we should have mainchain bonds (N-CA, CA-C, C-O)
+            # and sidechain bonds (CA-CB)
+            assert len(result['mc']) > 0, "Expected mainchain bonds for ALA"
+            assert len(result['sc']) > 0, "Expected sidechain bonds for ALA (CA-CB)"
+            # No hydrogens in input, so no H bonds
+            assert result['mc_h'] == ''
+            assert result['sc_h'] == ''
+            # ALA is not a het
+            assert result['het'] == ''
+            assert result['het_h'] == ''
+
+            # Only test first residue
+            print("  exercise_draw_residue_bonds: OK")
+            return
+
+  print("  exercise_draw_residue_bonds: OK")
+
+
+def exercise_track_amino_acid_atom():
+  """Test _track_amino_acid_atom backbone tracking for inter-residue bonds."""
+  from mmtbx.kinemage.validation import _track_amino_acid_atom
+  from mmtbx.monomer_library import pdb_interpretation
+  from mmtbx import monomer_library
+  from iotbx import pdb
+
+  pdb_io = pdb.input(source_info=None, lines=pdb_str)
+  mon_lib_srv = monomer_library.server.server()
+  ener_lib = monomer_library.server.ener_lib()
+  processed_pdb_file = pdb_interpretation.process(
+    mon_lib_srv=mon_lib_srv,
+    ener_lib=ener_lib,
+    pdb_inp=pdb_io,
+    substitute_non_crystallographic_unit_cell_if_necessary=True)
+
+  hierarchy = processed_pdb_file.all_chain_proxies.pdb_hierarchy
+  chain = list(hierarchy.models())[0].chains()[0]
+  residue_groups = list(chain.residue_groups())
+  assert len(residue_groups) == 3
+
+  # Simulate tracking through the 3 residues
+  prev_C_key = {}
+  prev_C_xyz = {}
+  prev_CA_key = {}
+  prev_CA_xyz = {}
+  prev_resid = None
+
+  for rg in residue_groups:
+    cur_C_xyz = {}
+    cur_C_key = {}
+    cur_CA_xyz = {}
+    cur_CA_key = {}
+    mc_parts = []
+    ca_parts = []
+    for ag in rg.atom_groups():
+      for atom in ag.atoms():
+        key = "key_%s_%s" % (atom.name.strip(), rg.resseq_as_int())
+        _track_amino_acid_atom(
+          atom, key, ' ', rg, prev_resid,
+          cur_C_xyz, cur_C_key, cur_CA_xyz, cur_CA_key,
+          prev_C_key, prev_C_xyz, prev_CA_key, prev_CA_xyz,
+          mc_parts, ca_parts)
+
+    if rg.resseq_as_int() > 1:
+      # After processing residue 2 or 3, there should be inter-residue
+      # connections if the previous residue had C/CA atoms
+      assert len(mc_parts) > 0 or len(ca_parts) > 0, \
+        "Expected inter-residue connections for residue %d" % rg.resseq_as_int()
+
+    prev_C_key = cur_C_key
+    prev_C_xyz = cur_C_xyz
+    prev_CA_key = cur_CA_key
+    prev_CA_xyz = cur_CA_xyz
+    prev_resid = rg.resid()
+
+  print("  exercise_track_amino_acid_atom: OK")
+
+
+def exercise_track_rna_dna_atom():
+  """Test _track_rna_dna_atom with mock RNA-like atoms."""
+  from mmtbx.kinemage.validation import _track_rna_dna_atom
+
+  # Create mock atom and residue_group objects
+  class MockAtom:
+    def __init__(self, name, xyz, i_seq=0):
+      self.name = name
+      self.xyz = xyz
+      self.i_seq = i_seq
+
+  class MockResidueGroup:
+    def __init__(self, resseq):
+      self._resseq = resseq
+    def resseq_as_int(self):
+      return self._resseq
+    def resid(self):
+      return "%4d " % self._resseq
+
+  # Track a P atom for residue 2
+  cur_O3_xyz = {}
+  cur_O3_key = {}
+  prev_O3_key = {' ': 'prev_O3_key'}
+  prev_O3_xyz = {' ': (1.0, 2.0, 3.0)}
+  p_hash_key = {}
+  p_hash_xyz = {}
+  c1_hash_key = {}
+  c1_hash_xyz = {}
+  c4_hash_key = {}
+  c4_hash_xyz = {}
+  mc_parts = []
+
+  rg = MockResidueGroup(2)
+  p_atom = MockAtom(' P  ', (4.0, 5.0, 6.0))
+
+  _track_rna_dna_atom(
+    p_atom, 'p_key_2', ' ', rg, '   1 ',
+    cur_O3_xyz, cur_O3_key,
+    prev_O3_key, prev_O3_xyz,
+    p_hash_key, p_hash_xyz,
+    c1_hash_key, c1_hash_xyz,
+    c4_hash_key, c4_hash_xyz,
+    mc_parts)
+
+  # P atom should be stored in p_hash
+  assert 2 in p_hash_key, "P atom not stored in p_hash_key"
+  assert p_hash_key[2] == 'p_key_2'
+  assert p_hash_xyz[2] == (4.0, 5.0, 6.0)
+  # Should have generated an O3'-P connection
+  assert len(mc_parts) == 1, "Expected 1 O3'-P connection, got %d" % len(mc_parts)
+
+  # Track C1' and C4' atoms
+  c1_atom = MockAtom(" C1'", (7.0, 8.0, 9.0))
+  c4_atom = MockAtom(" C4'", (10.0, 11.0, 12.0))
+
+  _track_rna_dna_atom(
+    c1_atom, 'c1_key_2', ' ', rg, '   1 ',
+    cur_O3_xyz, cur_O3_key,
+    prev_O3_key, prev_O3_xyz,
+    p_hash_key, p_hash_xyz,
+    c1_hash_key, c1_hash_xyz,
+    c4_hash_key, c4_hash_xyz,
+    mc_parts)
+  _track_rna_dna_atom(
+    c4_atom, 'c4_key_2', ' ', rg, '   1 ',
+    cur_O3_xyz, cur_O3_key,
+    prev_O3_key, prev_O3_xyz,
+    p_hash_key, p_hash_xyz,
+    c1_hash_key, c1_hash_xyz,
+    c4_hash_key, c4_hash_xyz,
+    mc_parts)
+
+  assert 2 in c1_hash_key
+  assert 2 in c4_hash_key
+
+  # Track O3' atom
+  o3_atom = MockAtom(" O3'", (13.0, 14.0, 15.0))
+  _track_rna_dna_atom(
+    o3_atom, 'o3_key_2', ' ', rg, '   1 ',
+    cur_O3_xyz, cur_O3_key,
+    prev_O3_key, prev_O3_xyz,
+    p_hash_key, p_hash_xyz,
+    c1_hash_key, c1_hash_xyz,
+    c4_hash_key, c4_hash_xyz,
+    mc_parts)
+
+  assert ' ' in cur_O3_key
+  assert cur_O3_key[' '] == 'o3_key_2'
+
+  print("  exercise_track_rna_dna_atom: OK")
+
+
+def exercise_make_multikin_with_ribbons():
+  """Test that make_multikin output includes ribbon content."""
+  from mmtbx.kinemage.validation import make_multikin
+  from mmtbx.monomer_library import pdb_interpretation
+  from mmtbx import monomer_library
+  from iotbx import pdb
+  import tempfile
+
+  # Use the 8-residue PDB with SS records for reliable ribbon generation
+  pdb_io = pdb.input(source_info=None, lines=pdb_ribbon_str)
+  mon_lib_srv = monomer_library.server.server()
+  ener_lib = monomer_library.server.ener_lib()
+  processed_pdb_file = pdb_interpretation.process(
+    mon_lib_srv=mon_lib_srv,
+    ener_lib=ener_lib,
+    pdb_inp=pdb_io,
+    substitute_non_crystallographic_unit_cell_if_necessary=True)
+
+  outfile = tempfile.mktemp(suffix='.kin')
+  try:
+    result = make_multikin(
+      f=outfile,
+      processed_pdb_file=processed_pdb_file,
+      pdbID="ribbon_mk",
+      keep_hydrogens=True)
+    assert os.path.exists(result), "Output file not created"
+    with open(result, 'r') as f:
+      content = f.read()
+
+    # Ribbon content should be present in the output
+    assert "master= {ribbon}" in content, "No ribbon content in make_multikin output"
+    assert "@subgroup {ribbon" in content, "Missing ribbon subgroup"
+
+    # Should also have standard kinemage elements
+    assert "@kinemage 1" in content
+    assert "@group {ribbon_mk}" in content
+
+    # Ribbon master controls
+    assert "@master {ribbon} indent" in content, "Missing ribbon master in header"
+    assert "@master {ribbon} off" in content, "Missing ribbon master off in footer"
+  finally:
+    if os.path.exists(outfile):
+      os.remove(outfile)
+  print("  exercise_make_multikin_with_ribbons: OK")
+
+
+def exercise_make_multikin_with_disulfide():
+  """Test that make_multikin includes disulfide bonds."""
+  from mmtbx.kinemage.validation import make_multikin
+  from mmtbx.monomer_library import pdb_interpretation
+  from mmtbx import monomer_library
+  from iotbx import pdb
+  import tempfile
+
+  pdb_io = pdb.input(source_info=None, lines=pdb_disulfide_str)
+  mon_lib_srv = monomer_library.server.server()
+  ener_lib = monomer_library.server.ener_lib()
+  processed_pdb_file = pdb_interpretation.process(
+    mon_lib_srv=mon_lib_srv,
+    ener_lib=ener_lib,
+    pdb_inp=pdb_io,
+    substitute_non_crystallographic_unit_cell_if_necessary=True)
+
+  outfile = tempfile.mktemp(suffix='.kin')
+  try:
+    result = make_multikin(
+      f=outfile,
+      processed_pdb_file=processed_pdb_file,
+      pdbID="ss_mk",
+      keep_hydrogens=True)
+    assert os.path.exists(result), "Output file not created"
+    with open(result, 'r') as f:
+      content = f.read()
+
+    # Disulfide bonds should be drawn
+    assert "@vectorlist {SS}" in content, "Missing SS vectorlist in output"
+    assert "color= yellow" in content, "SS bonds should be yellow"
+  finally:
+    if os.path.exists(outfile):
+      os.remove(outfile)
+  print("  exercise_make_multikin_with_disulfide: OK")
+
+
 def run():
   print("Testing mmtbx.kinemage.validation:")
   exercise_helper_functions()
@@ -361,6 +1077,16 @@ def run():
   exercise_build_kinemage()
   exercise_make_multikin()
   exercise_het_ion_water()
+  exercise_build_name_hash()
+  exercise_same_residue()
+  exercise_draw_residue_bonds()
+  exercise_track_amino_acid_atom()
+  exercise_track_rna_dna_atom()
+  exercise_disulfide_bonds()
+  exercise_make_multikin_with_ribbons()
+  exercise_make_multikin_with_disulfide()
+  exercise_ribbon_rendering()
+  exercise_ribbon_in_kinemage()
   print("All tests passed.")
 
 

--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -800,6 +800,7 @@ def get_default_header():
 @master {H's} indent
 @pointmaster 'H' {H's}
 @master {water} indent
+@master {ribbon} indent
 """
   return header
 
@@ -821,6 +822,7 @@ def get_footer():
 @master {Cbeta dev} on
 @master {base-P perp} on
 @master {hets} on
+@master {ribbon} off
 """
   return footer
 
@@ -884,7 +886,8 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
                     omega_result=None, rna_puckers_result=None,
                     cablam_result=None,
                     probe_dots_kin=None,
-                    ss_bonds=None, sites_cart=None):
+                    ss_bonds=None, sites_cart=None,
+                    ss_annotation=None):
   """Shared logic for building the kinemage string.
 
   Args:
@@ -906,6 +909,7 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
       Pass "" to suppress probe dots entirely.
     ss_bonds: list of (i_seq_0, i_seq_1) tuples for disulfide bonds
     sites_cart: Cartesian coordinates for all atoms
+    ss_annotation: iotbx.pdb.secondary_structure.annotation object, or None
   """
   kin_out = get_default_header()
   altid_controls = get_altid_controls(hierarchy=hierarchy)
@@ -955,6 +959,34 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
     cablam_result.out = None
     kin_out += cablam_result.as_kinemage()
     cablam_result.out = saved_out
+  # Ribbon rendering (off by default via footer master toggle)
+  try:
+    from mmtbx.kinemage.ribbon_rendering import (
+        build_secondary_structure_map, consolidate_sheets,
+        generate_chain_ribbons)
+    from mmtbx.kinemage.ribbons import chain_has_DNA, chain_has_RNA
+
+    ss_map = build_secondary_structure_map(hierarchy, annotation=ss_annotation)
+    consolidate_sheets(ss_map)
+
+    ribbon_kin = ""
+    ribbon_counter = 0
+    for model in hierarchy.models():
+      has_dna = any(chain_has_DNA(c) for c in model.chains())
+      has_rna = any(chain_has_RNA(c) for c in model.chains())
+      for chain in model.chains():
+        chain_color = get_chain_color(ribbon_counter)
+        ribbon_kin += generate_chain_ribbons(
+            chain=chain, secondary_structure=ss_map,
+            chain_id=chain.id, chain_color=chain_color,
+            has_dna=has_dna, has_rna=has_rna)
+        ribbon_counter += 1
+
+    if ribbon_kin:
+      kin_out += ribbon_kin
+  except Exception as e:
+    import sys
+    print("Warning: ribbon rendering failed: %s" % str(e), file=sys.stderr)
   if probe_dots_kin is not None:
     kin_out += probe_dots_kin
   else:
@@ -1013,6 +1045,27 @@ def make_multikin(f, processed_pdb_file, pdbID=None, keep_hydrogens=False):
     ignore_hd=True,
     outliers_only=True)
 
+  # Compute secondary structure annotation for ribbon rendering
+  try:
+    import mmtbx.secondary_structure
+    sec_str_from_pdb_file = None
+    if hasattr(processed_pdb_file, 'all_chain_proxies'):
+      pdb_inp = processed_pdb_file.all_chain_proxies.pdb_inp
+      if hasattr(pdb_inp, 'extract_secondary_structure'):
+        sec_str_from_pdb_file = pdb_inp.extract_secondary_structure()
+    ss_params = mmtbx.secondary_structure.manager.get_default_ss_params()
+    ss_params.secondary_structure.protein.search_method = "from_ca"
+    ss_params = ss_params.secondary_structure
+    from libtbx.utils import null_out
+    ss_manager = mmtbx.secondary_structure.manager(
+        hierarchy,
+        params=ss_params,
+        sec_str_from_pdb_file=sec_str_from_pdb_file,
+        log=null_out())
+    ss_annotation = ss_manager.actual_sec_str
+  except Exception:
+    ss_annotation = None
+
   kin_out = _build_kinemage(
     hierarchy=hierarchy,
     bond_hash=quick_bond_hash,
@@ -1027,7 +1080,8 @@ def make_multikin(f, processed_pdb_file, pdbID=None, keep_hydrogens=False):
     rna_puckers_result=rna_puckers_result,
     cablam_result=cablam_result,
     ss_bonds=ss_bonds,
-    sites_cart=sites_cart)
+    sites_cart=sites_cart,
+    ss_annotation=ss_annotation)
 
   outfile = open(f, 'w')
   outfile.write(kin_out)
@@ -1124,7 +1178,8 @@ def export_molprobity_result_as_kinemage(
     probe_file,
     keep_hydrogens=False,
     pdbID="PDB",
-    cablam_result=None):
+    cablam_result=None,
+    ss_annotation=None):
   assert (result.restraints is not None)
   i_seq_name_hash = build_name_hash(pdb_hierarchy=pdb_hierarchy)
   sites_cart = pdb_hierarchy.atoms().extract_xyz()
@@ -1154,4 +1209,5 @@ def export_molprobity_result_as_kinemage(
     rna_puckers_result=rna_puckers_result,
     cablam_result=cablam_result,
     ss_bonds=ss_bonds,
-    sites_cart=sites_cart)
+    sites_cart=sites_cart,
+    ss_annotation=ss_annotation)

--- a/mmtbx/programs/ribbons.py
+++ b/mmtbx/programs/ribbons.py
@@ -3,13 +3,15 @@ from __future__ import absolute_import, division, print_function
 from libtbx.program_template import ProgramTemplate
 import mmtbx.secondary_structure
 from pathlib import Path
-import numpy as np
 from mmtbx.kinemage.validation import get_chain_color
-from mmtbx.kinemage.ribbons import find_contiguous_protein_residues, find_contiguous_nucleic_acid_residues
-from mmtbx.kinemage.ribbons import make_protein_guidepoints, make_nucleic_acid_guidepoints
-from mmtbx.kinemage.ribbons import untwist_ribbon, swap_edge_and_face, _FindNamedAtomInResidue, _IsNucleicAcidResidue
-from mmtbx.kinemage.ribbons import chain_has_DNA, chain_has_RNA
-from mmtbx.kinemage.nrubs import Triple, NRUBS
+from mmtbx.kinemage.ribbons import (
+    find_contiguous_protein_residues, find_contiguous_nucleic_acid_residues,
+    make_protein_guidepoints, make_nucleic_acid_guidepoints,
+    untwist_ribbon, swap_edge_and_face, _IsNucleicAcidResidue,
+    chain_has_DNA, chain_has_RNA)
+from mmtbx.kinemage.ribbon_rendering import (
+    Range, build_secondary_structure_map, consolidate_sheets,
+    render_fancy_ribbon, generate_chain_ribbons)
 
 version = "1.3.0"
 
@@ -90,444 +92,8 @@ Output:
 
 # ------------------------------------------------------------------------------
 
-  def splineInterplate(self, pts, nIntervals):
-    # Returns a list of interpolated points between the points using a spline interpolation.
-    # Based on https://docs.scipy.org/doc/scipy/tutorial/interpolate/1D.html#parametric-spline-curves
-    # @param pts: The guidepoints to interpolate between (a list of 3D points with at least 6 points in it).
-    # The first and last points are duplicates to form knots, so are not interpolated between.
-    # @param nIntervals: The number of intervals to interpolate between each pair of guidepoints, skipping the first and last.
-    # @return: The list of interpolated points
-
-    nrubs = NRUBS()
-    points = []
-    for pt in pts:
-      points.append( Triple(pt[0], pt[1], pt[2]) )
-    res = nrubs.spline(points, nIntervals)
-    ret = []
-    for r in res:
-      ret.append( np.array((r.x, r.y, r.z)) )
-    return ret
-
-    # Adjust the points to match what is expected by the Java code.
-    # The Java code expects the first and last points to be duplicates of the second and second-to-last points.
-    points = pts[1:-1]
-
-# ------------------------------------------------------------------------------
-
-  # The original code constructed a NONE crayon for the fancy print, which did not add color to
-  # the output, re-using the colors specified by model or chain.  It sometimes also specified
-  # the RAINBOW crayon, which overwrites the colors with a rainbow color scheme across each chain.
-  # For the edges, it specified a constant crayon whose string value is deadblack
-  # and it adds "U " to make it un-pickable.
-  # We pull that logic into here by implementing the forRibbon() and shouldPrint() and
-  # getKinString() methods in our own class.
-  class Crayon:
-    def __init__(self, doRainBow, color=None):
-      self._doRainBow = doRainBow
-      self._color = color
-      self._rainbowColors = [ "blue", "sky", "cyan", "sea", "green", "lime", "yellow" ,"gold" ,"orange" ,"red" ]
-
-    # Rainbow color map changes the color once across the rainbow for each chain (the chain goes from
-    # blue to red).
-    # The non-rainbow, constant-colored map does not change.
-    def forRibbon(self, startGuide):
-      if self._doRainBow:
-        res = startGuide.prevRes
-        chain = res.parent()
-        firstChainResID = chain.residue_groups()[0].resseq
-        lastChainResID = chain.residue_groups()[-1].resseq
-        normRes = (int(res.resseq) - int(firstChainResID)) / (int(lastChainResID) - int(firstChainResID))
-        scaledIndex = int(normRes * len(self._rainbowColors))
-        if scaledIndex == len(self._rainbowColors):
-          scaledIndex -= 1
-        self._color = self._rainbowColors[scaledIndex]
-
-    def getKinString(self):
-      if self._color is None:
-        return ""
-      return self._color
-
-    # All of our elements should be visible in the output.
-    def shouldPrint(self):
-      return True
-
-  # Commented out the fields and did not include methods that we don't need for our implementation
-  # Switched getType() to making type public.
-  # Its fields should be based on the PDB secondary structure records.
-  class Range:
-    def __init__(self, pType = 'COIL', pChainId = '', pInit = 0, pEnd = 0, pSense = 0, pStrand = 1, pSheet = ' ', pFlipped = False):
-      # self._rangeIndex = 0
-      self.type = pType
-      self._chainId = pChainId
-      self.initSeqNum = pInit
-      self.endSeqNum = pEnd
-      #self._initICode = ' '
-      #self._endICode = ' '
-      self.sense = pSense    # 0 if first strand, 1 if parallel, -1 if anti-parallel
-      self.strand = pStrand   # Starts at 1 for each strand within a sheet and increases by 1
-      self.sheetID = pSheet
-      self.flipped = pFlipped  # Used by printing code to make the tops within a set of ribbons all point the same way
-      self.previous = None
-      self.next = None
-      self.duplicateOf = None
-
-    def __str__(self):
-      return 'Range: type={}, init={}, end={}, sense={}, strand={}, sheet={}, flipped={}'.format(
-        self.type, self.initSeqNum, self.endSeqNum, self.sense, self.strand, self.sheetID, self.flipped)
-
-  def ConsolidateSheets(self):
-    uniqueStrands = {}
-
-    # For each ribbon, record its predecessor in sheet, and check for duplicates
-    for rng in self.secondaryStructure.values():
-      if not rng.type == 'SHEET':
-        continue
-
-      key = str(int(rng.initSeqNum)) + rng._chainId
-      if not key in uniqueStrands:
-        uniqueStrands[key] = rng
-      else:
-        rng.duplicateOf = uniqueStrands[key]
-
-      # Now find this strand's previous and next strand.
-      for rng2 in self.secondaryStructure.values():
-        if not rng2.type == 'SHEET':
-          continue
-        if rng2.sheetID == rng.sheetID and rng2.strand == rng.strand-1:
-          rng.previous = rng2
-          rng2.next = rng
-
-      # Now go through and reassign previous/next fields in duplicates
-      for rng in self.secondaryStructure.values():
-        if not rng.type == 'SHEET':
-          continue
-        if rng.duplicateOf is None and rng.next is not None and rng.next.duplicateOf is not None:
-          rng.next.duplicateOf.previous = rng
-        if rng.duplicateOf is None and rng.previous is not None and rng.previous.duplicateOf is not None:
-          rng.previous = rng.previous.duplicateOf
-
-  class RibbonElement:
-    def __init__(self, other=None, setRange=None):
-      self.start = 0
-      self.end = 0
-      self.type = 'COIL'
-      self.range = setRange
-      if other is not None:
-        self.like(other)
-      if self.range is not None:
-        if self.range.type is None or self.range.type == 'TURN':
-          self.type = 'COIL'
-        else:
-          self.type = self.range.type
-
-    def sameSSE(self, that):
-      return self.type == that.type and self.range == that.range
-
-    def like(self, that):
-      self.start = that.start
-      self.end = that.end
-      self.type = that.type
-      self.range = that.range
-
-    def __lt__(self, that):
-      a = 0
-      b = 0
-      if self.range is not None:
-        a = self.range.strand
-      if that.range is not None:
-        b = that.range.strand
-      return a < b
-
-  # If the current point ID is the same as the previous point ID, we return the shorthand double-quote (") to
-  # indicate this.  To force a new point ID, set self._lastPointID to "" before calling this function.
-  def getPointID(self, point, start, end, interval, nIntervals):
-    if self._lastPointID is None:
-      self._lastPointID = ""
-
-    res = start.nextRes
-    if self.params.DNA_style and interval <= nIntervals // 2:
-      res = start.prevRes   # == first res, for RNA/DNA only
-
-    buf = res.atom_groups()[0].resname.strip() + " " + res.parent().id.strip() + " " + res.resseq.strip() + res.icode
-    res = buf.lower().strip()
-
-    if res == self._lastPointID:
-      res = '"'
-    else:
-      self._lastPointID = res
-
-    return res
-
-  def printFancy(self, guides, splines, i, lineBreak = False):
-    # Prints a fancy ribbon element with the given guidepoints and splines.
-    # @param guides: The guidepoints for the ribbon
-    # @param splines: The interpolated points for the ribbon
-    # @param i: The index of the guidepoint to print
-
-    ret = ""
-    # Not self.nIntervals, we want a local variable here
-    nIntervals = (len(splines) - 1) // (len(guides) - 3)
-    interval = i % nIntervals
-    startGuide = (i // nIntervals) + 1
-    ret += "{"
-    ret += self.getPointID(splines[i], guides[startGuide], guides[startGuide + 1], interval, nIntervals)
-    ret += "}"
-    if lineBreak:
-      ret += "P "
-    self.crayon.forRibbon(guides[startGuide])
-    ret += self.crayon.getKinString()
-    ret += " "
-    ret += "{:.3f} {:.3f} {:.3f}\n".format(splines[i][0], splines[i][1], splines[i][2])
-
-    return ret
-
-  def printFancyRibbon(self, guides, widthAlpha, widthBeta, listAlpha, listBeta, listCoil, listCoilOutline, doRainbow):
-    # Constructs a kinemage string for a ribbon representation of a protein or nucleic acid chain.
-    # Makes a triangulated ribbon with arrowheads, etc.
-    # @param guides: The guidepoints for the ribbon
-    # @param widthAlpha: The width of the alpha helix part of the ribbon
-    # @param widthBeta: The width of the beta sheet part of the ribbon
-    # @param listAlpha: The kinemage string describing the alpha helix part of the ribbon
-    # @param listBeta: The kinemage string describing the beta sheet part of the ribbon
-    # @param listCoil: The kinemage string describing the coil part of the ribbon
-    # @param listCoilOutline: The kinemage string describing the outline of the coil part of the ribbon
-    # @param doRainbow: Whether or not to color the ribbon by rainbow
-    # If false (the default), the protein style will be used instead.
-    # @return: The kinemage string for the ribbon representation
-
-    ret = ""
-
-    # Initialize local references
-    widthCoil = self.params.coil_width
-    secStruct = self.secondaryStructure
-
-    # Seven strands of guidpoints: coil, +/-alpha, +/-beta, +/-beta arrowheads.
-    # Each strand is a list of 3D points and there is a strand for each offset from the center spline.
-    halfWidths = [0.0, -widthAlpha/2, widthAlpha/2, -widthBeta/2, widthBeta/2, -widthBeta, widthBeta]
-    # Make a different empty list for each strand
-    strands = []
-    for _ in range(len(halfWidths)):
-      strands.append([])
-    for g in guides:
-      for i in range(len(halfWidths)):
-        strands[i].append(g.pos + g.dvec * halfWidths[i])
-
-    # Seven strands of interpolated points
-    splinepts = []
-    for i in range(len(strands)):
-      splinepts.append(self.splineInterplate(strands[i], self.nIntervals))
-
-    # Discovery of ribbon elements: ribbons, ropes, and arrows.
-    # We skip the regions associated with the first and last points, which are present to cause the
-    # curve to pass through those points (like knots) but are not interpolated between.
-    # We do that by looping through fewer entries and by adding 1 to the index.
-    ribbonElements = []
-    ribElement = self.RibbonElement()
-    prevRibElt = self.RibbonElement()
-    ribbonElements.append(ribElement)
-    # Element that is reused and copied when creating a new list entry
-    ribElement.type = None
-    for i in range(len(guides) - 1 - 2):
-      g1 = guides[i + 1]
-      g2 = guides[i + 2]
-
-      # The Java code reports that we're not really using ribbon elements, just reusing the
-      # class for convenience.  So not all of the member variables may be filled in.
-      currSS = self.RibbonElement(setRange=secStruct[int(g1.nextRes.resseq)])
-      nextSS = self.RibbonElement(setRange=secStruct[int(g2.nextRes.resseq)])
-
-      # Otherwise, we get one unit of coil before alpha or beta at start
-      if ribElement.type is None:
-        ribElement.like(currSS)
-
-      if i == 0 or not ribElement.sameSSE(currSS): # Helix / sheet starting
-        if currSS.type == 'HELIX' or currSS.type == 'SHEET':
-          ribElement.end = self.nIntervals*i + 1
-          ribElement = self.RibbonElement(currSS)
-          ribbonElements.append(ribElement)
-          # Every helix or sheet starts with a coil; see below
-          ribElement.start = self.nIntervals*i + 1
-      if not ribElement.sameSSE(nextSS): # Helix / sheet ending
-        if currSS.type == 'HELIX' or currSS.type == 'SHEET':
-          end = self.nIntervals*i + 0
-          if currSS.type == 'SHEET':
-            end += self.nIntervals - 1
-          ribElement.end = end
-          ribElement = self.RibbonElement()
-          ribbonElements.append(ribElement)
-          # Every helix or sheet flows into coil
-          ribElement.type = 'COIL'
-          ribElement.start = end
-    ribElement.end = len(splinepts[0]) - 1
-
-    # "Crayons" to use for coloring the ribbon, juggling them around to keep the edges black.
-    normalCrayon = self.Crayon(doRainbow)
-    edgeCrayon = self.Crayon(False)  # Default no color; the deadblack will be set on the vectorlist
-
-    # Sort the ribbon elements by strand number
-    ribbonElements.sort()
-
-    # Create a list of just sheets (Java STRANDs) for searching through
-    strands = [r for r in ribbonElements if r.type == 'SHEET']
-
-    for ribElement in ribbonElements:
-      stGuide = (ribElement.start // self.nIntervals) + 2
-      endGuide = (ribElement.end // self.nIntervals) - 1
-
-      if ribElement.type == 'HELIX':
-
-        k = (ribElement.start + ribElement.end) // 2
-        pt = splinepts[2][k]
-        v1 = splinepts[1][k] - pt
-        v2 = splinepts[1][k+1] - pt
-        cross = np.cross(v1, v2)
-        dot = np.dot( np.linalg.norm(cross), np.linalg.norm(np.array(guides[k//self.nIntervals+1].cvec)))
-
-        self.crayon = normalCrayon
-        ret += "@ribbonlist {fancy helix} " + listAlpha + "\n"
-        self._lastPointID = ""
-
-        for i in range(ribElement.start, ribElement.end):
-          if dot > 0:
-            # Flip the normals (for sidedness) by switching the order of these two lines.
-            ret += self.printFancy(guides, splinepts[2], i)
-            ret += self.printFancy(guides, splinepts[1], i)
-          else:
-            ret += self.printFancy(guides, splinepts[1], i)
-            ret += self.printFancy(guides, splinepts[2], i)
-        ret += self.printFancy(guides, splinepts[0], ribElement.end)  # Angled tip at end of helix
-        self.crayon = edgeCrayon
-        ret += "@vectorlist {fancy helix edges} width=1 " + listAlpha + " color= deadblack\n"
-        self._lastPointID = ""
-        # Black edge, left side
-        ret += self.printFancy(guides, splinepts[0], ribElement.start, True)
-        for i in range(ribElement.start, ribElement.end):
-          ret += self.printFancy(guides, splinepts[1], i)
-        ret += self.printFancy(guides, splinepts[0], ribElement.end)
-        # Black edge, right side
-        ret += self.printFancy(guides, splinepts[0], ribElement.start, True)
-        for i in range(ribElement.start, ribElement.end):
-          ret += self.printFancy(guides, splinepts[2], i)
-        ret += self.printFancy(guides, splinepts[0], ribElement.end)
-
-      elif ribElement.type == 'SHEET':
-
-        dot = 0.0     # Used to determine sidedness
-
-        # Don't do for the first strand in the sheet
-        if ribElement.range.strand != 1:
-          # Look for previous strand
-          for i in range(len(strands)):
-            curElt = strands[i]
-            if curElt.range == ribElement.range.previous:
-              prevRibElt = curElt
-              break
-
-          prevRange = prevRibElt.range
-          if prevRange is None:
-            prevRibElt = ribElement
-
-          # Detrmine sidedness using splinepts and normals
-          prevStGuide = (prevRibElt.start // self.nIntervals) + 2
-          prevEndGuide = (prevRibElt.end // self.nIntervals) + 1
-          curClosest = stGuide      # Find the pair of guidepoints closest to each other
-          prevClosest = prevStGuide # (one on each strand) to perform the test
-          closeDist = 1e10
-          for i in range(stGuide, endGuide+2 + 1):
-            for j in range(prevStGuide, endGuide+2 + 1):
-              # Look for closest pair of H-bonding partners
-              try:
-                O = _FindNamedAtomInResidue(guides[i].prevRes, "O")
-                N = _FindNamedAtomInResidue(guides[i].prevRes, "N")
-                dist = np.linalg.norm(O.pos - N.pos)
-                if dist < closeDist:
-                  closeDist = dist
-                  curClosest = i
-                  prevClosest = j
-              except Exception:
-                pass
-          kCur = min(self.nIntervals*(curClosest-1), len(splinepts[4]))
-          kPrev = min(self.nIntervals*(prevClosest-1), len(splinepts[4]))
-          ptCur = splinepts[4][kCur]
-          v1Cur = splinepts[3][kCur] - ptCur
-          # VBC Hack to get 1jj2 at least generating ribbons kins.  Doesn't seem to
-          # correctly generate beta sides though.  Error is kCur+1 generates an ArrayIndexOutOfBoundsException in splinepts[3]
-          if kCur+1 < len(splinepts[3]):
-            v2Cur = splinepts[3][kCur+1] - ptCur
-            crossCur = np.cross(v1Cur, v2Cur)
-            ptPrev = splinepts[4][kPrev]
-            v1Prev = splinepts[3][kPrev] - ptPrev
-            v2Prev = splinepts[3][kPrev+1] - ptPrev
-            crossPrev = np.cross(v1Prev, v2Prev)
-            dot = np.dot( crossCur, crossPrev)
-
-        self.crayon = normalCrayon
-        ret += "@ribbonlist {fancy sheet} " + listBeta + "\n"
-        self._lastPointID = ""
-        for i in range(ribElement.start, ribElement.end - 1):
-          # If strands are not "facing" the same way,
-          # flip the normals (for sidedness) by switching the order of these two lines, (ARK Spring2010)
-          if (dot < 0 and not prevRibElt.range.flipped) or (dot > 0 and prevRibElt.range.flipped):
-            ret += self.printFancy(guides, splinepts[4], i)
-            ret += self.printFancy(guides, splinepts[3], i)
-            ribElement.range.flipped = True
-          else:
-            ret += self.printFancy(guides, splinepts[3], i)
-            ret += self.printFancy(guides, splinepts[4], i)
-
-        # Ending *exactly* like this is critical to avoiding a break
-        # between the arrow body and arrow head!
-        if (dot < 0 and not prevRibElt.range.flipped) or (dot > 0 and prevRibElt.range.flipped):
-          ret += self.printFancy(guides, splinepts[6], ribElement.end - 2)
-          ret += self.printFancy(guides, splinepts[5], ribElement.end - 2)
-          ret += self.printFancy(guides, splinepts[0], ribElement.end)
-        else:
-          ret += self.printFancy(guides, splinepts[5], ribElement.end - 2)
-          ret += self.printFancy(guides, splinepts[6], ribElement.end - 2)
-          ret += self.printFancy(guides, splinepts[0], ribElement.end)
-        # Borders
-        self.crayon = edgeCrayon
-        ret += "@vectorlist {fancy sheet edges} width=1 " + listBeta + " color= deadblack\n"
-        self._lastPointID = ""
-        # Black edge, left side
-        ret += self.printFancy(guides, splinepts[0], ribElement.start, True)
-        for i in range(ribElement.start, ribElement.end - 1):
-          ret += self.printFancy(guides, splinepts[3], i)
-        ret += self.printFancy(guides, splinepts[5], ribElement.end - 2)
-        ret += self.printFancy(guides, splinepts[0], ribElement.end)
-        # Black edge, right side
-        ret += self.printFancy(guides, splinepts[0], ribElement.start, True)
-        for i in range(ribElement.start, ribElement.end - 1):
-          ret += self.printFancy(guides, splinepts[4], i)
-        ret += self.printFancy(guides, splinepts[6], ribElement.end - 2)
-        ret += self.printFancy(guides, splinepts[0], ribElement.end)
-
-      else: # Coil
-
-        # for black outlines on coils
-        if listCoilOutline is not None:
-          self.crayon = normalCrayon
-          ret += "@vectorlist {fancy coil edges} " + listCoilOutline + "\n"
-          self._lastPointID = ""
-          for i in range(ribElement.start, ribElement.end+1):
-            ret += self.printFancy(guides, splinepts[0], i)
-
-        self.crayon = normalCrayon
-        ret += "@vectorlist {fancy coil} " + listCoil + "\n"
-        self._lastPointID = ""
-        for i in range(ribElement.start, ribElement.end+1):
-          ret += self.printFancy(guides, splinepts[0], i)
-
-      # Reset the crayon for the next pass
-      self.crayon = normalCrayon
-
-    return ret
-
-# ------------------------------------------------------------------------------
-
   def run(self):
     self.model = self.data_manager.get_model()
-    self.nIntervals = 4
 
     # Apply a selection to the model if one is provided.  The default is to select atoms in the
     # first alternate location.
@@ -542,53 +108,26 @@ Output:
     # This should return None if there are no secondary structure records in the model.
     sec_str_from_pdb_file = self.model.get_ss_annotation()
 
-    # Analyze the secondary structure and make a dictionary that maps from residue sequence number to secondary structure type
-    # by filling in 'COIL' as a default value for each and then parsing all of the secondary structure records in the
-    # model and filling in the relevant values for them.
+    # Build the secondary structure map using the annotation API directly
     print('Finding secondary structure:', file=self.logger)
     params = mmtbx.secondary_structure.manager.get_default_ss_params()
-    params.secondary_structure.protein.search_method="ksdssp"
+    params.secondary_structure.protein.search_method = "from_ca"
     params = params.secondary_structure
     ss_manager = mmtbx.secondary_structure.manager(hierarchy,
                                                    params=params,
                                                    sec_str_from_pdb_file=sec_str_from_pdb_file,
                                                    log=self.logger)
-    self.secondaryStructure = {}
-    for model in hierarchy.models():
-      for chain in model.chains():
-        for residue_group in chain.residue_groups():
-          self.secondaryStructure[residue_group.resseq_as_int()] = self.Range()
-    for line in ss_manager.records_for_pdb_file().splitlines():
-      r = self.Range(line[0:5].strip())
-      if r.type == 'HELIX':
-        r.sheetID = line[11:14].strip()
-        r._chainId = line[19:21].strip()
-        r.initSeqNum = int(line[22:26].strip())
-        r.endSeqNum = int(line[33:38].strip())
-      elif r.type == 'SHEET':  # Java code marks this internally as STRAND but we leave it as SHEET
-        r.sheetID = line[11:14].strip()
-        r._chainId = line[21:22].strip()
-        r.initSeqNum = int(line[23:28].strip())
-        r.endSeqNum = int(line[33:38].strip())
-        r.sense = int(line[38:40].strip())
-        r.strand = int(line[7:10].strip())
-      elif r.type == 'TURN':
-        # In fact, we turn turns int coils, so we really don't care.
-        # r.sheetID = line[11:14].strip()
-        r._chainId = line[20:21].strip()
-        r.initSeqNum = int(line[22:26].strip())
-        r.endSeqNum = int(line[33:37].strip())
-      for i in range(r.initSeqNum,r.endSeqNum+1):
-        self.secondaryStructure[i] = r
-
-    self.ConsolidateSheets()
+    annotation = ss_manager.actual_sec_str
+    self.secondaryStructure = build_secondary_structure_map(
+        hierarchy, annotation=annotation, log=self.logger)
+    consolidate_sheets(self.secondaryStructure)
 
     # If we are treating nucleic acids as helices, change the record of each nucleic acid residue to be a helix.
     if self.params.nucleic_acid_as_helix:
-      r = self.Range('HELIX')
+      r = Range('HELIX')
       for res in hierarchy.residue_groups():
         if _IsNucleicAcidResidue(res.unique_resnames()[0]):
-          self.secondaryStructure[int(res.resseq)] = r
+          self.secondaryStructure[res.resseq_as_int()] = r
 
     # The name of the structure, which is the root of the input file name (no path, no extension)
     self.idCode = self.data_manager.get_default_model_name().split('.')[0]
@@ -631,18 +170,13 @@ Output:
         chainCount += 1
 
       # Determine whether DNA, RNA, or both are present in the model
-      hasDNA = False
-      hasRNA = False
-      for chain in model.chains():
-        if chain_has_DNA(chain):
-          hasDNA = True
-        if chain_has_RNA(chain):
-          hasRNA = True
+      hasDNA = any(chain_has_DNA(chain) for chain in model.chains())
+      hasRNA = any(chain_has_RNA(chain) for chain in model.chains())
 
       # Cycle over all chains in the model and make a group or subgroup for each chain
       # depending on whether we are grouping by model or not.
       for chain in model.chains():
-        print('Processing chain',chain.id, file=self.logger)
+        print('Processing chain', chain.id, file=self.logger)
 
         if self.params.do_protein:
           # Find the contiguous protein residues by CA distance
@@ -660,38 +194,35 @@ Output:
             # per-residue basis.
             bbColor = chainColors[chain.id]
             if bbColor == "white" and not (self.params.color_by == "solid"):
-              # Distinguish between the different types of secondary structure for the first chain (out of every 7th)
-              # if we're not coloring by solid colors
               outString += "@colorset {{alph{}}} red\n".format(chain.id)
               outString += "@colorset {{beta{}}} lime\n".format(chain.id)
               outString += "@colorset {{coil{}}} white\n".format(chain.id)
             else:
-              # Do all secondary structure in the same color for all but the first chain (out of every 7th) to clean up the display
               outString += "@colorset {{alph{}}} {}\n".format(chain.id, bbColor)
               outString += "@colorset {{beta{}}} {}\n".format(chain.id, bbColor)
               outString += "@colorset {{coil{}}} {}\n".format(chain.id, bbColor)
 
             for contig in contiguous_residue_lists:
               guidepoints = make_protein_guidepoints(contig)
-              print(' Made {} protein guidepoints for {} residues'.format(len(guidepoints),len(contig)), file=self.logger)
+              print(' Made {} protein guidepoints for {} residues'.format(len(guidepoints), len(contig)), file=self.logger)
               if self.params.untwist_ribbons:
                 print('  Untwisted ribbon', file=self.logger)
                 untwist_ribbon(guidepoints)
-              # There is always secondary structure looked up for protein residues, so we skip the case from the Java code
-              # where it can be missing.
               if self.params.do_plain_coils:
-                outString += self.printFancyRibbon(guidepoints, 2, 2.2,
-                      "color= {alph"+chain.id+"} master= {protein} master= {ribbon} master= {alpha}",
-                      "color= {beta"+chain.id+"} master= {protein} master= {ribbon} master= {beta}",
-                      "width= 4 color= {coil"+chain.id+"} master= {protein} master= {ribbon} master= {coil}",
-                      self.params.color_by == "rainbow");
+                outString += render_fancy_ribbon(guidepoints, self.secondaryStructure,
+                      width_alpha=2, width_beta=2.2,
+                      list_alpha="color= {alph"+chain.id+"} master= {protein} master= {ribbon} master= {alpha}",
+                      list_beta="color= {beta"+chain.id+"} master= {protein} master= {ribbon} master= {beta}",
+                      list_coil="width= 4 color= {coil"+chain.id+"} master= {protein} master= {ribbon} master= {coil}",
+                      do_rainbow=self.params.color_by == "rainbow")
               else:
-                outString += self.printFancyRibbon(guidepoints, 2, 2.2,
-                      "color= {alph"+chain.id+"} master= {protein} master= {ribbon} master= {alpha}",
-                      "color= {beta"+chain.id+"} master= {protein} master= {ribbon} master= {beta}",
-                      "width= 4 color= {coil"+chain.id+"} master= {protein} master= {ribbon} master= {coil}",
-                      "width= 6 color= deadblack master= {protein} master= {ribbon} master= {coil}",
-                      self.params.color_by == "rainbow")
+                outString += render_fancy_ribbon(guidepoints, self.secondaryStructure,
+                      width_alpha=2, width_beta=2.2,
+                      list_alpha="color= {alph"+chain.id+"} master= {protein} master= {ribbon} master= {alpha}",
+                      list_beta="color= {beta"+chain.id+"} master= {protein} master= {ribbon} master= {beta}",
+                      list_coil="width= 4 color= {coil"+chain.id+"} master= {protein} master= {ribbon} master= {coil}",
+                      list_coil_outline="width= 6 color= deadblack master= {protein} master= {ribbon} master= {coil}",
+                      do_rainbow=self.params.color_by == "rainbow")
 
         if self.params.do_nucleic_acid:
           # Find the contiguous nucleic acid residues by CA distance
@@ -715,25 +246,22 @@ Output:
 
             for contig in contiguous_residue_lists:
               guidepoints = make_nucleic_acid_guidepoints(contig)
-              print(' Made {} NA guidepoints for {} residues'.format(len(guidepoints),len(contig)), file=self.logger)
+              print(' Made {} NA guidepoints for {} residues'.format(len(guidepoints), len(contig)), file=self.logger)
               if self.params.untwist_ribbons:
                 print('  Untwisted ribbon', file=self.logger)
                 untwist_ribbon(guidepoints)
-              # If the model has both DNA and RNA, and if this chain is DNA, swap the edge and face so that
-              # we can distinguish between them in the same model.  Also, if the DNA_style parameter has been
-              # set, then always make this style.
               if self.params.DNA_style or (hasDNA and hasRNA and chain_has_DNA(chain)):
                 print('  Swapped edge and face (DNA style)', file=self.logger)
                 swap_edge_and_face(guidepoints)
               else:
                 print('  Using RNA style ribbons', file=self.logger)
 
-              outString += self.printFancyRibbon(guidepoints, 3.0, 3.0,
-                    "color= {nucl"+chain.id+"} master= {nucleic acid} master= {ribbon} master= {RNA helix?}",
-                    "color= {nucl"+chain.id+"} master= {nucleic acid} master= {ribbon} master= {A-form}",
-                    "width= 4 color= {ncoi"+chain.id+"} master= {nucleic acid} master= {ribbon} master= {coil}",
-                    None,
-                    self.params.color_by == "rainbow")
+              outString += render_fancy_ribbon(guidepoints, self.secondaryStructure,
+                    width_alpha=3.0, width_beta=3.0,
+                    list_alpha="color= {nucl"+chain.id+"} master= {nucleic acid} master= {ribbon} master= {RNA helix?}",
+                    list_beta="color= {nucl"+chain.id+"} master= {nucleic acid} master= {ribbon} master= {A-form}",
+                    list_coil="width= 4 color= {ncoi"+chain.id+"} master= {nucleic acid} master= {ribbon} master= {coil}",
+                    do_rainbow=self.params.color_by == "rainbow")
 
     # Write the output to the specified file.
     self.data_manager._write_text("Text", outString, self.params.output.filename)


### PR DESCRIPTION
## Summary

Extracts the ribbon-rendering logic from the `mmtbx.ribbons` program into a reusable
library module (`mmtbx/kinemage/ribbon_rendering.py`) and wires it into the MolProbity
kinemage output, so ribbons can be drawn as part of the integrated kinemage (off by
default). `mmtbx/programs/ribbons.py` is refactored to call the extracted code.

## What changed

**New `mmtbx/kinemage/ribbon_rendering.py`** — the ribbon-drawing logic previously living
as instance methods on `mmtbx.ribbons`'s `Program` class, lifted into module-level
functions (`spline_interpolate`, `consolidate_sheets`, `get_point_id`,
`format_ribbon_point`, `render_fancy_ribbon`, `generate_chain_ribbons`, plus
`build_secondary_structure_map` and small `Crayon`/`Range`/`RibbonElement` helpers). The
algorithm is unchanged.

**`mmtbx/programs/ribbons.py`** — the inline ribbon methods are removed and the program now
imports/delegates to `ribbon_rendering.py`. **`mmtbx.ribbons` output is byte-identical
before/after this change** (verified on a real structure), so this is a pure refactor.

**`mmtbx/kinemage/validation.py`** — `_build_kinemage` gains an `ss_annotation` parameter and
emits a `{ribbon}` subgroup (via `generate_chain_ribbons`) within the main model group;
`make_multikin` computes the secondary-structure annotation and threads it through;
`export_molprobity_result_as_kinemage` gains the pass-through. Header/footer get a
`{ribbon}` master toggle — **off by default**.

**`mmtbx/kinemage/tst_validation.py`** — 10 new tests covering ribbon rendering, the
ribbon-in-main-group placement, `build_name_hash` dict format, `_same_residue`, disulfide
bonds, `_draw_residue_bonds`, backbone-atom tracking, and end-to-end `make_multikin`.

## Notes

- Ribbon rendering is wrapped in a guard so that if it can't build ribbons for a given
  chain, the rest of the kinemage is still produced. For very short chains (fewer than 3
  residues) the underlying guide-vector construction can't run, so ribbons are skipped for
  that chain (a follow-up applies a proper 3-residue-minimum filter matching Prekin).
- Ribbons are off by default; existing kinemage output is unchanged unless the `{ribbon}`
  master is toggled on.

## Testing

- `mmtbx/kinemage/tst_validation.py` (16 tests incl. the 10 new) — all pass.
- `phenix_regression/validation/tst_kinemage.py` — passes.
- `mmtbx.ribbons` on a real structure: byte-identical output vs. before (refactor is
  behavior-preserving).
- `phenix.kinemage` on a real structure: ribbon subgroup + colorsets render; probe dots,
  disulfides, and het/water output are unchanged.
