### PR TITLE
iotbx.data_manager: build miller arrays once per file

### DIFF
--- a/iotbx/data_manager/map_coefficients.py
+++ b/iotbx/data_manager/map_coefficients.py
@@ -113,19 +113,24 @@ class MapCoefficientsDataManager(MillerArrayDataManager):
   def process_map_coefficients_file(self, filename):
     self.process_miller_array_file(filename)
 
-  def filter_map_coefficients_arrays(self, filename):
+  def filter_map_coefficients_arrays(self, filename, miller_arrays=None):
     '''
     Populate data structures by checking labels in miller_arrays to determine
     type and by setting all complex miller arrays as map coefficients
+
+    miller_arrays: the file's arrays if already built (see
+    MillerArrayDataManager._build_miller_arrays); built here otherwise.
     '''
+    if miller_arrays is None:
+      miller_arrays = self._build_miller_arrays(filename)
     # check for labels
     known_labels = mtz_map_coefficient_labels.union(cif_map_coefficient_labels)
     datatype = MapCoefficientsDataManager.datatype
-    self._child_filter_arrays(datatype, filename, known_labels)
+    self._child_filter_arrays(datatype, filename, known_labels,
+                              miller_arrays=miller_arrays)
 
     # check for complex arrays
     data = self.get_miller_array(filename)
-    miller_arrays = data.as_miller_arrays()
     current_labels = []
     labels = []
     types = {}

--- a/iotbx/data_manager/miller_array.py
+++ b/iotbx/data_manager/miller_array.py
@@ -230,9 +230,12 @@ class MillerArrayDataManager(DataManagerBase):
       array_type = 'nonsense'
     return array_type
 
-  def filter_miller_array_arrays(self, filename):
+  def filter_miller_array_arrays(self, filename, miller_arrays=None):
     '''
     Populate data structures with all arrays
+
+    miller_arrays: the file's arrays if already built (see
+    _build_miller_arrays); built here otherwise.
     '''
     if filename not in self._miller_array_arrays.keys():
       self._miller_array_arrays[filename] = {}
@@ -240,9 +243,8 @@ class MillerArrayDataManager(DataManagerBase):
       self._miller_array_types[filename] = {}
     if filename not in self._miller_array_array_types.keys():
       self._miller_array_array_types[filename] = {}
-    merge_equivalents = 'miller_array_skip_merge' not in self.custom_options
-    miller_arrays = self.get_miller_array(filename).\
-      as_miller_arrays(merge_equivalents=merge_equivalents)
+    if miller_arrays is None:
+      miller_arrays = self._build_miller_arrays(filename)
     labels = []
     for array in miller_arrays:
       label = array.info().label_string()
