### PR TITLE
probe2: batch the per-dot DotScorer calls into one call per atom

### DIFF
--- a/mmtbx/probe/Scoring.cpp
+++ b/mmtbx/probe/Scoring.cpp
@@ -256,6 +256,35 @@ DotScorer::CheckDotResult DotScorer::check_dot(
   return ret;
 }
 
+scitbx::af::shared<DotScorer::CheckDotResult> DotScorer::check_dots(
+  iotbx::pdb::hierarchy::atom const &sourceAtom,
+  scitbx::af::shared<Point> const &dots, double probeRadius,
+  scitbx::af::shared<iotbx::pdb::hierarchy::atom> const &interacting,
+  scitbx::af::shared<iotbx::pdb::hierarchy::atom> const &exclude,
+  double overlapScale)
+{
+  scitbx::af::shared<CheckDotResult> ret;
+  for (scitbx::af::shared<Point>::const_iterator d = dots.begin(); d != dots.end(); d++) {
+    CheckDotResult res = check_dot(sourceAtom, *d, probeRadius, interacting, exclude,
+      overlapScale);
+
+    // Drop the dots that per-dot callers discard: ones that should be ignored and
+    // annular dots that do not overlap.
+    if (res.overlapType == DotScorer::Ignore) {
+      continue;
+    }
+    if ((res.overlapType == DotScorer::NoOverlap) && res.annular) {
+      continue;
+    }
+
+    // Record which dot this result belongs to so that the caller can match the
+    // returned subset back to the input dots.
+    res.dotOffset = *d;
+    ret.push_back(res);
+  }
+  return ret;
+}
+
 DotScorer::InteractionType DotScorer::interaction_type(
   OverlapType overlapType, double gap, bool separateBadBumps) const
 {
@@ -616,6 +645,43 @@ std::string DotScorer::test()
     kept = as.trim_dots(source, ds.dots(), exclude);
     if ((kept.size() == 0) || (kept.size() >= ds.dots().size())) {
       return "DotScorer::test(): Unexpected non-excluded dot count for partially-overlapping case";
+    }
+
+    // Check that check_dots() returns the same results as calling check_dot() on
+    // each dot in turn and discarding ignored dots and non-overlapping annular dots.
+    {
+      double probeRad = 0.25;
+      scitbx::af::shared<iotbx::pdb::hierarchy::atom> interacting;
+      interacting.push_back(a);
+      scitbx::af::shared<iotbx::pdb::hierarchy::atom> emptyExclude;
+
+      scitbx::af::shared<CheckDotResult> batched =
+        as.check_dots(source, ds.dots(), probeRad, interacting, emptyExclude);
+      scitbx::af::shared<CheckDotResult> expected;
+      for (scitbx::af::shared<Point>::const_iterator d = ds.dots().begin();
+           d != ds.dots().end(); d++) {
+        CheckDotResult res = as.check_dot(source, *d, probeRad, interacting, emptyExclude);
+        if (res.overlapType == DotScorer::Ignore) { continue; }
+        if ((res.overlapType == DotScorer::NoOverlap) && res.annular) { continue; }
+        res.dotOffset = *d;
+        expected.push_back(res);
+      }
+      if (batched.size() == 0) {
+        return "DotScorer::test(): check_dots() returned no results for overlapping case";
+      }
+      if (batched.size() != expected.size()) {
+        return "DotScorer::test(): check_dots() size mismatch with per-dot check_dot()";
+      }
+      for (size_t i = 0; i < batched.size(); i++) {
+        if ((batched[i].overlapType != expected[i].overlapType)
+            || (batched[i].overlap != expected[i].overlap)
+            || (batched[i].gap != expected[i].gap)
+            || (batched[i].annular != expected[i].annular)
+            || (batched[i].dotOffset != expected[i].dotOffset)
+            || (batched[i].cause.data.get() != expected[i].cause.data.get())) {
+          return "DotScorer::test(): check_dots() result mismatch with per-dot check_dot()";
+        }
+      }
     }
   }
 

