### PR TITLE
super_cell.py: complete and generalize get_siiu, speed up manager

### DIFF
--- a/cctbx/crystal/super_cell.py
+++ b/cctbx/crystal/super_cell.py
@@ -5,54 +5,190 @@ from cctbx import uctbx
 import cctbx.crystal
 import iotbx.pdb.utils
 import boost_adaptbx.boost.python as bp
+import libtbx
 cctbx_maptbx_ext = bp.import_ext("cctbx_maptbx_ext")
 
-def get_siiu(pdb_hierarchy, crystal_symmetry, select_within_radius):
-  sites_cart = pdb_hierarchy.atoms().extract_xyz()
-  sst = crystal_symmetry.special_position_settings().site_symmetry_table(
-    sites_cart = sites_cart)
+# A site whose symmetry mate is within this distance is taken to lie on a
+# symmetry element and is moved onto it.  Coordinates written to three
+# decimals leave such a site within 0.002 A of its mate.
+min_distance_sym_equiv_coincident = 1.e-2
+
+class sym_equiv_tables(libtbx.slots_getstate_setstate):
+  """The tables get_siiu reads.
+
+  Both must be built from the same sites; neither records which, so a
+  mismatched pair gives wrong equivalents.
+  """
+
+  __slots__ = ["pair_sym_table", "site_symmetry_table"]
+
+  def __init__(self, pair_sym_table, site_symmetry_table):
+    self.pair_sym_table = pair_sym_table
+    self.site_symmetry_table = site_symmetry_table
+
+def get_sym_equiv_tables(sites_cart, crystal_symmetry, radius,
+                         min_distance_sym_equiv=None):
+  """Pair and site symmetry tables covering every contact within radius.
+
+  Neither depends on the selection, so one build serves many of them.
+
+  Parameters
+  ----------
+  sites_cart : flex.vec3_double
+  crystal_symmetry : cctbx.crystal.symmetry
+  radius : float
+      In Angstrom.
+  min_distance_sym_equiv : float, optional
+      min_distance_sym_equiv_coincident by default.
+
+  Returns
+  -------
+  sym_equiv_tables
+  """
+  # An empty crystal_symmetry is truthy, so test the members.
+  assert crystal_symmetry is not None, "no crystal_symmetry"
+  assert crystal_symmetry.unit_cell() is not None, "no unit cell"
+  assert crystal_symmetry.space_group() is not None, "no space group"
+  assert 0 <= radius < float("inf"), "radius is %s" % radius
+  if (min_distance_sym_equiv is None):
+    min_distance_sym_equiv = min_distance_sym_equiv_coincident
+  sps = crystal_symmetry.special_position_settings(
+    min_distance_sym_equiv=min_distance_sym_equiv)
+  site_symmetry_table = sps.site_symmetry_table(sites_cart=sites_cart)
+  # add_all_pairs searches to distance_cutoff*(1+is_inside_epsilon()), which
+  # defaults to 1e-6; the buffer matches.
+  pair_asu_table = sps.pair_asu_table(
+    distance_cutoff               = radius,
+    sites_cart                    = sites_cart,
+    site_symmetry_table           = site_symmetry_table,
+    asu_mappings_buffer_thickness = radius * (1 + 1.e-6))
+  # all_interactions_from_inside_asu keeps every operator of a group of
+  # symmetry-equivalent interactions.
+  return sym_equiv_tables(
+    pair_sym_table = pair_asu_table.extract_pair_sym_table(
+      skip_j_seq_less_than_i_seq       = False,
+      all_interactions_from_inside_asu = True),
+    site_symmetry_table = site_symmetry_table)
+
+def get_siiu(pdb_hierarchy=None, crystal_symmetry=None,
+             select_within_radius=None, sites_cart=None, selection=None,
+             buffer=1, min_distance_sym_equiv=0.5, symmetry_tables=None):
+  """Symmetry equivalents within select_within_radius+buffer of the selection.
+
+  Parameters
+  ----------
+  pdb_hierarchy : iotbx.pdb.hierarchy.root, optional
+      Supplies sites_cart when that is not given.
+  crystal_symmetry : cctbx.crystal.symmetry
+  select_within_radius : float
+      In Angstrom.
+  sites_cart : flex.vec3_double, optional
+  selection : iterable of int, optional
+      The sites to search around; all of them by default.
+  buffer : float
+  min_distance_sym_equiv : float
+      Pass min_distance_sym_equiv_coincident to keep a site written on a
+      symmetry element where it is.
+  symmetry_tables : sym_equiv_tables, optional
+      From get_sym_equiv_tables, to search several selections without
+      rebuilding them.
+
+  Returns
+  -------
+  tuple
+      ``({j_seq: [rt_mx_ji]}, [rt_mx_ji])``.  Applying rt_mx_ji to the
+      fractional coordinates of site j_seq places that equivalent near a
+      selected site, plus the distinct operators among them.  Operators
+      carry denominators (1, 12), so equal operators hash equally.  One
+      operator per equivalent, and an equivalent coincident with its site
+      is dropped.
+  """
+  if (symmetry_tables is None):
+    if (sites_cart is None):
+      assert pdb_hierarchy is not None, "no sites_cart and no pdb_hierarchy"
+      sites_cart = pdb_hierarchy.atoms().extract_xyz()
+    # +1 is nonbonded buffer, to match nonbonded_distance_cutoff
+    symmetry_tables = get_sym_equiv_tables(
+      sites_cart             = sites_cart,
+      crystal_symmetry       = crystal_symmetry,
+      radius                 = select_within_radius + buffer,
+      min_distance_sym_equiv = min_distance_sym_equiv)
+  if (selection is None):
+    selection = range(symmetry_tables.pair_sym_table.size())
+  matrices_by_j_seq = {}
+  normalised = {}
+  by_j_seq = {}
+  pair_sym_table = symmetry_tables.pair_sym_table
+  site_symmetry_table = symmetry_tables.site_symmetry_table
+  assert site_symmetry_table.indices().size() == pair_sym_table.size(), (
+    "the two tables cover different numbers of sites")
+  for i_seq in sorted(set(selection)):
+    assert 0 <= i_seq < pair_sym_table.size(), "selection index is %s" % i_seq
+    for j_seq, rt_mx_ji_list in pair_sym_table[i_seq].items():
+      by_key = None
+      # stl_vector_rt_mx has no __iter__, so a for-in loop falls back to the
+      # __getitem__ protocol and costs one C++ exception per vector.
+      for i_op in range(len(rt_mx_ji_list)):
+        rt_mx_ji = rt_mx_ji_list[i_op]
+        # Site j's own symmetry operators are recorded as the identity, so
+        # this drops them as well.
+        if (rt_mx_ji.is_unit_mx()): continue
+        if (by_key is None):
+          # matrices() builds a fresh tuple on each call, so cache it; None
+          # records a general position.
+          if (j_seq in matrices_by_j_seq):
+            site_symmetry_matrices = matrices_by_j_seq[j_seq]
+          elif (site_symmetry_table.is_special_position(j_seq)):
+            site_symmetry_matrices = site_symmetry_table.get(j_seq).matrices()
+            matrices_by_j_seq[j_seq] = site_symmetry_matrices
+          else:
+            site_symmetry_matrices = matrices_by_j_seq[j_seq] = None
+          by_key = by_j_seq.get(j_seq)
+          if (by_key is None):
+            by_key = by_j_seq[j_seq] = {}
+        if (site_symmetry_matrices is not None):
+          # The canonical coset member, so a union of selections gives the
+          # union of the results.  min() orders by rt_mx.__lt__, the
+          # ordering of space_group.make_tidy().
+          rt_mx_ji = min([rt_mx_ji.multiply(matrix)
+                          for matrix in site_symmetry_matrices])
+        # Equal operators hash equally only on equal denominators, so the
+        # normalised operator is the key.  A miss on an equal operator
+        # normalises it twice, which is harmless.
+        key = normalised.get(rt_mx_ji)
+        if (key is None):
+          key = normalised[rt_mx_ji] = rt_mx_ji.new_denominators(1, 12)
+        by_key[key] = None
   siiu = {}
