### PR TITLE
Fix altloc key in hierarchical JSON for multi-atom validation results

### DIFF
--- a/mmtbx/validation/__init__.py
+++ b/mmtbx/validation/__init__.py
@@ -275,6 +275,18 @@ class atoms(entity):
         return True
     return False
 
+  def get_consensus_altloc(self):
+    """
+    Altloc shared by the atoms in this result, or '' if none of them are in an
+    alternate conformation.  Unlike get_altloc(), atoms from conflicting
+    altlocs return '' rather than raising, so this is safe to call while
+    serializing results for arbitrary models.
+    """
+    altlocs = set(a.altloc for a in self.atoms_info if a.altloc.strip() != '')
+    if (len(altlocs) == 1):
+      return altlocs.pop()
+    return ''
+
   def nest_dict(self, level_list, upper_dict):
     inner_dict = {}
     if len(level_list) > 0:
@@ -282,7 +294,15 @@ class atoms(entity):
       try:
         upper_dict[getattr(self, next_level)] = self.nest_dict(level_list[1:], inner_dict)
       except AttributeError:
-        upper_dict[getattr(self.atoms_info[0], next_level)] = self.nest_dict(level_list[1:], inner_dict)
+        if (next_level == "altloc"):
+          # A multi-atom result can span residues where only some of the atoms
+          # are in an alternate conformation (e.g. a C-N-CA angle whose second
+          # residue has altlocs).  Keying on atoms_info[0] alone labels those
+          # as blank, which merges the A and B results into one bucket.
+          key = self.get_consensus_altloc()
+        else:
+          key = getattr(self.atoms_info[0], next_level)
+        upper_dict[key] = self.nest_dict(level_list[1:], inner_dict)
     else:
       return [json.loads(self.as_JSON())]
     return upper_dict

