### PR TITLE
Kinemage: build_kinemage_from_model helper, ribbon polish, and cablam/coil display toggles

### DIFF
--- a/mmtbx/kinemage/ribbon_rendering.py
+++ b/mmtbx/kinemage/ribbon_rendering.py
@@ -384,7 +384,7 @@ def render_fancy_ribbon(guides, secondary_structure, n_intervals=4,
     if rib_element.type is None:
       rib_element.like(curr_ss)
 
-    if i == 0 or not rib_element.same_sse(curr_ss):
+    if not rib_element.same_sse(curr_ss):
       if curr_ss.type == 'HELIX' or curr_ss.type == 'SHEET':
         rib_element.end = n_intervals * i + 1
         rib_element = RibbonElement(curr_ss)
@@ -694,18 +694,18 @@ def generate_chain_ribbons(chain, secondary_structure, chain_id,
           out += render_fancy_ribbon(
               guidepoints, secondary_structure,
               width_alpha=2.0, width_beta=2.2, width_coil=coil_width,
-              list_alpha="color= {alph" + chain_id + "} master= {protein} master= {ribbon} master= {alpha}",
-              list_beta="color= {beta" + chain_id + "} master= {protein} master= {ribbon} master= {beta}",
-              list_coil="width= 4 color= {coil" + chain_id + "} master= {protein} master= {ribbon} master= {coil}",
+              list_alpha="color= {alph" + chain_id + "} master= {protein ribbon} master= {alpha}",
+              list_beta="color= {beta" + chain_id + "} master= {protein ribbon} master= {beta}",
+              list_coil="width= 4 color= {coil" + chain_id + "} master= {protein ribbon} master= {coil}",
               do_rainbow=do_rainbow, dna_style=dna_style)
         else:
           out += render_fancy_ribbon(
               guidepoints, secondary_structure,
               width_alpha=2.0, width_beta=2.2, width_coil=coil_width,
-              list_alpha="color= {alph" + chain_id + "} master= {protein} master= {ribbon} master= {alpha}",
-              list_beta="color= {beta" + chain_id + "} master= {protein} master= {ribbon} master= {beta}",
-              list_coil="width= 4 fore color= {coil" + chain_id + "} master= {protein} master= {ribbon} master= {coil}",
-              list_coil_outline="width= 6 rear color= deadblack master= {protein} master= {ribbon} master= {coil}",
+              list_alpha="color= {alph" + chain_id + "} master= {protein ribbon} master= {alpha}",
+              list_beta="color= {beta" + chain_id + "} master= {protein ribbon} master= {beta}",
+              list_coil="width= 4 fore color= {coil" + chain_id + "} master= {protein ribbon} master= {coil}",
+              list_coil_outline="width= 6 rear color= deadblack master= {protein ribbon} master= {coil}",
               do_rainbow=do_rainbow, dna_style=dna_style)
 
   # --- Nucleic acid ribbons ---
@@ -732,9 +732,9 @@ def generate_chain_ribbons(chain, secondary_structure, chain_id,
         out += render_fancy_ribbon(
             guidepoints, secondary_structure,
             width_alpha=3.0, width_beta=3.0, width_coil=coil_width,
-            list_alpha="color= {nucl" + chain_id + "} master= {nucleic acid} master= {ribbon} master= {RNA helix?}",
-            list_beta="color= {nucl" + chain_id + "} master= {nucleic acid} master= {ribbon} master= {A-form}",
-            list_coil="width= 4 color= {ncoi" + chain_id + "} master= {nucleic acid} master= {ribbon} master= {coil}",
+            list_alpha="color= {nucl" + chain_id + "} master= {NA ribbon} master= {RNA helix?}",
+            list_beta="color= {nucl" + chain_id + "} master= {NA ribbon} master= {A-form}",
+            list_coil="width= 4 color= {ncoi" + chain_id + "} master= {NA ribbon} master= {coil}",
             do_rainbow=do_rainbow, dna_style=use_dna_style)
 
   return out

--- a/mmtbx/kinemage/ribbon_rendering.py
+++ b/mmtbx/kinemage/ribbon_rendering.py
@@ -404,6 +404,16 @@ def render_fancy_ribbon(guides, secondary_structure, n_intervals=4,
 
   rib_element.end = len(splinepts[0]) - 1
 
+  # Convert degenerate or too-short HELIX/SHEET elements to COIL.
+  # A 1-residue SS annotation produces start > end; a 2-residue one produces
+  # only ~3 spline points. Prekin avoids this via per-residue rendering;
+  # we filter them here instead.
+  for rib_elt in ribbon_elements:
+    if rib_elt.type in ('HELIX', 'SHEET'):
+      if rib_elt.end - rib_elt.start < n_intervals:
+        rib_elt.type = 'COIL'
+        rib_elt.range = None
+
   # Crayons for coloring
   normal_crayon = Crayon(do_rainbow)
   edge_crayon = Crayon(False)  # No color; deadblack set on vectorlist
@@ -642,7 +652,7 @@ def generate_chain_ribbons(chain, secondary_structure, chain_id,
                            do_nucleic_acid=True, untwist=True,
                            dna_style=False, do_plain_coils=False,
                            coil_width=1.0, color_by="secondary_structure",
-                           nucleic_acid_as_helix=True,
+                           nucleic_acid_as_sheet=True,
                            has_dna=False, has_rna=False):
   """Generate complete ribbon kinemage text for one chain.
 
@@ -661,7 +671,8 @@ def generate_chain_ribbons(chain, secondary_structure, chain_id,
     do_plain_coils: if True, omit coil outlines (halo)
     coil_width: width of the coil part
     color_by: "rainbow", "secondary_structure", or "solid"
-    nucleic_acid_as_helix: treat nucleic acids as helix in SS map
+    nucleic_acid_as_sheet: treat nucleic acids as sheet (flat ribbon with
+        arrowheads) in SS map, matching Prekin's BETA behavior
     has_dna: whether DNA is present in the model
     has_rna: whether RNA is present in the model
 
@@ -720,6 +731,14 @@ def generate_chain_ribbons(chain, secondary_structure, chain_id,
       else:
         out += "@colorset {{nucl{}}} {}\n".format(chain_id, chain_color)
         out += "@colorset {{ncoi{}}} {}\n".format(chain_id, chain_color)
+
+      # Mark nucleic acid residues as SHEET in the SS map when requested,
+      # producing flat ribbons with arrowheads (matching Prekin's BETA behavior).
+      if nucleic_acid_as_sheet:
+        sheet_range = Range('SHEET')
+        for contig in contiguous_lists:
+          for res in contig:
+            secondary_structure[res.resseq_as_int()] = sheet_range
 
       for contig in contiguous_lists:
         guidepoints = make_nucleic_acid_guidepoints(contig)

--- a/mmtbx/kinemage/ribbons.py
+++ b/mmtbx/kinemage/ribbons.py
@@ -67,7 +67,7 @@ def _FindContiguousResiduesByAtomDistances(chain, type_function, desired_atoms, 
         current_contig_residues.append(residue_group)
       else:
         # If not, start a new list for the current residue if we have at least one residue
-        if len(current_contig_residues) > 0:
+        if len(current_contig_residues) > 2:
           contiguous_residues.append(current_contig_residues)
         current_contig_residues = [residue_group]
 
@@ -75,8 +75,8 @@ def _FindContiguousResiduesByAtomDistances(chain, type_function, desired_atoms, 
     prev_atom = atom
 
   # After iterating through the chain, add any remaining contiguous residues to the main list
-  # if there are at least two.
-  if len(current_contig_residues) > 1:
+  # if there are at least three (matching Prekin's minimum fragment size).
+  if len(current_contig_residues) > 2:
     contiguous_residues.append(current_contig_residues)
 
   return contiguous_residues

--- a/mmtbx/kinemage/tst_validation.py
+++ b/mmtbx/kinemage/tst_validation.py
@@ -205,6 +205,78 @@ def exercise_make_multikin():
   print("  exercise_make_multikin: OK")
 
 
+def exercise_build_kinemage_from_model():
+  """Test the high-level build_kinemage_from_model helper with an
+  mmtbx.model.manager input (no explicit hydrogens)."""
+  from mmtbx.kinemage.validation import build_kinemage_from_model
+  import mmtbx.model
+  from iotbx import pdb
+
+  pdb_io = pdb.input(source_info=None, lines=pdb_str)
+  model = mmtbx.model.manager(model_input=pdb_io)
+
+  # probe_dots_kin="" skips the (expensive) probe2 call — we just want to
+  # exercise the hash/bond/validator plumbing here.
+  kin_out = build_kinemage_from_model(
+      model=model, pdbID="model_test", probe_dots_kin="")
+
+  assert "@kinemage 1" in kin_out, "Missing @kinemage header"
+  assert "@group {model_test}" in kin_out, "Missing @group"
+  assert "@subgroup" in kin_out, "Missing @subgroup"
+  assert "@vectorlist {mc}" in kin_out, "Missing mainchain vectorlist"
+  assert "master= {mainchain}" in kin_out, "Missing mainchain master"
+  assert "@vectorlist {Calphas}" in kin_out, "Missing Calphas vectorlist"
+  # Probe dots were suppressed — should not contain probe master
+  assert "master= {dots}" not in kin_out, \
+      "probe_dots_kin='' should suppress probe dots"
+  assert isinstance(kin_out, str)
+  print("  exercise_build_kinemage_from_model: OK")
+
+
+def exercise_build_kinemage_from_model_with_hydrogens():
+  """Test that build_kinemage_from_model renders H sticks when the model has
+  hydrogens placed. This regression-guards the bug where the non-H hierarchy
+  was fed into _build_kinemage and no H were ever drawn."""
+  from mmtbx.kinemage.validation import build_kinemage_from_model
+  from mmtbx.hydrogens import reduce_hydrogen
+  import mmtbx.model
+  from iotbx import pdb
+
+  pdb_io = pdb.input(source_info=None, lines=pdb_str)
+  model = mmtbx.model.manager(model_input=pdb_io)
+
+  # Place hydrogens with reduce2 so the hierarchy carries H atoms.
+  reduce_add_h_obj = reduce_hydrogen.place_hydrogens(
+      model=model,
+      use_neutron_distances=False,
+      n_terminal_charge="residue_one",
+      exclude_water=True,
+      stop_for_unknowns=False,
+      keep_existing_H=False)
+  reduce_add_h_obj.run()
+  hmodel = reduce_add_h_obj.get_model()
+
+  # Confirm the H model actually has H atoms before testing the kinemage side.
+  n_h = sum(1 for atom in hmodel.get_hierarchy().atoms()
+            if atom.element.strip() in ("H", "D"))
+  assert n_h > 0, \
+      "Test setup error: reduce2 did not add hydrogens to the model"
+
+  kin_out = build_kinemage_from_model(
+      model=hmodel, pdbID="hmodel_test", probe_dots_kin="")
+
+  # With H in the hierarchy and bond_hash, _build_kinemage should emit
+  # H vectorlists via get_kin_lots -> _draw_residue_bonds.
+  has_mc_h = "@vectorlist {mc H}" in kin_out
+  has_sc_h = "@vectorlist {sc H}" in kin_out
+  assert has_mc_h or has_sc_h, (
+      "Expected at least one H vectorlist ({mc H} / {sc H}) "
+      "in kinemage built from H-added model")
+  assert "master= {H's}" in kin_out, \
+      "Expected master= {H's} declaration when H sticks are drawn"
+  print("  exercise_build_kinemage_from_model_with_hydrogens: OK")
+
+
 def exercise_helper_functions():
   """Test the extracted helper functions individually."""
   from mmtbx.kinemage.validation import (
@@ -1087,6 +1159,8 @@ def run():
   exercise_disulfide_bonds()
   exercise_make_multikin_with_ribbons()
   exercise_make_multikin_with_disulfide()
+  exercise_build_kinemage_from_model()
+  exercise_build_kinemage_from_model_with_hydrogens()
   exercise_ribbon_rendering()
   exercise_ribbon_in_kinemage()
   print("All tests passed.")

--- a/mmtbx/kinemage/tst_validation.py
+++ b/mmtbx/kinemage/tst_validation.py
@@ -277,6 +277,67 @@ def exercise_build_kinemage_from_model_with_hydrogens():
   print("  exercise_build_kinemage_from_model_with_hydrogens: OK")
 
 
+def exercise_build_kinemage_from_model_toggles():
+  """Test the include_cablam_wheels and plain_coils toggles on
+  build_kinemage_from_model."""
+  from mmtbx.kinemage.validation import build_kinemage_from_model
+  import mmtbx.model
+  from iotbx import pdb
+
+  # --- Cablam wheels toggle ---
+  # Use the basic pdb_str fixture. cablam.as_kinemage always emits the
+  # cablam_wheels subgroup/trianglelist when include_wheels=True (even if
+  # the structure has no outliers), so absence is a clean signal.
+  pdb_io = pdb.input(source_info=None, lines=pdb_str)
+  model = mmtbx.model.manager(model_input=pdb_io)
+
+  # Default: wheels off.
+  kin_default = build_kinemage_from_model(
+      model=model, pdbID="toggle_test", probe_dots_kin="")
+  assert "@subgroup {cablam_wheels}" not in kin_default, (
+      "Default build_kinemage_from_model should suppress cablam wheels "
+      "(include_cablam_wheels=False)")
+  assert "{cablam_wheels_lines}" not in kin_default, (
+      "Default build_kinemage_from_model should suppress "
+      "cablam_wheels_lines")
+  # Outlier line markup still emitted.
+  assert "@subgroup {cablam outlier}" in kin_default, (
+      "Default output should still contain cablam outlier line markup")
+
+  # Opt back in: include_cablam_wheels=True restores the wheels subgroup.
+  kin_with_wheels = build_kinemage_from_model(
+      model=model, pdbID="toggle_test", probe_dots_kin="",
+      include_cablam_wheels=True)
+  assert "@subgroup {cablam_wheels}" in kin_with_wheels, (
+      "include_cablam_wheels=True should restore the cablam_wheels subgroup")
+  assert "{cablam_wheels_lines}" in kin_with_wheels, (
+      "include_cablam_wheels=True should restore cablam_wheels_lines")
+
+  # --- Plain coils toggle ---
+  # Use pdb_ribbon_str so ribbon rendering actually emits coil lists.
+  pdb_io_rb = pdb.input(source_info=None, lines=pdb_ribbon_str)
+  model_rb = mmtbx.model.manager(model_input=pdb_io_rb)
+
+  # Default: halo (rear deadblack outline) present on coil.
+  kin_halo = build_kinemage_from_model(
+      model=model_rb, pdbID="halo_test", probe_dots_kin="")
+  halo_line = "rear color= deadblack master= {protein ribbon} master= {coil}"
+  assert halo_line in kin_halo, (
+      "Default ribbon rendering should emit the rear deadblack coil halo")
+
+  # plain_coils=True: halo line suppressed.
+  kin_plain = build_kinemage_from_model(
+      model=model_rb, pdbID="plain_test", probe_dots_kin="",
+      plain_coils=True)
+  assert halo_line not in kin_plain, (
+      "plain_coils=True should suppress the rear deadblack coil halo")
+  # The colored coil list itself should still be there.
+  assert "master= {coil}" in kin_plain, (
+      "plain_coils=True should still emit the colored coil list")
+
+  print("  exercise_build_kinemage_from_model_toggles: OK")
+
+
 def exercise_helper_functions():
   """Test the extracted helper functions individually."""
   from mmtbx.kinemage.validation import (
@@ -1161,6 +1222,7 @@ def run():
   exercise_make_multikin_with_disulfide()
   exercise_build_kinemage_from_model()
   exercise_build_kinemage_from_model_with_hydrogens()
+  exercise_build_kinemage_from_model_toggles()
   exercise_ribbon_rendering()
   exercise_ribbon_in_kinemage()
   print("All tests passed.")

--- a/mmtbx/kinemage/tst_validation.py
+++ b/mmtbx/kinemage/tst_validation.py
@@ -534,7 +534,7 @@ def exercise_ribbon_rendering():
     assert "@subgroup" in ribbon_out
     assert "@colorset" in ribbon_out
     # Should contain ribbon list content
-    assert "master= {ribbon}" in ribbon_out
+    assert "master= {protein ribbon}" in ribbon_out
 
   print("  exercise_ribbon_rendering: OK")
 
@@ -558,8 +558,10 @@ def exercise_ribbon_in_kinemage():
   # Check that header and footer have ribbon master controls
   header = get_default_header()
   footer = get_footer()
-  assert "@master {ribbon} indent" in header, "Missing ribbon master in header"
-  assert "@master {ribbon} off" in footer, "Missing ribbon master in footer"
+  assert "@master {protein ribbon} indent" in header, "Missing protein ribbon master in header"
+  assert "@master {NA ribbon} indent" in header, "Missing NA ribbon master in header"
+  assert "@master {protein ribbon} off" in footer, "Missing protein ribbon master in footer"
+  assert "@master {NA ribbon} off" in footer, "Missing NA ribbon master in footer"
 
   # Build full kinemage from the 8-residue PDB with SS records
   pdb_io = pdb.input(source_info=None, lines=pdb_ribbon_str)
@@ -607,7 +609,7 @@ def exercise_ribbon_in_kinemage():
                           # placement (probe dots emit their own @group {dots})
 
   # Ribbon content should be present
-  assert "master= {ribbon}" in kin_out, "No ribbon content in kinemage output"
+  assert "master= {protein ribbon}" in kin_out, "No ribbon content in kinemage output"
   assert "@subgroup {ribbon" in kin_out, "Missing ribbon subgroup"
   assert "@colorset" in kin_out, "Missing ribbon colorset"
 
@@ -1016,7 +1018,7 @@ def exercise_make_multikin_with_ribbons():
       content = f.read()
 
     # Ribbon content should be present in the output
-    assert "master= {ribbon}" in content, "No ribbon content in make_multikin output"
+    assert "master= {protein ribbon}" in content, "No ribbon content in make_multikin output"
     assert "@subgroup {ribbon" in content, "Missing ribbon subgroup"
 
     # Should also have standard kinemage elements
@@ -1024,8 +1026,8 @@ def exercise_make_multikin_with_ribbons():
     assert "@group {ribbon_mk}" in content
 
     # Ribbon master controls
-    assert "@master {ribbon} indent" in content, "Missing ribbon master in header"
-    assert "@master {ribbon} off" in content, "Missing ribbon master off in footer"
+    assert "@master {protein ribbon} indent" in content, "Missing protein ribbon master in header"
+    assert "@master {protein ribbon} off" in content, "Missing protein ribbon master off in footer"
   finally:
     if os.path.exists(outfile):
       os.remove(outfile)

--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -800,7 +800,8 @@ def get_default_header():
 @master {H's} indent
 @pointmaster 'H' {H's}
 @master {water} indent
-@master {ribbon} indent
+@master {protein ribbon} indent
+@master {NA ribbon} indent
 """
   return header
 
@@ -822,7 +823,8 @@ def get_footer():
 @master {Cbeta dev} on
 @master {base-P perp} on
 @master {hets} on
-@master {ribbon} off
+@master {protein ribbon} off
+@master {NA ribbon} off
 """
   return footer
 

--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -361,12 +361,15 @@ def make_probe_dots_from_model(model_manager):
     mdc = m.detached_copy()
     r.append_model(mdc)
 
-    # Build a model manager for this sub-model
+    # Build a model manager for this sub-model, preserving restraint objects
+    # (e.g. CCD restraints for element-stub-shadowed residues like AS)
+    # so that probe2 gets correct bond topology.
     sub_model = mmtbx.model.manager(
       model_input=None,
       pdb_hierarchy=r,
       stop_for_unknowns=False,
       crystal_symmetry=model_manager.crystal_symmetry(),
+      restraint_objects=model_manager.get_restraint_objects(),
       log=null_out())
 
     # Run probe2 in kinemage output mode

--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -889,7 +889,9 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
                     cablam_result=None,
                     probe_dots_kin=None,
                     ss_bonds=None, sites_cart=None,
-                    ss_annotation=None):
+                    ss_annotation=None,
+                    include_cablam_wheels=False,
+                    plain_coils=False):
   """Shared logic for building the kinemage string.
 
   Args:
@@ -912,6 +914,14 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
     ss_bonds: list of (i_seq_0, i_seq_1) tuples for disulfide bonds
     sites_cart: Cartesian coordinates for all atoms
     ss_annotation: iotbx.pdb.secondary_structure.annotation object, or None
+    include_cablam_wheels: when True, include the cablam peptide-plane score
+      wheels (purple/magenta triangle wedges with a deadblack outline) in
+      addition to the cablam outlier line markup. Defaults to False; the
+      wheels are noisy in a multicrit viewer. Ignored when cablam_result is
+      None. Does not affect direct callers of cablamalyze.as_kinemage.
+    plain_coils: when True, skip the rear deadblack halo drawn behind each
+      colored coil ribbon list (passed through as do_plain_coils to
+      generate_chain_ribbons). Defaults to False (halo drawn).
   """
   kin_out = get_default_header()
   altid_controls = get_altid_controls(hierarchy=hierarchy)
@@ -959,7 +969,7 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
     # Suppress self.out write for assembled kinemage; use returned string only
     saved_out = cablam_result.out
     cablam_result.out = None
-    kin_out += cablam_result.as_kinemage()
+    kin_out += cablam_result.as_kinemage(include_wheels=include_cablam_wheels)
     cablam_result.out = saved_out
   # Ribbon rendering (off by default via footer master toggle)
   try:
@@ -981,7 +991,8 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
         ribbon_kin += generate_chain_ribbons(
             chain=chain, secondary_structure=ss_map,
             chain_id=chain.id, chain_color=chain_color,
-            has_dna=has_dna, has_rna=has_rna)
+            has_dna=has_dna, has_rna=has_rna,
+            do_plain_coils=plain_coils)
         ribbon_counter += 1
 
     if ribbon_kin:
@@ -1008,7 +1019,9 @@ def build_kinemage_from_model(
     cablam_result=None,
     ss_annotation=None,
     probe_dots_kin=None,
-    keep_hydrogens=False):
+    keep_hydrogens=False,
+    include_cablam_wheels=False,
+    plain_coils=False):
   """High-level kinemage builder that takes an mmtbx.model.manager.
 
   Encapsulates the i_seq_name_hash / bond_hash / ss_bonds / sites_cart plumbing
@@ -1029,6 +1042,10 @@ def build_kinemage_from_model(
       make_probe_dots_from_model(model) is called. Pass "" to suppress.
     keep_hydrogens: only used for the make_probe_dots() fallback inside
       _build_kinemage when probe_dots_kin is None and the fallback path fires.
+    include_cablam_wheels: when True, emit the cablam score wheels in addition
+      to the outlier line markup. Defaults to False for multicrit viewers.
+    plain_coils: when True, omit the rear deadblack halo behind coil ribbons.
+      Defaults to False.
 
   Returns:
     The kinemage string.
@@ -1113,9 +1130,12 @@ def build_kinemage_from_model(
       omega_result=omega_result,
       rna_puckers_result=rna_puckers_result,
       cablam_result=cablam_result,
-      probe_dots_kin=probe_dots_kin)
+      probe_dots_kin=probe_dots_kin,
+      include_cablam_wheels=include_cablam_wheels,
+      plain_coils=plain_coils)
 
-def make_multikin(f, processed_pdb_file, pdbID=None, keep_hydrogens=False):
+def make_multikin(f, processed_pdb_file, pdbID=None, keep_hydrogens=False,
+                  include_cablam_wheels=False, plain_coils=False):
   if pdbID is None:
     pdbID = "PDB"
   hierarchy = processed_pdb_file.all_chain_proxies.pdb_hierarchy
@@ -1202,7 +1222,9 @@ def make_multikin(f, processed_pdb_file, pdbID=None, keep_hydrogens=False):
     cablam_result=cablam_result,
     ss_bonds=ss_bonds,
     sites_cart=sites_cart,
-    ss_annotation=ss_annotation)
+    ss_annotation=ss_annotation,
+    include_cablam_wheels=include_cablam_wheels,
+    plain_coils=plain_coils)
 
   outfile = open(f, 'w')
   outfile.write(kin_out)
@@ -1300,7 +1322,9 @@ def export_molprobity_result_as_kinemage(
     keep_hydrogens=False,
     pdbID="PDB",
     cablam_result=None,
-    ss_annotation=None):
+    ss_annotation=None,
+    include_cablam_wheels=False,
+    plain_coils=False):
   assert (result.restraints is not None)
   i_seq_name_hash = build_name_hash(pdb_hierarchy=pdb_hierarchy)
   sites_cart = pdb_hierarchy.atoms().extract_xyz()
@@ -1331,4 +1355,6 @@ def export_molprobity_result_as_kinemage(
     cablam_result=cablam_result,
     ss_bonds=ss_bonds,
     sites_cart=sites_cart,
-    ss_annotation=ss_annotation)
+    ss_annotation=ss_annotation,
+    include_cablam_wheels=include_cablam_wheels,
+    plain_coils=plain_coils)

