### PR TITLE
reduce_hydrogen: do not strip H whose parent atoms are already bonded

### DIFF
--- a/mmtbx/hydrogens/reduce_hydrogen.py
+++ b/mmtbx/hydrogens/reduce_hydrogen.py
@@ -396,6 +396,10 @@ def workarounds_00345(model,
         bonded_to_i = fsc0[orig_h_i]
         bonded_to_j = fsc0[orig_h_j]
         if len(bonded_to_i) != 1 or len(bonded_to_j) != 1: continue
+        # An already-perceived bond between the two parent atoms means there is
+        # no missing link here.  The close H..H contact is then an artifact of
+        # the as-placed torsion, which the methyl/OH rotators resolve later.
+        if bonded_to_i[0] in fsc0[bonded_to_j[0]]: continue
         rt_mx_i = asu_mappings.get_rt_mx_i(pair)
         rt_mx_j = asu_mappings.get_rt_mx_j(pair)
         site_frac_i = unit_cell.fractionalize(atoms[bonded_to_i[0]].xyz)
@@ -752,8 +756,6 @@ class place_hydrogens():
     #if not self.exclude_water:
     #  self.model.add_hydrogens(1., occupancy=0.)
 
-    self.n_H_final = self.model.get_hd_selection().count(True)
-
     # List missing H
     mon_lib_srv = self.model.get_mon_lib_srv()
     for m in self.model.get_hierarchy().models():
@@ -767,6 +769,7 @@ class place_hydrogens():
                 print(msg%(c.id, r.resseq, r.resname), ma)
 
     self.model = workarounds_00345(model=self.model)
+    self.n_H_final = self.model.get_hd_selection().count(True)
 
     if self.print_time:
       self.print_times()

--- a/mmtbx/hydrogens/tst_add_hydrogen_14.py
+++ b/mmtbx/hydrogens/tst_add_hydrogen_14.py
@@ -1,0 +1,98 @@
+from __future__ import absolute_import, division, print_function
+import iotbx.pdb
+import mmtbx.model
+from libtbx.utils import null_out
+from mmtbx.hydrogens import reduce_hydrogen
+
+def run():
+  test_001()
+  test_002()
+
+# ------------------------------------------------------------------------------
+
+pdb_str_001 = """
+CRYST1   64.290   64.290   32.490  90.00  90.00 120.00 H 3           9
+ATOM     57  N   TYR A   4      15.190  27.150  14.710  1.00  7.30           N
+ATOM     58  CA  TYR A   4      14.520  26.160  15.530  1.00  9.70           C
+ATOM     59  C   TYR A   4      14.080  26.840  16.820  1.00 10.30           C
+ATOM     60  O   TYR A   4      14.850  27.500  17.430  1.00 12.10           O
+ATOM     61  CB  TYR A   4      15.340  24.840  15.890  1.00  9.80           C
+ATOM     62  CG  TYR A   4      15.430  24.000  14.680  1.00  9.60           C
+ATOM     63  CD1 TYR A   4      14.750  22.680  14.730  1.00 10.90           C
+ATOM     64  CD2 TYR A   4      16.080  24.240  13.530  1.00 11.30           C
+ATOM     65  CE1 TYR A   4      14.800  21.820  13.580  1.00 13.80           C
+ATOM     66  CE2 TYR A   4      16.060  23.380  12.290  1.00 13.20           C
+ATOM     67  CZ  TYR A   4      15.410  22.150  12.520  1.00 12.60           C
+ATOM     68  OH  TYR A   4      15.490  21.440  11.230  1.00 15.40           O
+ATOM     77  N   THR A   5      12.890  26.450  17.390  1.00  9.50           N
+ATOM     78  CA  THR A   5      12.550  27.000  18.750  1.00  9.60           C
+ATOM     79  C   THR A   5      12.370  25.920  19.750  1.00  7.50           C
+ATOM     80  O   THR A   5      11.900  24.740  19.380  1.00 10.00           O
+ATOM     81  CB  THR A   5      11.140  27.660  18.450  1.00 18.30           C
+ATOM     82  OG1 THR A   5      10.930  28.360  19.760  1.00 20.90           O
+ATOM     83  CG2 THR A   5      10.520  27.760  17.470  1.00 24.90           C
+ATOM     86  N   CYS A   6      12.800  26.250  20.890  1.00  8.10           N
+ATOM     87  CA  CYS A   6      12.630  25.410  22.060  1.00  8.30           C
+ATOM     88  C   CYS A   6      11.040  25.550  22.390  1.00 10.30           C
+ATOM     89  O   CYS A   6      10.590  26.610  22.770  1.00 10.10           O
+ATOM     90  CB  CYS A   6      13.450  25.910  23.210  1.00  7.70           C
+ATOM     91  SG  CYS A   6      13.130  24.890  24.650  1.00 12.50           S
+END
+"""
+
+def get_model_with_h(pdb_str):
+  model = mmtbx.model.manager(
+    model_input = iotbx.pdb.input(lines=pdb_str.split("\n"), source_info=None),
+    log         = null_out())
+  obj = reduce_hydrogen.place_hydrogens(model = model)
+  obj.run()
+  return obj
+
+# ------------------------------------------------------------------------------
+
+def test_001():
+  '''
+    A bond the restraints already know about is not a missing link.
+
+    workarounds_00345 removes a pair of H closer than 1.0 A whose parent heavy
+    atoms are within 1.6 A, on the premise that the parents carry an unperceived
+    bond and so should never have been hydrogenated. A real bond satisfies that
+    distance test too. Residues are hydrogenated with methyls at an arbitrary
+    torsion and rotated to staggered later, so an as-placed methyl can sit
+    eclipsed against its own parent's H: here THR 5 CB-CG2 is an ordinary 1.52 A
+    bond and HG22 lands 0.84 A from HB. Both were deleted, before the rotation
+    that separates them.
+
+    From 4RXN, where THR 5 lost HB and HG22 while THR 7 and THR 28 kept theirs
+    only because their starting torsion happened to land further away.
+  '''
+  h_atoms = {}
+  for ag in get_model_with_h(pdb_str_001).get_model().get_hierarchy().atom_groups():
+    h_atoms[ag.parent().resseq.strip()] = set(
+      a.name.strip() for a in ag.atoms() if a.element.strip() in ('H', 'D'))
+  assert 'HB' in h_atoms['5'], h_atoms['5']
+  assert 'HG22' in h_atoms['5'], h_atoms['5']
+  assert h_atoms['5'] == set(
+    ['H', 'HA', 'HB', 'HG1', 'HG21', 'HG22', 'HG23']), h_atoms['5']
+
+# ------------------------------------------------------------------------------
+
+def test_002():
+  '''
+    The reported H count is the count in the model that is returned.
+
+    n_H_final was taken before workarounds_00345 ran, so any H the workaround
+    removed was still counted: 4RXN reported 372 added and wrote 370. The number
+    is only printed, never asserted on, so a silent deletion stayed invisible
+    from both ends.
+  '''
+  obj = get_model_with_h(pdb_str_001)
+  n_reported = obj.get_counts().number_h_final
+  n_in_model = obj.get_model().get_hd_selection().count(True)
+  assert n_reported == n_in_model, (n_reported, n_in_model)
+
+# ------------------------------------------------------------------------------
+
+if __name__ == '__main__':
+  run()
+  print("OK")

--- a/mmtbx/run_tests.py
+++ b/mmtbx/run_tests.py
@@ -175,6 +175,7 @@ general_tests = [
   "$D/hydrogens/tst_add_hydrogen_11.py",
   "$D/hydrogens/tst_add_hydrogen_12.py",
   "$D/hydrogens/tst_add_hydrogen_13.py",
+  "$D/hydrogens/tst_add_hydrogen_14.py",
   #"$D/hydrogens/tst_add_hydrogen_time.py",
   "$D/hydrogens/tst_validate_H.py",
   "$D/hydrogens/tst_connectivity.py",


### PR DESCRIPTION
`workarounds_00345` rule 003 removes a pair of H closer than 1.0 A when their
parent heavy atoms are within 1.6 A, on the premise that the parents carry a bond
the restraints did not perceive. A bond that was perceived satisfies the same test.

Methyls are placed at an arbitrary torsion and rotated to staggered later, so an
as-placed methyl can sit eclipsed against its own parent's H. On 4RXN, THR 5's
CB-CG2 is an ordinary 1.52 A bond with HG22 0.84 A from HB, and both atoms are
deleted one step before the rotation that would have separated them. THR 7 and
THR 28 in the same file keep theirs only because their starting torsion landed
further away.

This skips the pair when the two parents are already bonded, using the
connectivity the function builds two lines above. The four ligand cases in
`tst_add_hydrogen_12` are unaffected: their links really are unperceived, so the
parents are not bonded and the rule still fires. That test still fails on its
first case if the workaround is disabled outright.

`n_H_final` was also read before the workaround ran, so the reported count never
saw the deletion: 4RXN prints 372 hydrogens added and writes 370. Moving the
assignment below the call fixes it.

`tst_add_hydrogen_14` covers both, on a 25-atom cut of 4RXN. The count assertion
is a guard against a future deletion added after the count is taken; it cannot
fail with the rule 003 fix in place.