--- a/mmtbx/probe/Scoring.h
+++ b/mmtbx/probe/Scoring.h
@@ -276,11 +276,16 @@ namespace molprobity {
       /// @brief Structure to hold the results from a call to check_dot()
       class CheckDotResult {
       public:
-        CheckDotResult() : overlapType(DotScorer::Ignore), overlap(0), gap(1e100), annular(false) {};
+        CheckDotResult() : overlapType(DotScorer::Ignore), overlap(0), gap(1e100), annular(false),
+          dotOffset(0,0,0) {};
         OverlapType overlapType;            ///< What kind of overlap, if any, was found
         iotbx::pdb::hierarchy::atom cause;  ///< Cause of the overlap, if overlapType != Ignore
         double  overlap;                    ///< Amount of overlap assigned to source atom if there is a clash
         double  gap;                        ///< Gap distance (overlap may only be a fraction of this).
+        /// Offset from the center of the source atom to the dot that was checked.  Filled in by
+        /// check_dots() (which returns a subset of the dots it was given) so that the caller can
+        /// tell which dot each result belongs to; left at the origin by check_dot().
+        Point   dotOffset;
         /// Was this an annular dot, which is further from the point on the source atom that is closest
         /// to the target atom than a point on the tangent edge of the target atom where the ray just
         /// grazes the surface of the atom.  @todo The math being done here is a bit opaque, so the
@@ -307,6 +312,30 @@ namespace molprobity {
       ///             and the other half for the other.
       CheckDotResult check_dot(iotbx::pdb::hierarchy::atom const &sourceAtom,
         Point const& dotOffset, double probeRadius,
+        scitbx::af::shared<iotbx::pdb::hierarchy::atom> const& interacting,
+        scitbx::af::shared<iotbx::pdb::hierarchy::atom> const& exclude,
+        double overlapScale = 0.5);
+
+      /// @brief Check all of an atom's dots against a specific set of interacting atoms.
+      ///
+      /// This calls check_dot() on each dot in turn and collects the results, avoiding a
+      /// Python-to-C++ boundary crossing (and marshalling of the atom lists) per dot.
+      /// Results whose overlapType is Ignore are dropped, as are annular dots whose
+      /// overlapType is NoOverlap; these are the dots that per-dot callers of check_dot()
+      /// discard.  Each returned result has its dotOffset field filled in with the dot
+      /// it belongs to, so the returned subset can be matched back to the input dots.
+      /// @param [in] sourceAtom Atom that the dots are offset with respect to.
+      /// @param [in] dots Vector of dot offsets from the center of the source atom.
+      /// @param [in] probeRadius Radius of the probe rolled between the two potentially-contacting atoms
+      ///             If this is < 0, invalid results will be returned, as for check_dot().
+      /// @param [in] interacting The atoms that are to be checked because they are close enough to
+      ///             sourceAtom to interact with it.  This list should not include any excluded atoms.
+      /// @param [in] excluded Atoms that are to be excluded from contact; a dot inside an excluded
+      ///             atom is not considered.
+      /// @param [in] overlapScale The fraction of overlap to assign to each of the two atoms.
+      /// @return One CheckDotResult per kept dot, in the order of the input dots.
+      scitbx::af::shared<CheckDotResult> check_dots(iotbx::pdb::hierarchy::atom const &sourceAtom,
+        scitbx::af::shared<Point> const &dots, double probeRadius,
         scitbx::af::shared<iotbx::pdb::hierarchy::atom> const& interacting,
         scitbx::af::shared<iotbx::pdb::hierarchy::atom> const& exclude,
         double overlapScale = 0.5);

--- a/mmtbx/probe/boost_python/probe_bpl.cpp
+++ b/mmtbx/probe/boost_python/probe_bpl.cpp
@@ -40,7 +40,14 @@ void set_atom_i_seq(iotbx::pdb::hierarchy::atom& atom, int i_seq) {
   atom.data->i_seq = i_seq;
 }
 
+/// @brief Helper function to expose CheckDotResult::dotOffset as a Python tuple
+/// (there is no to-Python converter registered for the Point type itself).
+boost::python::tuple check_dot_result_dot_offset(DotScorer::CheckDotResult const& r) {
+  return boost::python::make_tuple(r.dotOffset[0], r.dotOffset[1], r.dotOffset[2]);
+}
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(check_dot_overloads, DotScorer::check_dot, 5, 6)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(check_dots_overloads, DotScorer::check_dots, 5, 6)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(interaction_type_overloads, DotScorer::interaction_type, 2, 3)
 
 BOOST_PYTHON_MODULE(mmtbx_probe_ext)
@@ -101,7 +108,12 @@ BOOST_PYTHON_MODULE(mmtbx_probe_ext)
     .add_property("overlap", &DotScorer::CheckDotResult::overlap)
     .add_property("gap", &DotScorer::CheckDotResult::gap)
     .add_property("annular", &DotScorer::CheckDotResult::annular)
+    .add_property("dotOffset", make_function(check_dot_result_dot_offset))
     ;
+  // Define the flex array wrapping for this class because check_dots() returns
+  // a vector of them.
+  scitbx::boost_python::container_conversions::tuple_mapping_variable_capacity<
+    scitbx::af::shared<DotScorer::CheckDotResult> >();
 
   class_<DotScorer::ScoreDotsResult>("ScoreDotsResult", init<>())
     .add_property("valid", &DotScorer::ScoreDotsResult::valid)
@@ -140,6 +152,7 @@ BOOST_PYTHON_MODULE(mmtbx_probe_ext)
     .def("point_inside_atoms", &DotScorer::point_inside_atoms)
     .def("trim_dots", &DotScorer::trim_dots)
     .def("check_dot", &DotScorer::check_dot, check_dot_overloads())
+    .def("check_dots", &DotScorer::check_dots, check_dots_overloads())
     .def("count_surface_dots", &DotScorer::count_surface_dots)
     .def("score_dots", &DotScorer::score_dots)
     .def("interaction_type", &DotScorer::interaction_type, interaction_type_overloads())

--- a/mmtbx/programs/probe2.py
+++ b/mmtbx/programs/probe2.py
@@ -896,103 +896,94 @@ Note:
         for e in excluded:
           atomSet.discard(e)
 
-        # Check each dot to see if it interacts with non-bonded nearby target atoms.
+        # Batched: one C++ call for all of this atom's dots, rather than one
+        # crossing per dot.  Only dots needing handling come back (Ignore and
+        # non-overlapping annular dots are dropped); dotOffset identifies each.
         srcDots = self._dots[src]
         scale = self.params.overlap_scale_factor
-        for dotvect in srcDots:
+        interacting = list(atomSet)
+        for res in self._dotScorer.check_dots(src, srcDots, probeRadius, interacting, excluded, scale):
 
-          # Find out if there is an interaction
-          res = self._dotScorer.check_dot(src, dotvect, probeRadius, list(atomSet), excluded, scale)
-
-          # Classify the interaction and store appropriate results unless we should
-          # ignore the result because there was not valid overlap.
+          # Classify the interaction and store appropriate results.
           overlapType = res.overlapType
+          dotvect = res.dotOffset
 
-          # If the overlap type is NoOverlap, check dot to make sure it is not annular.
-          # This excludes dots that are further from the contact than dots could be at
-          # the ideal just-touched contact.
-          if overlapType == probeExt.OverlapType.NoOverlap and res.annular:
+          # If the cause of the dot is not in the target set, we ignore the dot.
+          if not res.cause in targetSet:
             continue
 
-          # Handle any dots that should not be ignored.
-          if overlapType != probeExt.OverlapType.Ignore:
+          # If the overlap type is not a Hydrogen bond, then check the occupancy of atoms where
+          # at least one of the pair is on the "" or " " alternate conformation to make sure the
+          # sum of their occupancies is greater than 1.
+          if overlapType != probeExt.OverlapType.HydrogenBond:
+            if (src.parent().altloc in ['',' ']) or (res.cause.parent().altloc in ['',' ']):
+              if src.occ + res.cause.occ <= 1:
+                continue
 
-            # If the cause of the dot is not in the target set, we ignore the dot.
-            if not res.cause in targetSet:
-              continue
+          # See whether this dot is allowed based on our parameters.
+          spo = self.params.output
+          show = False
+          interactionType = self._dotScorer.interaction_type(overlapType,res.gap, self.params.output.separate_worse_clashes)
+          if interactionType == probeExt.InteractionType.Invalid:
+            print('Warning: Invalid interaction type encountered (internal error)', file=self.logger)
+            continue
 
-            # If the overlap type is not a Hydrogen bond, then check the occupancy of atoms where
-            # at least one of the pair is on the "" or " " alternate conformation to make sure the
-            # sum of their occupancies is greater than 1.
-            if overlapType != probeExt.OverlapType.HydrogenBond:
-              if (src.parent().altloc in ['',' ']) or (res.cause.parent().altloc in ['',' ']):
-                if src.occ + res.cause.occ <= 1:
-                  continue
+          # Main branch if we're reporting other than bad clashes
+          if (not spo.only_report_bad_clashes):
+            # We are reporting other than bad clashes, see if our type is being reported
+            if spo.report_hydrogen_bonds and (overlapType == probeExt.OverlapType.HydrogenBond):
+              show = True
+            elif spo.report_clashes and (overlapType == probeExt.OverlapType.Clash):
+              show = True
+            elif spo.report_vdws and (overlapType == probeExt.OverlapType.NoOverlap):
+              show = True
+          else:
+            # We are only reporting bad clashes.  See if we're reporting clashes and this is
+            # a bad one.
+            if (spo.report_clashes and interactionType in [
+                  probeExt.InteractionType.Bump, probeExt.InteractionType.BadBump]):
+              show = True
 
-            # See whether this dot is allowed based on our parameters.
-            spo = self.params.output
-            show = False
-            interactionType = self._dotScorer.interaction_type(overlapType,res.gap, self.params.output.separate_worse_clashes)
-            if interactionType == probeExt.InteractionType.Invalid:
-              print('Warning: Invalid interaction type encountered (internal error)', file=self.logger)
-              continue
+          # If we're not showing this one, skip to the next
+          if not show:
+            continue
 
-            # Main branch if we're reporting other than bad clashes
-            if (not spo.only_report_bad_clashes):
-              # We are reporting other than bad clashes, see if our type is being reported
-              if spo.report_hydrogen_bonds and (overlapType == probeExt.OverlapType.HydrogenBond):
-                show = True
-              elif spo.report_clashes and (overlapType == probeExt.OverlapType.Clash):
-                show = True
-              elif spo.report_vdws and (overlapType == probeExt.OverlapType.NoOverlap):
-                show = True
-            else:
-              # We are only reporting bad clashes.  See if we're reporting clashes and this is
-              # a bad one.
-              if (spo.report_clashes and interactionType in [
-                    probeExt.InteractionType.Bump, probeExt.InteractionType.BadBump]):
-                show = True
+          # Determine the ptmaster (main/side chain interaction type) and keep track of
+          # counts for each type.
+          causeMainChain = self._inMainChain[res.cause]
+          causeSideChain = self._inSideChain[res.cause]
+          causeHet = self._inHet[res.cause]
+          ptmaster = ' '
+          if srcMainChain and causeMainChain:
+            if (not srcHet) and (not causeHet): # This may be a redundant check
+              ptmaster = 'M'
+              self._MCMCCount[interactionType] += 1
+          elif srcSideChain and causeSideChain:
+            if (not srcHet) and (not causeHet): # This may be a redundant check
+              ptmaster = 'S'
+              self._SCSCCount[interactionType] += 1
+          elif ( (srcMainChain and causeSideChain) or (srcSideChain and causeMainChain) ):
+            if (not srcHet) and (not causeHet): # This may be a redundant check
+              ptmaster = 'P'
+              self._MCSCCount[interactionType] += 1
+          else:
+            ptmaster = 'O'
+            self._otherCount[interactionType] += 1
 
-            # If we're not showing this one, skip to the next
-            if not show:
-              continue
+          # Find the locations of the dot and spike by scaling the dot vector by the atom radius and
+          # the (negative because it is magnitude) overlap.
+          loc = (srcXYZ[0]+dotvect[0], srcXYZ[1]+dotvect[1], srcXYZ[2]+dotvect[2])
+          dvLen = math.sqrt(dotvect[0]*dotvect[0]+dotvect[1]*dotvect[1]+dotvect[2]*dotvect[2])
+          if dvLen > 0:
+            spikeScale = (srcVdw - res.overlap) / dvLen
+            spikeloc = (srcXYZ[0]+dotvect[0]*spikeScale,
+                        srcXYZ[1]+dotvect[1]*spikeScale,
+                        srcXYZ[2]+dotvect[2]*spikeScale)
+          else:
+            spikeloc = loc
 
-            # Determine the ptmaster (main/side chain interaction type) and keep track of
-            # counts for each type.
-            causeMainChain = self._inMainChain[res.cause]
-            causeSideChain = self._inSideChain[res.cause]
-            causeHet = self._inHet[res.cause]
-            ptmaster = ' '
-            if srcMainChain and causeMainChain:
-              if (not srcHet) and (not causeHet): # This may be a redundant check
-                ptmaster = 'M'
-                self._MCMCCount[interactionType] += 1
-            elif srcSideChain and causeSideChain:
-              if (not srcHet) and (not causeHet): # This may be a redundant check
-                ptmaster = 'S'
-                self._SCSCCount[interactionType] += 1
-            elif ( (srcMainChain and causeSideChain) or (srcSideChain and causeMainChain) ):
-              if (not srcHet) and (not causeHet): # This may be a redundant check
-                ptmaster = 'P'
-                self._MCSCCount[interactionType] += 1
-            else:
-              ptmaster = 'O'
-              self._otherCount[interactionType] += 1
-
-            # Find the locations of the dot and spike by scaling the dot vector by the atom radius and
-            # the (negative because it is magnitude) overlap.
-            loc = (srcXYZ[0]+dotvect[0], srcXYZ[1]+dotvect[1], srcXYZ[2]+dotvect[2])
-            dvLen = math.sqrt(dotvect[0]*dotvect[0]+dotvect[1]*dotvect[1]+dotvect[2]*dotvect[2])
-            if dvLen > 0:
-              spikeScale = (srcVdw - res.overlap) / dvLen
-              spikeloc = (srcXYZ[0]+dotvect[0]*spikeScale,
-                          srcXYZ[1]+dotvect[1]*spikeScale,
-                          srcXYZ[2]+dotvect[2]*spikeScale)
-            else:
-              spikeloc = loc
-
-            # Save the dot
-            self._save_dot(src, res.cause, atomClass, loc, spikeloc, overlapType, res.gap, ptmaster, 0)
+          # Save the dot
+          self._save_dot(src, res.cause, atomClass, loc, spikeloc, overlapType, res.gap, ptmaster, 0)
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
`_generate_interaction_dots()` calls `DotScorer::check_dot()` once per dot, which
crosses the boost-python boundary and re-marshals the interacting and excluded
atom lists every time. On a typical NMR ensemble model that is roughly 275k calls
per model. Profiling on 2C6B put the per-dot Python loop and call overhead at
about 1.0 s/model while the geometry itself was under 0.1 us/dot.

This adds `DotScorer::check_dots()`, which loops `check_dot()` in C++ over all of
one atom's dots and returns only the results a per-dot caller would keep, dropping
`Ignore` results and non-overlapping annular dots. `CheckDotResult` gains a
`dotOffset` field so each returned result identifies its dot. probe2 now makes one
call per source atom instead of one per dot.

`check_dot()` itself is unchanged, so nothing is reimplemented and no value can
move. The only thing that changes is which results cross into Python.

### Reviewing

The `probe2.py` diff looks like 165 changed lines but only about 15 are real. Removing
the `if overlapType != Ignore:` level dedented the rest of the loop body; the contents
are character-identical apart from leading whitespace. `?w=1` shows the actual change.

### Verification

Output is unchanged. Comparing before and after on 1CRN, 9CSO (RNA with waters and a
ligand the monomer library does not know) and 1D3Z (10-model NMR ensemble), in both
kinemage and JSON output, about 25 MB total: every byte matches apart from the
`@caption` run-timestamp header.

clashscore2 agrees too. All ten per-model clashscores on 1D3Z match exactly and the
contact count is the same (41).

Timing on this machine:

| | before | after |
|---|---|---|
| probe dots, the three structures above | 56.8 s | 34.9 s |
| clashscore2 on 1D3Z | 27.0 s | 17.2 s |

`DotScorer::test()` gains a consistency case checking `check_dots()` against per-dot
`check_dot()` with the same filtering, comparing overlap type, overlap, gap, annular,
dot offset and cause identity. It passes, as do `tst_mmtbx_probe_ext.py` and
`mmtbx/regression/tst_probe.py`.

### Note

`CheckDotResult` grows by a `Point`, so its layout changes. Nothing outside
`Scoring.{h,cpp}` and the bindings references the type, but `mmtbx/reduce` links the
same `probelib` and will need the usual relink.
