### PR TITLE
Handle conda-forge c-compiler/cxx-compiler metapackages >=2.0.0

### DIFF
--- a/libtbx/SConscript
+++ b/libtbx/SConscript
@@ -805,14 +805,28 @@ int main() {
     cc = os.environ.get('CC', None)
     cxx = os.environ.get('CXX', None)
 
-    if cc is not None or cxx is not None:
-      print("Compiler settings:")
-      if cc is not None:
-        print("  CC: ", cc)
-      if cxx is not None:
-        print("  CXX:", cxx)
     if cc is None or cxx is None:
-      print("Warning: CC and/or CXX has not been set in the environment.")
+      # conda-forge compilers 2.0+ no longer require CC/CXX to be set; the
+      # compiler self-configures via a .cfg file next to the executable in
+      # the conda prefix's bin directory. Probe for it there instead of
+      # silently falling back to whatever compiler SCons finds on the PATH.
+      conda_bin = os.path.join(libtbx.env_config.get_conda_prefix(), 'bin')
+      if env_etc.compiler == 'darwin_conda':
+        probe_cc, probe_cxx = 'clang', 'clang++'
+      else:
+        probe_cc, probe_cxx = 'gcc', 'g++'
+      if cc is None and os.path.isfile(os.path.join(conda_bin, probe_cc)):
+        cc = os.path.join(conda_bin, probe_cc)
+      if cxx is None and os.path.isfile(os.path.join(conda_bin, probe_cxx)):
+        cxx = os.path.join(conda_bin, probe_cxx)
+      if cc is None or cxx is None:
+        raise Sorry(
+          "CC and/or CXX has not been set in the environment, and no "
+          "conda compiler was found in %s" % conda_bin)
+
+    print("Compiler settings:")
+    print("  CC: ", cc)
+    print("  CXX:", cxx)
 
     # use environment flags if available
     if libtbx.env.build_options.use_environment_flags:
@@ -862,18 +876,16 @@ int main() {
     env_etc.gcc_version = libtbx.env_config.get_gcc_version(command_name=cc)
     env_etc.cxx11_is_available = True
 
-    if cc is not None:
-      env_base.Replace(
-        CC=cc,
-        SHCC=cc,
-      )
-    if cxx is not None:
-      env_base.Replace(
-        CXX=cxx,
-        LINK=cxx,
-        SHCXX=cxx,
-        SHLINK=cxx,
-      )
+    env_base.Replace(
+      CC=cc,
+      SHCC=cc,
+    )
+    env_base.Replace(
+      CXX=cxx,
+      LINK=cxx,
+      SHCXX=cxx,
+      SHLINK=cxx,
+    )
     env_base.Replace(SHLIBSUFFIX=env_etc.shlibsuffix)
 
   elif env_etc.compiler.startswith("darwin"):


### PR DESCRIPTION
As of conda-forge/compilers-feedstock#78 (Aug 2026), activating the conda env will no longer set the CC, CXX, LDFLAGS etc environment variables. Instead the conda env contains config files like bin/arm64-apple-darwin-clang++.cfg. To handle this new setup, if CC and CXX are unset, then we check for the compiler binaries in the conda environment. If no CC/CXX and no binaries in conda-bin, then fail loudly.

See dials/dials#3243