### PR TITLE
Add a regression test for barbed_wire_analysis

### DIFF
--- a/mmtbx/run_tests.py
+++ b/mmtbx/run_tests.py
@@ -429,6 +429,7 @@ general_tests = [
   "$D/regression/tst_fmodel_2.py",
   "$D/regression/tst_rigid_bond_test.py",
   "$D/validation/regression/tst_cablam.py",
+  "$D/validation/regression/tst_barbed_wire_analysis.py",
   "$D/regression/real_space_refine_chain/tst_00.py",
   "$D/regression/real_space_refine_chain/tst_01.py",
   "$D/conformation_dependent_library/tst_omega_cdl.py",

--- a/mmtbx/validation/regression/tst_barbed_wire_analysis.py
+++ b/mmtbx/validation/regression/tst_barbed_wire_analysis.py
@@ -1,0 +1,87 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+import shutil
+import tempfile
+
+import libtbx.load_env
+from libtbx.utils import format_cpu_times
+from iotbx.data_manager import DataManager
+from mmtbx.validation import barbed_wire_analysis
+
+# pae_model.pdb is a real AlphaFold model, 309 residues with pLDDT in the
+# B-factor column, which is what this analysis is for.
+MODEL = libtbx.env.find_in_repositories(
+    relative_path="cctbx_project/mmtbx/regression/pdbs/pae_model.pdb",
+    test=os.path.isfile)
+
+CATEGORIES = set(["Predictive", "Near-predictive", "Unpacked high pLDDT",
+                  "Pseudostructure", "Barbed wire"])
+
+# do_probe() shells out to phenix.reduce and phenix.probe through a file it
+# writes into the current directory under a fixed name, so the test runs
+# somewhere private and checks the run leaves nothing behind.
+
+
+def run_analysis():
+  dm = DataManager()
+  dm.process_model_file(MODEL)
+  return barbed_wire_analysis.barbed_wire_analysis(model=dm.get_model())
+
+
+def exercise():
+  before = set(os.listdir("."))
+  bwa = run_analysis()
+  residues = list(bwa.res_dict.values())
+  assert len(residues) == 309, len(residues)
+
+  feedback = [r.feedback for r in residues]
+  unknown = set(f for f in feedback if f) - CATEGORIES
+  assert not unknown, unknown
+
+  # The two residues at each end have no classification: the backbone measures
+  # this depends on need neighbours on both sides.
+  blank = sorted(int(r.resseq) for r in residues if not r.feedback)
+  assert blank == [1, 2, 307, 308, 309], blank
+
+  # A confident model should come out mostly predictive. This is the assertion
+  # that fails loudly if phenix.probe or phenix.reduce cannot be run: with no
+  # contacts every packed residue is reported unpacked instead.
+  predictive = feedback.count("Predictive")
+  assert predictive >= 250, predictive
+
+  # Same failure, checked directly rather than through the classification.
+  with_contacts = sum(1 for r in residues
+                      if r.packing_hb or r.packing_vdw or r.packing_bo)
+  assert with_contacts >= 200, with_contacts
+
+  for name in ("Near-predictive", "Unpacked high pLDDT"):
+    assert name in feedback, name
+
+  # Six slots, one per problem class, '-' where that problem is absent.
+  for r in residues:
+    code = r.text_code if isinstance(r.text_code, str) else "".join(r.text_code)
+    assert len(code) in (0, 6), (r.resid, repr(code))
+
+  left = set(os.listdir(".")) - before
+  assert not left, "files left behind in %s: %s" % (os.getcwd(), sorted(left))
+
+
+def main():
+  if MODEL is None:
+    print("Skipping: pae_model.pdb not available")
+    return
+  cwd = os.getcwd()
+  tmp = tempfile.mkdtemp()
+  try:
+    os.chdir(tmp)
+    exercise()
+  finally:
+    os.chdir(cwd)
+    shutil.rmtree(tmp, ignore_errors=True)
+  print(format_cpu_times())
+  print("OK")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
`mmtbx/validation/barbed_wire_analysis.py` had no test. There is no
`tst_barbed_wire*` anywhere in the tree, it is not registered in
`mmtbx/run_tests.py`, and the only files importing it are its own program and
command-line wrappers.

That matters more than usual here, because the analysis shells out to
`phenix.reduce` and `phenix.probe` (there is a `#TODO update to Reduce2 and
Probe2` on `do_probe`). Nothing would have reported those going missing: the
contacts would come back empty, every packed residue would be classified
unpacked instead, and the suite would stay green.

This runs the analysis on `pae_model.pdb`, an AlphaFold model already in
`mmtbx/regression/pdbs`, 309 residues with pLDDT in the B-factor column. It
takes about 3.5 seconds and the classification is stable across repeated runs.

### What it asserts, and why each one earns its place

- The residue count, and that every non-empty category is one of the five the
  analysis defines.
- The first two and last three residues carry no classification, which
  documents the boundary behaviour rather than leaving it implied.
- `Predictive` covers at least 250 of the 309, and at least 200 residues have
  recorded contacts. **These are the two that catch a broken or missing
  `phenix.probe`.** Verified by stubbing `do_probe` to return an empty dict:
  both fire.
- `text_code` is either empty or six slots.
- The working directory is left clean. `do_probe` writes its input as
  `probe_contacts_temp.pdb` under a fixed name in the current directory, so the
  test runs in a `mkdtemp` and compares the directory listing before and after.
  Verified by stubbing out the `os.remove` cleanup: it fires.

The category counts are asserted as floors rather than exact numbers,
deliberately. They depend on the output of two external binaries, and an exact
count would be a platform tripwire rather than a regression test. The floors are
far enough from the observed values (277 predictive, 250 asserted) to survive
normal variation while still failing decisively when contacts go missing
entirely.

### Not addressed here

The fixed-name scratch file is a real concurrency hazard for anything running
two analyses in one process, and the reduce1/probe1 shell-out is what the
existing TODO is asking to replace. Both want their own change; this only makes
sure something notices if they break.
