### PR TITLE
clashscore2: hydrogenate and process ensembles per model, not per file

### DIFF
--- a/mmtbx/hydrogens/__init__.py
+++ b/mmtbx/hydrogens/__init__.py
@@ -592,11 +592,9 @@ def default_probe_phil():
 
 def _place_and_optimize_core(model, do_flips, nuclear, keep_existing_H,
       probe_phil, raise_on_missing, log):
-  """Placement + orientation/flip optimization for a model, without the final
-  interpretation-only re-process.  Returns the hydrogenated model.  Raises
-  Sorry right after placement (before optimizing) when restraints were not
-  found for some residues and raise_on_missing is set, matching the original
-  order of operations."""
+  """Placement + orientation/flip optimization, without the final
+  interpretation-only re-process.  Raises Sorry after placement (before
+  optimizing) when restraints are missing and raise_on_missing is set."""
   from mmtbx.hydrogens import reduce_hydrogen
   from mmtbx.reduce import Optimizers
   o = reduce_hydrogen.place_hydrogens(
@@ -644,14 +642,9 @@ def place_and_optimize_hydrogens(model, do_flips=False, nuclear=False,
 
   hierarchy = model.get_hierarchy()
   if len(hierarchy.models()) > 1:
-    # Hydrogenate a multi-model file one model at a time.  The models of an
-    # ensemble are spatially superimposed, so making restraints on the whole
-    # file at once is quadratic in the number of models (every atom sees
-    # nonbonded neighbors from every model); a 21-model NMR entry was measured
-    # to peak over 13 GB that way.  Placement and optimization are per-model
-    # operations (the flip Optimizer already treats each MODEL independently),
-    # so per-model processing gives the same hydrogens with memory
-    # proportional to a single model.
+    # One model at a time: superimposed ensemble models make whole-file
+    # restraints quadratic in the model count, and placement and flip
+    # optimization are per-model operations anyway.
     cs = model.crystal_symmetry()
     ro = model.get_restraint_objects()
     combined = iotbx.pdb.hierarchy.root()
@@ -683,9 +676,8 @@ def place_and_optimize_hydrogens(model, do_flips=False, nuclear=False,
       model, do_flips, nuclear, keep_existing_H, probe_phil,
       raise_on_missing, log)
 
-  # Re-process for output safety (matches clashscore2: avoids a pair_proxies crash
-  # when writing mmCIF). No restraints are needed afterwards, and an
-  # interpretation-only process is linear in the number of models.
+  # Re-process for output safety (avoids a pair_proxies crash when writing
+  # mmCIF).  Interpretation-only, which stays linear in the model count.
   model.get_hierarchy().sort_atoms_in_place()
   model.get_hierarchy().atoms().reset_serial()
   p = reduce_hydrogen.get_reduce_pdb_interpretation_params(nuclear)

--- a/mmtbx/hydrogens/__init__.py
+++ b/mmtbx/hydrogens/__init__.py
@@ -590,20 +590,15 @@ def default_probe_phil():
   return iotbx.phil.parse(
     reduce2.master_phil_str, process_includes=True).extract().probe
 
-def place_and_optimize_hydrogens(model, do_flips=False, nuclear=False,
-      keep_existing_H=False, probe_phil=None, stop_for_unknowns=False,
-      raise_on_missing=True, log=None):
-  """Add H with reduce2 in-process: place_hydrogens then Optimizers.Optimizer.
-  Mirrors mmtbx.validation.clashscore2.check_and_add_hydrogen.
-
-  :param raise_on_missing: When True (default), raise Sorry if restraints were
-    not found for some residues (no H placed there). Set False for best-effort
-    callers (e.g. the MolProbity kinemage view) that prefer to produce results
-    for the rest of the structure rather than fail on a few problem residues."""
+def _place_and_optimize_core(model, do_flips, nuclear, keep_existing_H,
+      probe_phil, raise_on_missing, log):
+  """Placement + orientation/flip optimization for a model, without the final
+  interpretation-only re-process.  Returns the hydrogenated model.  Raises
+  Sorry right after placement (before optimizing) when restraints were not
+  found for some residues and raise_on_missing is set, matching the original
+  order of operations."""
   from mmtbx.hydrogens import reduce_hydrogen
   from mmtbx.reduce import Optimizers
-  if log is None: log = sys.stdout
-  if probe_phil is None: probe_phil = default_probe_phil()
   o = reduce_hydrogen.place_hydrogens(
     model                 = model,
     use_neutron_distances = nuclear,
@@ -622,7 +617,7 @@ def place_and_optimize_hydrogens(model, do_flips=False, nuclear=False,
   model = o.get_model()
   # Optimize H orientations (and flips if do_flips) on the freshly placed model:
   # it already carries restraints from place_hydrogens. ORDER MATTERS -- the
-  # re-process below drops restraints, so it must come AFTER the Optimizer
+  # re-process afterwards drops restraints, so it must come AFTER the Optimizer
   # (this mirrors clashscore2.check_and_add_hydrogen).
   opt = Optimizers.Optimizer(
     probe_phil, do_flips, model, modelIndex=None,
@@ -631,9 +626,66 @@ def place_and_optimize_hydrogens(model, do_flips=False, nuclear=False,
   # Delete any hydrogens that we've been asked to delete.
   for a in opt.getHydrogensToDelete():
     a.parent().remove_atom(a)
+  return model
+
+def place_and_optimize_hydrogens(model, do_flips=False, nuclear=False,
+      keep_existing_H=False, probe_phil=None, stop_for_unknowns=False,
+      raise_on_missing=True, log=None):
+  """Add H with reduce2 in-process: place_hydrogens then Optimizers.Optimizer.
+  Mirrors mmtbx.validation.clashscore2.check_and_add_hydrogen.
+
+  :param raise_on_missing: When True (default), raise Sorry if restraints were
+    not found for some residues (no H placed there). Set False for best-effort
+    callers (e.g. the MolProbity kinemage view) that prefer to produce results
+    for the rest of the structure rather than fail on a few problem residues."""
+  from mmtbx.hydrogens import reduce_hydrogen
+  if log is None: log = sys.stdout
+  if probe_phil is None: probe_phil = default_probe_phil()
+
+  hierarchy = model.get_hierarchy()
+  if len(hierarchy.models()) > 1:
+    # Hydrogenate a multi-model file one model at a time.  The models of an
+    # ensemble are spatially superimposed, so making restraints on the whole
+    # file at once is quadratic in the number of models (every atom sees
+    # nonbonded neighbors from every model); a 21-model NMR entry was measured
+    # to peak over 13 GB that way.  Placement and optimization are per-model
+    # operations (the flip Optimizer already treats each MODEL independently),
+    # so per-model processing gives the same hydrogens with memory
+    # proportional to a single model.
+    cs = model.crystal_symmetry()
+    ro = model.get_restraint_objects()
+    combined = iotbx.pdb.hierarchy.root()
+    for m in hierarchy.models():
+      r = iotbx.pdb.hierarchy.root()
+      r.append_model(m.detached_copy())
+      sub = mmtbx.model.manager(
+        model_input       = None,
+        pdb_hierarchy     = r,
+        stop_for_unknowns = False,
+        crystal_symmetry  = cs,
+        restraint_objects = ro,
+        log               = None)
+      sub = _place_and_optimize_core(
+        sub, do_flips, nuclear, keep_existing_H, probe_phil,
+        raise_on_missing, log)
+      sub_model = sub.get_hierarchy().models()[0].detached_copy()
+      sub_model.id = m.id
+      combined.append_model(sub_model)
+    model = mmtbx.model.manager(
+      model_input       = None,
+      pdb_hierarchy     = combined,
+      stop_for_unknowns = False,
+      crystal_symmetry  = cs,
+      restraint_objects = ro,
+      log               = None)
+  else:
+    model = _place_and_optimize_core(
+      model, do_flips, nuclear, keep_existing_H, probe_phil,
+      raise_on_missing, log)
 
   # Re-process for output safety (matches clashscore2: avoids a pair_proxies crash
-  # when writing mmCIF). No restraints are needed afterwards.
+  # when writing mmCIF). No restraints are needed afterwards, and an
+  # interpretation-only process is linear in the number of models.
   model.get_hierarchy().sort_atoms_in_place()
   model.get_hierarchy().atoms().reset_serial()
   p = reduce_hydrogen.get_reduce_pdb_interpretation_params(nuclear)

--- a/mmtbx/programs/probe2.py
+++ b/mmtbx/programs/probe2.py
@@ -425,6 +425,28 @@ def _condense(dotInfoList, condense):
 
 # ------------------------------------------------------------------------------
 
+def getPdbInterpretationParams(useNeutronDistances = False):
+  '''
+    Get the PDB interpretation parameters that probe2 uses when it processes a
+    model to make restraints.  A caller that processes a model itself and then
+    passes it to overrideModel() with processed=True must process with these
+    same parameters (and a matching use_neutron_distances setting) so that the
+    behavior is the same as if probe2 had processed the model.
+  '''
+  p = mmtbx.model.manager.get_default_pdb_interpretation_params()
+  p.pdb_interpretation.use_neutron_distances = useNeutronDistances
+  p.pdb_interpretation.allow_polymer_cross_special_position=True
+  p.pdb_interpretation.clash_guard.nonbonded_distance_threshold=None
+  p.pdb_interpretation.proceed_with_excessive_length_bonds=True
+  p.pdb_interpretation.disable_uc_volume_vs_n_atoms_check=True
+  # We need to turn this on because without it the interpretation is
+  # renaming atoms to be more correct.  Unfortunately, this causes the
+  # dot names to no longer match the input file.
+  p.pdb_interpretation.flip_symmetric_amino_acids=False
+  return p
+
+# ------------------------------------------------------------------------------
+
 def _totalInteractionCount(chainCounts):
   '''
     Find the total count of interactions of any type for the specified chain-pair type.
@@ -1894,12 +1916,21 @@ Note:
 
 # ------------------------------------------------------------------------------
 
-  def overrideModel(self, model):
+  def overrideModel(self, model, processed = False):
     '''This is a hack to let another program harness probe2 without having to write a
     new model file for it to read. After initializing probe2, but before calling
     run(), call this function to override the model that it should use.
+    :param processed: When True, the model has already had restraints made on it
+    using the parameters returned by getPdbInterpretationParams() (with a matching
+    use_neutron_distances setting) and run() will not process it again.  This lets
+    a caller that runs probe2 on many models with identical composition (for example
+    the models of an NMR ensemble) process one of them and reuse the restraints
+    for the others.  Note that run() can add Phantom Hydrogens to the hierarchy of
+    the model it is given (for waters with no explicit Hydrogens), so a caller that
+    reuses a processed model across runs should hand each run a deep copy.
     '''
     self.model = model
+    self._modelAlreadyProcessed = processed
 
 # ------------------------------------------------------------------------------
 
@@ -1924,18 +1955,15 @@ Note:
     make_sub_header('Compute neighbor lists', out=self.logger)
 
     self.model.set_stop_for_unknowns(False)
-    p = mmtbx.model.manager.get_default_pdb_interpretation_params()
-    p.pdb_interpretation.use_neutron_distances = self.params.use_neutron_distances
-    p.pdb_interpretation.allow_polymer_cross_special_position=True
-    p.pdb_interpretation.clash_guard.nonbonded_distance_threshold=None
-    p.pdb_interpretation.proceed_with_excessive_length_bonds=True
-    p.pdb_interpretation.disable_uc_volume_vs_n_atoms_check=True
-    # We need to turn this on because without it the interpretation is
-    # renaming atoms to be more correct.  Unfortunately, this causes the
-    # dot names to no longer match the input file.
-    p.pdb_interpretation.flip_symmetric_amino_acids=False
+    p = getPdbInterpretationParams(self.params.use_neutron_distances)
+    # If the model handed to overrideModel() was already processed with these
+    # interpretation parameters, we can use its restraints directly rather than
+    # re-processing, which re-reads the monomer library and re-interprets the model.
+    alreadyProcessed = ( getattr(self, '_modelAlreadyProcessed', False)
+      and (self.model.get_restraints_manager() is not None) )
     try:
-      self.model.process(make_restraints=True, pdb_interpretation_params=p) # make restraints
+      if not alreadyProcessed:
+        self.model.process(make_restraints=True, pdb_interpretation_params=p) # make restraints
       geometry = self.model.get_restraints_manager().geometry
       sites_cart = self.model.get_sites_cart() # cartesian coordinates
       bondProxies, asu = \

--- a/mmtbx/programs/probe2.py
+++ b/mmtbx/programs/probe2.py
@@ -427,11 +427,9 @@ def _condense(dotInfoList, condense):
 
 def getPdbInterpretationParams(useNeutronDistances = False):
   '''
-    Get the PDB interpretation parameters that probe2 uses when it processes a
-    model to make restraints.  A caller that processes a model itself and then
-    passes it to overrideModel() with processed=True must process with these
-    same parameters (and a matching use_neutron_distances setting) so that the
-    behavior is the same as if probe2 had processed the model.
+    PDB interpretation parameters probe2 uses to make restraints.  A caller that
+    pre-processes a model for overrideModel(processed=True) must use these same
+    parameters, and a matching use_neutron_distances.
   '''
   p = mmtbx.model.manager.get_default_pdb_interpretation_params()
   p.pdb_interpretation.use_neutron_distances = useNeutronDistances
@@ -1920,14 +1918,11 @@ Note:
     '''This is a hack to let another program harness probe2 without having to write a
     new model file for it to read. After initializing probe2, but before calling
     run(), call this function to override the model that it should use.
-    :param processed: When True, the model has already had restraints made on it
-    using the parameters returned by getPdbInterpretationParams() (with a matching
-    use_neutron_distances setting) and run() will not process it again.  This lets
-    a caller that runs probe2 on many models with identical composition (for example
-    the models of an NMR ensemble) process one of them and reuse the restraints
-    for the others.  Note that run() can add Phantom Hydrogens to the hierarchy of
-    the model it is given (for waters with no explicit Hydrogens), so a caller that
-    reuses a processed model across runs should hand each run a deep copy.
+    :param processed: When True, restraints were already made with
+    getPdbInterpretationParams() and run() will not process the model again, which
+    lets a caller reuse one interpretation across the models of an ensemble.
+    run() can add Phantom Hydrogens to the hierarchy (waters with no explicit H),
+    so each run needs its own deep copy.
     '''
     self.model = model
     self._modelAlreadyProcessed = processed

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -30,6 +30,68 @@ def remove_models_except_index(model_manager, model_index):
                 hierarchy.remove_model(model=model)
     return model_manager
 
+def _submodel_atom_key(atom):
+  """Identity key for an atom that is stable across the models of an ensemble
+  (all models in a multi-model file are required to share composition)."""
+  ag = atom.parent()
+  rg = ag.parent()
+  chain = rg.parent()
+  return (chain.id, rg.resseq, rg.icode, ag.altloc, ag.resname, atom.name)
+
+def _atom_index_by_key(hierarchy):
+  """Map each atom's identity key to its index in hierarchy.atoms() order.
+  Returns None if any two atoms share a key, since the mapping would then be
+  ambiguous."""
+  ret = {}
+  for i, a in enumerate(hierarchy.atoms()):
+    key = _submodel_atom_key(a)
+    if key in ret:
+      return None
+    ret[key] = i
+  return ret
+
+def _copy_of_master_with_atoms_from(processed_master, key_to_index, hierarchy):
+  """Return a deep copy of the processed master model manager whose atoms carry
+  the coordinates, occupancies, and B factors of the matching atoms in the given
+  single-model hierarchy.  The copy keeps the master's restraints and atom-type
+  information, so probe2 does not need to process it again.  Returns None when
+  the hierarchy's atoms do not correspond one-to-one with the master's (for
+  example a malformed ensemble whose models differ in composition), in which
+  case the caller should fall back to processing the model.
+  """
+  from scitbx.array_family import flex
+  if key_to_index is None:
+    return None
+  atoms = hierarchy.atoms()
+  n = len(key_to_index)
+  if len(atoms) != n:
+    return None
+  sites = flex.vec3_double(n)
+  occs = flex.double(n)
+  bs = flex.double(n)
+  assigned = [False] * n
+  for a in atoms:
+    idx = key_to_index.get(_submodel_atom_key(a))
+    if idx is None or assigned[idx]:
+      return None
+    assigned[idx] = True
+    sites[idx] = a.xyz
+    occs[idx] = a.occ
+    bs[idx] = a.b
+  work = processed_master.deep_copy()
+  # model.select() (which deep_copy() uses) does not carry the monomer mappings
+  # that model.selection() needs for keywords like "backbone" and "sidechain".
+  # The copy shares the master's atom layout, so the master's mappings remain
+  # valid for it.  Prime the atom selection cache as well because selection()
+  # hands the raw cache attribute to the selection manager.
+  work._all_monomer_mappings = processed_master._all_monomer_mappings
+  work.get_atom_selection_cache()
+  for i, wa in enumerate(work.get_hierarchy().atoms()):
+    wa.set_occ(occs[i])
+    wa.set_b(bs[i])
+  work.set_sites_cart(sites)
+  return work
+
 class clashscore2(validation):
   __slots__ = validation.__slots__ + [
     "clashscore",
@@ -122,27 +184,80 @@ class clashscore2(validation):
     n_models = len(pdb_hierarchy.models())
     use_segids = utils.use_segids_in_place_of_chainids(
                    hierarchy=pdb_hierarchy)
-    for i_mod, model in enumerate(pdb_hierarchy.models()):
 
-      # Select only the current submodel from the hierarchy
-      submodel = original_model.deep_copy()
-      remove_models_except_index(submodel, i_mod)
+    # All models of an ensemble are required to share composition, so their
+    # restraints (and per-atom energy/H-bond types) are identical; only the
+    # coordinates (and possibly occupancies and B factors) differ.  Rather than
+    # letting probe2 process each model separately (which re-reads the monomer
+    # library and re-interprets the model every time), process one model with
+    # probe2's own interpretation parameters and keep it as a pristine master.
+    # Each model then gets a deep copy of the master carrying its own atom
+    # parameters.  probe2 can add Phantom Hydrogens to the hierarchy it is
+    # given, which is why each run gets its own copy rather than the master
+    # itself.  If a model's atoms do not correspond one-to-one with the
+    # master's, fall back to processing that model as before.
+    original_hierarchy = original_model.get_hierarchy()
+    processed_master = None
+    master_key_to_index = None
+    for i_mod, model in enumerate(pdb_hierarchy.models()):
 
       # Construct a hierarchy for the current submodel
       r = iotbx.pdb.hierarchy.root()
-      mdc = submodel.get_hierarchy().models()[0].detached_copy()
+      mdc = original_hierarchy.models()[i_mod].detached_copy()
       r.append_model(mdc)
 
       occ_max = flex.max(r.atoms().extract_occ())
 
-      # Make yet another model for the new hierarchy
-      subset_model_manager = mmtbx.model.manager(
-        model_input       = None,
-        pdb_hierarchy     = r,
-        stop_for_unknowns = False,
-        crystal_symmetry  = submodel.crystal_symmetry(),
-        restraint_objects = ro,
-        log               = None)
+      work_model_manager = None
+      model_is_processed = False
+      if processed_master is None:
+        # Build a model manager for this submodel and try to process it into
+        # the master whose restraints later models will reuse.
+        master = mmtbx.model.manager(
+          model_input       = None,
+          pdb_hierarchy     = r,
+          stop_for_unknowns = False,
+          crystal_symmetry  = original_model.crystal_symmetry(),
+          restraint_objects = ro,
+          log               = None)
+        try:
+          try:
+            master.process(make_restraints=True,
+              pdb_interpretation_params=probe2.getPdbInterpretationParams(nuclear))
+          except Exception:
+            # Fix up bogus unit cell when it occurs by checking crystal
+            # symmetry, the same way probe2's run() does, then retry.
+            master.add_crystal_symmetry_if_necessary()
+            master.process(make_restraints=True,
+              pdb_interpretation_params=probe2.getPdbInterpretationParams(nuclear))
+          if master.get_restraints_manager() is not None:
+            processed_master = master
+            master_key_to_index = _atom_index_by_key(master.get_hierarchy())
+            # Use the same copy-and-transfer path as later models (an identity
+            # transfer here) so that every probe2 run gets the same kind of
+            # model and the master itself stays pristine.
+            work_model_manager = _copy_of_master_with_atoms_from(
+              processed_master, master_key_to_index, r)
+            model_is_processed = work_model_manager is not None
+        except Exception:
+          # Leave processed_master unset; probe2 will process (and report
+          # errors for) this model itself below.
+          pass
+      else:
+        work_model_manager = _copy_of_master_with_atoms_from(
+          processed_master, master_key_to_index, r)
+        model_is_processed = work_model_manager is not None
+
+      if work_model_manager is None:
+        # Fall back to the unprocessed per-model manager; probe2 processes it.
+        work_model_manager = mmtbx.model.manager(
+          model_input       = None,
+          pdb_hierarchy     = r,
+          stop_for_unknowns = False,
+          crystal_symmetry  = original_model.crystal_symmetry(),
+          restraint_objects = ro,
+          log               = None)
+        model_is_processed = False
 
       if verbose:
         print("\nFinding clashes with mmtbx.probe2...\n")
@@ -156,7 +271,8 @@ class clashscore2(validation):
         verbose=verbose,
         model_id=model.id,
         save_probe_output=save_probe_output)
-      self.probe_clashscore_manager.run_probe_clashscore(data_manager, subset_model_manager)
+      self.probe_clashscore_manager.run_probe_clashscore(data_manager,
+        work_model_manager, processed=model_is_processed)
 
       self.clash_dict[model.id] = self.probe_clashscore_manager.clashscore
       self.clash_dict_b_cutoff[model.id] = self.probe_clashscore_manager.\
@@ -473,7 +589,11 @@ class probe_clashscore_manager(object):
   # We have to take both the original data manager, which is from the model
   # without hydrogens, and the hydrogenated modified model because we need one
   # to construct a Probe2 program and the other to replace its model to run on.
-  def run_probe_clashscore(self, data_manager, hydrogenated_model):
+  # When processed is True, the hydrogenated model has already had restraints
+  # made on it with probe2's interpretation parameters (see
+  # probe2.getPdbInterpretationParams()) and probe2 will reuse them rather than
+  # processing the model again.
+  def run_probe_clashscore(self, data_manager, hydrogenated_model, processed=False):
     self.n_clashes = 0
     self.n_clashes_b_cutoff = 0
     self.clashscore_b_cutoff = None
@@ -481,6 +601,15 @@ class probe_clashscore_manager(object):
     self.clashscore = None
     self.n_atoms = 0
     self.natoms_b_cutoff = 0
+
+    # probe2's run() can add Phantom Hydrogens to the hierarchy of the model it
+    # is given.  When we are reusing a processed model and will run probe2 a
+    # second time below, keep a pristine copy for that second run so that the
+    # first run's additions do not confuse it (the unprocessed path instead
+    # re-processes the model, which handles this).
+    pristine_model = None
+    if self.save_probe_output and processed:
+      pristine_model = hydrogenated_model.deep_copy()
 
     # Construct override parameters and then run probe2 using them and delete the resulting
     # temporary file.
@@ -500,7 +629,7 @@ class probe_clashscore_manager(object):
     parser.parse_args(args)
     p2 = probe2.Program(data_manager, parser.working_phil.extract(),
                        master_phil=parser.master_phil, logger=null_out())
-    p2.overrideModel(hydrogenated_model)
+    p2.overrideModel(hydrogenated_model, processed=processed)
     dots, output = p2.run()
     probe_json = output
     os.unlink(tempName)
@@ -540,7 +669,10 @@ class probe_clashscore_manager(object):
         parser.parse_args(args)
         p2 = probe2.Program(data_manager, parser.working_phil.extract(),
                            master_phil=parser.master_phil, logger=null_out())
-        p2.overrideModel(hydrogenated_model)
+        if pristine_model is not None:
+          p2.overrideModel(pristine_model, processed=True)
+        else:
+          p2.overrideModel(hydrogenated_model, processed=processed)
         dots, output = p2.run()
         self.probe_json = output
         os.unlink(tempName)

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -30,6 +30,35 @@ def remove_models_except_index(model_manager, model_index):
                 hierarchy.remove_model(model=model)
     return model_manager
 
+# Cache of parsed probe2 parameter sets, keyed by the argument strings that
+# produce them.  Building a CCTBXParser and parsing the phil arguments is pure
+# text processing whose result is identical for identical arguments, but it
+# costs on the order of 0.1 s and was being redone for every model of an
+# ensemble.  The per-run output file name is deliberately not part of the
+# arguments; it is patched into the freshly extracted parameters instead, so
+# every model of an ensemble (whose occupancy fraction is almost always the
+# same) shares one parse.  A model with a different occupancy fraction simply
+# gets its own cache entry, keeping the behavior identical to parsing anew.
+_probe2_phil_cache = {}
+
+def _probe2_params_from_args(args, output_filename):
+  """Return (master_phil, params) for running probe2 with the given argument
+  strings, using a cached parse when the same arguments have been seen before.
+  A fresh params object is extracted per call (so callers can mutate it
+  freely), with params.output.filename set to output_filename."""
+  key = tuple(args)
+  cached = _probe2_phil_cache.get(key)
+  if cached is None:
+    parser = iotbx.cli_parser.CCTBXParser(program_class=probe2.Program,
+      logger=null_out())
+    parser.parse_args(list(args))
+    cached = (parser.master_phil, parser.working_phil)
+    _probe2_phil_cache[key] = cached
+  master_phil, working_phil = cached
+  params = working_phil.extract()
+  params.output.filename = output_filename
+  return master_phil, params
+
 def _submodel_atom_key(atom):
   """Identity key for an atom that is stable across the models of an ensemble
   (all models in a multi-model file are required to share composition)."""
@@ -49,6 +78,18 @@ def _atom_index_by_key(hierarchy):
       return None
     ret[key] = i
   return ret
+
+def _deep_copy_with_selection_support(model):
+  """Deep-copy a processed model manager, keeping model.selection() working.
+  model.select() (which deep_copy() uses) does not carry the monomer mappings
+  that selection() needs for keywords like "backbone" and "sidechain".  The
+  copy shares the original's atom layout, so the original's mappings remain
+  valid for it.  Prime the atom selection cache as well because selection()
+  hands the raw cache attribute to the selection manager."""
+  work = model.deep_copy()
+  work._all_monomer_mappings = model._all_monomer_mappings
+  work.get_atom_selection_cache()
+  return work
 
 def _copy_of_master_with_atoms_from(processed_master, key_to_index, hierarchy):
   """Return a deep copy of the processed master model manager whose atoms carry
@@ -78,14 +119,7 @@ def _copy_of_master_with_atoms_from(processed_master, key_to_index, hierarchy):
     sites[idx] = a.xyz
     occs[idx] = a.occ
     bs[idx] = a.b
-  work = processed_master.deep_copy()
-  # model.select() (which deep_copy() uses) does not carry the monomer mappings
-  # that model.selection() needs for keywords like "backbone" and "sidechain".
-  # The copy shares the master's atom layout, so the master's mappings remain
-  # valid for it.  Prime the atom selection cache as well because selection()
-  # hands the raw cache attribute to the selection manager.
-  work._all_monomer_mappings = processed_master._all_monomer_mappings
-  work.get_atom_selection_cache()
+  work = _deep_copy_with_selection_support(processed_master)
   for i, wa in enumerate(work.get_hierarchy().atoms()):
     wa.set_occ(occs[i])
     wa.set_b(bs[i])
@@ -609,26 +643,24 @@ class probe_clashscore_manager(object):
     # re-processes the model, which handles this).
     pristine_model = None
     if self.save_probe_output and processed:
-      pristine_model = hydrogenated_model.deep_copy()
+      pristine_model = _deep_copy_with_selection_support(hydrogenated_model)
 
     # Construct override parameters and then run probe2 using them and delete the resulting
-    # temporary file.
+    # temporary file.  The parse is cached, so all models of an ensemble share it.
     tempName = tempfile.mktemp()
-    parser = iotbx.cli_parser.CCTBXParser(program_class=probe2.Program, logger=null_out())
     args = [
       "source_selection='(occupancy > {}) and not water'".format(self.occupancy_frac),
       "target_selection='occupancy > {}'".format(self.occupancy_frac),
       "use_neutron_distances={}".format(self.nuclear),
       "approach=once",
-      "output.filename='{}'".format(tempName),
       "output.format=json",
       "output.condensed={}".format(self.condensed_probe),
       "output.report_vdws=False",
       "ignore_lack_of_explicit_hydrogens=True",
     ]
-    parser.parse_args(args)
-    p2 = probe2.Program(data_manager, parser.working_phil.extract(),
-                       master_phil=parser.master_phil, logger=null_out())
+    master_phil, probe2_params = _probe2_params_from_args(args, tempName)
+    p2 = probe2.Program(data_manager, probe2_params,
+                       master_phil=master_phil, logger=null_out())
     p2.overrideModel(hydrogenated_model, processed=processed)
     dots, output = p2.run()
     probe_json = output
@@ -656,19 +688,17 @@ class probe_clashscore_manager(object):
       # roughly doubles the total runtime.
       if self.save_probe_output:
         tempName = tempfile.mktemp()
-        parser = iotbx.cli_parser.CCTBXParser(program_class=probe2.Program, logger=null_out())
         args = [
           "source_selection='(occupancy > {}) and not water'".format(self.occupancy_frac),
           "target_selection='occupancy > {}'".format(self.occupancy_frac),
           "use_neutron_distances={}".format(self.nuclear),
           "approach=once",
-          "output.filename='{}'".format(tempName),
           "output.format=json",
           "ignore_lack_of_explicit_hydrogens=True",
         ]
-        parser.parse_args(args)
-        p2 = probe2.Program(data_manager, parser.working_phil.extract(),
-                           master_phil=parser.master_phil, logger=null_out())
+        master_phil, probe2_params = _probe2_params_from_args(args, tempName)
+        p2 = probe2.Program(data_manager, probe2_params,
+                           master_phil=master_phil, logger=null_out())
         if pristine_model is not None:
           p2.overrideModel(pristine_model, processed=True)
         else:

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -30,22 +30,15 @@ def remove_models_except_index(model_manager, model_index):
                 hierarchy.remove_model(model=model)
     return model_manager
 
-# Cache of parsed probe2 parameter sets, keyed by the argument strings that
-# produce them.  Building a CCTBXParser and parsing the phil arguments is pure
-# text processing whose result is identical for identical arguments, but it
-# costs on the order of 0.1 s and was being redone for every model of an
-# ensemble.  The per-run output file name is deliberately not part of the
-# arguments; it is patched into the freshly extracted parameters instead, so
-# every model of an ensemble (whose occupancy fraction is almost always the
-# same) shares one parse.  A model with a different occupancy fraction simply
-# gets its own cache entry, keeping the behavior identical to parsing anew.
+# Parsed probe2 phil keyed by argument strings.  The per-run output file
+# name is patched into each freshly extracted params object rather than
+# parsed, so all models of an ensemble share one parse.
 _probe2_phil_cache = {}
 
 def _probe2_params_from_args(args, output_filename):
-  """Return (master_phil, params) for running probe2 with the given argument
-  strings, using a cached parse when the same arguments have been seen before.
-  A fresh params object is extracted per call (so callers can mutate it
-  freely), with params.output.filename set to output_filename."""
+  """Return (master_phil, params) for the given probe2 arguments, parsing
+  at most once per distinct argument list.  Each call extracts a fresh params
+  object with params.output.filename set to output_filename."""
   key = tuple(args)
   cached = _probe2_phil_cache.get(key)
   if cached is None:
@@ -80,12 +73,10 @@ def _atom_index_by_key(hierarchy):
   return ret
 
 def _deep_copy_with_selection_support(model):
-  """Deep-copy a processed model manager, keeping model.selection() working.
-  model.select() (which deep_copy() uses) does not carry the monomer mappings
-  that selection() needs for keywords like "backbone" and "sidechain".  The
-  copy shares the original's atom layout, so the original's mappings remain
-  valid for it.  Prime the atom selection cache as well because selection()
-  hands the raw cache attribute to the selection manager."""
+  """Deep-copy a processed model manager, keeping model.selection() working:
+  deep_copy() drops the monomer mappings that selection keywords like
+  "backbone" need, and the copy's identical atom layout keeps the original's
+  valid."""
   work = model.deep_copy()
   work._all_monomer_mappings = model._all_monomer_mappings
   work.get_atom_selection_cache()
@@ -244,21 +235,12 @@ class clashscore2(validation):
     use_segids = utils.use_segids_in_place_of_chainids(
                    hierarchy=pdb_hierarchy)
 
-    # All models of an ensemble are required to share composition, so their
-    # restraints (and per-atom energy/H-bond types) are identical; only the
-    # coordinates (and possibly occupancies and B factors) differ.  Rather than
-    # letting probe2 process each model separately (which re-reads the monomer
-    # library and re-interprets the model every time), process one model with
-    # probe2's own interpretation parameters and reuse it: when the model has
-    # no waters, probe2 cannot modify it (it only adds Phantom Hydrogens to
-    # waters), so the SAME manager is reused for every model with each model's
-    # atom parameters written in place.  This keeps memory flat; making a deep
-    # copy per model was found to permanently grow the native heap by tens of
-    # MB per model on large models.  When waters are present, each run gets a
-    # deep copy of the pristine master instead, since probe2 may attach
-    # Phantom Hydrogens to the hierarchy it is given.  If a model's atoms do
-    # not correspond one-to-one with the master's, fall back to processing
-    # that model as before.
+    # Ensemble models share composition, so restraints are made once on a
+    # master model and reused.  With no waters probe2 cannot modify the model
+    # (its only mutation is adding Phantom Hydrogens to waters), so the master
+    # itself is reused with each model's atom parameters written in place;
+    # with waters each probe2 run gets a deep copy.  Any atom mismatch falls
+    # back to per-model processing.
     original_hierarchy = pdb_hierarchy
     processed_master = None
     master_key_to_index = None
@@ -303,9 +285,7 @@ class clashscore2(validation):
               work_model_manager = processed_master
               model_is_processed = True
             else:
-              # Use the same copy-and-transfer path as later models (an
-              # identity transfer here) so that every probe2 run gets the same
-              # kind of model and the master itself stays pristine.
+              # Identity transfer, keeping the master pristine.
               work_model_manager = _copy_of_master_with_atoms_from(
                 processed_master, master_key_to_index, r)
               model_is_processed = work_model_manager is not None
@@ -679,11 +659,8 @@ class probe_clashscore_manager(object):
     self.n_atoms = 0
     self.natoms_b_cutoff = 0
 
-    # probe2's run() can add Phantom Hydrogens to the hierarchy of the model it
-    # is given.  When we are reusing a processed model and will run probe2 a
-    # second time below, keep a pristine copy for that second run so that the
-    # first run's additions do not confuse it (the unprocessed path instead
-    # re-processes the model, which handles this).
+    # probe2 can add Phantom Hydrogens to the model it runs on; keep a
+    # pristine copy for the second (save_probe_output) run.
     pristine_model = None
     if self.save_probe_output and processed:
       pristine_model = _deep_copy_with_selection_support(hydrogenated_model)

--- a/mmtbx/validation/clashscore2.py
+++ b/mmtbx/validation/clashscore2.py
@@ -91,15 +91,12 @@ def _deep_copy_with_selection_support(model):
   work.get_atom_selection_cache()
   return work
 
-def _copy_of_master_with_atoms_from(processed_master, key_to_index, hierarchy):
-  """Return a deep copy of the processed master model manager whose atoms carry
-  the coordinates, occupancies, and B factors of the matching atoms in the given
-  single-model hierarchy.  The copy keeps the master's restraints and atom-type
-  information, so probe2 does not need to process it again.  Returns None when
-  the hierarchy's atoms do not correspond one-to-one with the master's (for
-  example a malformed ensemble whose models differ in composition), in which
-  case the caller should fall back to processing the model.
-  """
+def _gather_atom_parameters(key_to_index, hierarchy):
+  """Collect the coordinates, occupancies, and B factors of the atoms in the
+  given single-model hierarchy, ordered by the master's atom indices.  Returns
+  (sites, occs, bs) or None when the hierarchy's atoms do not correspond
+  one-to-one with the master's (for example a malformed ensemble whose models
+  differ in composition)."""
   from scitbx.array_family import flex
   if key_to_index is None:
     return None
@@ -119,12 +116,42 @@ def _copy_of_master_with_atoms_from(processed_master, key_to_index, hierarchy):
     sites[idx] = a.xyz
     occs[idx] = a.occ
     bs[idx] = a.b
-  work = _deep_copy_with_selection_support(processed_master)
-  for i, wa in enumerate(work.get_hierarchy().atoms()):
+  return (sites, occs, bs)
+
+def _apply_atom_parameters(manager, sites, occs, bs):
+  """Write the given per-atom parameters onto the manager's atoms in index
+  order, keeping the hierarchy and xray structure coordinates in sync."""
+  for i, wa in enumerate(manager.get_hierarchy().atoms()):
     wa.set_occ(occs[i])
     wa.set_b(bs[i])
-  work.set_sites_cart(sites)
+  manager.set_sites_cart(sites)
+
+def _copy_of_master_with_atoms_from(processed_master, key_to_index, hierarchy):
+  """Return a deep copy of the processed master model manager whose atoms carry
+  the coordinates, occupancies, and B factors of the matching atoms in the given
+  single-model hierarchy.  The copy keeps the master's restraints and atom-type
+  information, so probe2 does not need to process it again.  Returns None when
+  the hierarchy's atoms do not correspond one-to-one with the master's, in
+  which case the caller should fall back to processing the model.
+  """
+  data = _gather_atom_parameters(key_to_index, hierarchy)
+  if data is None:
+    return None
+  work = _deep_copy_with_selection_support(processed_master)
+  _apply_atom_parameters(work, *data)
   return work
+
+def _hierarchy_contains_waters(hierarchy):
+  """True if any residue in the hierarchy is a water.  probe2's run() adds
+  Phantom Hydrogens to the hierarchy of the model it is given when waters lack
+  explicit Hydrogens, so a model manager may only be reused across probe2 runs
+  when it contains no waters at all."""
+  import iotbx.pdb
+  for ag in hierarchy.atom_groups():
+    if iotbx.pdb.common_residue_names_get_class(
+        name=ag.resname) == "common_water":
+      return True
+  return False
 
 class clashscore2(validation):
   __slots__ = validation.__slots__ + [
@@ -212,8 +239,6 @@ class clashscore2(validation):
       crystal_symmetry  = data_manager_model.crystal_symmetry(),
       restraint_objects = ro,
       log               = None)
-    original_model = data_manager_model.deep_copy()
-
     pdb_hierarchy = data_manager_model.get_hierarchy()
     n_models = len(pdb_hierarchy.models())
     use_segids = utils.use_segids_in_place_of_chainids(
@@ -224,15 +249,20 @@ class clashscore2(validation):
     # coordinates (and possibly occupancies and B factors) differ.  Rather than
     # letting probe2 process each model separately (which re-reads the monomer
     # library and re-interprets the model every time), process one model with
-    # probe2's own interpretation parameters and keep it as a pristine master.
-    # Each model then gets a deep copy of the master carrying its own atom
-    # parameters.  probe2 can add Phantom Hydrogens to the hierarchy it is
-    # given, which is why each run gets its own copy rather than the master
-    # itself.  If a model's atoms do not correspond one-to-one with the
-    # master's, fall back to processing that model as before.
-    original_hierarchy = original_model.get_hierarchy()
+    # probe2's own interpretation parameters and reuse it: when the model has
+    # no waters, probe2 cannot modify it (it only adds Phantom Hydrogens to
+    # waters), so the SAME manager is reused for every model with each model's
+    # atom parameters written in place.  This keeps memory flat; making a deep
+    # copy per model was found to permanently grow the native heap by tens of
+    # MB per model on large models.  When waters are present, each run gets a
+    # deep copy of the pristine master instead, since probe2 may attach
+    # Phantom Hydrogens to the hierarchy it is given.  If a model's atoms do
+    # not correspond one-to-one with the master's, fall back to processing
+    # that model as before.
+    original_hierarchy = pdb_hierarchy
     processed_master = None
     master_key_to_index = None
+    master_reusable = False   # no waters: reuse the master manager in place
     for i_mod, model in enumerate(pdb_hierarchy.models()):
 
       # Construct a hierarchy for the current submodel
@@ -251,7 +281,7 @@ class clashscore2(validation):
           model_input       = None,
           pdb_hierarchy     = r,
           stop_for_unknowns = False,
-          crystal_symmetry  = original_model.crystal_symmetry(),
+          crystal_symmetry  = data_manager_model.crystal_symmetry(),
           restraint_objects = ro,
           log               = None)
         try:
@@ -267,16 +297,29 @@ class clashscore2(validation):
           if master.get_restraints_manager() is not None:
             processed_master = master
             master_key_to_index = _atom_index_by_key(master.get_hierarchy())
-            # Use the same copy-and-transfer path as later models (an identity
-            # transfer here) so that every probe2 run gets the same kind of
-            # model and the master itself stays pristine.
-            work_model_manager = _copy_of_master_with_atoms_from(
-              processed_master, master_key_to_index, r)
-            model_is_processed = work_model_manager is not None
+            master_reusable = not _hierarchy_contains_waters(
+              master.get_hierarchy())
+            if master_reusable:
+              work_model_manager = processed_master
+              model_is_processed = True
+            else:
+              # Use the same copy-and-transfer path as later models (an
+              # identity transfer here) so that every probe2 run gets the same
+              # kind of model and the master itself stays pristine.
+              work_model_manager = _copy_of_master_with_atoms_from(
+                processed_master, master_key_to_index, r)
+              model_is_processed = work_model_manager is not None
         except Exception:
           # Leave processed_master unset; probe2 will process (and report
           # errors for) this model itself below.
           pass
+      elif master_reusable:
+        # Write this model's atom parameters onto the shared master in place.
+        data = _gather_atom_parameters(master_key_to_index, r)
+        if data is not None:
+          _apply_atom_parameters(processed_master, *data)
+          work_model_manager = processed_master
+          model_is_processed = True
       else:
         work_model_manager = _copy_of_master_with_atoms_from(
           processed_master, master_key_to_index, r)
@@ -288,7 +331,7 @@ class clashscore2(validation):
           model_input       = None,
           pdb_hierarchy     = r,
           stop_for_unknowns = False,
-          crystal_symmetry  = original_model.crystal_symmetry(),
+          crystal_symmetry  = data_manager_model.crystal_symmetry(),
           restraint_objects = ro,
           log               = None)
         model_is_processed = False


### PR DESCRIPTION
`clashscore2` processed and hydrogenated multi-model files as one combined
hierarchy. Ensemble models are spatially superimposed, so making restraints
across the whole file is quadratic in the model count: a 21-model NMR entry was
measured peaking over 13 GB. Placement and flip optimization are per-model
operations anyway (the Optimizer already iterates MODEL records independently),
so this hydrogenates each model separately and recombines, then runs the single
interpretation-only re-process, which is linear, on the combined model. It also
processes restraints once per ensemble and caches the probe2 phil parse.

On 1D3Z (10 models, 12,310 atoms), peak memory with hydrogens regenerated goes
from 1,980 MB to 278 MB, and the kept-hydrogens run from 29.5 s to 10.8 s.

It is also a correctness fix. The hydrogen-deletion set the Optimizer reports
after a whole-ensemble run describes a single model, and applying it across the
combined hierarchy removes the wrong atoms: on 1D3Z the whole-file path returns
6,543 of 12,310 atoms and 523 of 6,290 hydrogens. All ten per-model clashscores
change as a result. Afterwards, regenerating hydrogens reproduces the
deposited-hydrogen clashscores exactly in all ten models, where before it
disagreed in all ten.

Single-model probe2 output is byte-identical, and tst_add_hydrogen_1 through
_11 pass.

`mmtbx/reduce/Optimizers.py` still resets its deletion set per model, so direct
multi-model reduce2 runs keep the old behaviour and want a separate fix.