-  # +1 is nonbonded buffer, to match nonbonded_distance_cutoff
-  cutoff = select_within_radius+1
-  conn_asu_mappings = crystal_symmetry.special_position_settings().\
-    asu_mappings(buffer_thickness=cutoff)
-  conn_asu_mappings.process_sites_cart(
-    original_sites      = sites_cart,
-    site_symmetry_table = sst)
-  conn_pair_asu_table = cctbx.crystal.pair_asu_table(
-    asu_mappings=conn_asu_mappings)
-  conn_pair_asu_table.add_all_pairs(
-    distance_cutoff=cutoff)
-  pair_generator = cctbx.crystal.neighbors_fast_pair_generator(
-    conn_asu_mappings,
-    distance_cutoff=cutoff)
-  all_ops_mat = []
-  all_ops = []
-  for pair in pair_generator:
-    rt_mx_i = conn_asu_mappings.get_rt_mx_i(pair)
-    rt_mx_j = conn_asu_mappings.get_rt_mx_j(pair)
-    rt_mx_ji = rt_mx_i.inverse().multiply(rt_mx_j)
-    #print(rt_mx_ji, str(rt_mx_ji))
-    if str(rt_mx_ji)=="x,y,z": continue
-    siiu.setdefault(pair.j_seq, []).append(rt_mx_ji)
-    as_xyz = rt_mx_ji.as_xyz()
-    if(not as_xyz in all_ops):
-      all_ops.append(as_xyz)
-      all_ops_mat.append(rt_mx_ji)
-  for k,v in zip(siiu.keys(), siiu.values()): # remove duplicates!
-    siiu[k] = list(set(v))
-  return siiu, all_ops_mat
+  for j_seq, by_key in by_j_seq.items():
+    siiu[j_seq] = list(by_key)
+  # Every operator that reached a by_key is in normalised, on denominators
+  # (1, 12) and so hashing consistently.
+  return siiu, list(dict.fromkeys(normalised.values()))
 