--- a/mmtbx/kinemage/validation.py
+++ b/mmtbx/kinemage/validation.py
@@ -996,6 +996,125 @@ def _build_kinemage(hierarchy, bond_hash, i_seq_name_hash, pdbID,
   kin_out += get_footer()
   return kin_out
 
+def build_kinemage_from_model(
+    model,
+    pdbID="PDB",
+    rot_outliers=None,
+    rama_result=None,
+    cb_result=None,
+    restraints_result=None,
+    omega_result=None,
+    rna_puckers_result=None,
+    cablam_result=None,
+    ss_annotation=None,
+    probe_dots_kin=None,
+    keep_hydrogens=False):
+  """High-level kinemage builder that takes an mmtbx.model.manager.
+
+  Encapsulates the i_seq_name_hash / bond_hash / ss_bonds / sites_cart plumbing
+  that _build_kinemage requires. Callers may inject already-run validator
+  results, a pre-computed secondary-structure annotation, and pre-computed
+  probe dots to avoid duplicated work.
+
+  Args:
+    model: mmtbx.model.manager. If it has no restraints manager, one will be
+      attached via .process(make_restraints=True).
+    pdbID: structure identifier string.
+    rot_outliers, rama_result, cb_result, restraints_result, omega_result,
+      rna_puckers_result, cablam_result: pre-run validator results. Any that
+      are None will be run internally with outliers_only=True.
+    ss_annotation: iotbx.pdb.secondary_structure.annotation, or None to
+      compute one via mmtbx.secondary_structure.manager (search_method=from_ca).
+    probe_dots_kin: pre-computed probe dots kinemage string. If None,
+      make_probe_dots_from_model(model) is called. Pass "" to suppress.
+    keep_hydrogens: only used for the make_probe_dots() fallback inside
+      _build_kinemage when probe_dots_kin is None and the fallback path fires.
+
+  Returns:
+    The kinemage string.
+  """
+  if model.get_restraints_manager() is None:
+    model.process(make_restraints=True)
+
+  hierarchy = model.get_hierarchy()
+  geometry = model.get_restraints_manager().geometry
+
+  i_seq_name_hash = build_name_hash(pdb_hierarchy=hierarchy)
+  sites_cart = hierarchy.atoms().extract_xyz()
+  flags = geometry_restraints.flags.flags(default=True)
+  pair_proxies = geometry.pair_proxies(flags=flags, sites_cart=sites_cart)
+  bond_proxies = pair_proxies.bond_proxies
+  bond_hash = _build_bond_hash(bond_proxies, i_seq_name_hash)
+  ss_bonds = _build_ss_bond_list(bond_proxies, i_seq_name_hash)
+
+  has_protein = any(chain.is_protein()
+                    for mdl in hierarchy.models() for chain in mdl.chains())
+  has_rna = any(chain.is_na()
+                for mdl in hierarchy.models() for chain in mdl.chains())
+
+  if rot_outliers is None:
+    rot_outliers = rotalyze(pdb_hierarchy=hierarchy, outliers_only=True)
+  if rama_result is None:
+    rama_result = ramalyze(pdb_hierarchy=hierarchy, outliers_only=True)
+  if cb_result is None:
+    cb_result = cbetadev(pdb_hierarchy=hierarchy, outliers_only=True)
+  if omega_result is None:
+    omega_result = omegalyze.omegalyze(
+        pdb_hierarchy=hierarchy, nontrans_only=True, out=None, quiet=True)
+  if cablam_result is None and has_protein:
+    from mmtbx.validation.cablam import cablamalyze
+    from libtbx.utils import null_out
+    cablam_result = cablamalyze(
+        pdb_hierarchy=hierarchy, outliers_only=True,
+        out=null_out(), quiet=True)
+  if rna_puckers_result is None and has_rna:
+    rna_puckers_result = rna_validate.rna_puckers(pdb_hierarchy=hierarchy)
+  if restraints_result is None:
+    from mmtbx.validation.restraints import combined as _restraints_combined
+    restraints_result = _restraints_combined(
+        pdb_hierarchy=hierarchy,
+        xray_structure=model.get_xray_structure(),
+        geometry_restraints_manager=geometry,
+        ignore_hd=True,
+        outliers_only=True)
+
+  if ss_annotation is None:
+    try:
+      import mmtbx.secondary_structure
+      from libtbx.utils import null_out
+      ss_params = mmtbx.secondary_structure.manager.get_default_ss_params()
+      ss_params.secondary_structure.protein.search_method = "from_ca"
+      ss_params = ss_params.secondary_structure
+      ss_manager = mmtbx.secondary_structure.manager(
+          hierarchy, params=ss_params, log=null_out())
+      ss_annotation = ss_manager.actual_sec_str
+    except Exception:
+      ss_annotation = None
+
+  if probe_dots_kin is None:
+    try:
+      probe_dots_kin = make_probe_dots_from_model(model)
+    except Exception:
+      probe_dots_kin = ""
+
+  return _build_kinemage(
+      hierarchy=hierarchy,
+      bond_hash=bond_hash,
+      i_seq_name_hash=i_seq_name_hash,
+      pdbID=pdbID,
+      rot_outliers=rot_outliers,
+      rama_result=rama_result,
+      cb_result=cb_result,
+      restraints_result=restraints_result,
+      keep_hydrogens=keep_hydrogens,
+      ss_bonds=ss_bonds,
+      sites_cart=sites_cart,
+      ss_annotation=ss_annotation,
+      omega_result=omega_result,
+      rna_puckers_result=rna_puckers_result,
+      cablam_result=cablam_result,
+      probe_dots_kin=probe_dots_kin)
+
 def make_multikin(f, processed_pdb_file, pdbID=None, keep_hydrogens=False):
   if pdbID is None:
     pdbID = "PDB"

--- a/mmtbx/programs/ribbons.py
+++ b/mmtbx/programs/ribbons.py
@@ -211,17 +211,17 @@ Output:
               if self.params.do_plain_coils:
                 outString += render_fancy_ribbon(guidepoints, self.secondaryStructure,
                       width_alpha=2, width_beta=2.2,
-                      list_alpha="color= {alph"+chain.id+"} master= {protein} master= {ribbon} master= {alpha}",
-                      list_beta="color= {beta"+chain.id+"} master= {protein} master= {ribbon} master= {beta}",
-                      list_coil="width= 4 color= {coil"+chain.id+"} master= {protein} master= {ribbon} master= {coil}",
+                      list_alpha="color= {alph"+chain.id+"} master= {protein ribbon} master= {alpha}",
+                      list_beta="color= {beta"+chain.id+"} master= {protein ribbon} master= {beta}",
+                      list_coil="width= 4 color= {coil"+chain.id+"} master= {protein ribbon} master= {coil}",
                       do_rainbow=self.params.color_by == "rainbow")
               else:
                 outString += render_fancy_ribbon(guidepoints, self.secondaryStructure,
                       width_alpha=2, width_beta=2.2,
-                      list_alpha="color= {alph"+chain.id+"} master= {protein} master= {ribbon} master= {alpha}",
-                      list_beta="color= {beta"+chain.id+"} master= {protein} master= {ribbon} master= {beta}",
-                      list_coil="width= 4 color= {coil"+chain.id+"} master= {protein} master= {ribbon} master= {coil}",
-                      list_coil_outline="width= 6 color= deadblack master= {protein} master= {ribbon} master= {coil}",
+                      list_alpha="color= {alph"+chain.id+"} master= {protein ribbon} master= {alpha}",
+                      list_beta="color= {beta"+chain.id+"} master= {protein ribbon} master= {beta}",
+                      list_coil="width= 4 color= {coil"+chain.id+"} master= {protein ribbon} master= {coil}",
+                      list_coil_outline="width= 6 color= deadblack master= {protein ribbon} master= {coil}",
                       do_rainbow=self.params.color_by == "rainbow")
 
         if self.params.do_nucleic_acid:
@@ -258,9 +258,9 @@ Output:
 
               outString += render_fancy_ribbon(guidepoints, self.secondaryStructure,
                     width_alpha=3.0, width_beta=3.0,
-                    list_alpha="color= {nucl"+chain.id+"} master= {nucleic acid} master= {ribbon} master= {RNA helix?}",
-                    list_beta="color= {nucl"+chain.id+"} master= {nucleic acid} master= {ribbon} master= {A-form}",
-                    list_coil="width= 4 color= {ncoi"+chain.id+"} master= {nucleic acid} master= {ribbon} master= {coil}",
+                    list_alpha="color= {nucl"+chain.id+"} master= {NA ribbon} master= {RNA helix?}",
+                    list_beta="color= {nucl"+chain.id+"} master= {NA ribbon} master= {A-form}",
+                    list_coil="width= 4 color= {ncoi"+chain.id+"} master= {NA ribbon} master= {coil}",
                     do_rainbow=self.params.color_by == "rainbow")
 
     # Write the output to the specified file.

--- a/mmtbx/programs/ribbons.py
+++ b/mmtbx/programs/ribbons.py
@@ -48,10 +48,12 @@ selection = (altloc ' ' or altloc '' or altloc a)
   .type = atom_selection
   .short_caption = Atom selection
   .help = Atom selection description
-nucleic_acid_as_helix = True
+nucleic_acid_as_sheet = True
   .type = bool
-  .short_caption = Draw nucleic acids as helix
-  .help = If true, draw nucleic acids as helix rather than treating as coil because there are not secondary structure records for them
+  .short_caption = Draw nucleic acids as sheet
+  .help = If true, draw nucleic acids as flat sheet ribbons with arrowheads \
+    (matching Prekin's BETA behavior) rather than treating as coil, since \
+    there are not secondary structure records for them
 '''
 
 # ------------------------------------------------------------------------------
@@ -122,9 +124,11 @@ Output:
         hierarchy, annotation=annotation, log=self.logger)
     consolidate_sheets(self.secondaryStructure)
 
-    # If we are treating nucleic acids as helices, change the record of each nucleic acid residue to be a helix.
-    if self.params.nucleic_acid_as_helix:
-      r = Range('HELIX')
+    # If we are treating nucleic acids as sheets, change the record of each
+    # nucleic acid residue to SHEET, producing flat ribbons with arrowheads
+    # (matching Prekin's BETA behavior for nucleic acids).
+    if self.params.nucleic_acid_as_sheet:
+      r = Range('SHEET')
       for res in hierarchy.residue_groups():
         if _IsNucleicAcidResidue(res.unique_resnames()[0]):
           self.secondaryStructure[res.resseq_as_int()] = r

--- a/mmtbx/validation/cablam.py
+++ b/mmtbx/validation/cablam.py
@@ -1374,8 +1374,14 @@ class cablamalyze(validation):
 
   #{{{ as_kinemage
   #-----------------------------------------------------------------------------
-  def as_kinemage(self, chain_id=None):
+  def as_kinemage(self, chain_id=None, include_wheels=True):
     #output cablam validation as kinemage markup, returns string
+    #
+    #include_wheels=True emits the purple/magenta peptide-plane score wheels
+    #(and their deadblack outline) alongside the outlier line markup. Set to
+    #False to emit only the {cablam disfavored} / {cablam outlier} /
+    #{ca geom outlier} line subgroups — useful when the wheels are too busy
+    #for an embedded multicrit kinemage viewer.
     kin_out = '\n@subgroup {cablam disfavored} dominant\n'
     kin_out += '@vectorlist {cablam disfavored} color= purple width= 4 master={cablam disfavored} off' #default off
     for result in self.results:
@@ -1403,56 +1409,57 @@ class cablamalyze(validation):
         continue
       if result.feedback.c_alpha_geom_outlier:
         kin_out += result.as_kinemage(mode="ca_geom")
-    #----------------------------
-    #"wheels" show favorable and unfavorabe regions for each peptide plane involved in a cablam outlier
-    #Some additional calculations are required to generate these wheels
-    cablam_contours = fetch_peptide_expectations()
-    wheels_list = []
-    for result in self.results:
-      if not result.has_ca:
-        continue
-      if chain_id is not None and result.chain_id.strip() != chain_id.strip():
-        continue
-      if result.feedback.cablam_disfavored:
-        wheels_list.extend(result.calculate_kinemage_wheels(cablam_contours=cablam_contours))
-    #wheels are made of 10-degree wedges, each wedge drawn as a triangle
-    kin_out += '\n@subgroup {cablam_wheels} dominant master={cablam wheels}\n'
-    kin_out += '@trianglelist {cablam_wheels} alpha=0.75'
-    for cablam_wheel in wheels_list:
-      wheel = cablam_wheel[0]
-      wheel_center = cablam_wheel[1]
-      for wedge in wheel:
-        if wedge is None:
+    if include_wheels:
+      #----------------------------
+      #"wheels" show favorable and unfavorabe regions for each peptide plane involved in a cablam outlier
+      #Some additional calculations are required to generate these wheels
+      cablam_contours = fetch_peptide_expectations()
+      wheels_list = []
+      for result in self.results:
+        if not result.has_ca:
           continue
-        elif wedge.cablam_score < 0.01:
-          color = 'magenta'
-        else:
-          color = 'purple'
-        kin_out += self.cablam_wheel_triangle(wheel_center, wedge, color)
-    #a thin black line outlining the wheel greatly aids visual interpretation
-    kin_out += '\n@vectorlist {cablam_wheels_lines} color=deadblack width= 1 alpha=0.75'
-    for cablam_wheel in wheels_list:
-      wheel = cablam_wheel[0]
-      wheel_center = cablam_wheel[1]
-      prevwedge = wheel[-1]
-      new_poly = ' P' #starts a new polyline in kinemage format, print this for each new wheel
-      for wedge in wheel:
-        if wedge and prevwedge:
-          kin_out += '\n{}%s %.3f %.3f %.3f' % (new_poly, wedge.start[0], wedge.start[1], wedge.start[2])
-          kin_out += '\n{} %.3f %.3f %.3f' % (wedge.end[0], wedge.end[1], wedge.end[2])
-        elif wedge and not prevwedge:
-          kin_out += '\n{}%s %.3f %.3f %.3f' % (new_poly, wheel_center[0], wheel_center[1], wheel_center[2])
-          kin_out += '\n{} %.3f %.3f %.3f' % (wedge.start[0], wedge.start[1], wedge.start[2])
-          kin_out += '\n{} %.3f %.3f %.3f' % (wedge.end[0], wedge.end[1], wedge.end[2])
-        elif prevwedge and not wedge:
-          kin_out += '\n{}%s %.3f %.3f %.3f' % (new_poly, prevwedge.end[0], prevwedge.end[1], prevwedge.end[2])
-          kin_out += '\n{} %.3f %.3f %.3f' % (wheel_center[0], wheel_center[1], wheel_center[2])
-        else:
+        if chain_id is not None and result.chain_id.strip() != chain_id.strip():
+          continue
+        if result.feedback.cablam_disfavored:
+          wheels_list.extend(result.calculate_kinemage_wheels(cablam_contours=cablam_contours))
+      #wheels are made of 10-degree wedges, each wedge drawn as a triangle
+      kin_out += '\n@subgroup {cablam_wheels} dominant master={cablam wheels}\n'
+      kin_out += '@trianglelist {cablam_wheels} alpha=0.75'
+      for cablam_wheel in wheels_list:
+        wheel = cablam_wheel[0]
+        wheel_center = cablam_wheel[1]
+        for wedge in wheel:
+          if wedge is None:
+            continue
+          elif wedge.cablam_score < 0.01:
+            color = 'magenta'
+          else:
+            color = 'purple'
+          kin_out += self.cablam_wheel_triangle(wheel_center, wedge, color)
+      #a thin black line outlining the wheel greatly aids visual interpretation
+      kin_out += '\n@vectorlist {cablam_wheels_lines} color=deadblack width= 1 alpha=0.75'
+      for cablam_wheel in wheels_list:
+        wheel = cablam_wheel[0]
+        wheel_center = cablam_wheel[1]
+        prevwedge = wheel[-1]
+        new_poly = ' P' #starts a new polyline in kinemage format, print this for each new wheel
+        for wedge in wheel:
+          if wedge and prevwedge:
+            kin_out += '\n{}%s %.3f %.3f %.3f' % (new_poly, wedge.start[0], wedge.start[1], wedge.start[2])
+            kin_out += '\n{} %.3f %.3f %.3f' % (wedge.end[0], wedge.end[1], wedge.end[2])
+          elif wedge and not prevwedge:
+            kin_out += '\n{}%s %.3f %.3f %.3f' % (new_poly, wheel_center[0], wheel_center[1], wheel_center[2])
+            kin_out += '\n{} %.3f %.3f %.3f' % (wedge.start[0], wedge.start[1], wedge.start[2])
+            kin_out += '\n{} %.3f %.3f %.3f' % (wedge.end[0], wedge.end[1], wedge.end[2])
+          elif prevwedge and not wedge:
+            kin_out += '\n{}%s %.3f %.3f %.3f' % (new_poly, prevwedge.end[0], prevwedge.end[1], prevwedge.end[2])
+            kin_out += '\n{} %.3f %.3f %.3f' % (wheel_center[0], wheel_center[1], wheel_center[2])
+          else:
+            prevwedge = wedge
+            continue
           prevwedge = wedge
-          continue
-        prevwedge = wedge
-        new_poly=''
-    #----------------------------
+          new_poly=''
+      #----------------------------
     kin_out += '\n'
     # Write to self.out for backward compatibility with standalone use
     if self.out is not None:


### PR DESCRIPTION
## Summary

Follow-on kinemage work building on the ribbon-rendering PR (#1197). This bundles
the high-level `build_kinemage_from_model` helper together with the ribbon polish
and display-toggle fixes, because the toggles thread through the helper and the two
cannot be cleanly separated.

Five commits (all in `mmtbx/kinemage/` plus the cablam wheel gating):

1. **Fix errant ribbon triangle and rename ribbon master controls** — remove the
   `i == 0` short-circuit in ribbon element discovery that produced a duplicate
   1-unit sheet element when a chain starts on a SHEET residue (visible in 1ubq).
   Rename the ribbon masters `{protein}`/`{nucleic acid}` → `{protein ribbon}`/
   `{NA ribbon}` so they no longer collide with the molecular-representation masters.

2. **Add `build_kinemage_from_model` high-level helper** — a single entry point that
   takes an `mmtbx.model.manager`, runs (or accepts pre-run) validators, computes the
   secondary-structure annotation and probe dots, and assembles the kinemage. Wraps the
   `i_seq_name_hash` / `bond_hash` / `ss_bonds` / `sites_cart` plumbing that
   `_build_kinemage` requires.

3. **Add `include_cablam_wheels` and `plain_coils` toggles** — the cablam score wheels
   are gated behind `include_wheels` in `cablamalyze.as_kinemage` (default `True` for
   standalone use) and `include_cablam_wheels` in the builders (default `False` for
   multicrit viewers, where they are too noisy). `plain_coils` suppresses the rear
   deadblack halo behind coil ribbons. Both flags are threaded through `_build_kinemage`,
   `build_kinemage_from_model`, `make_multikin`, and `export_molprobity_result_as_kinemage`.

4. **Pass `restraint_objects` to probe sub-models** so custom ligand restraints are
   honored during probe-dot generation.

5. **Fix ribbon rendering: NA as sheet, 3-residue minimum, short-element filter** —
   nucleic-acid ribbons now render as SHEET (flat with arrowheads), matching Prekin's
   BETA behavior; the minimum contiguous segment is raised to 3 residues (matching
   Prekin's `fragment.number > 5`), fixing crashes from 1-residue segments and removing
   2-residue stubs; degenerate/short HELIX/SHEET elements are demoted to COIL.

## Testing

- `mmtbx/kinemage/tst_validation.py`: all 20 exercises pass, including the new
  `build_kinemage_from_model` helper/hydrogens/toggle tests and the ribbon tests.
- phenix_regression `validation/tst_kinemage.py`: OK.
- `phenix.kinemage` and `mmtbx.kinemage.validation.run()` on 1nxbH: 3481 greentint
  probe dots (unchanged vs master), ribbons render with the renamed masters, cablam
  wheels off by default in the assembled multicrit output.
- `mmtbx.ribbons` standalone program: renders with the new masters.
- New builder parameters all default to backward-compatible values; the existing
  `export_molprobity_result_as_kinemage` caller in `mmtbx/command_line/molprobity.py`
  is unaffected.
- `libtbx.find_clutter` and `py_compile` clean on all changed files.