@@ -530,8 +532,11 @@ fmodel {
     setattr(self, '_custom_%s_phil' % datatype,
             iotbx.phil.parse(custom_phil_str, process_includes=True))
 
-    # add to child datatypes
-    MillerArrayDataManager.miller_array_child_datatypes.append(datatype)
+    # add to child datatypes (a class-level list shared by every DataManager
+    # in the process; without the guard each DataManager() appended again and
+    # the k-th one filtered, and built, every file k times over)
+    if datatype not in MillerArrayDataManager.miller_array_child_datatypes:
+      MillerArrayDataManager.miller_array_child_datatypes.append(datatype)
 
     return custom_phil_str
 
@@ -808,12 +813,23 @@ user_selected_labels: %s
     types = self._get_array_array_types(datatype, filename)
     return types.get(label, getattr(self, self._default_array_type_str % datatype))
 
+  def _build_miller_arrays(self, filename):
+    '''
+    The miller arrays of a processed file. as_miller_arrays() runs the full
+    builder (seconds on a large cif), so the filters share one call.
+    '''
+    merge_equivalents = 'miller_array_skip_merge' not in self.custom_options
+    return self.get_miller_array(filename).as_miller_arrays(
+      merge_equivalents=merge_equivalents)
+
   def _filter_miller_array_child_datatypes(self, filename):
-    # filter arrays (e.g self.filter_map_coefficients_arrays)
+    # filter arrays (e.g self.filter_map_coefficients_arrays), all from one
+    # build of the file
+    miller_arrays = self._build_miller_arrays(filename)
     for datatype in MillerArrayDataManager.miller_array_child_datatypes:
       function_name = 'filter_%s_arrays' % datatype
       if hasattr(self, function_name):
-        getattr(self, function_name)(filename)
+        getattr(self, function_name)(filename, miller_arrays=miller_arrays)
 
   def _check_miller_array_default_filename(self, datatype, filename=None):
     '''
@@ -896,7 +912,8 @@ user_selected_labels: %s
       raise Sorry('%s does not have any arrays labeled %s' %
                   (filename, label))
 
-  def _child_filter_arrays(self, datatype, filename, known_labels):
+  def _child_filter_arrays(self, datatype, filename, known_labels,
+                           miller_arrays=None):
     '''
     Populate data structures by checking labels in miller arrays to determine
     child type
@@ -908,8 +925,8 @@ user_selected_labels: %s
     user_labels[filename] = []
 
     data = self.get_miller_array(filename)
-    merge_equivalents = 'miller_array_skip_merge' not in self.custom_options
-    miller_arrays = data.as_miller_arrays(merge_equivalents=merge_equivalents)
+    if miller_arrays is None:
+      miller_arrays = self._build_miller_arrays(filename)
     labels = []
     types = {}
     # array_types = {}

--- a/iotbx/regression/tst_data_manager.py
+++ b/iotbx/regression/tst_data_manager.py
@@ -1340,10 +1340,68 @@ def test_scattering_table_mixins():
   for scattering_table in ['wk1995', 'it1992', 'n_gaussian']:
     assert dm.map_scattering_table_type(scattering_table) == 'x_ray'
 
+def test_miller_array_single_build():
+  '''
+  A reflection file is built into miller arrays once per DataManager, whatever
+  the number of miller_array child datatypes and of DataManagers constructed
+  in the process. as_miller_arrays() runs the full builder (seconds on large
+  cifs); the parent filter and the map_coefficients filter used to run it
+  three times per file, and the class-level child list grew on every
+  DataManager() so the k-th one ran it 3k times.
+  '''
+  from cctbx import crystal, miller
+  from cctbx.array_family import flex
+  import iotbx.mtz
+  from iotbx.reflection_file_reader import any_reflection_file
+  from iotbx.data_manager.miller_array import MillerArrayDataManager
+
+  cs = crystal.symmetry(unit_cell=(10, 20, 30, 90, 90, 90),
+                        space_group_symbol='P 21 21 21')
+  ms = miller.build_set(cs, anomalous_flag=False, d_min=3.0)
+  f = ms.array(data=flex.double(ms.size(), 10.0), sigmas=flex.double(ms.size(), 1.0))
+  f.set_observation_type_xray_amplitude()
+  fwt = ms.array(data=flex.complex_double(ms.size(), complex(1.0, 2.0)))
+  mtz_dataset = f.as_mtz_dataset(column_root_label='FOBS')
+  mtz_dataset.add_miller_array(fwt, column_root_label='FWT',
+                               label_decorator=iotbx.mtz.ccp4_label_decorator())
+  data_mtz = 'tst_data_manager_single_build.mtz'
+  mtz_dataset.mtz_object().write(data_mtz)
+
+  n_builds = [0]
+  orig = any_reflection_file.as_miller_arrays
+  def counting(self, *args, **kwds):
+    n_builds[0] += 1
+    return orig(self, *args, **kwds)
+  any_reflection_file.as_miller_arrays = counting
+  try:
+    for datatypes, custom_options in (
+        (['miller_array', 'map_coefficients'], None),
+        (['miller_array', 'map_coefficients'], None),
+        (['miller_array'], None),
+        (['miller_array', 'map_coefficients'], ['miller_array_skip_merge'])):
+      n_builds[0] = 0
+      dm = DataManager(datatypes=datatypes, custom_options=custom_options)
+      dm.process_miller_array_file(data_mtz)
+      arrays = dm.get_miller_arrays()
+      assert n_builds[0] == 1, (datatypes, custom_options, n_builds[0])
+      labels = sorted(a.info().label_string() for a in arrays)
+      assert labels == ['FOBS,SIGFOBS', 'FWT,PHWT'], labels
+      if 'map_coefficients' in datatypes:
+        assert dm.get_map_coefficients_labels() == ['FWT,PHWT'], \
+          dm.get_map_coefficients_labels()
+        mc = dm.get_map_coefficients_arrays(labels=['FWT,PHWT'])
+        assert len(mc) == 1 and mc[0].is_complex_array()
+      children = MillerArrayDataManager.miller_array_child_datatypes
+      assert len(children) == len(set(children)), children
+  finally:
+    any_reflection_file.as_miller_arrays = orig
+  os.remove(data_mtz)
+
 # -----------------------------------------------------------------------------
 if __name__ == '__main__':
 
   test_data_manager()
+  test_miller_array_single_build()
   test_model_datatype()
   test_sequence_datatype()
   test_json_datatype()


### PR DESCRIPTION
## Why

Reading a reflection file through the DataManager cost three full
`as_miller_arrays()` builds, and the number grew with every DataManager
constructed in the process:

- `process_miller_array_file` runs `_filter_miller_array_child_datatypes`,
  which calls one filter per entry of `MillerArrayDataManager.miller_array_child_datatypes`.
  The parent filter (`filter_miller_array_arrays`) built the arrays, the
  map_coefficients filter built them again in `_child_filter_arrays`, and
  built them a third time for its complex-array scan.
- `miller_array_child_datatypes` is a class-level list, and
  `_add_miller_array_phil_str` appended to it on every `DataManager()`
  construction. The k-th DataManager in a process therefore looped over k
  copies of each datatype and built every file 3k times (measured on a
  small cif: 3, 6, 9 builds for three successive DataManagers).

`as_miller_arrays()` is the expensive step of a reflection read: seconds on
large deposited structure-factor cifs, so the DataManager path was 2.5x the
cost of a plain `any_reflection_file` read on both cif and mtz.

## What is done

- `_filter_miller_array_child_datatypes` builds the arrays once
  (`_build_miller_arrays`, honouring the `miller_array_skip_merge` option)
  and hands them to every filter through a new `miller_arrays=None`
  parameter. Each filter still builds on its own when called without it, so
  the public signatures keep working.
- `_add_miller_array_phil_str` appends a datatype to the class-level list
  only if it is not there yet.
- Regression test `test_miller_array_single_build` in
  `iotbx/regression/tst_data_manager.py`: writes a small mtz with an
  amplitude array and a map-coefficient pair, constructs four DataManagers in
  a row with different datatype sets and options, and asserts exactly one
  build per DataManager, the expected parent and child labels, and no
  duplicates in the class list. It fails on master with 3 builds.

## Gains

DataManager read in a fresh process (`DataManager().process_miller_array_file`
+ `get_miller_arrays`), deposited SF files, cctbx at 0fa242a223:

| file | before | after | plain any_reflection_file read |
|---|---|---|---|
| 4ybb-sf.cif (114 MB, 3.06 M reflections) | 12.07 s | 5.49 s | 4.74 s |
| 4ybb-sf.mtz | 7.86 s | 3.04 s | 2.65 s |
| 6i7v-sf.cif (88 MB, 1.26 M reflections) | 9.15 s | 4.19 s | 3.61 s |
| 6i7v-sf.mtz | 6.22 s | 2.43 s | 2.00 s |

The DataManager read is now within ~15% of a bare `any_reflection_file`
read on both formats; peak RSS of the reading process drops as well (4ybb
cif 2235 -> 1709 MB, mtz 1200 -> 805 MB). The arrays returned are identical
(checked against the direct build by the miller-array read benchmark's
parity gate).

## Notes

- The complex-array scan in `filter_map_coefficients_arrays` used to build
  with the default merge setting regardless of `miller_array_skip_merge`,
  while the other two builds honoured it. It now uses the same arrays as the
  rest, so the option applies uniformly. Merging only affects arrays with
  sigmas, which complex arrays do not have, so map coefficients are unchanged.
- Pre-existing and left alone: `get_map_coefficients_arrays()` with no labels
  raises "no known map_coefficients arrays" on master too, because the child's
  all-labels dictionary is never populated; the label-explicit call works.

## Testing

- `iotbx/regression/tst_data_manager.py` passes (including the new test).
- `libtbx.find_clutter` and `libtbx.find_unused_imports_crude` clean on the
  three files.