-def apply_symop_sites_cart(sites_cart, op, fm, om):
-  sites_frac = fm * sites_cart
-  sites_frac_copy = flex.vec3_double(
-    [op*site_frac for site_frac in sites_frac])
-  return om*sites_frac_copy
+def sym_equiv_sites_cart(sites_cart, unit_cell, rt_mx, selection=None):
+  """Cartesian sites imaged by rt_mx.
 
-def apply_symop_inplace_chain(chain, op, fm, om):
-  sites_cart = chain.atoms().extract_xyz()
-  sites_cart_copy = apply_symop_sites_cart(sites_cart, op, fm, om)
-  chain.atoms().set_xyz(sites_cart_copy)
+  Parameters
+  ----------
+  sites_cart : flex.vec3_double
+  unit_cell : cctbx.uctbx.unit_cell
+  rt_mx : cctbx.sgtbx.rt_mx
+  selection : flex.size_t, optional
+      The sites to image; all of them by default.
+
+  Returns
+  -------
+  flex.vec3_double
+  """
+  if (selection is not None):
+    sites_cart = sites_cart.select(selection)
+  return ((unit_cell.matrix_cart(rt_mx.r()) * sites_cart)
+          + unit_cell.orthogonalize(rt_mx.t().as_double()))
+
+def apply_symop_inplace_chain(chain, op, unit_cell):
+  chain.atoms().set_xyz(sym_equiv_sites_cart(
+    sites_cart=chain.atoms().extract_xyz(), unit_cell=unit_cell, rt_mx=op))
 
 class manager(object):
   def __init__(self,
@@ -70,8 +206,7 @@ class manager(object):
     self.siiu                 = siiu
     self.pdb_hierarchy        = pdb_hierarchy
     self.chain_op_dict        = {}
-    self.fm = crystal_symmetry.unit_cell().fractionalization_matrix()
-    self.om = crystal_symmetry.unit_cell().orthogonalization_matrix()
+    self.unit_cell = crystal_symmetry.unit_cell()
     #
     assert pdb_hierarchy.models_size() == 1, "one model is expected"
     # Get operators
@@ -100,7 +235,8 @@ class manager(object):
         cntr+=1
         chain_dc.id = new_id
         new_ids.append(new_id)
-        apply_symop_inplace_chain(chain=chain_dc, op=op, fm=self.fm, om=self.om)
+        apply_symop_inplace_chain(
+          chain=chain_dc, op=op, unit_cell=self.unit_cell)
         new_chains.append(chain_dc)
       self.chain_op_dict[op] = new_ids
     for c in new_chains:
@@ -206,7 +342,8 @@ class manager(object):
     for op, cids in zip(self.chain_op_dict.keys(), self.chain_op_dict.values()):
       sel_str = " or ".join(["chain %s"%it for it in cids])
       sel = self.scasc.selection(sel_str)
-      sites_cart_copy = apply_symop_sites_cart(sites_cart, op, self.fm, self.om)
+      sites_cart_copy = sym_equiv_sites_cart(
+        sites_cart=sites_cart, unit_cell=self.unit_cell, rt_mx=op)
       all_xyz.set_selected(sel, sites_cart_copy)
     self.super_cell_hierarchy.atoms().set_xyz(all_xyz)
     self.super_sphere_hierarchy = self.super_cell_hierarchy.select(

--- a/cctbx/crystal/super_cell.py
+++ b/cctbx/crystal/super_cell.py
@@ -275,18 +275,20 @@ class manager(object):
       mask_value_outside_molecule = 0,
       radii                       = radii,
       wrapping                    = False)
-    # Select the inside of the mask (discard the rest). This is super-sphere
+    # Select the inside of the mask (discard the rest). This is super-sphere.
+    # The mask is read for every atom at once, rather than one call per atom.
+    nx, ny, nz = n_real
+    fx, fy, fz = (fm_ss*self.super_cell_hierarchy.atoms().extract_xyz()).parts()
+    grid_index = ((((fx*nx).iround() % nx) * ny
+                   + ((fy*ny).iround() % ny)) * nz
+                  + ((fz*nz).iround() % nz))
+    inside_atom = mask.as_1d().select(grid_index.as_size_t()) == 1
     for chain in self.super_cell_hierarchy.chains():
       for rg in chain.residue_groups():
-        sites_frac = fm_ss * rg.atoms().extract_xyz()
-        inside = False
-        for site_frac in sites_frac:
-          if(mask.value_at_closest_grid_point(site_frac)==1):
-            inside = True
-            break
-        if(not inside):
+        i_seqs = rg.atoms().extract_i_seq()
+        if(not inside_atom.select(i_seqs).count(True)):
           #chain.remove_residue_group(rg)
-          self.keep_selection.set_selected(rg.atoms().extract_i_seq(), False)
+          self.keep_selection.set_selected(i_seqs, False)
     if(debug_files):
       self.super_cell_hierarchy.write_pdb_file(file_name="ss_cut.pdb",
         crystal_symmetry = box.crystal_symmetry())

--- a/cctbx/crystal/super_cell.py
+++ b/cctbx/crystal/super_cell.py
@@ -167,7 +167,7 @@ def get_siiu(pdb_hierarchy=None, crystal_symmetry=None,
   return siiu, list(dict.fromkeys(normalised.values()))
 
 def sym_equiv_sites_cart(sites_cart, unit_cell, rt_mx, selection=None):
-  """Cartesian sites imaged by rt_mx.
+  """The symmetry-equivalent sites rt_mx generates.
 
   Parameters
   ----------
@@ -175,7 +175,7 @@ def sym_equiv_sites_cart(sites_cart, unit_cell, rt_mx, selection=None):
   unit_cell : cctbx.uctbx.unit_cell
   rt_mx : cctbx.sgtbx.rt_mx
   selection : flex.size_t, optional
-      The sites to image; all of them by default.
+      The sites to transform; all of them by default.
 
   Returns
   -------

--- a/cctbx/crystal/super_cell.py
+++ b/cctbx/crystal/super_cell.py
@@ -151,9 +151,10 @@ def get_siiu(pdb_hierarchy=None, crystal_symmetry=None,
           # ordering of space_group.make_tidy().
           rt_mx_ji = min([rt_mx_ji.multiply(matrix)
                           for matrix in site_symmetry_matrices])
-        # Equal operators hash equally only on equal denominators, so the
-        # normalised operator is the key.  A miss on an equal operator
-        # normalises it twice, which is harmless.
+        # The key is the operator as it arrived, the value that operator on
+        # denominators (1, 12).  Equal operators hash equally only on equal
+        # denominators, so a lookup misses when one arrives on others; that
+        # costs a second normalisation and nothing else.
         key = normalised.get(rt_mx_ji)
         if (key is None):
           key = normalised[rt_mx_ji] = rt_mx_ji.new_denominators(1, 12)
@@ -161,8 +162,8 @@ def get_siiu(pdb_hierarchy=None, crystal_symmetry=None,
   siiu = {}
   for j_seq, by_key in by_j_seq.items():
     siiu[j_seq] = list(by_key)
-  # Every operator that reached a by_key is in normalised, on denominators
-  # (1, 12) and so hashing consistently.
+  # The values are the normalised operators, which hash consistently, so
+  # equal ones collapse here however they arrived.
   return siiu, list(dict.fromkeys(normalised.values()))
 
 def sym_equiv_sites_cart(sites_cart, unit_cell, rt_mx, selection=None):

--- a/cctbx/crystal/super_cell.py
+++ b/cctbx/crystal/super_cell.py
@@ -279,9 +279,10 @@ class manager(object):
     # The mask is read for every atom at once, rather than one call per atom.
     nx, ny, nz = n_real
     fx, fy, fz = (fm_ss*self.super_cell_hierarchy.atoms().extract_xyz()).parts()
-    grid_index = ((((fx*nx).iround() % nx) * ny
-                   + ((fy*ny).iround() % ny)) * nz
-                  + ((fz*nz).iround() % nz))
+    # closest_grid_point puts a tie on the lower index: ceil(x - 1/2).
+    grid_index = (((flex.ceil(fx*nx - 0.5).iround() % nx) * ny
+                   + (flex.ceil(fy*ny - 0.5).iround() % ny)) * nz
+                  + (flex.ceil(fz*nz - 0.5).iround() % nz))
     inside_atom = mask.as_1d().select(grid_index.as_size_t()) == 1
     for chain in self.super_cell_hierarchy.chains():
       for rg in chain.residue_groups():

--- a/cctbx/crystal/super_cell.py
+++ b/cctbx/crystal/super_cell.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 import iotbx.pdb
 from scitbx.array_family import flex
 from cctbx import uctbx
-import cctbx.crystal
 import iotbx.pdb.utils
 import boost_adaptbx.boost.python as bp
 import libtbx

--- a/cctbx/crystal/tst_super_cell.py
+++ b/cctbx/crystal/tst_super_cell.py
@@ -4,7 +4,6 @@ from cctbx.crystal import super_cell
 import mmtbx.model
 import libtbx.load_env
 from libtbx.utils import null_out
-import math
 from scitbx.array_family import flex
 
 pdb_str_1yjp = """

--- a/cctbx/crystal/tst_sym_equiv_near_sites.py
+++ b/cctbx/crystal/tst_sym_equiv_near_sites.py
@@ -1,0 +1,666 @@
+from __future__ import absolute_import, division, print_function
+from cctbx import crystal
+from cctbx.crystal import super_cell
+from cctbx import sgtbx
+from cctbx.development import debug_utils
+from libtbx.test_utils import Exception_expected, approx_equal
+from scitbx.array_family import flex
+import sys
+
+def sym_equiv_near_selection(symmetry_tables, primary_selection):
+  """The equivalents get_siiu finds in prebuilt tables, without the
+  operator list."""
+  return super_cell.get_siiu(
+    selection=primary_selection, symmetry_tables=symmetry_tables)[0]
+
+def sym_equiv_within_radius(sites_cart, crystal_symmetry, radius,
+                            primary_selection):
+  """The equivalents get_siiu finds within radius, without the operator
+  list."""
+  return super_cell.get_siiu(
+    sites_cart             = sites_cart,
+    crystal_symmetry       = crystal_symmetry,
+    select_within_radius   = radius,
+    selection              = primary_selection,
+    buffer                 = 0,
+    min_distance_sym_equiv = super_cell.min_distance_sym_equiv_coincident)[0]
+
+def general_position_structure(space_group_info=None, n_sites=12):
+  """A structure with all sites in general positions and fixed coordinates."""
+  if (space_group_info is None):
+    space_group_info = sgtbx.space_group_info("P 21 21 21")
+  cs = crystal.symmetry(
+    unit_cell=space_group_info.any_compatible_unit_cell(volume=3000.),
+    space_group_info=space_group_info)
+  sites_frac = flex.vec3_double()
+  for i in range(n_sites):
+    sites_frac.append((
+      (0.0417 + 0.0713 * i) % 0.83,
+      (0.1103 + 0.0891 * i) % 0.79,
+      (0.0629 + 0.1097 * i) % 0.87))
+  return cs, cs.unit_cell().orthogonalize(sites_frac)
+
+def brute_force_sym_equiv(sites_cart, crystal_symmetry, radius,
+                          primary_selection, n_shifts=2):
+  """Equivalents within *radius* of a selected site, from all operators over
+  a block of lattice translations, without asu_mappings.
+
+  Compares operators, so it is valid only for sites in general positions.
+  """
+  unit_cell = crystal_symmetry.unit_cell()
+  sites_frac = unit_cell.fractionalize(sites_cart=sites_cart)
+  selected_fracs = [sites_frac[i_seq] for i_seq in primary_selection]
+  identity_as_xyz = sgtbx.rt_mx().as_xyz()
+  result = {}
+  for rotation_op in crystal_symmetry.space_group().all_ops():
+    for i in range(-n_shifts, n_shifts + 1):
+      for j in range(-n_shifts, n_shifts + 1):
+        for k in range(-n_shifts, n_shifts + 1):
+          op = rotation_op + (i, j, k)
+          as_xyz = op.as_xyz()
+          if (as_xyz == identity_as_xyz): continue
+          for j_seq in range(sites_frac.size()):
+            equiv_frac = op * sites_frac[j_seq]
+            for selected_frac in selected_fracs:
+              if (unit_cell.distance(equiv_frac, selected_frac) <= radius):
+                result.setdefault(j_seq, set()).add(as_xyz)
+                break
+  return result
+
+def as_xyz_sets(equivalents):
+  """{j_seq: set of operator strings}."""
+  result = {}
+  for j_seq, ops in equivalents.items():
+    result[j_seq] = set([op.as_xyz() for op in ops])
+  return result
+
+def sym_equiv_positions(unit_cell, sites_frac, equivalents):
+  """{j_seq: sorted Cartesian equivalent positions}."""
+  result = {}
+  for j_seq, ops in equivalents.items():
+    result[j_seq] = sorted(
+      [unit_cell.orthogonalize(op * sites_frac[j_seq]) for op in ops])
+  return result
+
+def unique_positions(positions, tolerance=1.e-4):
+  """Sorted positions, with duplicates closer than *tolerance* dropped."""
+  result = []
+  for position in sorted(positions):
+    if (len(result) == 0
+        or not approx_equal(position, result[-1], eps=tolerance, out=None)):
+      result.append(position)
+  return result
+
+def brute_force_sym_equiv_positions(sites_cart, crystal_symmetry, radius,
+                                primary_selection, n_shifts=2):
+  """Equivalent positions within *radius* of a selected site, from all
+  operators over a block of lattice translations, without asu_mappings.
+
+  Positions rather than operators, so this holds for sites on special
+  positions too.  Equivalents coincident with their site are dropped.
+  """
+  unit_cell = crystal_symmetry.unit_cell()
+  sites_frac = unit_cell.fractionalize(sites_cart=sites_cart)
+  selected_fracs = [sites_frac[i_seq] for i_seq in primary_selection]
+  result = {}
+  for rotation_op in crystal_symmetry.space_group().all_ops():
+    for i in range(-n_shifts, n_shifts + 1):
+      for j in range(-n_shifts, n_shifts + 1):
+        for k in range(-n_shifts, n_shifts + 1):
+          op = rotation_op + (i, j, k)
+          for j_seq in range(sites_frac.size()):
+            equiv_frac = op * sites_frac[j_seq]
+            if (unit_cell.distance(equiv_frac, sites_frac[j_seq]) <= 1.e-6):
+              continue
+            for selected_frac in selected_fracs:
+              if (unit_cell.distance(equiv_frac, selected_frac) <= radius):
+                result.setdefault(j_seq, []).append(
+                  unit_cell.orthogonalize(equiv_frac))
+                break
+  for j_seq in result:
+    result[j_seq] = unique_positions(result[j_seq])
+  return result
+
+def differences(expected, obtained):
+  """Per j_seq, what is missing from and extra in *obtained*."""
+  result = {}
+  for j_seq in set(expected) | set(obtained):
+    missing = expected.get(j_seq, set()) - obtained.get(j_seq, set())
+    extra = obtained.get(j_seq, set()) - expected.get(j_seq, set())
+    if (missing or extra):
+      result[j_seq] = (sorted(missing), sorted(extra))
+  return result
+
+def assert_same_positions(expected, obtained, info):
+  """The two position tables list the same equivalents."""
+  assert sorted(obtained) == sorted(expected), (
+    info, sorted(expected), sorted(obtained))
+  for j_seq, positions in expected.items():
+    assert len(obtained[j_seq]) == len(positions), (
+      info, j_seq, len(positions), len(obtained[j_seq]))
+    assert approx_equal(obtained[j_seq], positions, eps=1.e-4), (info, j_seq)
+
+def exercise_matches_brute_force(space_group_info):
+  """Every equivalent a direct search finds is found, and no others.
+
+  The larger radii reach far enough to give an atom equivalents of itself.
+  """
+  primary_selection = [0, 3, 7]
+  cs, sites_cart = general_position_structure(space_group_info)
+  n_equivalents = 0
+  for radius in [1.0, 2.0, 5.0, 8.0]:
+    obtained = as_xyz_sets(sym_equiv_within_radius(
+      sites_cart       = sites_cart,
+      crystal_symmetry = cs,
+      radius           = radius,
+      primary_selection     = primary_selection))
+    expected = brute_force_sym_equiv(
+      sites_cart       = sites_cart,
+      crystal_symmetry = cs,
+      radius           = radius,
+      primary_selection     = primary_selection)
+    assert obtained == expected, (
+      str(space_group_info), radius, differences(expected, obtained))
+    n_equivalents += len(expected)
+  # The smallest radii can find nothing; the sweep as a whole must not.
+  assert n_equivalents > 0, str(space_group_info)
+
+def exercise_brute_force_block_is_large_enough(space_group_info):
+  """The reference enumerations cover enough lattice translations.
+
+  Only the largest radius needs checking: a block big enough there is big
+  enough for any smaller radius.
+  """
+  primary_selection = [0, 3, 7]
+  radius = 8.0
+  cs, sites_cart = general_position_structure(space_group_info)
+  near = brute_force_sym_equiv(
+    sites_cart, cs, radius, primary_selection, n_shifts=2)
+  far = brute_force_sym_equiv(
+    sites_cart, cs, radius, primary_selection, n_shifts=3)
+  assert near == far, (str(space_group_info), differences(far, near))
+  near = brute_force_sym_equiv_positions(
+    sites_cart, cs, radius, primary_selection, n_shifts=2)
+  far = brute_force_sym_equiv_positions(
+    sites_cart, cs, radius, primary_selection, n_shifts=3)
+  assert_same_positions(far, near, str(space_group_info))
+
+def exercise_a_smaller_selection_is_a_subset():
+  """Selecting two atoms returns part of what selecting every atom returns."""
+  cs, sites_cart = general_position_structure()
+  radius = 5.0
+  everything = as_xyz_sets(sym_equiv_within_radius(
+    sites_cart, cs, radius, primary_selection=list(range(sites_cart.size()))))
+  subset = as_xyz_sets(sym_equiv_within_radius(
+    sites_cart, cs, radius, primary_selection=[0, 1]))
+  assert len(subset) > 0
+  assert len(subset) < len(everything)
+  for j_seq, ops in subset.items():
+    assert j_seq in everything
+    assert ops.issubset(everything[j_seq])
+
+def exercise_both_pair_directions():
+  """Equivalents are reported from either end of a pair."""
+  cs, sites_cart = general_position_structure()
+  radius = 5.0
+  symmetry_tables = super_cell.get_sym_equiv_tables(
+    sites_cart, cs, radius)
+  n_checked = 0
+  for i_seq in range(sites_cart.size()):
+    forward = sym_equiv_near_selection(
+      symmetry_tables, [i_seq])
+    for j_seq, ops in forward.items():
+      if (j_seq == i_seq): continue
+      backward = sym_equiv_near_selection(
+        symmetry_tables, [j_seq])
+      assert i_seq in backward, (i_seq, j_seq)
+      backward_as_xyz = set([op.as_xyz() for op in backward[i_seq]])
+      for op in ops:
+        inverse_as_xyz = op.inverse().new_denominators(1, 12).as_xyz()
+        assert inverse_as_xyz in backward_as_xyz, (
+          i_seq, j_seq, op.as_xyz(), sorted(backward_as_xyz))
+        n_checked += 1
+  assert n_checked > 0
+
+def exercise_distances_hold():
+  """A returned operator places its atom within the radius of a selected
+  site.
+  """
+  cs, sites_cart = general_position_structure()
+  radius = 5.0
+  primary_selection = [0, 5]
+  sites_frac = cs.unit_cell().fractionalize(sites_cart=sites_cart)
+  equivalents = sym_equiv_within_radius(
+    sites_cart, cs, radius, primary_selection=primary_selection)
+  assert len(equivalents) > 0
+  for j_seq, ops in equivalents.items():
+    for op in ops:
+      equiv_frac = op * sites_frac[j_seq]
+      distances = [cs.unit_cell().distance(equiv_frac, sites_frac[i_seq])
+                   for i_seq in primary_selection]
+      assert min(distances) <= radius * (1 + 1.e-6), (j_seq, op.as_xyz())
+
+def exercise_identity_excluded():
+  """No returned operator is the identity."""
+  cs, sites_cart = general_position_structure()
+  equivalents = sym_equiv_within_radius(
+    sites_cart, cs, radius=5.0,
+    primary_selection=list(range(sites_cart.size())))
+  assert len(equivalents) > 0
+  identity_as_xyz = sgtbx.rt_mx().as_xyz()
+  for j_seq, ops in equivalents.items():
+    for op in ops:
+      assert op.as_xyz() != identity_as_xyz
+
+def special_position_structure(unit_cell=(6, 7, 28, 90, 90, 90)):
+  """A structure whose first site lies on the two-fold of C 1 2 1."""
+  cs = crystal.symmetry(unit_cell=unit_cell, space_group_symbol="C 1 2 1")
+  sites_frac = flex.vec3_double([
+    (0.0,   0.2,  0.0),
+    (0.13,  0.31, 0.07),
+    (0.21,  0.44, 0.19)])
+  return cs, sites_frac, cs.unit_cell().orthogonalize(sites_frac)
+
+def exercise_self_equivalents_of_a_selected_site():
+  """An atom's own symmetry equivalents are reported.
+
+  Site 0 lies on the two-fold, site 1 is in a general position.
+  """
+  cs, sites_frac, sites_cart = special_position_structure()
+  for i_seq in [0, 1]:
+    equivalents = sym_equiv_within_radius(
+      sites_cart, cs, radius=5.0, primary_selection=[i_seq])
+    obtained = sym_equiv_positions(cs.unit_cell(), sites_frac, equivalents)
+    expected = brute_force_sym_equiv_positions(sites_cart, cs, 5.0, [i_seq])
+    # Four equivalents for site 0 and five for site 1.
+    assert len(expected[i_seq]) > 1, i_seq
+    assert_same_positions(expected, obtained, i_seq)
+
+def exercise_prebuilt_table():
+  """A separately built table gives the same answer as building it inline."""
+  cs, sites_cart = general_position_structure()
+  radius = 5.0
+  primary_selection = [0, 4, 9]
+  direct = sym_equiv_within_radius(
+    sites_cart, cs, radius, primary_selection=primary_selection)
+  staged = sym_equiv_near_selection(
+    super_cell.get_sym_equiv_tables(sites_cart, cs, radius),
+    primary_selection)
+  assert len(direct) > 0
+  assert as_xyz_sets(direct) == as_xyz_sets(staged)
+
+def exercise_operators_are_hash_stable():
+  """Returned operators survive a set round trip.
+
+  Equal rt_mx with different translation denominators hash differently, so a
+  set can hold an un-normalised operator twice.
+  """
+  cs, sites_cart = general_position_structure()
+  equivalents = sym_equiv_within_radius(
+    sites_cart, cs, radius=5.0, primary_selection=[0, 2, 6])
+  assert len(equivalents) > 0
+  for j_seq, ops in equivalents.items():
+    assert len(set([op.as_xyz() for op in ops])) == len(ops)
+    ops_set = set(ops)
+    assert len(ops_set) == len(ops), j_seq
+    for op in ops:
+      assert op in ops_set
+      assert sgtbx.rt_mx(op.as_xyz()).new_denominators(1, 12) in ops_set
+
+def near_special_position_structure():
+  """A structure whose first site sits 0.2 A off the two-fold of C 1 2 1.
+
+  Its symmetry mate is 0.4 A away, too far for the site to be taken onto the
+  axis.
+  """
+  cs = crystal.symmetry(unit_cell=(20, 24, 28, 90, 90, 90),
+                        space_group_symbol="C 1 2 1")
+  sites_frac = flex.vec3_double([
+    (0.01, 0.2,  0.0),
+    (0.13, 0.31, 0.07)])
+  return cs, sites_frac, cs.unit_cell().orthogonalize(sites_frac)
+
+def exercise_a_site_near_an_element_is_general():
+  """A site near a symmetry element keeps every equivalent of its own."""
+  cs, sites_frac, sites_cart = near_special_position_structure()
+  symmetry_tables = super_cell.get_sym_equiv_tables(
+    sites_cart, cs, 5.0)
+  special = list(
+    symmetry_tables.site_symmetry_table.special_position_indices())
+  assert special == [], special
+  equivalents = sym_equiv_within_radius(
+    sites_cart, cs, 5.0, primary_selection=[0])
+  obtained = sym_equiv_positions(cs.unit_cell(), sites_frac, equivalents)
+  expected = brute_force_sym_equiv_positions(sites_cart, cs, 5.0, [0])
+  assert len(expected) > 0
+  assert_same_positions(expected, obtained, "near an element")
+
+def exercise_a_neighbour_near_an_element_keeps_its_equivalents():
+  """A neighbour lying near a symmetry element keeps every equivalent of its
+  own that is in range.
+  """
+  cs = crystal.symmetry(unit_cell=(9.579, 10.153, 11.64, 90, 90, 90),
+                        space_group_symbol="P -1")
+  # Site 1 lies 0.1775 A off the inversion centre at (1/2, 0, 0).  Under
+  # x,y+1,z it is 4.99 A from site 0, under -x+1,-y+1,-z it is 5.34 A.
+  sites_frac = flex.vec3_double([
+    (0.672825, 0.536167, 0.113296),
+    (0.506371, -0.016354, 0.001298),
+    (0.493881, 0.352158, 0.718093)])
+  sites_cart = cs.unit_cell().orthogonalize(sites_frac)
+  equivalents = sym_equiv_within_radius(
+    sites_cart, cs, 5.0, primary_selection=[0])
+  obtained = sym_equiv_positions(cs.unit_cell(), sites_frac, equivalents)
+  expected = brute_force_sym_equiv_positions(sites_cart, cs, 5.0, [0])
+  assert len(expected) > 0
+  assert_same_positions(expected, obtained, "neighbour near an element")
+
+def exercise_result_is_lists_of_operators():
+  """The keys are plain ints and the values are lists of rt_mx."""
+  cs, sites_cart = general_position_structure()
+  equivalents = sym_equiv_within_radius(
+    sites_cart, cs, 5.0, primary_selection=[0, 3, 7])
+  assert isinstance(equivalents, dict)
+  assert len(equivalents) > 0
+  for j_seq, ops in equivalents.items():
+    assert isinstance(j_seq, int), type(j_seq)
+    assert isinstance(ops, list), (j_seq, type(ops))
+    assert len(ops) > 0
+    for op in ops:
+      assert isinstance(op, sgtbx.rt_mx)
+
+def exercise_operators_from_mixed_denominators():
+  """Equal operators arriving on different denominators collapse to one."""
+  table = crystal.pair_sym_table(2)
+  ops = sgtbx.stl_vector_rt_mx()
+  rt_mx = sgtbx.rt_mx("-x,y+1/2,-z")
+  ops.append(rt_mx.new_denominators(1, 12))
+  ops.append(rt_mx.new_denominators(1, 24))
+  ops.append(sgtbx.rt_mx("x+1,y,z"))
+  table[0][1] = ops
+  cs = crystal.symmetry(unit_cell=(30, 30, 30, 90, 90, 90),
+                        space_group_symbol="P 1")
+  site_symmetry_table = cs.special_position_settings().site_symmetry_table(
+    sites_cart=flex.vec3_double([(1, 2, 3), (4, 5, 6)]))
+  equivalents = sym_equiv_near_selection(
+    super_cell.sym_equiv_tables(table, site_symmetry_table), [0])
+  assert sorted(equivalents) == [1], sorted(equivalents)
+  obtained = equivalents[1]
+  assert len(obtained) == 2, [op.as_xyz() for op in obtained]
+  assert len(set(obtained)) == len(obtained)
+  assert set([op.t().den() for op in obtained]) == set([12])
+
+def exercise_primary_selection_contract():
+  """The selection is taken as a set, an empty one gives nothing, and an
+  index outside the sites is rejected.
+  """
+  cs, sites_cart = general_position_structure()
+  radius = 5.0
+  once = as_xyz_sets(sym_equiv_within_radius(
+    sites_cart, cs, radius, primary_selection=[0, 3]))
+  repeated = as_xyz_sets(sym_equiv_within_radius(
+    sites_cart, cs, radius, primary_selection=[3, 0, 3, 0]))
+  assert len(once) > 0
+  assert once == repeated
+  assert sym_equiv_within_radius(
+    sites_cart, cs, radius, primary_selection=[]) == {}
+  for i_seq in [-1, sites_cart.size()]:
+    try:
+      sym_equiv_within_radius(
+        sites_cart, cs, radius, primary_selection=[i_seq])
+    except AssertionError as e:
+      assert str(e) == f"selection index is {i_seq}", str(e)
+    else:
+      raise Exception_expected
+
+def exercise_every_selected_site_contributes():
+  """Selecting many atoms is the union of selecting each of them.
+
+  Two selected sites can reach one equivalent of an atom on a special
+  position by different operators, so which operator is reported must not
+  depend on the selection.
+  """
+  cs, sites_cart = general_position_structure()
+  cases = [(cs, sites_cart, list(range(sites_cart.size())))]
+  for fixture in special_position_fixtures:
+    space_group_symbol, unit_cell, fracs, selection = fixture
+    cs = crystal.symmetry(unit_cell=unit_cell,
+                          space_group_symbol=space_group_symbol)
+    cases.append((cs, cs.unit_cell().orthogonalize(flex.vec3_double(fracs)),
+                  selection))
+  radius = 5.0
+  for cs, sites_cart, primary_selection in cases:
+    together = as_xyz_sets(sym_equiv_within_radius(
+      sites_cart, cs, radius, primary_selection=primary_selection))
+    apart = {}
+    for i_seq in primary_selection:
+      one = sym_equiv_within_radius(
+        sites_cart, cs, radius, primary_selection=[i_seq])
+      for j_seq, ops in as_xyz_sets(one).items():
+        apart.setdefault(j_seq, set()).update(ops)
+    assert len(together) > 0
+    assert together == apart, differences(apart, together)
+
+def exercise_requires_crystal_symmetry():
+  """None and an empty crystal.symmetry are rejected."""
+  cs, sites_cart = general_position_structure()
+  placeholder = crystal.symmetry()
+  assert placeholder.unit_cell() is None
+  assert placeholder.space_group_info() is None
+  for bad, message in [(None, "no crystal_symmetry"),
+                       (placeholder, "no unit cell")]:
+    try:
+      sym_equiv_within_radius(sites_cart, bad, 5.0, [0])
+    except AssertionError as e:
+      assert str(e) == message, str(e)
+    else:
+      raise Exception_expected
+
+# Fixtures whose first site lies on a symmetry element, with the sites to
+# select.
+special_position_fixtures = [
+  ("C 1 2 1", (6, 7, 28, 90, 90, 90),                 # two-fold
+   [(0.0, 0.2, 0.0), (0.13, 0.31, 0.07), (0.21, 0.44, 0.19)], [0, 1]),
+  ("F m m 2", (9.673, 12.574, 16.444, 90, 90, 90),    # mirror, F centred
+   [(0.0, 1 / 6., 0.0), (0.113, 0.207, 0.331), (0.717, 0.311, 0.613)], [1, 2]),
+  ("R 3 :H", (12.1, 12.1, 16.7, 90, 90, 120),         # three-fold
+   [(0.0, 0.0, 0.11), (0.213, 0.331, 0.07), (0.41, 0.62, 0.28)], [1, 2]),
+  ("P 43 21 2", (12.1, 12.1, 16.7, 90, 90, 90),       # two-fold at (x, x, 0)
+   [(0.19, 0.19, 0.0), (0.113, 0.407, 0.231), (0.617, 0.311, 0.513)], [1, 2]),
+  ("P -1", (7, 8, 9, 90, 90, 90),                     # inversion centre
+   [(0.0, 0.0, 0.0), (0.21, 0.33, 0.14), (0.44, 0.19, 0.37)], [1, 2]),
+  ("P m -3 m", (9, 9, 9, 90, 90, 90),                 # site symmetry m-3m
+   [(0.0, 0.0, 0.0), (0.213, 0.331, 0.07), (0.41, 0.28, 0.62)], [1, 2]),
+]
+
+def selected_site_near_an_element_structure():
+  """A structure whose first site sits 0.15 A off an inversion centre, the
+  others in general positions.
+  """
+  space_group_info = sgtbx.space_group_info("P 1 21/c 1")
+  cs = crystal.symmetry(
+    unit_cell=space_group_info.any_compatible_unit_cell(volume=700.),
+    space_group_info=space_group_info)
+  # The equivalents of sites 1 and 2 fall just inside the radius used below.
+  sites_frac = flex.vec3_double([
+    (0.00632,  0.005007, 0.012803),
+    (0.845806, 0.150766, 0.661288),
+    (0.698725, 0.188033, 0.675395),
+    (0.87933,  0.832146, 0.150299)])
+  return cs, sites_frac, cs.unit_cell().orthogonalize(sites_frac)
+
+def exercise_a_selected_site_near_an_element_keeps_its_neighbours():
+  """A selected site lying near a symmetry element still finds the
+  equivalents around it, and none beyond the radius.
+  """
+  cs, sites_frac, sites_cart = selected_site_near_an_element_structure()
+  radius = 4.0
+  equivalents = sym_equiv_within_radius(
+    sites_cart, cs, radius, primary_selection=[0])
+  obtained = sym_equiv_positions(cs.unit_cell(), sites_frac, equivalents)
+  expected = brute_force_sym_equiv_positions(sites_cart, cs, radius, [0])
+  assert len(expected) > 1
+  assert_same_positions(expected, obtained, "selected site near an element")
+  # Nothing is reported beyond the radius either.
+  for j_seq, ops in equivalents.items():
+    for op in ops:
+      distance = cs.unit_cell().distance(
+        op * sites_frac[j_seq], sites_frac[0])
+      assert distance <= radius * (1 + 1.e-6), (j_seq, op.as_xyz(), distance)
+
+def exercise_a_radius_that_is_not_a_distance_is_rejected():
+  """A negative, infinite or NaN radius is rejected."""
+  cs, sites_cart = general_position_structure()
+  for radius in [-1.0, float("inf"), float("nan")]:
+    try:
+      super_cell.get_sym_equiv_tables(sites_cart, cs, radius)
+    except AssertionError as e:
+      assert str(e) == f"radius is {radius}", str(e)
+    else:
+      raise Exception_expected
+
+def exercise_tables_must_cover_the_same_sites():
+  """Two tables built for different numbers of sites are rejected."""
+  cs, sites_cart = general_position_structure()
+  symmetry_tables = super_cell.get_sym_equiv_tables(
+    sites_cart, cs, 5.0)
+  fewer = super_cell.get_sym_equiv_tables(
+    sites_cart[:4], cs, 5.0).site_symmetry_table
+  try:
+    sym_equiv_near_selection(
+      super_cell.sym_equiv_tables(symmetry_tables.pair_sym_table, fewer), [0])
+  except AssertionError as e:
+    assert str(e) == "the two tables cover different numbers of sites", str(e)
+  else:
+    raise Exception_expected
+
+def exercise_a_site_written_on_an_element_is_coincident():
+  """A site on a symmetry element is recognised at the precision it is written.
+
+  Three decimals leave a site within 0.002 A of its mate; the 0.03 offset
+  puts it 0.042 A off the axis and 0.085 A from its mate.
+  """
+  cs = crystal.symmetry(unit_cell=(20, 24, 28, 90, 90, 90),
+                        space_group_symbol="C 1 2 1")
+  # The two-fold runs along (0, y, 0).
+  for offset, on_the_element in [(0.0005, True), (0.03, False)]:
+    sites_cart = flex.vec3_double([
+      (offset, 4.8, offset), (2.6, 7.44, 1.96)])
+    symmetry_tables = super_cell.get_sym_equiv_tables(
+      sites_cart, cs, 5.0)
+    special = list(
+      symmetry_tables.site_symmetry_table.special_position_indices())
+    assert special == ([0] if on_the_element else []), (offset, special)
+
+def exercise_special_positions_are_complete():
+  """Every equivalent of an atom on a symmetry element is reported, exactly
+  once.
+  """
+  n_checked = 0
+  for fixture in special_position_fixtures:
+    space_group_symbol, unit_cell, fracs, selection = fixture
+    cs = crystal.symmetry(unit_cell=unit_cell,
+                          space_group_symbol=space_group_symbol)
+    sites_frac = flex.vec3_double(fracs)
+    sites_cart = cs.unit_cell().orthogonalize(sites_frac)
+    for radius in [4.0, 6.0]:
+      equivalents = sym_equiv_within_radius(
+        sites_cart, cs, radius, primary_selection=selection)
+      obtained = sym_equiv_positions(cs.unit_cell(), sites_frac, equivalents)
+      expected = brute_force_sym_equiv_positions(
+        sites_cart, cs, radius, selection)
+      assert_same_positions(expected, obtained, (space_group_symbol, radius))
+      assert len(expected) > 0, (space_group_symbol, radius)
+      for j_seq, ops in equivalents.items():
+        assert len(ops) == len(obtained[j_seq]), (
+          space_group_symbol, radius, j_seq)
+        n_checked += len(ops)
+  assert n_checked > 0
+
+def exercise_tolerance_admits_a_three_decimal_worst_case():
+  """Rounding moves a site up to 0.0005 A along each of three axes, so across
+  an inversion centre its mate is 2*sqrt(3)*0.0005 = 0.0017 A away.  The
+  tolerance has to clear that, not just the 0.0014 A of a two-axis offset.
+  """
+  cs = crystal.symmetry(unit_cell=(21, 23, 25, 90, 90, 90),
+                        space_group_symbol="P -1")
+  sites_cart = flex.vec3_double([(0.0005, 0.0005, 0.0005), (7.3, 8.1, 9.7)])
+  sites_frac = cs.unit_cell().fractionalize(sites_cart)
+  mate = cs.unit_cell().distance(
+    sites_frac[0], tuple(-x for x in sites_frac[0]))
+  assert abs(mate - 0.0017320) < 1.e-6, mate
+  symmetry_tables = super_cell.get_sym_equiv_tables(
+    sites_cart, cs, 5.0)
+  special = list(
+    symmetry_tables.site_symmetry_table.special_position_indices())
+  assert special == [0], special
+
+def exercise_a_contact_exactly_at_the_radius_is_reported():
+  """A contact lying exactly at the radius is reported."""
+  n_checked = 0
+  # The cell edge is the radius, so a lattice translation lands on it.
+  for edge in [4.0, 6.0, 7.0, 8.0]:
+    cs = crystal.symmetry(unit_cell=(edge, 7.0, 28.0, 90, 90, 90),
+                          space_group_symbol="C 1 2 1")
+    sites_frac = flex.vec3_double([(0.0, 0.2, 0.0), (0.31, 0.44, 0.19)])
+    sites_cart = cs.unit_cell().orthogonalize(sites_frac)
+    equivalents = sym_equiv_within_radius(
+      sites_cart, cs, edge, primary_selection=[0])
+    obtained = sym_equiv_positions(cs.unit_cell(), sites_frac, equivalents)
+    expected = brute_force_sym_equiv_positions(sites_cart, cs, edge, [0])
+    assert_same_positions(expected, obtained, edge)
+    at_the_edge = [
+      op for op in equivalents[0]
+      if abs(cs.unit_cell().distance(op * sites_frac[0], sites_frac[0])
+             - edge) < 1.e-9]
+    assert len(at_the_edge) > 0, edge
+    n_checked += len(at_the_edge)
+  assert n_checked > 0
+
+def exercise_selection_order_does_not_change_the_result():
+  """Reversing the selection order leaves the operator lists identical, in
+  the same order.
+  """
+  cs, sites_cart = general_position_structure()
+  forward = sym_equiv_within_radius(
+    sites_cart, cs, 5.0, primary_selection=[0, 3, 7])
+  reverse = sym_equiv_within_radius(
+    sites_cart, cs, 5.0, primary_selection=[7, 3, 0])
+  assert len(forward) > 0
+  assert list(forward) == list(reverse)
+  for j_seq in forward:
+    assert ([op.as_xyz() for op in forward[j_seq]]
+            == [op.as_xyz() for op in reverse[j_seq]]), j_seq
+
+def run_call_back(flags, space_group_info):
+  exercise_matches_brute_force(space_group_info)
+  exercise_brute_force_block_is_large_enough(space_group_info)
+
+def run():
+  exercise_a_smaller_selection_is_a_subset()
+  exercise_both_pair_directions()
+  exercise_distances_hold()
+  exercise_identity_excluded()
+  exercise_self_equivalents_of_a_selected_site()
+  exercise_prebuilt_table()
+  exercise_operators_are_hash_stable()
+  exercise_operators_from_mixed_denominators()
+  exercise_primary_selection_contract()
+  exercise_requires_crystal_symmetry()
+  exercise_a_radius_that_is_not_a_distance_is_rejected()
+  exercise_tables_must_cover_the_same_sites()
+  exercise_a_site_written_on_an_element_is_coincident()
+  exercise_tolerance_admits_a_three_decimal_worst_case()
+  exercise_a_contact_exactly_at_the_radius_is_reported()
+  exercise_selection_order_does_not_change_the_result()
+  exercise_special_positions_are_complete()
+  exercise_a_selected_site_near_an_element_keeps_its_neighbours()
+  exercise_a_site_near_an_element_is_general()
+  exercise_a_neighbour_near_an_element_keeps_its_equivalents()
+  exercise_result_is_lists_of_operators()
+  exercise_every_selected_site_contributes()
+  debug_utils.parse_options_loop_space_groups(sys.argv[1:], run_call_back)
+  print("OK")
+
+if (__name__ == "__main__"):
+  run()

--- a/cctbx/crystal/tst_sym_equiv_near_sites.py
+++ b/cctbx/crystal/tst_sym_equiv_near_sites.py
@@ -83,11 +83,15 @@ def sym_equiv_positions(unit_cell, sites_frac, equivalents):
   return result
 
 def unique_positions(positions, tolerance=1.e-4):
-  """Sorted positions, with duplicates closer than *tolerance* dropped."""
+  """Positions, with duplicates closer than *tolerance* dropped.
+
+  Compares against every position kept: two positions can share a coordinate
+  to within rounding, so sorting does not bring duplicates together.
+  """
   result = []
-  for position in sorted(positions):
-    if (len(result) == 0
-        or not approx_equal(position, result[-1], eps=tolerance, out=None)):
+  for position in positions:
+    if (not True in [approx_equal(position, kept, eps=tolerance, out=None)
+                     for kept in result]):
       result.append(position)
   return result
 
@@ -131,14 +135,26 @@ def differences(expected, obtained):
       result[j_seq] = (sorted(missing), sorted(extra))
   return result
 
-def assert_same_positions(expected, obtained, info):
-  """The two position tables list the same equivalents."""
+def assert_same_positions(expected, obtained, info, tolerance=1.e-4):
+  """The two position tables list the same equivalents, in any order.
+
+  Two positions can share a coordinate to within rounding, so their order
+  after sorting is not the same on every platform; each position is matched
+  to one of its own instead.
+  """
   assert sorted(obtained) == sorted(expected), (
     info, sorted(expected), sorted(obtained))
   for j_seq, positions in expected.items():
-    assert len(obtained[j_seq]) == len(positions), (
-      info, j_seq, len(positions), len(obtained[j_seq]))
-    assert approx_equal(obtained[j_seq], positions, eps=1.e-4), (info, j_seq)
+    unmatched = list(obtained[j_seq])
+    assert len(unmatched) == len(positions), (
+      info, j_seq, len(positions), len(unmatched))
+    for position in positions:
+      for i_candidate, candidate in enumerate(unmatched):
+        if (approx_equal(position, candidate, eps=tolerance, out=None)):
+          del unmatched[i_candidate]
+          break
+      else:
+        raise AssertionError((info, j_seq, position, obtained[j_seq]))
 
 def exercise_matches_brute_force(space_group_info):
   """Every equivalent a direct search finds is found, and no others.

--- a/cctbx/run_tests.py
+++ b/cctbx/run_tests.py
@@ -31,6 +31,7 @@ tst_list = [
   "$D/crystal/tst_ext.py",
   "$D/crystal/tst_distance_based_connectivity.py",
   "$D/crystal/tst_super_cell.py",
+  ["$D/crystal/tst_sym_equiv_near_sites.py", "I41/acd"],
   "$D/adptbx/boost_python/tst_adptbx.py",
   #["$D/adptbx/boost_python/tst_hirshfeld.py", "--fix-random-seeds"],
   "$D/miller/boost_python/tst_miller.py",


### PR DESCRIPTION
# Complete the list of symmetry copies get_siiu finds

`get_siiu_sym_equiv` -> `master` · 3 commits · `cctbx/crystal/super_cell.py` (+255/-58), `cctbx/crystal/tst_sym_equiv_near_sites.py` (new, 666), `cctbx/run_tests.py` (+1)

---

`super_cell.manager` surrounds a model with its symmetry copies, so that a calculation on one region sees the crystal contacts around it. `get_siiu` decides which copies come close enough to be worth generating.

It was missing some. Each contact between two atoms was recorded from one side only, so a copy that reaches the model from the other side never got generated. On one of the test structures that costs a whole chain copy, with a contact at 6.7 A, well inside the 7 A search radius.

The search now goes through cctbx's pair tables, which already do this bookkeeping: both ends of every contact, atoms sitting on symmetry elements, and operators that are equal but written differently.

`get_siiu` can now also be asked about a chosen set of atoms instead of the whole model, which is what endo_exo and the water protonation work needs. Called the old way, it behaves as before.

Separately, `manager` looks up its mask for all atoms in one go instead of one call per atom. That was most of its runtime on large structures: 35 s to 2.6 s for 2000 atoms in I 41/a c d.

Nothing visible changes for users: on the five `tst_super_cell.py` structures the super sphere, which is what consumers read, comes out identical. Only the intermediate super cell grows, on the one structure with the missing operator.

The rest is detail, for the deeper read.

## Details

### `get_siiu`

It walked `neighbors_fast_pair_generator` directly, which lists each pair once from inside the ASU. It now builds a `pair_asu_table` and extracts a `pair_sym_table` with `all_interactions_from_inside_asu=True`, which lists pairs from both ends and keeps every operator of a group of symmetry-equivalent interactions. Operators that only appeared as the reverse of a pair were dropped before.

New arguments, all defaulting to the previous behaviour (whole hierarchy, `+1` buffer, 0.5 A tolerance):

- `sites_cart` and `selection`: the sites to search around, instead of always the whole hierarchy.
- `symmetry_tables`: prebuilt tables from the new `get_sym_equiv_tables`, so a caller querying several selections at one radius does not rebuild them each time. Neither table depends on the selection.
- `buffer`, `min_distance_sym_equiv`: the two constants that were hard-coded. `min_distance_sym_equiv_coincident` (1e-2) is there for callers that want a site written on a symmetry element at three decimals recognised, without 0.5 A snapping a site that is genuinely off the element.

What the result now guarantees:

- One operator per equivalent for an atom on a special position: the canonical member of the coset the site symmetry generates. A union of selections gives the union of the results, and which operator represents an equivalent does not depend on the selection.
- Operators carry `(1, 12)` denominators. `rt_mx` compares equal across differing denominators but does not hash equal, so the old `list(set(v))` dedup could keep an operator twice; the `all_ops` list deduped on `as_xyz` strings instead.
- An equivalent coincident with the site it came from is dropped, as before.

### Other changes

- `sym_equiv_sites_cart` replaces `apply_symop_sites_cart`: it takes the unit cell and works in Cartesian space, rather than taking fractionalization and orthogonalization matrices and round-tripping through a Python list.
- `manager` reads the super-cell mask for every atom at once. The per-atom `value_at_closest_grid_point` call was most of its time on a large structure: 11.0 s of 11.5 s for 2000 atoms in P 43 21 2, over the 176000 atoms of the super cell. On 2000-atom random structures: P 21 21 21 6.7 -> 0.6 s, P 43 21 2 10.0 -> 0.9 s, I 41/a c d 35.3 -> 2.6 s.

### Effect on `manager`

Atom counts on the `tst_super_cell.py` fixtures at radius 6, master vs this branch:

| fixture | operators | super cell | super sphere |
| --- | --- | --- | --- |
| huge_box | 0 -> 0 | 38 -> 38 | 38 -> 38 |
| one_chain | 7 -> 8 | 304 -> 342 | 160 -> 160 |
| 1yjp | 30 -> 30 | 2046 -> 2046 | 576 -> 576 |
| 3q2c | 7 -> 7 | 6296 -> 6296 | 1399 -> 1399 |
| fraction | 20 -> 20 | 1344 -> 1344 | 528 -> 528 |

`one_chain` picks up one operator that `get_siiu` was missing, a real contact at 6.662 A inside its own 7.0 A cutoff. It is masked out of the sphere, so `super_sphere_hierarchy`, which is what consumers read, is unchanged on all five.

### Testing

`cctbx/crystal/tst_sym_equiv_near_sites.py`, 24 exercises, checked against a brute-force enumeration over all space group operators and a block of lattice translations. There are two references: operators, for sites in general positions, and positions, for special positions where several operators give one equivalent. Fixtures cover a two-fold, a mirror in an F-centred group, a three-fold, an inversion centre and site symmetry m-3m, plus sites lying just off an element.

Run bare it sweeps the `debug_utils` space groups; given a symbol it runs that group alone. Registered in `cctbx/run_tests.py` as `["$D/crystal/tst_sym_equiv_near_sites.py", "I41/acd"]`, 1.8 s there. `cctbx/crystal/tst_super_cell.py`, as expanded in e8a16bf5, is unchanged by this branch and passes, 39 s.

### For reviewers

- The only consumers are `mmtbx/geometry_restraints/quantum_restraints_manager.py` and qrefine's `super_cell.py` wrapper, both through `manager`, and both read `super_sphere_hierarchy`.
- `mmtbx/regression/tst_flipping_his.py` was not run: it shells out to external programs.
- Preparatory consolidation for later PRs of endo_exo and water protonation heuristics.