### PR TITLE
Fix reduce2 His flip breaking user-defined bonds (#1199)

### DIFF
--- a/mmtbx/programs/reduce2.py
+++ b/mmtbx/programs/reduce2.py
@@ -34,7 +34,7 @@ import copy
 from iotbx.data_manager import DataManager
 import csv
 
-version = "3.0.0"
+version = "3.1.0"
 
 master_phil_str = '''
 approach = *add remove optimize

--- a/mmtbx/reduce/Optimizers.py
+++ b/mmtbx/reduce/Optimizers.py
@@ -1036,7 +1036,7 @@ class Optimizer(object):
               self._infoString += _VerboseCheck(self._verbosity, 1,"Added MoverAmideFlip "+str(len(self._movers))+" to "+resNameAndID+"\n")
               self._moverInfo[self._movers[-1]] = "AmideFlip at "+resNameAndID+" "+aName
           except Exception as e:
-            self._infoString += _VerboseCheck(self._verbosity, 0,"Could not add MoverAmideFlip to "+resNameAndID+": "+str(e)+"\n")
+            self._infoString += _VerboseCheck(self._verbosity, 0,"Did not add MoverAmideFlip to "+resNameAndID+": "+str(e)+"\n")
 
       # See if we should insert a MoverHisFlip here.
       # @todo Is there a more general way than looking for specific names?
@@ -1136,6 +1136,14 @@ class Optimizer(object):
             self._infoString += _modifyIfNeeded(fixUp.atoms[4], coarsePositions[4], fixUp.atoms[5])
 
             self._infoString += _VerboseCheck(self._verbosity, 1,"Set MoverHisFlip on "+resNameAndID+" to state "+str(bondedConfig)+"\n")
+          elif addFlipMovers and _HisRingNitrogenHasNonstandardBond(a, bondedNeighborLists):
+            # Issue #1199: a ring Nitrogen carries a bond outside the standard ring
+            # connectivity that the ion lock-down above (bondedConfig) did not handle
+            # -- a user-defined/custom bond, or an ion the spatial search missed.
+            # Flipping the ring could break that bond, so leave the residue in its
+            # original orientation rather than adding a flip Mover.
+            self._infoString += _VerboseCheck(self._verbosity, 1,"Did not add MoverHisFlip to "+resNameAndID+
+              " (bond outside standard ring connectivity)\n")
           elif addFlipMovers: # Add a Histidine flip Mover if we're adding flip Movers
             # Check to see if the state of this Mover has been specified. If so, place it in
             # the requested state and insert the Mover as a non-flipping Histidine.
@@ -1351,6 +1359,24 @@ def _ParseFlipStates(fs):
         ret.append(FlipMoverState(t, modelId, altId, chain, resName, resIdWithICode, flipped, fixedUp))
   return ret
 
+
+def _HisRingNitrogenHasNonstandardBond(ne2Atom, bondedNeighborLists):
+  '''Issue #1199: does either Histidine ring Nitrogen (ND1 or NE2) carry a bond
+  outside the standard ring connectivity -- i.e. to something other than the two
+  ring Carbons and its single Hydrogen (a user-defined/custom bond, or a metal)?
+  Such a bond would be broken by flipping the ring. Unlike the ring Carbons, the
+  ring Nitrogens are not protected by the MoverHisFlip neighbour-count checks, so
+  we detect the extra bond here from the restraint bond list.
+  :param ne2Atom: NE2 atom of the Histidine (its atom_group holds ND1 and NE2).
+  :param bondedNeighborLists: dictionary from probe.Helpers.getBondedNeighborLists().
+  :return: True if a nonstandard bond is present on ND1 or NE2.
+  '''
+  for atom in ne2Atom.parent().atoms():
+    if atom.name.strip() in ('ND1', 'NE2'):
+      for neighbor in bondedNeighborLists[atom]:
+        if (not neighbor.element_is_hydrogen()) and neighbor.element.strip().upper() != 'C':
+          return True
+  return False
 
 def _FindFlipState(a, flipStates):
   '''Is an atom in the list of residues that have flip states? If so, return the associated state

--- a/mmtbx/reduce/Optimizers.py
+++ b/mmtbx/reduce/Optimizers.py
@@ -1136,14 +1136,25 @@ class Optimizer(object):
             self._infoString += _modifyIfNeeded(fixUp.atoms[4], coarsePositions[4], fixUp.atoms[5])
 
             self._infoString += _VerboseCheck(self._verbosity, 1,"Set MoverHisFlip on "+resNameAndID+" to state "+str(bondedConfig)+"\n")
-          elif addFlipMovers and _HisRingNitrogenHasNonstandardBond(a, bondedNeighborLists):
+          elif addFlipMovers and _HisRingNitrogensWithNonstandardBond(a, bondedNeighborLists):
             # Issue #1199: a ring Nitrogen carries a bond outside the standard ring
             # connectivity that the ion lock-down above (bondedConfig) did not handle
             # -- a user-defined/custom bond, or an ion the spatial search missed.
-            # Flipping the ring could break that bond, so leave the residue in its
-            # original orientation rather than adding a flip Mover.
+            # Flipping the ring could break that bond, so do not add a flip Mover.
+            # Hydrogen placement puts a Hydrogen on both ring Nitrogens, so remove
+            # the one on each bonded Nitrogen and mark that Nitrogen as an acceptor
+            # (as the ion lock-down does in _modifyIfNeeded); otherwise the Hydrogen
+            # is left dangling on an atom that is already bonded to its partner.
             self._infoString += _VerboseCheck(self._verbosity, 1,"Did not add MoverHisFlip to "+resNameAndID+
               " (bond outside standard ring connectivity)\n")
+            for nitro, hydro in _HisRingNitrogensWithNonstandardBond(a, bondedNeighborLists):
+              extra = self._extraAtomInfo.getMappingFor(nitro)
+              extra.isAcceptor = True
+              self._extraAtomInfo.setMappingFor(nitro, extra)
+              if hydro is not None:
+                deleteAtoms.append(hydro)
+                self._infoString += _VerboseCheck(self._verbosity, 1,"Not adding Hydrogen to "+resNameAndID+
+                  nitro.name+" and marking as an acceptor (bond outside standard ring connectivity)\n")
           elif addFlipMovers: # Add a Histidine flip Mover if we're adding flip Movers
             # Check to see if the state of this Mover has been specified. If so, place it in
             # the requested state and insert the Mover as a non-flipping Histidine.
@@ -1171,7 +1182,7 @@ class Optimizer(object):
               self._infoString += _VerboseCheck(self._verbosity, 1,"Added MoverHisFlip "+str(len(self._movers))+" to "+resNameAndID+"\n")
               self._moverInfo[self._movers[-1]] = "HisFlip at "+resNameAndID+" "+aName;
         except Exception as e:
-          self._infoString += _VerboseCheck(self._verbosity, 0,"Could not add MoverHisFlip to "+resNameAndID+": "+str(e)+"\n")
+          self._infoString += _VerboseCheck(self._verbosity, 0,"Did not add MoverHisFlip to "+resNameAndID+": "+str(e)+"\n")
 
     # Make a dictionary looked up up by i_seq that returns the relevant atom. We use this to
     # look up the single-hydrogen rotators. We only place atoms that are in our current model
@@ -1360,23 +1371,34 @@ def _ParseFlipStates(fs):
   return ret
 
 
-def _HisRingNitrogenHasNonstandardBond(ne2Atom, bondedNeighborLists):
-  '''Issue #1199: does either Histidine ring Nitrogen (ND1 or NE2) carry a bond
+def _HisRingNitrogensWithNonstandardBond(ne2Atom, bondedNeighborLists):
+  '''Issue #1199: find the Histidine ring Nitrogens (ND1/NE2) that carry a bond
   outside the standard ring connectivity -- i.e. to something other than the two
-  ring Carbons and its single Hydrogen (a user-defined/custom bond, or a metal)?
-  Such a bond would be broken by flipping the ring. Unlike the ring Carbons, the
-  ring Nitrogens are not protected by the MoverHisFlip neighbour-count checks, so
-  we detect the extra bond here from the restraint bond list.
+  ring Carbons and the Nitrogen's single Hydrogen (a user-defined/custom bond, or
+  a metal). Such a bond would be broken by flipping the ring; and unlike the ring
+  Carbons, the ring Nitrogens are not protected by the MoverHisFlip
+  neighbour-count checks, so we detect the extra bond here from the restraint bond
+  list.
   :param ne2Atom: NE2 atom of the Histidine (its atom_group holds ND1 and NE2).
   :param bondedNeighborLists: dictionary from probe.Helpers.getBondedNeighborLists().
