### PR TITLE
Repair dps_extended.get_new_detector

### DIFF
--- a/rstbx/indexing_api/lattice.py
+++ b/rstbx/indexing_api/lattice.py
@@ -176,14 +176,14 @@ class _():
 
     if len(new_detector) > 1 and len(new_detector.hierarchy()) > 1:
       h = new_detector.hierarchy()
-      h.set_local_frame(fast_axis=h.get_fast_axis(),
-                        slow_axis=h.get_slow_axis(),
-                        origin=matrix.col(h.get_origin()) + origin_offset)
+      h.set_frame(fast_axis=h.get_fast_axis(),
+                  slow_axis=h.get_slow_axis(),
+                  origin=matrix.col(h.get_origin()) + origin_offset)
     else:
       for panel in new_detector:
-        panel.set_local_frame(fast_axis=panel.get_fast_axis(),
-                              slow_axis=panel.get_slow_axis(),
-                              origin=matrix.col(panel.get_origin()) + origin_offset)
+        panel.set_frame(fast_axis=panel.get_fast_axis(),
+                        slow_axis=panel.get_slow_axis(),
+                        origin=matrix.col(panel.get_origin()) + origin_offset)
 
     return new_detector
 

--- a/rstbx/indexing_api/lattice.py
+++ b/rstbx/indexing_api/lattice.py
@@ -174,16 +174,10 @@ class _():
     import copy
     new_detector = copy.deepcopy(old_detector)
 
-    if len(new_detector) > 1 and len(new_detector.hierarchy()) > 1:
-      h = new_detector.hierarchy()
-      h.set_frame(fast_axis=h.get_fast_axis(),
-                  slow_axis=h.get_slow_axis(),
-                  origin=matrix.col(h.get_origin()) + origin_offset)
-    else:
-      for panel in new_detector:
-        panel.set_frame(fast_axis=panel.get_fast_axis(),
-                        slow_axis=panel.get_slow_axis(),
-                        origin=matrix.col(panel.get_origin()) + origin_offset)
+    h = new_detector.hierarchy()
+    h.set_frame(fast_axis=h.get_fast_axis(),
+                slow_axis=h.get_slow_axis(),
+                origin=matrix.col(h.get_origin()) + origin_offset)
 
     return new_detector
 


### PR DESCRIPTION
This is to fix https://github.com/dials/dials/issues/3213. Please look at the discussion there.

@phyy-nx 
> Yes dropping the else path makes sense to me.

In this PR I kept the old (`else`) code path because the unification would change the behaviour (whether to store the shift in the hierarchy root or panels). Please feel free to delete the old branch if you think we don't need to preserve the old behaviour.

> For the hierarchy root there should be no difference between set_frame and set_local_frame, right?

Right. Both should do the same for the root. I nonetheless changed it to `set_frame`, because `get_origin` etc is semantically global.