### PR TITLE
Add configurable parallelism, convergence, and a NumFreq Hessian to orca_manager

### DIFF
--- a/mmtbx/geometry_restraints/orca_manager.py
+++ b/mmtbx/geometry_restraints/orca_manager.py
@@ -71,7 +71,7 @@ class orca_manager(base_qm_manager.base_qm_manager):
    8    58.8800869   71.4618835   28.1663680
    8    62.2022254   74.3474953   29.5553167
   16    59.4829095   73.6048329   29.8973572'''
-    f=open('orca_%s.engrad' % self.preamble, 'r')
+    f=open('orca_%s.engrad' % self.preamble, 'r', encoding='utf-8')
     lines = f.read()
     del f
     lines = lines.split('#')
@@ -96,7 +96,7 @@ class orca_manager(base_qm_manager.base_qm_manager):
 
   def read_charge(self):
     filename = self.get_log_filename()
-    f=open(filename, 'r')
+    f=open(filename, 'r', encoding='utf-8')
     lines=f.readlines()
     del f
     #Sum of atomic charges:   -1.0000000
@@ -110,7 +110,7 @@ class orca_manager(base_qm_manager.base_qm_manager):
 
   def read_energy(self):
     filename = self.get_log_filename()
-    f=open(filename, 'r')
+    f=open(filename, 'r', encoding='utf-8')
     lines=f.readlines()
     del f
     for line in lines:
@@ -126,7 +126,7 @@ class orca_manager(base_qm_manager.base_qm_manager):
     filename = self.get_coordinate_filename()
     if not os.path.exists(filename):
       raise Sorry('QM output filename not found: %s' % filename)
-    f=open(filename, 'r')
+    f=open(filename, 'r', encoding='utf-8')
     lines = f.read()
     del f
     rc = flex.vec3_double()

--- a/mmtbx/geometry_restraints/orca_manager.py
+++ b/mmtbx/geometry_restraints/orca_manager.py
@@ -7,7 +7,20 @@ from scitbx.array_family import flex
 from mmtbx.geometry_restraints import base_qm_manager
 from mmtbx.geometry_restraints.base_qm_manager import harkcal, bohrang
 
+# Named %geom convergence presets. Keys are ORCA %geom Tol keywords; values are
+# in ORCA atomic units.
+GEOM_CONVERGENCE = {
+  'looser': {'TolE': 2e-4, 'TolRMSG': 5e-4, 'TolMaxG': 3e-3, 'TolRMSD': 1.5e-2, 'TolMaxD': 3e-2},
+}
+
 class orca_manager(base_qm_manager.base_qm_manager):
+
+  # Geometry optimisation keyword (gradients-only jobs override to 'EnGrad').
+  optimisation = 'LooseOpt'
+  # None, a GEOM_CONVERGENCE preset name, or a dict of Tol* overrides.
+  geom_convergence = None
+  # ORCA executable path (falls back to $PHENIX_ORCA when None).
+  exe = None
 
   error_lines = [
                   'ORCA finished by error termination in GSTEP',
@@ -20,6 +33,8 @@ class orca_manager(base_qm_manager.base_qm_manager):
   def get_coordinate_filename(self): return 'orca_%s.xyz' % self.preamble
 
   def get_log_filename(self): return 'orca_%s.log' % self.preamble
+
+  def get_hessian_filename(self): return f'orca_{self.preamble}.hess'
 
   def read_engrad_output(self):
     '''#
@@ -122,10 +137,11 @@ class orca_manager(base_qm_manager.base_qm_manager):
     return rc
 
   def get_cmd(self, env='PHENIX_ORCA'):
-    if not os.environ.get(env, False):
+    exe = self.exe or os.environ.get(env)
+    if not exe:
       raise Sorry(f'Shell Environment Variable "{env}" not set to point to Orca exe')
     cmd = '%s orca_%s.in' % (
-      os.environ[env],
+      exe,
       self.preamble,
       )
     return cmd