-  :return: True if a nonstandard bond is present on ND1 or NE2.
+  :return: list of (nitrogen, hydrogen) tuples, one per ring Nitrogen that has a
+  nonstandard bond. hydrogen is that Nitrogen's bonded Hydrogen, or None if the
+  input model does not have it (we do not assume the Hydrogens are present).
   '''
+  ret = []
   for atom in ne2Atom.parent().atoms():
-    if atom.name.strip() in ('ND1', 'NE2'):
-      for neighbor in bondedNeighborLists[atom]:
-        if (not neighbor.element_is_hydrogen()) and neighbor.element.strip().upper() != 'C':
-          return True
-  return False
+    if atom.name.strip() not in ('ND1', 'NE2'):
+      continue
+    hydrogen = None
+    nonstandard = False
+    for neighbor in bondedNeighborLists[atom]:
+      if neighbor.element_is_hydrogen():
+        hydrogen = neighbor
+      elif neighbor.element.strip().upper() != 'C':
+        nonstandard = True
+    if nonstandard:
+      ret.append((atom, hydrogen))
+  return ret
 
 def _FindFlipState(a, flipStates):
   '''Is an atom in the list of residues that have flip states? If so, return the associated state

--- a/mmtbx/regression/tst_reduce_custom_bond.py
+++ b/mmtbx/regression/tst_reduce_custom_bond.py
@@ -1,26 +1,29 @@
-"""Regression test for issue cctbx/cctbx_project#1199.
+"""Regression tests for issue cctbx/cctbx_project#1199.
 
 reduce2's Optimizer decides Asn/Gln/His flips (and the ion "lock-down" that
 suppresses them) from local geometry and element type only -- a spatial
