### PR TITLE
Add macOS build instructions for cctbx.xfel.

### DIFF
--- a/xfel/conda_envs/README.md
+++ b/xfel/conda_envs/README.md
@@ -36,6 +36,47 @@ $ echo $PWD/build/conda_setpaths.sh
 ```
 To activate the cctbx environment, `source` the script that was printed in the final step.
 
+## Linux build without psana
+
+psana is only needed to read XTC data from LCLS. To build without it, use
+linux_environment.yml in place of psana_environment.yml. gemmi is a normal
+dependency of that environment, so the separate --no-deps install is not needed.
+
+```
+$ mkdir cctbx; cd cctbx
+$ wget https://raw.githubusercontent.com/cctbx/cctbx_project/master/libtbx/auto_build/bootstrap.py
+$ wget https://raw.githubusercontent.com/cctbx/cctbx_project/master/xfel/conda_envs/linux_environment.yml
+$ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+$ bash Miniconda3-latest-Linux-x86_64.sh -b -p $PWD/mc3
+$ source mc3/etc/profile.d/conda.sh
+$ conda env create -f linux_environment.yml -p $PWD/conda_base
+$ conda activate `pwd`/conda_base
+$ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base --nproc=48 \
+    --no-boost-src hot update build
+$ echo $PWD/build/conda_setpaths.sh
+```
+To activate the cctbx environment, `source` the script that was printed in the final step.
+
+## macOS build
+
+psana is not available for macOS, so this build cannot read XTC data from LCLS. Everything else in
+cctbx.xfel is supported.
+
+```
+$ mkdir cctbx; cd cctbx
+$ curl -LO https://raw.githubusercontent.com/cctbx/cctbx_project/master/libtbx/auto_build/bootstrap.py
+$ curl -LO https://raw.githubusercontent.com/cctbx/cctbx_project/master/xfel/conda_envs/macos_environment.yml
+$ curl -LO https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
+$ bash Miniconda3-latest-MacOSX-arm64.sh -b -p $PWD/mc3
+$ source mc3/etc/profile.d/conda.sh
+$ conda env create -f macos_environment.yml -p $PWD/conda_base
+$ conda activate `pwd`/conda_base
+$ python bootstrap.py --builder=xfel --use-conda=$PWD/conda_base --nproc=6 \
+    --no-boost-src hot update build
+$ echo $PWD/build/conda_setpaths.sh
+```
+To activate the cctbx environment, `source` the script that was printed in the final step.
+
 ## LCLS build
 
 This section is removed because the new LCLS facilities do not have the limitations of the old psana cluster.

--- a/xfel/conda_envs/linux_environment.yml
+++ b/xfel/conda_envs/linux_environment.yml
@@ -1,0 +1,86 @@
+name: linux_env
+channels:
+ - conda-forge
+ - cctbx
+ - nodefaults
+
+dependencies:
+ # conda compilers
+ - c-compiler
+ - cxx-compiler
+ - scons
+
+ # python
+ - python
+ - pip
+ - biopython
+ - ipython
+
+ # testing
+ - pytest
+ - pytest-xdist
+
+ # documentation
+ - docutils
+ - numpydoc
+ - sphinx
+
+ # graphics
+ - pillow
+ - reportlab
+ - wxpython
+ - pyopengl
+ - mesa-libgl-devel-conda-x86_64
+
+ # HDF5 (main libraries come with psana)
+ - h5py
+ - hdf5plugin  # [unix]
+
+ # other
+ - libsvm
+ - mrcfile
+ - psutil
+ - mpi4py
+ - pandas
+ - pybind11
+ - setuptools
+ - natsort
+
+ # cctbx channel
+ - libsvm_py
+
+ # dials
+ - jinja2
+ - msgpack-python
+ - msgpack-c
+ - msgpack-cxx
+ - ordered-set
+ - python-blosc
+ - scikit-learn
+ - tqdm
+ - eigen
+ - dials-data
+ - pint
+ - nxmx
+ - gemmi
+ - hatchling
+
+ # xia2
+ - tabulate
+
+ # Phenix
+ - send2trash
+ - PyRTF
+
+ # xfel gui
+ - mysql
+ - mysqlclient
+ - pydrive2
+
+ # Avoid numpy 1.21.[01234]
+ # See https://github.com/cctbx/cctbx_project/issues/627
+ - numpy=1.20|>=1.21.5
+
+ # boost
+ - boost
+ - boost-cpp

--- a/xfel/conda_envs/macos_environment.yml
+++ b/xfel/conda_envs/macos_environment.yml
@@ -1,0 +1,88 @@
+name: macos_env
+channels:
+ - conda-forge
+ - cctbx
+ - nodefaults
+
+dependencies:
+ # conda compilers
+ - c-compiler
+ - cxx-compiler
+ - scons
+
+ # python
+ - python
+ - pip
+ - biopython
+ - ipython
+
+ # testing
+ - pytest
+ - pytest-xdist
+
+ # documentation
+ - docutils
+ - numpydoc
+ - sphinx
+
+ # graphics
+ - pillow
+ - reportlab
+ - wxpython>=4.2.0=*_5
+ - pyopengl
+ - python.app
+
+ # HDF5
+ - h5py
+ - hdf5plugin<=6
+
+ # other
+ - libsvm
+ - mrcfile
+ - psutil
+ - mpi4py
+ - pandas
+ - pybind11
+ - setuptools
+ - natsort
+
+ # cctbx channel
+ - libsvm_py
+
+ # dials
+ - jinja2
+ - msgpack-python
+ - msgpack-c
+ - msgpack-cxx
+ - ordered-set
+ - python-blosc
+ - scikit-learn
+ - tqdm
+ - eigen
+ - dials-data
+ - pint
+ - nxmx
+ - gemmi
+ - hatchling
+
+ # xia2
+ - tabulate
+
+ # Phenix
+ - send2trash
+ - PyRTF
+
+ # xfel gui
+ - mysql
+ - mysqlclient
+ - pydrive2
+
+ # Avoid numpy 1.21.[01234]
+ # See https://github.com/cctbx/cctbx_project/issues/627
+ - numpy=1.20|>=1.21.5
+
+ # boost
+ # conda-forge froze boost/boost-cpp at 1.85. Those headers do not compile with
+ # the clang in current Xcode (boost/mpl enum cast, fixed in boost 1.87).
+ - libboost-devel
+ - libboost-python-devel


### PR DESCRIPTION
psana is incompatible with macOS and is not included in this build, so macOS does not support XTC files. A macos_environment.yml file is added so macOS installation exactly mirrors the linux instructions.