### PR TITLE
xfel.ui_server: fix root password handling on database init

### DIFF
--- a/xfel/ui/command_line/ui_server.py
+++ b/xfel/ui/command_line/ui_server.py
@@ -64,7 +64,7 @@ def run(args):
            params.db.name is not None and len(params.db.name) > 0
     import getpass
     if params.db.server.root_password:
-            rootw = params.db.server.root_password
+      rootpw = params.db.server.root_password
     else:
       print("Initializing")
       print("You must specify a root password")
@@ -106,7 +106,6 @@ def run(args):
     params.db.name = ''
     print("Changing password")
     app = db_application(params)
-    rootpw = params.db.server.root_password
     app.execute_query("ALTER USER 'root'@'localhost' IDENTIFIED BY '%s'"%(rootpw))
     params.db.password = rootpw
     print("Creating empty database %s"%new_db)


### PR DESCRIPTION
PR #808 broke the interactive root-password path when initializing a new database. The password entered at the getpass prompt was discarded: a later line unconditionally overwrote rootpw with the db.server.root_password phil parameter, which is None in the interactive case, so ALTER USER ... IDENTIFIED BY '%s' % None set root's password to the literal string "None" instead of what the user typed.

The non-interactive path (db.server.root_password passed on the command line) kept working because of that same overwrite, but its intended branch assigned to a misspelled variable (rootw) and was dead code.

Fix the typo so the branch sets rootpw, and drop the redundant overwrite so the interactively entered password survives to ALTER USER.