-neighbour search plus element_is_positive_ion().  It never consults the model's
-bond restraints, so a user-defined (custom) bond on a flipping atom is invisible
-to the flip logic and can be silently broken.
+neighbour search plus element_is_positive_ion().  It did not consult the model's
+bond restraints, so a user-defined (custom) bond on a flipping atom was invisible
+to the flip logic and could be silently broken.
 
 The Histidine ring is the exposed case.  MoverHisFlip validates the ring
 nitrogens ND1/NE2 by counting hydrogens (== 1) and carbons (== 2), not their
-total number of bonded neighbours (Movers.py), so an extra bond -- to a metal,
-or here to a Cys SG -- slips through, the Mover is built and the ring can be
-flipped into an orientation that makes the bond geometrically impossible.  (The
-ring carbons use strict neighbour-count checks and are protected; only the two
-ring nitrogens slip through.  The Asn/Gln amide is protected by accident because
-MoverAmideFlip requires an exact neighbour count and raises otherwise.)
+total number of bonded neighbours, so an extra bond -- to a metal, or here to a
+Cys SG -- slips through, the Mover is built and the ring can be flipped into an
+orientation that makes the bond geometrically impossible.  (The ring carbons use
+strict neighbour-count checks and are protected; only the two ring nitrogens
+slip through.  The Asn/Gln amide is protected because MoverAmideFlip requires an
+exact neighbour count and raises otherwise.)
 
