### PR TITLE
model: preserve stop_for_unknowns across manager.select()

### DIFF
--- a/mmtbx/model/model.py
+++ b/mmtbx/model/model.py
@@ -3955,6 +3955,7 @@ class manager(object):
       crystal_symmetry           = self._crystal_symmetry,
       restraint_objects          = self._restraint_objects,
       monomer_parameters         = self._monomer_parameters,
+      stop_for_unknowns          = self._stop_for_unknowns,
       expand_with_mtrix          = False,
       pdb_hierarchy              = new_pdb_hierarchy,
       log                        = self.log)

--- a/mmtbx/regression/model/tst_model_2.py
+++ b/mmtbx/regression/model/tst_model_2.py
@@ -628,8 +628,29 @@ END
   assert not m4.altlocs_present_only_hd()
 
 
+def exercise_select_preserves_stop_for_unknowns():
+  # model.manager.select() must carry stop_for_unknowns onto the selected
+  # model. Otherwise a model built with stop_for_unknowns=False silently
+  # reverts to the constructor default (True) after any selection, which breaks
+  # pipelines (e.g. reduce2/clashscore2 with custom ligands) that deliberately
+  # tolerate unknown residues.
+  # Default (True) is preserved across select().
+  inp = iotbx.pdb.input(lines=pdb_str_1, source_info=None)
+  m_default = mmtbx.model.manager(model_input=inp)
+  assert m_default.get_stop_for_unknowns() is True
+  m_default_sel = m_default.select(m_default.selection("all"))
+  assert m_default_sel.get_stop_for_unknowns() is True
+  # Explicit False is preserved across select() (the behavior being fixed).
+  inp2 = iotbx.pdb.input(lines=pdb_str_1, source_info=None)
+  m_false = mmtbx.model.manager(model_input=inp2, stop_for_unknowns=False)
+  assert m_false.get_stop_for_unknowns() is False
+  m_false_sel = m_false.select(m_false.selection("all"))
+  assert m_false_sel.get_stop_for_unknowns() is False, \
+    "select() must preserve stop_for_unknowns=False onto the selected model"
+
 if (__name__ == "__main__"):
   t0 = time.time()
+  exercise_select_preserves_stop_for_unknowns()
   exercise_altlocs_present()
   exercise_macromolecule_plus_hetatms_by_chain_selections()
   exercise_ss_creation_crash()


### PR DESCRIPTION
## Summary

`mmtbx.model.manager.select()` rebuilds the selected model via the `manager(...)`
constructor, forwarding `crystal_symmetry`, `restraint_objects`, and
`monomer_parameters` — but **not** `stop_for_unknowns`. So a model created with
`stop_for_unknowns=False` silently reverts to the constructor default (`True`) after
any `.select()`. Downstream interpretation of the selected model then raises `Sorry`
on unknown residues that the caller intended to tolerate (e.g. the reduce2/clashscore2
pipeline with custom ligands).

This forwards `self._stop_for_unknowns` into the `select()` rebuild.

```python
       monomer_parameters         = self._monomer_parameters,
+      stop_for_unknowns          = self._stop_for_unknowns,
       expand_with_mtrix          = False,
```

### Scope

One line in `model.py` plus a regression in `tst_model_2.py`. The behavioral change is
narrow: models left at the default `stop_for_unknowns=True` are unaffected (the rebuilt
model was already `True`); only models that explicitly set `False` change — they now
correctly keep `False` across `select()`.

Split out from a larger custom-ligand fix so it can be reviewed on its own; the other
half (a prime/star atom-name synonym fallback in `pdb_interpretation`) is held back
separately as it overlaps ongoing nucleic-acid atom-name work.

## Testing

- New `exercise_select_preserves_stop_for_unknowns` in
  `mmtbx/regression/model/tst_model_2.py`: asserts `select()` preserves both the default
  `True` and an explicit `False`. It **fails on master** (selected model reverts to
  `True`) and passes with this change.
- `tst_model_2.py` full run passes, as do `tst_model_ncs`, `tst_model_mtrix`,
  `tst_model_biomt_mtrix`, and `tst_model_remove_alternative_conformations`.
- `libtbx.find_clutter` and `py_compile` clean.
