### PR TITLE
clashscore2: add ignore_missing_restraints for models with unknown ligands

### DIFF
--- a/mmtbx/programs/clashscore2.py
+++ b/mmtbx/programs/clashscore2.py
@@ -36,6 +36,7 @@ Options:
   verbose=True              verbose text output
   b_factor_cutoff=40        B factor cutoff for clash analysis
   do_flips=False            Do flips when adding Hs, overides keep_hydrogens
+  ignore_missing_restraints=False  Continue if restraints for a residue are missing
 
 Example:
 
@@ -84,6 +85,13 @@ Example:
     .help = '''Save full non-condensed probe output with VDW contacts \
                (for Coot). Roughly doubles runtime.'''
 
+  ignore_missing_restraints = False
+    .type = bool
+    .short_caption = Don't stop if restraints for a residue are missing.
+    .help = Don't stop if restraints for a residue are missing. Those residues \
+            get no hydrogens added, but their heavy atoms still take part in \
+            the contact analysis.
+
   clash_cutoff = -0.4
     .type = float
     .help = '''dummy variable for MolProbity, will be removed after MP update'''
@@ -124,7 +132,8 @@ Example:
       verbose=self.params.verbose and not quiet,
       b_factor_cutoff=self.params.b_factor_cutoff,
       do_flips=self.params.do_flips,
-      save_probe_output=self.params.save_probe_output)
+      save_probe_output=self.params.save_probe_output,
+      ignore_missing_restraints=self.params.ignore_missing_restraints)
     if self.params.json:
       print(self.results.as_JSON(self.info_json))
     elif self.params.verbose:

--- a/mmtbx/regression/tst_reduce_switch.py
+++ b/mmtbx/regression/tst_reduce_switch.py
@@ -148,6 +148,53 @@ def test_clashscore2_delegates():
   assert _h_count(out_model) > 0
   print("test_clashscore2_delegates OK")
 
+# Same peptide plus an unknown ligand (UNL). mon_lib_query returns None for this
+# residue name, so reduce2 records it in no_H_placed_mlq -- which is what the
+# missing-restraints handling keys off. (Many made-up 3-letter codes resolve to
+# some monomer entry instead and would not exercise this path at all.)
+pdb_str_unknown_ligand = pdb_str.replace("TER\nEND\n", "") + """\
+HETATM   16  C1  UNL B   1      15.000   5.000   5.000  1.00 20.00           C
+HETATM   17  C2  UNL B   1      16.400   5.000   5.000  1.00 20.00           C
+HETATM   18  O1  UNL B   1      17.100   6.100   5.000  1.00 20.00           O
+TER
+END
+"""
+
+def test_clashscore2_ignore_missing_restraints():
+  """check_and_add_hydrogen aborts on a restraint-less ligand by default, and
+  continues best-effort when ignore_missing_restraints=True.
+
+  Pins the plumbing of ignore_missing_restraints through to
+  place_and_optimize_hydrogens(raise_on_missing=...). The 2-tuple return shape is
+  unchanged on both paths.
+  """
+  from mmtbx.validation import clashscore2
+  from libtbx.utils import Sorry
+  probe_phil = reduce_switch.default_probe_phil()
+
+  # Default: the ligand with no restraints aborts the whole run.
+  try:
+    clashscore2.check_and_add_hydrogen(
+      probe_parameters=probe_phil,
+      data_manager_model=model_from_str(pdb_str_unknown_ligand),
+      nuclear=False, keep_hydrogens=True, do_flips=False, log=null_out())
+  except Sorry as e:
+    assert "Restraints were not found" in str(e), str(e)
+  else:
+    raise AssertionError("expected Sorry for a ligand with no restraints when "
+                         "ignore_missing_restraints=False")
+
+  # Best-effort: completes, still returns the 2-tuple, and the rest of the model
+  # still gets hydrogens.
+  out_model, changed = clashscore2.check_and_add_hydrogen(
+    probe_parameters=probe_phil,
+    data_manager_model=model_from_str(pdb_str_unknown_ligand),
+    nuclear=False, keep_hydrogens=True, do_flips=False,
+    ignore_missing_restraints=True, log=null_out())
+  assert changed is True
+  assert _h_count(out_model) > 0
+  print("test_clashscore2_ignore_missing_restraints OK")
+
 def _make_all_asn_backwards(hierarchy):
   """Swap OD1/ND2 on every ASN so reduce wants to flip them back. Returns count."""
   n = 0
@@ -420,6 +467,7 @@ if __name__ == "__main__":
   test_get_nqh_flips_requires_h()
   test_get_nqh_flips_detects_flip()
   test_clashscore2_delegates()
+  test_clashscore2_ignore_missing_restraints()
   test_clash_none_when_no_h_reduce2()
   test_clash_scores_existing_h_reduce2()
   test_flip_nqh_skips_h_less_model_reduce2()

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -64,6 +64,7 @@ class clashscore2(validation):
       verbose=False,
       do_flips=False,
       save_probe_output=False,