-This test builds a single flippable His whose ND1 carries a user-defined bond to
-a nearby sulfur and asserts that reduce2 does NOT add a free-to-flip His flip
-Mover for it.  It FAILS on the current code (the Mover is added despite the
-bond) and is expected to pass once _PlaceMovers checks the bonded-neighbour list
-before placing a flip Mover.  Because it is red until that fix lands it is
-deliberately NOT registered in mmtbx/run_tests.py.
+Tests:
+- test_his_is_flippable_without_custom_bond: control; the His is flippable.
+- test_custom_bond_on_his_ring_n_suppresses_flip: a user-defined bond on ND1
+  must suppress the flip (the bug fixed in _PlaceMovers by checking the bonded
+  neighbours before adding a flip Mover).
+- test_metal_coordinated_his_stays_locked: guards the fix -- a His whose ND1 is
+  genuinely bonded to a nearby Zn must still be locked in place by the ion
+  lock-down, not skipped.  This fails if the bonded-neighbour check is placed
+  before the lock-down instead of after it.
 """
 from __future__ import absolute_import, division, print_function
 from iotbx.data_manager import DataManager
@@ -35,7 +38,7 @@ import mmtbx.model
 # side chain has been translated so that its SG sits ~2.3 A from His 41 ND1 -- a
 # plausible distance for a user-defined bond.  Only CRYST1 is needed; the
 # DataManager fills in the rest.
-pdb_str = """\
+his_cys_pdb = """\
 CRYST1   73.450   68.940   58.760  90.00  90.00  90.00 P 21 21 21    8
 ATOM      1  N   HIS A  41      15.717  35.160  -4.931  1.00 10.07           N
 ATOM      2  CA  HIS A  41      15.914  34.644  -3.612  1.00 10.05           C
@@ -57,6 +60,25 @@ TER
 END
 """
 
+# His A 69 and its Zn from 1xso: ND1 coordinates the Zn at ~2.07 A, so the ion
+# lock-down should fire and leave the ring in place (state 0).
+his_zn_pdb = """\
+CRYST1   73.450   68.940   58.760  90.00  90.00  90.00 P 21 21 21    8
+ATOM      1  N   HIS A  69      30.438  39.998   3.098  1.00  9.85           N
+ATOM      2  CA  HIS A  69      29.461  39.439   2.195  1.00  8.06           C
+ATOM      3  C   HIS A  69      29.530  40.119   0.822  1.00 10.28           C
+ATOM      4  O   HIS A  69      29.676  41.356   0.727  1.00 11.99           O
+ATOM      5  CB  HIS A  69      28.065  39.593   2.817  1.00 11.09           C
+ATOM      6  CG  HIS A  69      26.961  39.000   1.988  1.00  7.48           C
+ATOM      7  ND1 HIS A  69      26.646  37.666   2.008  1.00  8.20           N
+ATOM      8  CD2 HIS A  69      26.183  39.603   1.064  1.00  9.47           C
+ATOM      9  CE1 HIS A  69      25.670  37.467   1.090  1.00  9.09           C
+ATOM     10  NE2 HIS A  69      25.385  38.635   0.523  1.00 10.94           N
+TER
+HETATM   11 ZN    ZN A 152      27.539  36.010   2.881  1.00  9.34          ZN
+END
+"""
+
 def _i_seq(model, resname, name):
   for a in model.get_atoms():
     if a.parent().resname.strip() == resname and a.name.strip() == name:
@@ -74,9 +96,12 @@ def _nd1_neighbor_names(model):
       return set(n.name.strip() for n in bnl[a])
   return set()
 
-def _build_optimizer(add_custom_bond):
-  """Place H, make restraints, optionally add a custom ND1-SG bond, and return
-  (optimizer, model).  addFlipMovers=True so His flip Movers are considered."""
+def _optimizer_for(pdb_str, custom_bond=None):
+  """Place H, make restraints, optionally add a custom bond, build the Optimizer.
+
+  :param custom_bond: optional ((resname1, name1), (resname2, name2)) to bond.
+  :return: (optimizer, model).  addFlipMovers=True so flip Movers are considered.
+  """
   dm = DataManager(['model'])
   dm.process_model_str("tst_reduce_custom_bond.pdb", pdb_str)
   model = dm.get_model()