@@ -150,33 +166,46 @@ SOSCFStart 0.00033 # Default value of orbital gradient is 0.0033. Here reduced b
 end
 %maxcore 2048
 '''
-    addiotnal_options=''
-    ptr=1
-    if gradients_only:
-      ptr=2
+    if self.nproc > 1:
+      standard_options = f'%pal nprocs {int(self.nproc)} end\n' + standard_options
+    additional_options=''
+    keyword = 'EnGrad' if gradients_only else self.optimisation
     outl = '%s\n! %s %s %s %s %s\n%s\n' % (standard_options,
                                        self.method,
                                        self.basis_set,
                                        self.solvent_model,
-                                       ['Opt', 'LooseOpt', 'EnGrad'][ptr],
-                                       addiotnal_options,
+                                       keyword,
+                                       additional_options,
                                        '',
                                        )
     return outl
 
-  def get_coordinate_lines(self, optimise_ligand=True, optimise_h=True, constrain_torsions=False):
+  def get_coordinate_lines(self, optimise_ligand=True, optimise_h=True, constrain_torsions=False, sites_cart=None):
     outl = '* xyz %s %s\n' % (self.get_charge(), self.get_multiplicity())
     for i, atom in enumerate(self.atoms):
+      xyz = sites_cart[i] if sites_cart is not None else atom.xyz
       outl += ' %s %0.5f %0.5f %0.5f # %s %s\n' % (
         atom.element,
-        atom.xyz[0],
-        atom.xyz[1],
-        atom.xyz[2],
+        xyz[0],
+        xyz[1],
+        xyz[2],
         atom.id_str(),
         i,
         )
     outl += '*\n'
     return outl
+
+  def _resolve_geom_convergence(self):
+    gc = self.geom_convergence
+    if gc is None: return {}
+    if isinstance(gc, str): return GEOM_CONVERGENCE[gc]
+    return gc
+
+  def _geom_tol_lines(self):
+    lines = ''
+    for key, value in self._resolve_geom_convergence().items():
+      lines += f'  {key} {value}\n'
+    return lines
 
   def get_input_lines(self, optimise_ligand=True, optimise_h=True, constrain_torsions=False, gradients=False):
     outl = self._input_header(gradients_only=gradients)
@@ -184,9 +213,8 @@ end
                                       optimise_h=optimise_h,
                                       constrain_torsions=constrain_torsions,
                                       )
-    freeze_outl = '''%geom
-      Constraints
-'''
+    # Constraints sub-block (may stay empty).
+    constraints_outl = ''
     added = 0
     for i, (sel, atom) in enumerate(zip(self.ligand_atoms_array, self.atoms)):
       if optimise_h and atom.element in ['H', 'D']: continue
@@ -206,29 +234,65 @@ end
           for j in torsions: tmp += ' %s' % self.atoms[j].name.strip()
           tmp += '\n'
       if tmp:
-        freeze_outl += tmp
+        constraints_outl += tmp
       if sel and optimise_ligand: continue
-      freeze_outl += '{C %d C} # Constraining xyz %s\n' % (i, atom.id_str())
+      constraints_outl += '{C %d C} # Constraining xyz %s\n' % (i, atom.id_str())
       added+=1
-    freeze_outl += 'end\nend\n'
-    if added: outl+=freeze_outl
+    # Optional %geom Tol* overrides sit ahead of Constraints in the same block.
+    tol_lines = self._geom_tol_lines()
+    if added or tol_lines:
+      outl += '%geom\n'
+      outl += tol_lines
+      if added:
+        outl += '      Constraints\n'
+        outl += constraints_outl
+        outl += 'end\n'
+      outl += 'end\n'
     assert outl.find('Opt')>-1 or outl.find('EnGrad')>-1
     return outl
 
-  # def get_engrad(self):
-  #   outl = '! %s %s %s EnGrad\n\n' % (self.method,
-  #                                     self.basis_set,
-  #                                     self.solvent_model)
-  #   outl += self.get_coordinate_lines()
-  #   if outl in self.energies:
-  #     self.times.append(0)
-  #     return self.energies[outl]
-  #   self.write_input(outl)
-  #   self.run_cmd()
-  #   energy, gradients = self.read_engrad_output()
-  #   self.print_timings(energy)
-  #   self.energies[outl] = (energy, gradients)
-  #   return energy, gradients
+  def get_engrad(self):
+    '''Single-point energy and gradient (ORCA EnGrad); cached by input string.'''
+    outl = self._input_header(gradients_only=True)
+    outl += self.get_coordinate_lines()
+    if outl in self.energies:
+      self.times.append(0)
+      return self.energies[outl]
+    self.write_input(outl)
+    self.run_cmd()
+    energy, gradients = self.read_engrad_output()
+    self.energies[outl] = (energy, gradients)
+    return energy, gradients
+
+  def run_hessian(self, sites_cart=None, hessian_atoms=None, partial=True, log=None):
+    '''Run an ORCA NumFreq and return the absolute path to the .hess file.
+
+    sites_cart (a flex.vec3_double in self.atoms order) supplies the geometry;
+    self.atoms xyz is used when it is None. When partial and hessian_atoms (a
+    list of 0-based indices) are given, only those atoms are displaced via
+    %freq Partial_Hess; ORCA still writes the full 3N x 3N Hessian.'''
+    outl = '%maxcore 2048\n'
+    if self.nproc > 1:
+      outl += f'%pal nprocs {int(self.nproc)} end\n'
+    keywords = ' '.join(w for w in (self.method,
+                                    self.basis_set,
+                                    self.solvent_model,
+                                    'NumFreq') if w)
+    outl += f'! {keywords}\n'
+    if partial and hessian_atoms:
+      sel = ' '.join(str(int(i)) for i in sorted(set(hessian_atoms)))
+      outl += f'%freq\n  Partial_Hess {{{sel}}} end\nend\n'
+    outl += self.get_coordinate_lines(sites_cart=sites_cart)
+    self.write_input(outl)
+    hess_name = self.get_hessian_filename()
+    # A prior run's Hessian must not survive an aborted NumFreq and be read back.
+    if os.path.exists(hess_name):
+      os.remove(hess_name)
+    self.run_cmd(log=log)
+    if not os.path.exists(hess_name):
+      raise Sorry(f'ORCA NumFreq did not produce {hess_name}; '
+                  f'check {self.get_log_filename()}')
+    return os.path.abspath(hess_name)
 
   def cleanup(self, level=None, verbose=False):
     if not self.preamble: return

--- a/mmtbx/geometry_restraints/tst_orca_manager.py
+++ b/mmtbx/geometry_restraints/tst_orca_manager.py
@@ -1,0 +1,213 @@
+"""Fast unit tests for mmtbx.geometry_restraints.orca_manager.
+
+No ORCA binary is needed: every exercise checks the input string the manager
+generates (optimisation keyword, %pal parallel line, %geom Tol overrides, the
+NumFreq Hessian input) or the assembled command line. The one exercise that
+drives get_hessian() stubs out run_cmd so ORCA is never launched.
+"""
+from __future__ import absolute_import, division, print_function
+import os
+import shutil
+import tempfile
+
+import iotbx.pdb
+from scitbx.array_family import flex
+from libtbx.utils import Sorry
+
+from mmtbx.geometry_restraints import orca_manager
+
+# A tiny Zn(II) site: two water donors (O) and the metal (ZN).
+METAL_PDB = """\
+HETATM    1  O   HOH A   1      59.041  72.758  32.575  1.00 20.00           O
+HETATM    2  O   HOH A   2      57.856  75.840  29.342  1.00 20.00           O
+HETATM    3 ZN    ZN A   3      59.483  73.605  29.897  1.00 20.00          ZN
+"""
+
+
+def make_manager(preamble, ligand_flags=(1, 0, 0), pdb_str=METAL_PDB,
+                 method='HF', basis_set='def2-SVP', solvent_model='CPCM',
+                 charge=2, multiplicity=1, nproc=1):
+  """Build an orca_manager from a PDB string. The hierarchy is stashed on the
+  manager so atom.parent() (used by id_str) stays valid."""
+  hier = iotbx.pdb.input(source_info=None,
+                         lines=pdb_str.splitlines()).construct_hierarchy()
+  atoms = hier.atoms()
+  assert atoms.size() == len(ligand_flags)
+  m = orca_manager.orca_manager(atoms, method, basis_set, solvent_model,
+                                charge, multiplicity, nproc, preamble=preamble)
+  m.program_goal = 'opt'
+  m.set_ligand_atoms(list(ligand_flags))
+  m._tst_hier = hier  # keep the hierarchy (and atom.parent() chain) alive
+  return m
+
+
+def bang_line(text):
+  """The single ORCA keyword line, e.g. '! HF def2-SVP CPCM LooseOpt '."""
+  for line in text.splitlines():
+    if line.startswith('! '):
+      return line
+  return ''
+
+
+def exercise_parallel_and_optimisation():
+  """%pal only when nproc>1; optimisation keyword is configurable."""
+  # defaults: no %pal, LooseOpt
+  out = make_manager('def').get_input_lines()
+  assert '%pal' not in out, out
+  assert 'LooseOpt' in bang_line(out), bang_line(out)
+
+  # nproc>1 emits %pal in the header
+  out4 = make_manager('p4', nproc=4).get_input_lines()
+  assert '%pal nprocs 4 end' in out4, out4
+
+  # optimisation='Opt' gives '! ... Opt' and no LooseOpt anywhere
+  m = make_manager('opt')
+  m.optimisation = 'Opt'
+  out_opt = m.get_input_lines()
+  assert 'LooseOpt' not in out_opt, out_opt
+  assert ' Opt' in bang_line(out_opt), bang_line(out_opt)
+
+  # gradients still map to EnGrad regardless of optimisation
+  grad = make_manager('grad').get_input_lines(gradients=True)
+  assert 'EnGrad' in bang_line(grad), bang_line(grad)
+  assert 'LooseOpt' not in grad
+  print('  parallel/optimisation OK')
+
+
+def exercise_geom_convergence():
+  """Tol* overrides land inside %geom, ahead of Constraints."""
+  preset = orca_manager.GEOM_CONVERGENCE['looser']
+
+  # named preset, with constraints present (ligand_flags [1,0,0])
+  m = make_manager('geom')
+  m.geom_convergence = 'looser'
+  out = m.get_input_lines()
+  gi, ti, ci = out.index('%geom'), out.index('TolMaxD'), out.index('Constraints')
+  assert gi < ti < ci, out                     # Tol lines between %geom and Constraints
+  for key in preset:
+    assert '  %s ' % key in out, (key, out)
+  assert 'TolMaxD 0.03' in out, out            # 3e-2 formats to 0.03
+
+  # a plain dict is injected verbatim
+  m.geom_convergence = {'TolMaxD': 0.05, 'TolE': 1e-3}
+  out2 = m.get_input_lines()
+  assert 'TolMaxD 0.05' in out2, out2
+  assert 'TolE 0.001' in out2, out2
+  g2, t2, c2 = out2.index('%geom'), out2.index('TolMaxD'), out2.index('Constraints')
+  assert g2 < t2 < c2, out2
+
+  # default (None) injects no Tol lines
+  m.geom_convergence = None
+  assert 'Tol' not in m.get_input_lines()
+
+  # Tol overrides but no constraints: %geom block with no Constraints sub-block
+  mnc = make_manager('nocon', ligand_flags=(1, 1, 1))
+  mnc.geom_convergence = 'looser'
+  out_nc = mnc.get_input_lines()
+  assert '%geom' in out_nc, out_nc
+  assert 'Constraints' not in out_nc, out_nc
+  assert 'TolMaxD 0.03' in out_nc, out_nc
+  print('  geom convergence OK')
+
+
+def exercise_get_cmd():
+  """self.exe wins; otherwise $PHENIX_ORCA; otherwise Sorry."""
+  m = make_manager('cmd')
+  saved = os.environ.pop('PHENIX_ORCA', None)
+  try:
+    # neither exe nor env -> Sorry
+    m.exe = None
+    try:
+      m.get_cmd()
+      raise AssertionError('expected Sorry when neither exe nor env is set')
+    except Sorry:
+      pass
+    # explicit exe is used
+    m.exe = '/opt/orca/orca'
+    assert m.get_cmd() == '/opt/orca/orca orca_cmd.in', m.get_cmd()
+    # env fallback when exe is None
+    m.exe = None
+    os.environ['PHENIX_ORCA'] = '/env/orca'
+    assert m.get_cmd() == '/env/orca orca_cmd.in', m.get_cmd()
+  finally:
+    os.environ.pop('PHENIX_ORCA', None)
+    if saved is not None:
+      os.environ['PHENIX_ORCA'] = saved
+  print('  get_cmd OK')
+
+
+def drive_hessian(m, **kwds):
+  """Run run_hessian with run_cmd stubbed (ORCA never launched): the stub writes
+  a placeholder .hess so the method succeeds. Return (written .in, path)."""
+  def fake_run_cmd(log=None):
+    with open(m.get_hessian_filename(), 'w') as f:  # ORCA would write this
+      f.write('$hessian\n')
+  m.run_cmd = fake_run_cmd
+  path = m.run_hessian(**kwds)
+  with open(m.get_input_filename()) as f:
+    written = f.read()
+  return written, path
+
+
+def exercise_hessian():
+  """run_hessian writes a single NumFreq .in and returns the .hess path.
+
+  Everything runs in a temp dir; run_cmd is stubbed so ORCA is never launched.
+  """
+  cwd = os.getcwd()
+  tmp = tempfile.mkdtemp(prefix='tst_orca_')
+  os.chdir(tmp)
+  try:
+    # partial Hessian: indices sorted + de-duplicated; one monolithic .in
+    m = make_manager('hess')
+    assert m.get_hessian_filename() == 'orca_hess.hess'
+    inp, path = drive_hessian(m, hessian_atoms=[1, 0, 1])
+    assert 'NumFreq' in inp, inp
+    assert 'Partial_Hess {0 1}' in inp, inp
+    assert '%maxcore 2048' in inp, inp
+    assert '%pal' not in inp, inp
+    assert '* xyz 2 1' in inp, inp                # charge 2, multiplicity 1
+    assert path == os.path.abspath(m.get_hessian_filename()), path
+    assert os.path.exists(path)
+
+    # full Hessian: no %freq block
+    full, _ = drive_hessian(make_manager('hfull'))
+    assert 'NumFreq' in full and 'Partial_Hess' not in full, full
+
+    # partial=False ignores hessian_atoms
+    nofreq, _ = drive_hessian(make_manager('hno'), hessian_atoms=[0, 1], partial=False)
+    assert 'Partial_Hess' not in nofreq, nofreq
+
+    # nproc>1 -> %pal in the Hessian header too
+    inp4, _ = drive_hessian(make_manager('h4', nproc=4), hessian_atoms=[0])
+    assert '%pal nprocs 4 end' in inp4, inp4
+
+    # sites_cart overrides the geometry
+    sc = flex.vec3_double([(1, 2, 3)] * 3)
+    inpsc, _ = drive_hessian(make_manager('hsc'), sites_cart=sc)
+    assert '1.00000 2.00000 3.00000' in inpsc, inpsc
+
+    # a run that produces no .hess raises Sorry
+    mf = make_manager('hfail')
+    mf.run_cmd = lambda log=None: None
+    try:
+      mf.run_hessian()
+      raise AssertionError('expected Sorry when no .hess is produced')
+    except Sorry:
+      pass
+  finally:
+    os.chdir(cwd)
+    shutil.rmtree(tmp, ignore_errors=True)
+  print('  hessian OK')
+
+
+def run():
+  exercise_parallel_and_optimisation()
+  exercise_geom_convergence()
+  exercise_get_cmd()
+  exercise_hessian()
+
+
+if __name__ == '__main__':
+  run()
+  print('OK')

--- a/mmtbx/geometry_restraints/tst_orca_manager.py
+++ b/mmtbx/geometry_restraints/tst_orca_manager.py
@@ -140,11 +140,11 @@ def drive_hessian(m, **kwds):
   """Run run_hessian with run_cmd stubbed (ORCA never launched): the stub writes
   a placeholder .hess so the method succeeds. Return (written .in, path)."""
   def fake_run_cmd(log=None):
-    with open(m.get_hessian_filename(), 'w') as f:  # ORCA would write this
+    with open(m.get_hessian_filename(), 'w', encoding='utf-8') as f:  # ORCA would write this
       f.write('$hessian\n')
   m.run_cmd = fake_run_cmd
   path = m.run_hessian(**kwds)
-  with open(m.get_input_filename()) as f:
+  with open(m.get_input_filename(), encoding='utf-8') as f:
     written = f.read()
   return written, path
 

--- a/mmtbx/run_tests.py
+++ b/mmtbx/run_tests.py
@@ -60,6 +60,7 @@ general_tests = [
   "$D/geometry_restraints/tst_ramachandran.py",
   "$D/geometry_restraints/tst_manager.py",
   "$D/geometry_restraints/tst_xtb_manager.py",
+  "$D/geometry_restraints/tst_orca_manager.py",
   "$D/geometry_restraints/external.py",
   "$D/regression/tst_map_type_parser.py",
   "$D/rsr/tst.py",


### PR DESCRIPTION
Adds configurable options to `orca_manager`, mirroring the `xtb_manager` Hessian work in #1210 so the two managers expose a consistent public API.

- `%pal nprocs N` when `nproc > 1` (previously `nproc` was ignored, so ORCA always ran serial).
- A settable `optimisation` keyword (default `LooseOpt`).
- `%geom` convergence overrides via `geom_convergence`: `None`, a `GEOM_CONVERGENCE` preset name (e.g. `'looser'`), or a dict of `Tol*` settings, injected ahead of the `Constraints` sub-block.
- An `exe` attribute that `get_cmd` uses ahead of `$PHENIX_ORCA`.
- A revived `get_engrad` (the commented-out version called a nonexistent `print_timings`; its one caller, `qm_manager.main`, was broken).
- `run_hessian(sites_cart=None, hessian_atoms=None, partial=True, log=None) -> path`: an ORCA `NumFreq` (optionally partial over selected atoms) returning the `.hess` path. Public surface matches `xtb_manager.run_hessian` (#1210); internals stay orca-idiomatic (one monolithic `.in`).

Backward-compatible: with defaults (`nproc=1`, no `optimisation`/`geom_convergence`/`exe`), the generated input is byte-identical to before. The one behavior change is that `nproc>1` now parallelizes ORCA (was silently serial) - a bugfix.

Tests: `mmtbx/geometry_restraints/tst_orca_manager.py` (registered in `mmtbx/run_tests.py`; no ORCA binary needed).