+      ignore_missing_restraints=False,
       out=sys.stdout):
     validation.__init__(self)
     self.b_factor_cutoff = b_factor_cutoff
@@ -98,6 +99,7 @@ class clashscore2(validation):
       verbose=verbose,
       keep_hydrogens=keep_hydrogens,
       do_flips = do_flips,
+      ignore_missing_restraints=ignore_missing_restraints,
       log=out)
 
     # Save the hydrogenated model for downstream use (e.g. kinemage generation)
@@ -599,6 +601,7 @@ def check_and_add_hydrogen(
         verbose=False,
         n_hydrogen_cut_off=0,
         do_flips=False,
+        ignore_missing_restraints=False,
         log=None,
         stop_for_unknowns=True):
   """
@@ -613,6 +616,12 @@ def check_and_add_hydrogen(
     verbose (bool): verbosity of printout
     n_hydrogen_cut_off (int): when number of hydrogen atoms < n_hydrogen_cut_off
       force keep_hydrogens tp True
+    ignore_missing_restraints (bool): when False (default), raise a Sorry if
+      restraints were not found for some residues (e.g. unknown ligands). When
+      True, continue on a best-effort basis: those residues simply get no
+      hydrogens added, and the rest of the model is still analyzed. This also
+      relaxes stop_for_unknowns for the re-process step, since a residue with no
+      restraints necessarily leaves atoms with unknown energy types.
 
   Returns:
     (model): Model with hydrogens added
@@ -653,7 +662,13 @@ def check_and_add_hydrogen(
       nuclear         = nuclear,
       keep_existing_H = False,
       probe_phil      = probe_parameters,
-      stop_for_unknowns = stop_for_unknowns,
+      # Best-effort mode has to open both gates: raise_on_missing covers the
+      # "no restraints for this residue" check, and stop_for_unknowns covers the
+      # unknown-atom-type check in the re-process that follows. Relaxing only the
+      # first still aborts the run on the second. Mirrors the pairing already used
+      # by mmtbx/programs/validate_ligands.py.
+      stop_for_unknowns = stop_for_unknowns and not ignore_missing_restraints,
+      raise_on_missing = not ignore_missing_restraints,
       log             = log)
     return data_manager_model, True
   else:


### PR DESCRIPTION
## Summary

`clashscore2` aborts with a `Sorry` when a model contains a residue with no restraints
(e.g. an unknown ligand), so the whole contact analysis fails because of one problem
residue — even though the rest of the structure is perfectly analyzable.

This adds an **`ignore_missing_restraints`** option (phil parameter on the program, keyword
on `clashscore2` and `check_and_add_hydrogen`) that continues on a best-effort basis:
residues without restraints simply get no hydrogens added, while their heavy atoms still
take part in the contact analysis. **Default `False`, preserving current behavior.**

The naming and phil style mirror the existing `ignore_missing_restraints` in
`mmtbx/programs/reduce2.py`.

### Both gates have to open

`check_and_add_hydrogen` already delegates to `mmtbx.hydrogens.place_and_optimize_hydrogens`
but did not forward `raise_on_missing`. That alone turns out to be insufficient — there are
two checks in series:

1. `raise_on_missing` → *"Restraints were not found for the following residues"*
2. `stop_for_unknowns` → *"Fatal problems interpreting model file: … unknown nonbonded energy
   type symbols"*, in the re-process that follows

Relaxing only the first still aborts the run on the second, just with a different message.
So best-effort mode relaxes both. This mirrors the pairing already used by
`mmtbx/programs/validate_ligands.py:150-158`, which passes `stop_for_unknowns=False` and
`raise_on_missing=False` together.

### Compatibility

The 2-tuple return of `check_and_add_hydrogen` is **unchanged**, so all existing callers
(`clashscore2`, `undowser2`, `tst_reduce_switch`) are unaffected — the new parameter is
purely additive and keyword-only in practice.

## Testing

- New `test_clashscore2_ignore_missing_restraints` in `mmtbx/regression/tst_reduce_switch.py`:
  a model with an unknown ligand raises `Sorry` by default and completes with
  `ignore_missing_restraints=True`. (The fixture uses `UNL` specifically — many made-up
  three-letter codes resolve to some monomer entry and would not exercise this path at all.)
- Full `tst_reduce_switch.py` passes, including `test_clashscore2_delegates`, which pins the
  2-tuple return — unchanged, demonstrating no API break.
- `mmtbx/validation/regression/tst_undowser2.py` passes (indirect caller).
- End-to-end: `clashscore2(..., ignore_missing_restraints=True)` on an unknown-ligand model
  completes and yields the usual `flat_results` / `summary_results` JSON plus a populated
  `hydrogenated_model`; with the default it still raises `Sorry`.
- No change on normal models: `mmtbx.clashscore2` on 1nxbH gives clashscore 294.57 both with
  and without this patch.
- `libtbx.find_clutter` and `py_compile` clean.