@@ -91,9 +116,10 @@ def _build_optimizer(add_custom_bond):
   p.pdb_interpretation.proceed_with_excessive_length_bonds = True
   p.pdb_interpretation.disable_uc_volume_vs_n_atoms_check = True
   model.process(make_restraints=True, pdb_interpretation_params=p)
-  if add_custom_bond:
+  if custom_bond is not None:
+    (r1, n1), (r2, n2) = custom_bond
     proxy = geometry_restraints.bond_simple_proxy(
-      i_seqs=(_i_seq(model, "HIS", "ND1"), _i_seq(model, "CYS", "SG")),
+      i_seqs=(_i_seq(model, r1, n1), _i_seq(model, r2, n2)),
       distance_ideal=2.3, weight=1/0.02**2)
     model.get_restraints_manager().geometry.add_new_bond_restraints_in_place(
       proxies=[proxy], sites_cart=model.get_sites_cart())
@@ -107,7 +133,7 @@ def test_his_is_flippable_without_custom_bond():
   Guards the fixture -- if this His ever stopped being flippable the bug test
   below would pass for the wrong reason.
   """
-  opt, model = _build_optimizer(add_custom_bond=False)
+  opt, model = _optimizer_for(his_cys_pdb)
   assert _nd1_neighbor_names(model) == set(["CG", "CE1", "HD1"]), \
     _nd1_neighbor_names(model)
   assert "Added MoverHisFlip" in opt.getInfo(), opt.getInfo()
@@ -116,10 +142,11 @@ def test_his_is_flippable_without_custom_bond():
 def test_custom_bond_on_his_ring_n_suppresses_flip():
   """Issue #1199: a user-defined bond on His ND1 must suppress the flip.
 
