### PR TITLE
reduce2/clashscore2: preserve user restraint objects for custom ligands

### DIFF
--- a/mmtbx/hydrogens/reduce_hydrogen.py
+++ b/mmtbx/hydrogens/reduce_hydrogen.py
@@ -857,6 +857,18 @@ class place_hydrogens():
     # end TODO
     pdb_hierarchy = self.model.get_hierarchy()
     mon_lib_srv = self.model.get_mon_lib_srv()
+    # Load any user-provided restraint CIF objects into the server so that
+    # mon_lib_query() finds them and does not generate auto_* CIF objects
+    # with empty type_energy values that would overwrite the user entries.
+    ro = self.model.get_restraint_objects()
+    if ro:
+      for fname, cif_obj in ro:
+        if cif_obj is not None:
+          try:
+            mon_lib_srv.process_cif_object(
+              cif_object=cif_obj, file_name=fname)
+          except Exception:
+            pass
     #XXX This breaks for 1jxt, residue 2, TYR
     for m in pdb_hierarchy.models():
       for chain in m.chains():

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -106,12 +106,13 @@ class clashscore2(validation):
     # First we must rebuild the model from the new hierarchy so that the copy can succeed.
     # Make a copy of the original model to use for submodel processing, we'll trim atoms out
     # of it for each submodel.
+    ro = data_manager_model.get_restraint_objects()
     data_manager_model = mmtbx.model.manager(
       model_input       = None,
       pdb_hierarchy     = data_manager_model.get_hierarchy(),
       stop_for_unknowns = False,
       crystal_symmetry  = data_manager_model.crystal_symmetry(),
-      restraint_objects = None,
+      restraint_objects = ro,
       log               = None)
     original_model = data_manager_model.deep_copy()
 
@@ -138,7 +139,7 @@ class clashscore2(validation):
         pdb_hierarchy     = r,
         stop_for_unknowns = False,
         crystal_symmetry  = submodel.crystal_symmetry(),
-        restraint_objects = None,
+        restraint_objects = ro,
         log               = None)
 
       if verbose:


### PR DESCRIPTION
## Summary

Fixes the reduce2 → clashscore2 pipeline for custom ligands that carry user-supplied
restraint CIFs (e.g. from eLBOW), where the user's restraints were being lost:

1. **`reduce_hydrogen.py`** — in `place_hydrogens`, load any user-provided restraint CIF
   objects into `mon_lib_srv` before querying residues. Otherwise `mon_lib_query()`
   generates `auto_*` CIF objects with empty `type_energy` values that overwrite the
   user's entries.
2. **`clashscore2.py`** — preserve `restraint_objects` when rebuilding the model from a
   hierarchy (both the initial rebuild and each trimmed submodel), instead of hardcoding
   `restraint_objects=None` and silently dropping them.

### Scope / why it's small

This is the low-risk half of a larger custom-ligand fix, split out deliberately. Both
changes are **no-ops for models without user restraints**: `get_restraint_objects()`
returns `None` in that case, so clashscore2 passes the same `None` it did before, and the
new reduce_hydrogen block is guarded by `if ro:`. So standard models are byte-for-byte
unaffected.

The remaining two hunks from the original fix touch core interpretation code
(`model.manager.select()` propagating `stop_for_unknowns`, and a prime/star atom-name
synonym fallback in `pdb_interpretation`) and have a much broader blast radius, so they
are held back for separate maintainer review rather than bundled here.

## Testing

- `mmtbx.clashscore2` on 1nxbH: **byte-identical clashscore to master** (294.57 both
  ways) — confirms the rebuild change is a no-op when no user restraints are present.
- `mmtbx/hydrogens/tst_add_hydrogen_{1,2,3,5,7,10,11}.py`: all pass (reduce2 H-placement
  unaffected on the no-restraints path).
- `libtbx.find_clutter` and `py_compile` clean on both changed files.