--- a/mmtbx/validation/regression/tst_mp_validate_bonds.py
+++ b/mmtbx/validation/regression/tst_mp_validate_bonds.py
@@ -147,6 +147,72 @@ ATOM    672  C5    C B 118      24.316  86.326  84.289  1.00103.70           C
 ATOM    673  C6    C B 118      23.387  85.879  83.432  1.00104.01           C
 """
 
+def exercise_altloc_hierarchy():
+  """
+  Results that span atoms with different altlocs must be filed in the
+  hierarchical JSON under the altloc they actually belong to.  In pdb_str_1 the
+  ASP 10 CB has a blank altloc while CG/OD1/OD2 have A and B conformers, so the
+  CB-CG bond and the CB-CG-OD angles each mix a blank atom with an alternate
+  one.  Keying those on the first atom alone filed both conformers under the
+  blank altloc, collapsing the A and B results into one bucket.
+  """
+  dm = DataManager()
+  dm.process_model_str("1",pdb_str_1)
+  model = dm.get_model("1")
+  model.set_stop_for_unknowns(False)
+  hierarchy = model.get_hierarchy()
+  p = manager.get_default_pdb_interpretation_params()
+  p.pdb_interpretation.allow_polymer_cross_special_position=True
+  p.pdb_interpretation.flip_symmetric_amino_acids=False
+  p.pdb_interpretation.clash_guard.nonbonded_distance_threshold = None
+  model.set_log(log = null_out())
+  model.process(make_restraints=True, pdb_interpretation_params=p)
+  geometry = model.get_restraints_manager().geometry
+  atoms = hierarchy.atoms()
+  bonds = mp_bonds(
+    pdb_hierarchy=hierarchy,
+    pdb_atoms=atoms,
+    geometry_restraints_manager=geometry,
+    outliers_only=False)
+  angles = mp_angles(
+    pdb_hierarchy=hierarchy,
+    pdb_atoms=atoms,
+    geometry_restraints_manager=geometry,
+    outliers_only=False)
+  # every result must sit under the altloc shared by its atoms, where atoms with
+  # a blank altloc are compatible with any conformer
+  for label, results in [("bonds", bonds), ("angles", angles)]:
+    hier = json.loads(results.as_JSON())['hierarchical_results']
+    for model_id, chains in hier.items():
+      for chain_id, resids in chains.items():
+        for resid, altlocs in resids.items():
+          for altloc, entries in altlocs.items():
+            for entry in entries:
+              present = set([a.strip() for a in entry['atoms_altloc']])
+              present.discard('')
+              if len(present) == 1:
+                expected = present.pop()
+              else:
+                expected = ''
+              assert altloc == expected, \
+                "tst_mp_validate_bonds "+label+" result "+ \
+                str(entry['atoms_name'])+" with altlocs "+ \
+                str(entry['atoms_altloc'])+" is filed under altloc '"+ \
+                altloc+"', expected '"+expected+"'"
+  # ASP 10 mixes a blank CB with A/B conformers, so all three buckets exist
+  asp10_bonds = json.loads(bonds.as_JSON())['hierarchical_results']['']['A']['  10 ']
+  assert sorted(asp10_bonds.keys()) == ['', 'A', 'B'], \
+    "tst_mp_validate_bonds ASP 10 bond altloc keys changed, now: "+str(sorted(asp10_bonds.keys()))
+  assert len(asp10_bonds['']) == 4, "tst_mp_validate_bonds ASP 10 blank altloc bond count changed, now: "+str(len(asp10_bonds['']))
+  assert len(asp10_bonds['A']) == 3, "tst_mp_validate_bonds ASP 10 altloc A bond count changed, now: "+str(len(asp10_bonds['A']))
+  assert len(asp10_bonds['B']) == 3, "tst_mp_validate_bonds ASP 10 altloc B bond count changed, now: "+str(len(asp10_bonds['B']))
+  asp10_angles = json.loads(angles.as_JSON())['hierarchical_results']['']['A']['  10 ']
+  assert sorted(asp10_angles.keys()) == ['', 'A', 'B'], \
+    "tst_mp_validate_bonds ASP 10 angle altloc keys changed, now: "+str(sorted(asp10_angles.keys()))
+  assert len(asp10_angles['']) == 4, "tst_mp_validate_bonds ASP 10 blank altloc angle count changed, now: "+str(len(asp10_angles['']))
+  assert len(asp10_angles['A']) == 4, "tst_mp_validate_bonds ASP 10 altloc A angle count changed, now: "+str(len(asp10_angles['A']))
+  assert len(asp10_angles['B']) == 4, "tst_mp_validate_bonds ASP 10 altloc B angle count changed, now: "+str(len(asp10_angles['B']))
+
 def exercise_mp_validate_bonds():
   dm = DataManager()
   #print(help(dm))
@@ -195,6 +261,8 @@ def exercise_mp_validate_bonds():
 if (__name__ == "__main__"):
   t0 = time.time()
   bonds_dict, angles_dict = exercise_mp_validate_bonds()
+  # must run before the cif conversion below renames the chain
+  exercise_altloc_hierarchy()
   convert_pdb_to_cif_for_pdb_str(locals(), chain_addition="LONGCHAIN", hetatm_name_addition = "", key_str="pdb_", print_new_string = False)
   bonds_dict_cif, angles_dict_cif = exercise_mp_validate_bonds()
   assert bonds_dict['summary_results'] == bonds_dict_cif['summary_results'], "tst_mp_validate_bonds summary results changed between pdb and cif version"


### PR DESCRIPTION
## Problem

`atoms.nest_dict` builds the `hierarchical_results` JSON by nesting on
`model_id`/`chain_id`/`resid`/`altloc`. The `atoms` class has none of those in
`__slots__`, so every level falls back to `getattr(self.atoms_info[0], level)`.

For the `altloc` level that is wrong whenever a result spans atoms with different
altlocs. The first atom may have a blank altloc while a later one belongs to conformer
A or B, so both conformers get filed under the blank altloc key and merged into a single
list, which breaks the one-result-per-altloc structure consumers expect.

Concrete example, the C-N-CA angle at residue 67 of 6m4j where residue 68 has A/B
conformers. Atom 0 is the C of residue 67 with a blank altloc, atom 2 is the CA of
residue 68 conformer A:

```
before:  altloc='' -> 11 entries   (both conformers merged in with 9 non-alt angles)
after:   altloc='' -> 9 entries
         altloc='A' -> 1 entry   score=-7.00  outlier=True
         altloc='B' -> 1 entry   score=+1.86  outlier=False
```

Only the A conformer is an outlier. Under the bug both were reported under one blank key,
so a consumer reading the hierarchy could not tell which conformer was bad.

## Scope

Every `atoms`-derived class that emits hierarchical JSON is affected:

| File | Classes |
|---|---|
| `mmtbx/validation/restraints.py` | `restraint` and its `bond`, `angle`, `dihedral`, `chirality`, `planarity` subclasses |
| `mmtbx/validation/clashscore.py` | `clash` (also used by `clashscore2.py`) |
| `mmtbx/validation/mp_validate_bonds.py` | `mp_bond`, `mp_angle` |
| `mmtbx/validation/rna_validate.py` | `rna_bond`, `rna_angle` |

The `residue`-derived validations (ramalyze, rotalyze, cbetadev, cablam, omegalyze,
suitealyze, undowser, undowser2) are **not** affected. They use `residue.nest_dict`,
where a real `altloc` slot exists and no fallback is taken.

`clash` is the worst case in practice: probe reports contacts between arbitrary atom
pairs, and `clashscore.py:313` sorts `atoms_info` by atom id string, so which atom
supplies the altloc key is effectively arbitrary.

## Fix

Special-case the `altloc` level to use the altloc shared by the result's atoms.

The new `get_consensus_altloc` deliberately does **not** assert when the atoms carry
conflicting altlocs, unlike the existing `get_altloc`. A probe clash can legitimately
pair a conformer A atom with a conformer B atom, and serialization must not raise on
that; it returns the blank key instead.

## Tests

Adds a regression test to `mmtbx/validation/regression/tst_mp_validate_bonds.py`. Its
existing `pdb_str_1` fixture already covers the case: ASP A 10 has A/B altlocs on
CG/OD1/OD2 while CB stays blank, so the CB-CG bond and the CB-CG-OD angles each mix a
blank atom with an alternate one.

The test asserts the general invariant that a result is filed under the altloc shared by
its atoms, plus the specific bucket counts for ASP 10. On unpatched code it fails with:

```
AssertionError: tst_mp_validate_bonds bonds result [' CB ', ' CG '] with altlocs
['', 'A'] is filed under altloc '', expected 'A'
```

It is added as a separate function called before `convert_pdb_to_cif_for_pdb_str`,
since that call renames the chain and would invalidate chain-specific assertions.

**No existing regression test changes value.** `count_dict_values` counts leaf
occurrences recursively through both dicts and lists, so relocating a result between
altloc buckets leaves every total unchanged. Verified by running `tst_mp_validate_bonds`,
`tst_mp_geo`, `tst_clashscore`, `tst_chiral_validation`, `tst_undowser`, `tst_undowser2`,
`tst_cbetadev` and `tst_restraints`, all passing. `libtbx.find_clutter` is clean on both
changed files.

(Unrelated, noted in passing: `tst_rna_validate.py` currently fails on
`len(rv.angles.results) == 47` returning 14. It fails identically without this change,
so it is pre-existing and not caused by this PR.)

## Note for reviewers

This changes the `hierarchical_results` output shape for the classes listed above:
results that previously appeared under `""` will now appear under `"A"` / `"B"`. Flagging
given the release timing. `flat_results` and `summary_results` are untouched.

There are some related JSON schema issues in this area that are **not** addressed here
(the `score` key having different signed/absolute definitions across modules, and the
`sigma` field name reading as a z-score when it is the restraint esd). I will raise those
separately on cctbxbb rather than bundle them into a bug fix.