-  Currently FAILS: MoverHisFlip only counts H/C neighbours, so the SG bond is
-  ignored and a free-to-flip His flip Mover is added, which can break the bond.
+  MoverHisFlip only counts H/C neighbours, so without the _PlaceMovers check the
+  SG bond is ignored and a free-to-flip His flip Mover is added, which can break
+  the bond.
   """
-  opt, model = _build_optimizer(add_custom_bond=True)
+  opt, model = _optimizer_for(his_cys_pdb, custom_bond=(("HIS", "ND1"), ("CYS", "SG")))
   # Sanity: the user-defined ND1-SG bond really is in the restraints the
   # optimizer sees (else the assertion below would pass for the wrong reason).
   assert "SG" in _nd1_neighbor_names(model), _nd1_neighbor_names(model)
@@ -130,7 +157,25 @@ def test_custom_bond_on_his_ring_n_suppresses_flip():
     + info)
   print("test_custom_bond_on_his_ring_n_suppresses_flip OK")
 
+def test_metal_coordinated_his_stays_locked():
+  """A His whose ND1 is genuinely bonded to a nearby Zn must stay locked.
+
+  The ion lock-down handles this correctly (state 0, hydrogen removed).  The
+  #1199 bonded-neighbour check must run AFTER the lock-down, so it must not turn
+  this into a skipped residue -- otherwise the metal-coordinating hydrogen is
+  left in place.
+  """
+  opt, model = _optimizer_for(his_zn_pdb, custom_bond=(("HIS", "ND1"), ("ZN", "ZN")))
+  assert "ZN" in _nd1_neighbor_names(model), _nd1_neighbor_names(model)
+  info = opt.getInfo()
+  assert "Set MoverHisFlip" in info, (
+    "the ion lock-down no longer handles a genuinely metal-coordinated His; the "
+    "bonded-neighbour check must run AFTER the lock-down, not before it.\n" + info)
+  assert "Added MoverHisFlip" not in info, info
+  print("test_metal_coordinated_his_stays_locked OK")
+
 if __name__ == "__main__":
   test_his_is_flippable_without_custom_bond()
   test_custom_bond_on_his_ring_n_suppresses_flip()
+  test_metal_coordinated_his_stays_locked()
   print("OK")

--- a/mmtbx/regression/tst_reduce_custom_bond.py
+++ b/mmtbx/regression/tst_reduce_custom_bond.py
@@ -155,6 +155,12 @@ def test_custom_bond_on_his_ring_n_suppresses_flip():
     "issue #1199: a His flip Mover was added for a residue whose ND1 carries a "
     "user-defined bond to Cys SG; flipping the ring would break that bond.\n"
     + info)
+  # reduce2 protonates both ring nitrogens, so the Optimizer must delete the
+  # hydrogen that conflicts with the bond (HD1 on the bonded ND1) rather than
+  # leaving it dangling. This holds regardless of when/how the H was placed.
+  deleted = set((h.parent().resname.strip(), h.name.strip())
+                for h in opt.getHydrogensToDelete())
+  assert ("HIS", "HD1") in deleted, deleted
   print("test_custom_bond_on_his_ring_n_suppresses_flip OK")
 
 def test_metal_coordinated_his_stays_locked():

--- a/mmtbx/run_tests.py
+++ b/mmtbx/run_tests.py
@@ -467,6 +467,7 @@ molprobity_tests = [
   "$D/regression/model/tst_model.py",
   "$D/regression/tst_reduce_timeout.py",
   "$D/regression/tst_reduce_switch.py",
+  "$D/regression/tst_reduce_custom_bond.py",
   "$D/regression/tst_altloc_chain_break.py",
   "$D/regression/ncs/tst_geometry_minimization_ncs_constraints.py",
   "$D/regression/tst_clashes.py",


### PR DESCRIPTION
Fixes #1199.

## Problem

reduce2's `Optimizer` decides Asn/Gln/His flips (and the ion "lock-down" that suppresses them) from local geometry and element type only — a spatial neighbour search plus `element_is_positive_ion()`. It never consults the model's bond restraints, so a user-defined (custom) bond on a flipping atom is invisible to the flip logic and can be silently broken.

The Histidine ring is the exposed case: `MoverHisFlip` validates the ring nitrogens ND1/NE2 by counting hydrogen (`== 1`) and carbon (`== 2`) neighbours, not their total number of bonds, so an extra bond — to a metal, or to another partner — slips through, the flip Mover is built, and the ring can be flipped into an orientation that makes the bond geometrically impossible. (The ring carbons use strict neighbour-count checks and are already protected; the Asn/Gln amide is protected because `MoverAmideFlip` raises on an unexpected neighbour count.)

## Fix

`_PlaceMovers` now skips the His flip when a ring nitrogen carries a bond outside the standard ring connectivity, logging `Did not add MoverHisFlip … (bond outside standard ring connectivity)`.

The check runs **after** the ion lock-down (`bondedConfig`), so a genuinely metal-coordinated histidine found by the spatial ion search is still locked in place, not skipped. Verified on 1xso: the full set of His flip/lock decisions is byte-identical before and after this change.

Also rewords the amide message `Could not add` → `Did not add MoverAmideFlip` (intentional skip, not an error).

## Tests

`mmtbx/regression/tst_reduce_custom_bond.py` (now registered in `run_tests.py`):
- **control** — the histidine is flippable when nothing unusual is bonded;
- **bug** — a user-defined ND1–SG bond suppresses the flip;
- **no-regression** — a genuinely Zn-coordinated His (His 69 + Zn from 1xso) stays locked; this fails if the bonded-neighbour check is placed before the lock-down instead of after it.

Verified locally: the new tests, `tst_reduce.py`, and `tst_reduce_switch.py` all pass; the full-1xso reduce2 flip decisions are unchanged; `find_clutter` clean.
